### PR TITLE
docs: commit to proprietary source-available license (closes #4)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,37 @@
+Copyright (c) 2026 Ben Seymour. All rights reserved.
+
+Source-Available Proprietary License
+
+The source code in this repository is made publicly available for inspection
+and personal non-commercial use only.
+
+You may:
+- Read, study, and evaluate the source code.
+- Run the software for personal, non-commercial use in your own household.
+- Fork the repository to propose changes via pull request.
+
+You may not, without a separate written commercial license from the copyright
+holder:
+- Use the software, or any substantial portion of it, for commercial purposes.
+- Redistribute, sublicense, or publish copies of the source code or compiled
+  binaries, with or without modification.
+- Incorporate the source code into another product or project that is
+  distributed to third parties.
+
+The copyright holder reserves the right to re-license this software at any
+time, including under an open-source or commercial license, without obligation
+to any party.
+
+GPL-LICENSED UPSTREAM COMPONENTS: This repository does not redistribute
+Timekpr-nExT, e2guardian, AdGuard Home, or Ansible. Those components are
+installed separately by end-users and governed solely by their own licenses
+(GPL-3.0 or GPL-2.0 as applicable). See docs/licensing-analysis.md for the
+full analysis of how this project interacts with GPL-licensed components.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF,
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -171,8 +171,15 @@ server. See [`docs/client-install.md`](docs/client-install.md).
 
 ## License
 
-The dashboard and tooling in this repository are intended to be released
-under a permissive license (final choice TBD — see Option B / Option C in
-[`docs/licensing-analysis.md`](docs/licensing-analysis.md)). All GPL-licensed
-upstream tools are used across process boundaries and are not redistributed
-as part of this repository.
+The dashboard and tooling in this repository are released under a
+**proprietary source-available license** — see [`LICENSE`](LICENSE).
+Source code is publicly available for inspection and personal non-commercial
+use. Commercial use requires a separate written agreement with the copyright
+holder. The copyright holder retains the right to re-license under different
+terms (including an open-source license) at any time.
+
+All GPL-licensed upstream tools (Timekpr-nExT, e2guardian, AdGuard Home,
+Ansible) are used across process and network boundaries and are not
+redistributed as part of this repository. See
+[`docs/licensing-analysis.md`](docs/licensing-analysis.md) for the full
+analysis.

--- a/docs/licensing-analysis.md
+++ b/docs/licensing-analysis.md
@@ -21,7 +21,7 @@
 | FleetDM | **MIT** (core); proprietary (`/ee/` directory) | None | Core is permissive; premium features require commercial license |
 | SaltStack | **Apache-2.0** | None | Permissive |
 | osquery (used by FleetDM) | **Apache-2.0** | None | Permissive |
-| Custom dashboard | **Your choice** | — | Entirely new code; no license constraints from the above apply unless the dashboard links GPL code at the binary level |
+| Custom dashboard | **Proprietary source-available** | — | Entirely new code; no license constraints from the above apply unless the dashboard links GPL code at the binary level. See decision note below. |
 
 ---
 
@@ -127,6 +127,26 @@ The one firm constraint that applies regardless of chosen license: **any distrib
 
 ---
 
+## Decision (closes #4)
+
+**Chosen: Option C — proprietary source-available.**
+
+The dashboard is released under a custom proprietary source-available license
+(see `LICENSE` at the repo root). Key properties of this choice:
+
+- Source code is publicly visible for inspection and personal non-commercial use.
+- Commercial use requires a separate written agreement with the copyright holder.
+- Since all dashboard code is original work by a single copyright holder with no
+  external contributors, the owner retains full re-licensing rights. This means
+  moving to a permissive open-source license (e.g. Apache-2.0 or MIT) or to a
+  structured commercial model is equally available in the future — no options
+  are foreclosed by starting here.
+
+The GPL-boundary rules in the rest of this document are unchanged; they apply
+regardless of what license the dashboard carries.
+
+---
+
 ## Quick-reference: per-component obligations when distributing
 
 | Component | If you distribute it unchanged | If you modify it and distribute it |
@@ -138,4 +158,4 @@ The one firm constraint that applies regardless of chosen license: **any distrib
 | Ansible (GPL-3.0) | Must provide or point to source | Must release modified source under GPL-3.0 |
 | SaltStack (Apache-2.0) | Must include license and notice | May keep changes proprietary; must include notice |
 | FleetDM core (MIT) | Must include copyright notice | May keep changes proprietary |
-| Custom dashboard (your choice) | Per your chosen license | Per your chosen license |
+| Custom dashboard (proprietary source-available) | See `LICENSE`; personal non-commercial use only | See `LICENSE`; commercial use requires a separate written agreement |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,10 +25,9 @@ Goal: a runnable, empty-but-correct dashboard skeleton and a CI baseline.
 
 - Create `server/` Python package layout (`pyproject.toml`, `src/dashboard`,
   `tests/`, `Dockerfile`, `.dockerignore`).
-- Pick and pin the dashboard's open-source license file (`LICENSE`) — the
-  decision in [`licensing-analysis.md`](licensing-analysis.md) is between
-  Option B (MIT/Apache-2.0) and Option C (proprietary). Default
-  assumption pending decision: **Apache-2.0**.
+- [x] Pin the dashboard license — **proprietary source-available** (Option C,
+  decided in issue #4). `LICENSE` is at the repo root;
+  [`licensing-analysis.md`](licensing-analysis.md) has the decision rationale.
 - Add `pre-commit` config: `black`, `ruff`, `mypy --strict`.
 - Add a minimal FastAPI app that serves a "hello, no policy yet" page.
 - Add a GitHub Actions workflow that lints, type-checks, runs tests, and

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.0"
 description = "Parental-controls dashboard: FastAPI orchestrator for Timekpr-nExT, ActivityWatch, e2guardian, and AdGuard Home."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "TBD" }
+license = { text = "Proprietary" }
 authors = [{ name = "Ben Seymour" }]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Resolves the open license decision from issue #4 by choosing **Option C — proprietary source-available**.

- **`LICENSE`** — new file at repo root. Custom proprietary source-available license: source is publicly visible for inspection and personal non-commercial use; commercial use requires a separate written agreement; copyright holder retains full re-licensing rights.
- **`README.md`** — license section updated to reflect the decision and link to `LICENSE`.
- **`docs/licensing-analysis.md`** — dashboard row in the component table updated; quick-reference table updated; new **Decision** section added recording the rationale for Option C and noting that all re-licensing paths (open-source or commercial) remain open because the copyright is held entirely by one party with no external contributors.
- **`docs/roadmap.md`** — Phase 1 license item marked done, referencing issue #4.
- **`server/pyproject.toml`** — minimal stub created with `license = {text = "Proprietary"}` to satisfy the acceptance criteria; full scaffolding is Phase 1 work.

## Why proprietary source-available preserves all future options

Since all dashboard code is original work by a single copyright holder with no external contributors (and no CLA obligations to anyone), the owner can re-license at any time — to Apache-2.0, MIT, a commercial SaaS license, or anything else. Starting proprietary source-available does not foreclose any path; it simply means the default for third parties is "read and evaluate, ask before shipping."

## Test plan

- [ ] `LICENSE` file exists at repo root and is not empty
- [ ] `README.md` license section references `LICENSE` and no longer says "TBD"
- [ ] `docs/licensing-analysis.md` Decision section present; component table and quick-reference table updated
- [ ] `docs/roadmap.md` Phase 1 license bullet marked `[x]`
- [ ] `server/pyproject.toml` present with `license = {text = "Proprietary"}`

https://claude.ai/code/session_01WrCZAA3wXx8Gq2RJN4zkBZ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrCZAA3wXx8Gq2RJN4zkBZ)_