### PR TITLE
Add Claude Code workflow commands ported from next-digital-wall-calendar

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -1,0 +1,53 @@
+# Claude Code commands
+
+Slash commands for working on this repository, invoked as `/<name>` from
+Claude Code. They were adapted from the workflow commands in the
+sibling [`next-digital-wall-calendar`](https://github.com/BenSeymourODB/next-digital-wall-calendar)
+repo and rewritten for this project's stack (Python / FastAPI / SQLite, a
+roadmap-phase workflow, and the strict license boundaries described in
+`CLAUDE.md`).
+
+All of them read `CLAUDE.md` first and respect its non-negotiables: no GPL
+imports, subprocess/REST isolation for GPL tools, no GPL binaries in the
+image, `mypy --strict`, and the deliberately bounded tamper-resistance
+posture.
+
+## Available commands
+
+| Command | What it does |
+| ------- | ------------ |
+| `/implement-issue` | Picks one eligible roadmap ticket and delivers it end-to-end: branch + worktree, plan, tests, the black/ruff/mypy/pytest gate, a draft PR, a self-review pass, and review follow-up. |
+| `/review-issues` | Analyzes all open issues for blockers, enablers, and synergies; writes `docs/issue-dependency-analysis.md` + `docs/issue-cross-reference-updates.md` and appends cross-reference sections to the issues. |
+| `/code-review` | Orchestrates a read-only cleanliness review: spawns the five `code-review-*` agents in parallel, dedupes findings, and files `code-review`-labelled GitHub issues. |
+| `/code-review-fix` | Reads open `code-review` issues, prioritizes them, and executes fixes one at a time through the quality gate, closing each when green. |
+| `code-review-complexity` / `code-review-concerns` / `code-review-dead-code` / `code-review-readability` / `code-review-patterns` | Specialized review agents invoked by `/code-review`. Each emits findings in a fixed `FINDING:` format. Not meant to be run directly, though they can be. |
+
+## Conventions these commands assume
+
+- **Tooling:** `pip install -e "server/[dev]"`, then the gate
+  `black server/src/ server/tests/ && ruff check server/src/ server/tests/
+  && mypy --strict server/src/ && pytest server/tests/ -m "not integration"
+  --strict-markers -q --cov=dashboard --cov-fail-under=80` (mirrors CI).
+- **GitHub:** use the GitHub MCP tools (`mcp__github__*`) when running in an
+  environment that provides them (e.g. Claude Code on the web); fall back to
+  the `gh` CLI locally. The commands are written to work either way.
+- **Sequencing:** roadmap phase (`docs/roadmap.md`) + `phase-N` issue labels
+  + GitHub "Blocked by" links are the source of truth. The
+  [roadmap project board](https://github.com/users/BenSeymourODB/projects/2)
+  is the visual tracker; `/implement-issue` discovers any project field IDs
+  at runtime rather than hardcoding them.
+- **Plans:** `/implement-issue` looks for a matching plan in `.claude/plans/`
+  and writes one there if none exists before implementing.
+- **Worktrees:** `/implement-issue` runs each ticket in its own
+  `.claude/worktrees/issue-<n>-<slug>` worktree (gitignored).
+
+## Deliberately not ported
+
+The calendar repo also ships `browser-qa` and `review-with-video` commands.
+Both are tightly coupled to a built SvelteKit/React UI driven through a
+Playwright harness. This project's frontends (`server/frontend/admin/`,
+`server/frontend/app/`) are only lightly scaffolded and have no E2E
+toolchain yet, so those commands would be speculative here. When a frontend
+and its Playwright setup land (see `docs/roadmap.md` Phase 9), porting them
+is worthwhile — until then `/implement-issue` step 8 covers the
+build-the-frontend checks that do apply today.

--- a/.claude/commands/code-review-complexity.md
+++ b/.claude/commands/code-review-complexity.md
@@ -1,0 +1,95 @@
+# Code Review Agent: Complexity & CRAP Analysis
+
+You are a specialized code review agent focused on **complexity and
+maintainability metrics**. Your job is to scan the codebase and identify
+code that is too complex for humans and agents to easily understand and
+maintain.
+
+## Scope
+
+Scan all `.py` files under `server/src/dashboard/` **excluding**:
+
+- Test files (`server/tests/`, `test_*.py`)
+- Generated files (Alembic migration scaffolding under
+  `server/migrations/versions/` — flag only genuinely hand-written
+  complexity there)
+
+## What to look for
+
+### 1. Long functions (>40 lines)
+
+Read each source file and identify functions/methods exceeding 40 lines of
+actual logic (excluding blank lines, docstrings, and comments). These are
+prime candidates for extraction.
+
+### 2. Large modules (>300 lines)
+
+Flag modules exceeding 300 lines of source code. In this codebase a module
+that large usually means a `dashboard.*` submodule has taken on more than
+its single responsibility (see the module split in `CLAUDE.md`).
+
+### 3. Deep nesting (3+ levels)
+
+Conditionals, loops, `try/except`, and `async with` blocks nested 3 or more
+levels deep are hard to follow and test.
+
+### 4. High parameter count (4+)
+
+Functions with 4+ positional parameters suggest the function is doing too
+much or wants a dataclass / Pydantic model for its config.
+
+### 5. Async / subprocess complexity
+
+This codebase drives external tools as subprocesses and external services
+over REST/SSH. Flag:
+
+- Tangled `asyncio` flows (nested `gather`, manual task juggling, missing
+  `await`, fire-and-forget tasks with no error handling).
+- Subprocess invocations whose argument-building and stdout-parsing are
+  crammed into one large function rather than split (build args → run →
+  parse result).
+
+### 6. `Any` / type-escape complexity
+
+`mypy --strict` is required. Flag functions that lean on `Any`,
+`# type: ignore`, or `cast()` to paper over complexity rather than model it.
+
+### 7. Approximate CRAP score
+
+For each complex function, check whether a corresponding test exists under
+`server/tests/` (the test tree mirrors the package layout). Code that is
+both complex AND untested is the highest priority.
+
+- CRAP = complexity * (1 - test_coverage)^2
+- If no test module exists for a source module, assume 0% coverage for that
+  module's functions.
+
+## Output format
+
+Return your findings using EXACTLY this format (one block per finding):
+
+```
+FINDING: {Critical|High|Medium|Low} | {file_path}:{start_line}-{end_line} | complexity
+DESCRIPTION: {what the issue is, with specific metrics like line count, nesting depth, param count}
+SUGGESTION: {specific refactoring recommendation - name the extracted functions/modules}
+EFFORT: {S|M|L}
+```
+
+## Severity guide
+
+- **Critical**: CRAP issue (complex + untested), or function >100 lines
+- **High**: function >60 lines, nesting >4 levels, module >500 lines, or a
+  tangled async flow with no error handling
+- **Medium**: function >40 lines, nesting 3 levels, module >300 lines, or
+  `Any`/`cast` used to dodge complexity
+- **Low**: 4+ parameters, or repeated small subprocess/parse blocks that
+  want a shared helper
+
+## Instructions
+
+1. Use Glob to find all source files in scope (`server/src/dashboard/**/*.py`).
+2. Use Read to examine each file (start with the largest files first).
+3. Analyze each file against the criteria above.
+4. Return ALL findings in the structured format.
+5. Be specific — include exact line numbers and function names.
+6. Suggest concrete refactoring steps, not vague advice.

--- a/.claude/commands/code-review-concerns.md
+++ b/.claude/commands/code-review-concerns.md
@@ -1,0 +1,107 @@
+# Code Review Agent: Separation of Concerns & License Boundaries
+
+You are a specialized code review agent focused on **separation of
+concerns, single-responsibility, and this project's license boundaries**.
+Your job is to find code where responsibilities are mixed in ways that hurt
+testability, reusability, and comprehension — and, critically, any place
+where the dashboard's process/network boundary against GPL components is
+collapsed.
+
+**Read `CLAUDE.md` → "License boundaries" and "Code conventions" first.**
+
+## Scope
+
+Scan all `.py` files under `server/src/dashboard/` **excluding** test files.
+
+## What to look for
+
+### 1. License-boundary violations (highest priority)
+
+These are architectural invariants, not style. Flag as **Critical**:
+
+- Any `import timekpr*`, `import ansible.*`, or other import of a GPL
+  project's Python modules from dashboard code.
+- `timekpra` or `ansible-playbook` being invoked any way other than as a
+  subprocess (`asyncio.create_subprocess_exec` / `subprocess.run`).
+- Parsing Timekpr-nExT's on-disk state with its own parsing code instead of
+  the CLI's stdout.
+- ActivityWatch or AdGuard Home being integrated at the source level
+  instead of over their REST APIs.
+- e2guardian being integrated in code rather than via config files + a
+  reload signal.
+- Anything that would put a GPL binary inside the dashboard image.
+
+If a boundary looks like it's being collapsed "for convenience", that's a
+finding — the rule is to update the design docs first, not to collapse it.
+
+### 2. The `dashboard.*` module split
+
+`CLAUDE.md` prescribes a split: `web` (FastAPI app + mounts), `api` (DTOs +
+JSON routes), `policy` (model, DB, grant ledger), `integrations` (inbound
+external APIs), `transport.{ssh,ansible,activitywatch,adguard}`, `events`
+(WebSocket). Flag code that lands in the wrong layer, e.g.:
+
+- DB/ORM access inside `web` or `transport` instead of `policy`.
+- Transport (SSH/subprocess/REST) calls made directly from `api` or `web`
+  route handlers instead of going through a `transport.*` facade.
+- DTOs (request/response shapes) defined in `policy` instead of `api`.
+
+### 3. Business logic in route handlers
+
+API routes in `dashboard.api` / `dashboard.integrations` should delegate to
+the service/policy layer. Flag routes where validation, computation, budget
+math, or complex data manipulation happens directly in the handler instead
+of in a reusable function.
+
+### 4. God modules / mixed responsibilities
+
+Modules that handle too many concerns at once — e.g. config loading +
+business logic + I/O in one file, or a transport facade that also owns
+policy decisions. A `dashboard.*` submodule should have one clear job.
+
+### 5. Missing abstraction layers
+
+Repeated patterns that should be extracted — e.g. the same auth/session
+check copy-pasted across routes, the same SSH-connect + run + parse dance
+repeated per `timekpra` command, the same idempotency-by-`source_ref`
+handling duplicated across integration endpoints.
+
+### 6. Tangled module dependencies
+
+Circular imports or import chains that couple layers that should be
+independent (e.g. `policy` importing from `web`).
+
+## Output format
+
+Return your findings using EXACTLY this format (one block per finding):
+
+```
+FINDING: {Critical|High|Medium|Low} | {file_path}:{start_line}-{end_line} | {separation-of-concerns|license-boundary}
+DESCRIPTION: {what concerns are mixed / which boundary is at risk, with specifics}
+SUGGESTION: {how to separate - name the new module/function/facade to extract}
+EFFORT: {S|M|L}
+```
+
+## Severity guide
+
+- **Critical**: any license-boundary violation (category 1), or a god
+  module with 5+ distinct responsibilities.
+- **High**: transport/DB calls made directly from route handlers, heavy
+  business logic in a route, or code in the wrong `dashboard.*` layer.
+- **Medium**: repeated auth/validation/transport patterns not extracted, a
+  module doing 2-3 unrelated things.
+- **Low**: minor coupling, slightly mixed concerns that don't significantly
+  hurt maintainability.
+
+## Instructions
+
+1. Use Glob to find all source files in scope.
+2. Start with `transport/` (license boundaries live here), then
+   `integrations/`, then `api/`, then `web/`, then `policy/`.
+3. Use Read to examine each file for mixed responsibilities and boundary
+   violations.
+4. Use Grep to check for cross-layer imports (`import timekpr`,
+   `import ansible`, `from dashboard.web` inside `policy`, etc.) and
+   repeated code.
+5. Return ALL findings in the structured format.
+6. Be specific about WHAT to extract and WHERE it belongs.

--- a/.claude/commands/code-review-dead-code.md
+++ b/.claude/commands/code-review-dead-code.md
@@ -1,0 +1,95 @@
+# Code Review Agent: Dead Code & Unused Exports
+
+You are a specialized code review agent focused on **dead code, unused
+exports, and vestigial dependencies**. Your job is to find code that is no
+longer serving a purpose and is adding maintenance burden.
+
+## Scope
+
+Scan `server/src/dashboard/`, `server/tests/`, and
+`server/pyproject.toml`. (The Svelte frontends under `server/frontend/` are
+in scope only if they contain real code beyond the hello-world scaffold.)
+
+## What to look for
+
+### 1. Unused public functions / classes in `dashboard.*`
+
+For each public name (no leading underscore) exported from a
+`dashboard.*` module, verify it is imported or used somewhere. Pay special
+attention to the service/policy layer and the transport facades, where
+helper functions accumulate. Use Grep to confirm each name's usages across
+`server/`.
+
+### 2. Unused dependencies in `pyproject.toml`
+
+The runtime dependency list is intentionally seeded ahead of the code that
+uses it (each entry is grouped by the phase that will need it). Distinguish:
+
+- **Genuinely dead**: a dependency that is neither imported now nor
+  earmarked for a near-term phase. Flag it.
+- **Forward-declared**: an unpinned stub for an upcoming phase (the
+  `pyproject.toml` comments say as much). Do NOT flag these as dead — note
+  them as "forward-declared, not yet used" at most, Low severity.
+
+Read `pyproject.toml`, then Grep each dependency's import name across
+`server/src/`.
+
+### 3. Vestigial / superseded code
+
+Code left behind after a refactor or a superseded design decision — e.g. an
+old config-loading path after the `pydantic-settings` loader lands, or a
+placeholder kept past the phase that replaced it. Cross-check against
+`docs/roadmap.md` to tell "not built yet" from "built then abandoned".
+
+### 4. Commented-out code blocks
+
+Blocks of commented-out code (3+ consecutive commented lines that look like
+code, not prose/docstrings). These should be restored or removed.
+
+### 5. Empty / placeholder packages past their phase
+
+The package tree was scaffolded with empty `__init__.py` modules. An empty
+package is fine while its phase is pending; flag one only if its phase has
+landed and it should now contain code but doesn't (Low severity, as a
+reminder).
+
+### 6. Orphaned tests
+
+Test modules whose corresponding source module was deleted or significantly
+renamed, or tests that no longer assert anything meaningful.
+
+## Output format
+
+Return your findings using EXACTLY this format (one block per finding):
+
+```
+FINDING: {Critical|High|Medium|Low} | {file_path} | dead-code
+DESCRIPTION: {what is unused/dead and how you verified it}
+SUGGESTION: {remove, consolidate, or flag for review}
+EFFORT: {S|M|L}
+```
+
+## Severity guide
+
+- **Critical**: a genuinely dead runtime dependency that adds attack
+  surface or image weight.
+- **High**: an unused public module/function with real logic, or a large
+  block (>50 lines) of vestigial code.
+- **Medium**: an unused public export from an otherwise-used module.
+- **Low**: small commented-out blocks, forward-declared deps, empty
+  post-phase packages, minor unused internals.
+
+## Instructions
+
+1. Use Glob to inventory all source and test files.
+2. For public exports: Read each `dashboard.*` module, then Grep each
+   exported name across `server/`.
+3. For dependencies: Read `pyproject.toml`, then Grep each dependency name
+   in `server/src/`; classify dead vs forward-declared using the file's own
+   comments and `docs/roadmap.md`.
+4. For commented code: Grep for `^\s*#` runs that contain code-like syntax
+   across multiple lines.
+5. Return ALL findings in the structured format.
+6. Be careful to distinguish "scaffolded ahead of its phase" (expected)
+   from "abandoned after a refactor" (dead) — false positives on the former
+   waste the maintainer's time.

--- a/.claude/commands/code-review-fix.md
+++ b/.claude/commands/code-review-fix.md
@@ -1,0 +1,110 @@
+# Code Review Fix — remediation command
+
+You are the **remediation executor** for code review findings. Your job is
+to read open code-review issues from GitHub, help the user prioritize, and
+execute fixes one at a time.
+
+**Read `CLAUDE.md` first** — every fix must respect the license boundaries,
+the `dashboard.*` module split, `mypy --strict`, and the bounded
+tamper-resistance posture.
+
+Where this guide shows `gh ...`, use the GitHub MCP tools (`mcp__github__*`)
+instead when your environment provides them; fall back to the `gh` CLI when
+running locally.
+
+## Step 1: Fetch open findings
+
+List all open GitHub Issues with the `code-review` label:
+
+```bash
+gh issue list --label code-review --state open \
+  --json number,title,labels,body --limit 100
+```
+
+Parse the issues into a table:
+
+| #     | Severity | Category | File   | Issue | Effort |
+| ----- | -------- | -------- | ------ | ----- | ------ |
+| {num} | {sev}    | {cat}    | {path} | {desc}| {S/M/L}|
+
+Sort by: Critical first, then High, Medium, Low. Within the same severity,
+Small effort before Medium before Large. Surface any `license-boundary`
+findings at the very top regardless of stated severity — those are
+architectural invariants.
+
+## Step 2: Ask what to fix
+
+Present the table and ask the user:
+
+- "Which issues would you like to address? (issue numbers, 'all', or 'top N')"
+- Recommend starting with Critical+Small and High+Small for maximum impact
+  per unit effort, and clearing any `license-boundary` finding first.
+
+## Step 3: Execute fixes
+
+For each selected issue, in order:
+
+1. **Read the issue body** to understand the finding, file, and suggestion.
+2. **Read the affected file** to understand the current code.
+3. **Implement the suggested fix** (or a better one if you identify it).
+   Keep changes scoped to the finding — don't refactor unrelated code.
+4. **Run the quality gate** from the repo root:
+   ```bash
+   black server/src/ server/tests/
+   ruff check --fix server/src/ server/tests/
+   mypy --strict server/src/
+   ```
+5. **Run the relevant tests** (the unit selection CI uses):
+   ```bash
+   pytest server/tests/ -m "not integration" --strict-markers -q \
+     --cov=dashboard --cov-fail-under=80
+   ```
+   If the fix touches a transport or external boundary, also run its
+   integration tests via the Docker Compose recipe in `docs/testing.md`.
+6. **If all checks pass**, note the fix is ready.
+7. **If checks fail**, diagnose and fix before moving on.
+
+After each fix, report what changed and confirm checks pass.
+
+## Step 4: Close resolved issues
+
+After all selected fixes pass:
+
+1. **Stage and commit** with a message referencing the issue numbers and
+   the standard footer:
+   ```
+   fix: address code review findings #{issue1}, #{issue2}
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+   Co-authored-by: Claude <noreply@anthropic.com>
+   ```
+2. **Close each resolved issue** with a comment:
+   ```bash
+   gh issue close {number} --comment "Resolved in commit {sha}. {summary}"
+   ```
+
+## Step 5: Summary
+
+Present a remediation summary:
+
+| Issue              | Status                    | Changes            |
+| ------------------ | ------------------------- | ------------------ |
+| #{number}: {title} | Fixed / Skipped / Partial | {what was changed} |
+
+**Quality checks:** all passing / {details of any failures}
+**Remaining open issues:** {count}
+
+## Important notes
+
+- **Never skip quality checks** — every fix must pass black, ruff,
+  `mypy --strict`, and the unit tests (coverage gate 80%).
+- **One fix at a time** — don't batch unrelated fixes into one change.
+- **Preserve existing tests** — never remove or weaken a test to make a fix
+  pass; if a test reveals a real problem, fix the code.
+- **Never collapse a license boundary** to make a finding "go away" — if a
+  finding seems to require it, stop and raise it in the issue thread.
+- **Ask before large refactors** — if a fix would touch >5 files, confirm
+  with the user first.
+- **Follow `CLAUDE.md` conventions** — all fixes must adhere to the
+  project's standards and the `dashboard.*` module split.

--- a/.claude/commands/code-review-patterns.md
+++ b/.claude/commands/code-review-patterns.md
@@ -1,0 +1,111 @@
+# Code Review Agent: Pattern Consistency
+
+You are a specialized code review agent focused on **pattern consistency
+across the codebase**. Your job is to find places where established patterns
+are broken, leading to inconsistency that makes the codebase harder to
+navigate and maintain.
+
+**Read `CLAUDE.md` → "Code conventions" and "Repository layout" first** —
+they define the intended module split and conventions you are checking
+against.
+
+## Scope
+
+Scan all `.py` files under `server/src/dashboard/` and the matching tests
+under `server/tests/`.
+
+## What to look for
+
+### 1. API route structure consistency
+
+Compare the route handlers in `dashboard.api` (and
+`dashboard.integrations`). Check for consistent patterns in:
+
+- Auth / session verification — do all protected routes check the same way?
+- Input validation — is it consistently done with Pydantic models?
+- Error responses — same shape and status codes across routes?
+- Response shape — do routes return data through consistent DTOs?
+- Service-layer delegation — do all routes call into `policy`/services the
+  same way rather than some doing work inline?
+
+Read several route modules and compare.
+
+### 2. Transport facade consistency
+
+The `transport.{ssh,ansible,activitywatch,adguard}` packages should follow
+parallel shapes:
+
+- Subprocess-based transports (`ssh`/`timekpra`, `ansible`) should build
+  args → run → parse in a consistent structure.
+- REST-based transports (`activitywatch`, `adguard`) should use the same
+  HTTP client conventions, timeout handling, and error mapping.
+- Audit-logging of issued commands should be done the same way everywhere.
+
+Flag a transport that invents its own structure where a sibling already
+established one.
+
+### 3. Error handling & logging patterns
+
+- Are errors caught and handled consistently?
+- Is logging done through the project's structured logging setup rather
+  than ad-hoc `print()` or bare loggers?
+- Are there bare `except Exception:` blocks that swallow errors without
+  logging or re-raising?
+
+### 4. Import & module-layout consistency
+
+- Are imports consistent (absolute `dashboard.*` imports, `import type`
+  equivalents via `TYPE_CHECKING` where used)?
+- Does each module sit in the layer `CLAUDE.md` prescribes?
+- Is `__init__.py` used consistently (thin packages vs re-export surfaces)?
+
+### 5. Pydantic / model conventions
+
+- Are request/response DTOs consistently defined in `dashboard.api`, and
+  ORM models in `dashboard.policy`?
+- Is there one consistent approach to model config (e.g. `model_config`,
+  field validators), or a mix?
+
+### 6. Test patterns
+
+- Does `server/tests/` mirror the package layout (the prescribed
+  convention)?
+- Do tests use the shared fixtures (`db`, `client`, `mock_subprocess`)
+  rather than re-inventing them?
+- Are integration tests consistently marked `@pytest.mark.integration`?
+- Do all testable modules actually have tests?
+
+## Output format
+
+Return your findings using EXACTLY this format (one block per finding):
+
+```
+FINDING: {Critical|High|Medium|Low} | {file_path} | pattern-consistency
+DESCRIPTION: {what pattern is broken, referencing the established pattern and the deviation}
+SUGGESTION: {which pattern to standardize on and what to change}
+EFFORT: {S|M|L}
+```
+
+## Severity guide
+
+- **Critical**: inconsistent error handling that could mask bugs or leak
+  information, or a transport that bypasses the established subprocess/REST
+  structure in a way that risks the license boundary.
+- **High**: inconsistent API route patterns that make the surface
+  unpredictable, or a module placed in the wrong layer.
+- **Medium**: mixed model/DTO placement, inconsistent fixture usage,
+  inconsistent component/module structure.
+- **Low**: minor import-style inconsistencies, test placement variations.
+
+## Instructions
+
+1. Start by reading 2-3 route modules to establish the "expected" API
+   pattern, then read the rest and flag deviations.
+2. Read the transport facades side by side to compare their shapes.
+3. Use Grep to check import patterns, `print(` usage, and bare
+   `except Exception` blocks.
+4. Check that `server/tests/` mirrors `server/src/dashboard/` and that
+   shared fixtures are reused.
+5. Return ALL findings in the structured format.
+6. When flagging inconsistency, always specify which pattern is the
+   MAJORITY (and thus the standard to converge on).

--- a/.claude/commands/code-review-readability.md
+++ b/.claude/commands/code-review-readability.md
@@ -1,0 +1,101 @@
+# Code Review Agent: Naming & Readability
+
+You are a specialized code review agent focused on **naming conventions,
+readability, and human comprehension**. Your job is to find code that is
+harder to understand than it needs to be.
+
+## Scope
+
+Scan all `.py` files under `server/src/dashboard/` **excluding** test
+files. The codebase is formatted with **black** (line length 100) and
+linted with **ruff** — do not flag anything those tools already enforce
+(formatting, import sorting, unused imports). Focus on what they cannot
+catch.
+
+## What to look for
+
+### 1. Magic numbers & strings
+
+Literal numbers or strings used in logic without a named constant:
+
+- Timeouts, retry counts, backoff intervals, poll cadences.
+- Budget/grace-period math (`grace_seconds`, warning thresholds like
+  15/5/1 minutes) embedded inline instead of named.
+- HTTP status codes or external API paths hard-coded mid-logic.
+- AdGuard/ActivityWatch REST endpoint strings repeated inline.
+
+### 2. Unclear variable/function names
+
+- Single-letter variables outside trivial loop counters.
+- Abbreviations that aren't universally understood (standard ones like
+  `id`, `url`, `db`, `tz`, `uid` are fine).
+- Boolean names that don't read as yes/no questions (prefer `is_`, `has_`,
+  `can_`, `should_`).
+- Functions whose names don't describe what they do or return.
+
+### 3. Missing or weak type annotations
+
+`mypy --strict` is required, so most signatures are typed — but flag:
+
+- Public functions returning bare containers (`dict`, `list`) where a typed
+  model or `TypedDict`/dataclass would document the shape.
+- Overuse of `Any`, `object`, or `# type: ignore` where a precise type is
+  available.
+
+### 4. Missing docstrings on public APIs
+
+Public functions/classes in `dashboard.*` (especially `policy`, `api`, and
+the `transport.*` facades) should carry at least a one-line docstring
+explaining their purpose. Flag undocumented public names that aren't
+self-explanatory.
+
+### 5. Long boolean expressions
+
+Conditions with 3+ clauses joined by `and`/`or` that aren't extracted into
+a descriptively named variable or helper (e.g. budget-eligibility or
+schedule-window checks).
+
+### 6. Misleading or stale comments
+
+Comments that restate the code, contradict it, or have drifted out of date
+— especially comments describing a license boundary or a transport
+contract that the code no longer matches.
+
+### 7. Inconsistent style within a file
+
+Mixed approaches in one module — e.g. some functions use early returns,
+others deep `if/else`; mixed `async`/sync styles for the same kind of work.
+
+## Output format
+
+Return your findings using EXACTLY this format (one block per finding):
+
+```
+FINDING: {Critical|High|Medium|Low} | {file_path}:{line_number} | readability
+DESCRIPTION: {the readability issue, with the specific name or snippet}
+SUGGESTION: {the improved name, extracted constant, or refactored expression}
+EFFORT: {S|M|L}
+```
+
+## Severity guide
+
+- **Critical**: misleading names that could cause bugs (e.g. a function
+  named `grant_time` that revokes), or a stale comment that misstates a
+  license boundary.
+- **High**: magic numbers in budget/enforcement logic, completely unclear
+  function purposes, `Any` hiding an important shape.
+- **Medium**: missing docstrings on complex public functions, long boolean
+  expressions, weakly-typed public returns.
+- **Low**: minor naming nits, trivial magic numbers, small style
+  inconsistencies.
+
+## Instructions
+
+1. Use Glob to find all source files in scope.
+2. Read files in this order: `policy/` (public API surface), then
+   `transport/`, then `api/` and `integrations/`, then `web/` and
+   `events/`.
+3. Use Grep to spot magic numbers (`\b\d{2,}\b` outside obvious constants)
+   and bare `Any` / `# type: ignore`.
+4. Return ALL findings in the structured format.
+5. Suggest specific improved names or extractions — not just "rename this".

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,155 @@
+# Code cleanliness review
+
+You are the **orchestrator** for a code cleanliness review of this
+repository (the FastAPI dashboard under `server/`, plus the lightly
+scaffolded Svelte frontends). You coordinate specialized review agents,
+deduplicate findings, and create GitHub Issues for actionable items.
+
+**Read `CLAUDE.md` first.** Several findings categories below are specific
+to this project's rules — the license boundaries (no GPL imports;
+subprocess/REST isolation), the `dashboard.*` module split, `mypy --strict`,
+and the bounded tamper-resistance posture.
+
+Where this guide shows `gh ...`, use the GitHub MCP tools (`mcp__github__*`)
+instead when your environment provides them; fall back to the `gh` CLI when
+running locally.
+
+## Step 1: Baseline checks
+
+Run these first and note any pre-existing failures (they are separate from
+the cleanliness findings, but worth recording):
+
+```bash
+black --check server/src/ server/tests/
+ruff check server/src/ server/tests/
+mypy --strict server/src/
+```
+
+If any fail, note the failures but continue with the review.
+
+## Step 2: Spawn review agents
+
+Launch **all 5 agents in parallel** using the Agent tool. Each should be an
+`Explore`-type agent. Give each agent the full contents of its corresponding
+command file as the prompt:
+
+1. **Complexity & CRAP** — read `.claude/commands/code-review-complexity.md`
+   and use its contents as the agent prompt.
+2. **Separation of concerns & license boundaries** — read
+   `.claude/commands/code-review-concerns.md` and use its contents as the
+   agent prompt.
+3. **Dead code & unused exports** — read
+   `.claude/commands/code-review-dead-code.md` and use its contents as the
+   agent prompt.
+4. **Naming & readability** — read
+   `.claude/commands/code-review-readability.md` and use its contents as
+   the agent prompt.
+5. **Pattern consistency** — read
+   `.claude/commands/code-review-patterns.md` and use its contents as the
+   agent prompt.
+
+Wait for all agents to complete.
+
+## Step 3: Collect and deduplicate findings
+
+Parse all agent results. Each finding follows this format:
+
+```
+FINDING: {severity} | {file_path}:{line_range} | {category}
+DESCRIPTION: {what the issue is}
+SUGGESTION: {specific refactoring recommendation}
+EFFORT: {S|M|L}
+```
+
+Deduplicate:
+
+- If multiple agents flag the same file+line range, merge into one finding,
+  keeping the highest severity.
+- If agents flag different issues in the same file, keep them separate but
+  note they can be addressed together.
+
+**Always escalate any finding that touches a license boundary** (a GPL
+import, a collapsed subprocess/REST boundary, a GPL binary heading into the
+image) to at least High, regardless of which agent raised it — these are
+architectural invariants, not style.
+
+## Step 4: Create GitHub Issues
+
+For each finding (or group of related findings for the same file), create a
+GitHub Issue.
+
+First, check for existing open issues with the `code-review` label to avoid
+duplicates (`mcp__github__search_issues`, or
+`gh issue list --label code-review --state open`). If an existing issue
+covers the same file and concern, comment on it instead of creating a new
+one.
+
+**Issue format:**
+
+```
+Title: [Code Review] {brief description} - {relative file path}
+
+Labels: code-review, {severity}, {category}
+
+Body:
+## Finding
+**File:** `{file_path}:{line_range}`
+**Category:** {category}
+**Severity:** {severity}
+**Effort:** {effort}
+
+## Issue
+{description}
+
+## Suggestion
+{suggestion}
+
+## Context
+Found during automated code review on {today's date}.
+```
+
+**Label mapping:**
+
+- Severity labels: `critical`, `high`, `medium`, `low`
+- Category labels: `complexity`, `separation-of-concerns`, `dead-code`,
+  `readability`, `pattern-consistency`, `license-boundary`
+- All issues get the `code-review` label.
+
+If labels don't exist yet, create them first.
+
+## Step 5: Summary report
+
+Present a summary to the user:
+
+### Code Review Summary - {date}
+
+| Severity | Count |
+| -------- | ----- |
+| Critical | N     |
+| High     | N     |
+| Medium   | N     |
+| Low      | N     |
+
+**Top 5 actionable items** (ranked by severity, then by effort ascending):
+
+1. {finding summary} - {issue link} - Effort: {S/M/L}
+2. ...
+
+**Baseline check results:**
+
+- black: {pass/fail}
+- ruff: {pass/fail with count}
+- mypy --strict: {pass/fail with count}
+
+**Next steps:** run `/code-review-fix` to address findings, or review
+individual issues on GitHub.
+
+## Important notes
+
+- This is a **read-only review**. Do NOT modify any source code.
+- Be conservative with Critical severity — reserve it for genuine
+  architectural problems (a license-boundary violation always qualifies).
+- Group related findings for the same file into a single issue when they
+  share a root cause.
+- If an agent returns no findings for a category, that's fine — note it in
+  the summary as a clean area.

--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,0 +1,352 @@
+# Implement issue
+
+You are an implementation agent for the `linux-parental-controls-toolkit`
+repo. You can be invoked manually as `/implement-issue` or by a scheduled
+driver. Each run picks one eligible ticket from the repo's roadmap and
+delivers it end-to-end. Think deeply with extended thinking before
+non-trivial decisions — this is a high-effort run.
+
+**Read `CLAUDE.md` first**, then skim
+[`docs/roadmap.md`](../../docs/roadmap.md). The hard rules below are
+non-negotiable; most of them come straight from `CLAUDE.md` and exist to
+keep the dashboard from becoming a derivative work of any GPL component.
+
+## Hard rules
+
+- **License boundaries (see `CLAUDE.md` → "License boundaries"):**
+  - Never `import` a GPL project's Python modules — no `import timekpr*`,
+    no `import ansible.*`. Drive `timekpra` and `ansible-playbook` as
+    subprocesses (`asyncio.create_subprocess_exec` / `subprocess.run`).
+  - Talk to ActivityWatch and AdGuard Home over their REST APIs only.
+  - Configure e2guardian by writing config files and signalling a reload —
+    no code-level integration.
+  - Never bundle GPL binaries inside the dashboard Docker image. If a rule
+    becomes inconvenient, **stop and update the design docs first** — do
+    not silently collapse a process/network boundary.
+- **Tamper resistance is bounded** (`CLAUDE.md` → "Tamper resistance is
+  deliberately bounded"). Do not implement anti-tamper hooks, kernel
+  modules, eBPF, obfuscation, or `/etc`/`/usr`/boot lockdown. If a ticket
+  seems to call for hardening beyond what's documented, push back in the
+  issue thread instead of building it.
+- **Python:** 3.11+, type-annotate all public functions, `mypy --strict`
+  must pass. No new dependency without a sentence in the PR description
+  justifying why an existing one doesn't suffice.
+- **Tests required.** Land tests with the code (prefer test-first). Tests
+  live under `server/tests/` mirroring the package layout. NEVER weaken or
+  delete a test to make it pass — if a test reveals a real design problem,
+  fix the design.
+- **Git hygiene:** never `--no-verify`, never force-push, never amend a
+  published commit. Don't commit `.coverage`, build output, or
+  `.claude/worktrees/`.
+
+Where this guide shows `gh ...`, use the GitHub MCP tools
+(`mcp__github__*`) instead when you're running in an environment that
+provides them (e.g. Claude Code on the web); fall back to the `gh` CLI
+when running locally. The two are interchangeable for everything below.
+
+## Source of truth for sequencing
+
+This repo sequences work by **roadmap phase**, not by a dense custom
+project board:
+
+- [`docs/roadmap.md`](../../docs/roadmap.md) — phased delivery plan. Phase
+  order (0 → 11) is the primary ordering.
+- Phase labels on issues: `phase-1` … `phase-11`. An issue's label tells
+  you which milestone it belongs to.
+- GitHub's native **"Blocked by"** links and any `decision-needed` label.
+- Roadmap project board: <https://github.com/users/BenSeymourODB/projects/2>.
+  The board is the visual tracker; the phase label + roadmap doc are the
+  authoritative ordering. If the board has a usable `Status` /
+  `Priority` field, prefer it — discover the field/option IDs at runtime
+  (see "Optional: project board" below) rather than assuming any.
+
+## 0. Pre-flight
+
+```bash
+git fetch --prune origin
+git checkout main && git pull --ff-only origin main
+```
+
+If `git status -s` shows uncommitted state on `main` or the checkout
+fails, a previous run left local state dirty. Post a comment on the most
+recent in-progress issue describing what was found, then exit cleanly —
+manual cleanup is needed before scheduled work resumes.
+
+Then prune stale worktrees so concurrent runs don't accumulate:
+
+```bash
+git worktree prune
+git worktree list
+```
+
+If a listed worktree's branch has a merged PR, remove it:
+`git worktree remove <path>`.
+
+## 1. Unblock pass
+
+`Blocked by` links and `decision-needed` labels go stale after PRs merge
+and decisions land. Before triage, take a quick pass:
+
+- For each open issue with a `Blocked by` relationship, check whether all
+  blockers are now `CLOSED`. If so, the issue is eligible.
+- For `decision-needed` issues, check whether the decision has been
+  recorded (usually in `docs/` or an ADR). If the decision is made,
+  remove the `decision-needed` label or note it so the dependent work can
+  proceed.
+
+This pass is fast. Always run it before triage.
+
+## 2. Pick the next ticket
+
+```bash
+gh issue list --state open \
+  --json number,title,url,labels,body --limit 100
+```
+
+Apply this filter:
+
+1. Issue is `OPEN`.
+2. Not `decision-needed` unless the decision has actually been made (the
+   ticket then becomes ordinary work).
+3. Every "Blocked by" issue is `CLOSED` (check the issue body and any
+   tracked relationships).
+4. No open PR already closes it: `gh pr list --state open --search "in:body Closes #<n>"`.
+5. No claim comment from `implement-issue` newer than 6 hours:
+   `gh issue view <n> --json comments` and look for an
+   `implement-issue claiming` marker.
+
+**Order:** by roadmap phase ascending (Phase 1 before Phase 2 …) using the
+`phase-N` label, then by issue number ascending. Prefer issues that
+unblock the most downstream work. Pick the first match.
+
+**Resume case:** if a prior run left a worktree under
+`.claude/worktrees/issue-<n>-…` with no open PR, it's a crashed run. Pick
+that issue back up, reuse the worktree (`cd` into it,
+`git fetch && git rebase origin/main`).
+
+**Nothing eligible?** Pick the highest-priority blocked or
+`decision-needed` item, post a comment summarizing what's still blocking
+it and what step would clear it, and exit cleanly.
+
+Once selected:
+
+1. Comment on the issue: `🤖 implement-issue claiming this for the next session.`
+2. (If the project board has a `Status` field — see below — set it to
+   "In Progress" for this item.)
+
+## 3. Worktree (concurrent runs can collide)
+
+Each run uses its own git worktree so concurrent runs cannot stomp on each
+other:
+
+```bash
+slug=$(echo "<issue-title>" | tr 'A-Z' 'a-z' | tr -cs 'a-z0-9' '-' | sed 's/^-//;s/-$//' | cut -c1-30)
+worktree=".claude/worktrees/issue-<n>-${slug}"
+branch="claude/issue-<n>-${slug}"
+
+if [ -d "$worktree" ]; then
+  cd "$worktree" && git fetch && git rebase origin/main
+else
+  git worktree add -b "$branch" "$worktree" origin/main
+  cd "$worktree"
+fi
+pip install -e "server/[dev]"
+```
+
+If the branch already exists from a crashed prior run, reuse it:
+`git worktree add "$worktree" "$branch"` (no `-b`).
+
+`.claude/worktrees/` is intentionally untracked (and should be gitignored
+— add it if it isn't). Leave the directory intact when exiting; pre-flight
+prunes stale ones.
+
+## 4. Read the plan
+
+Look in `.claude/plans/` for a file matching the feature/issue. If a plan
+exists, read it before writing code. If none exists, enter planning mode,
+produce a plan grounded in the issue's acceptance criteria and the
+relevant `docs/` design (architecture, server-deployment,
+client-notifications, etc.), and save it to `.claude/plans/<feature>.md`
+before implementing. The design docs in `docs/` are authoritative — never
+contradict them; if the issue requires a change to a documented decision,
+update the doc in the same PR.
+
+## 5. Phases
+
+Break the work into 2–4 phases (e.g. schema/models → service layer → API
+routes → UI, or transport facade → command builders → tests). Commit and
+push at the end of each phase. The first push opens a draft PR; subsequent
+pushes update it.
+
+## 6. Tests
+
+Write tests for every behavior — unit at minimum, plus integration where a
+transport or external boundary is involved. Integration tests are marked
+`@pytest.mark.integration` and run against the Docker Compose environment
+documented in [`docs/testing.md`](../../docs/testing.md); the unit job
+excludes them. NEVER weaken or delete a test to make it pass.
+
+## 7. Implement, validate, push (per phase)
+
+Run the full quality gate from the repo root after each phase. These mirror
+the CI `lint` and `test` jobs:
+
+```bash
+black server/src/ server/tests/
+ruff check --fix server/src/ server/tests/
+mypy --strict server/src/
+pytest server/tests/ -m "not integration" --strict-markers -q \
+  --cov=dashboard --cov-report=term-missing --cov-fail-under=80
+```
+
+All four must succeed (coverage gate is 80%). `pre-commit run --all-files`
+should also be clean. Then commit (HEREDOC body, ending with the standard
+footer below) and push.
+
+Standard commit footer (matches the repo's existing history):
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-authored-by: Claude <noreply@anthropic.com>
+```
+
+On the first push, open a draft PR:
+
+```bash
+gh pr create --draft \
+  --title "feat(<scope>): <summary> (#<n>)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+<1-3 bullets>
+
+## Plan
+
+Linked plan: `.claude/plans/<file>.md`
+Roadmap: docs/roadmap.md → Phase <N>
+
+## License-boundary note
+
+<Confirm no GPL imports / no GPL binaries added to the image, or "N/A — no
+transport or packaging changes in this PR".>
+
+## Test plan
+
+- [ ] ...
+
+Closes #<n>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## 8. UI changes → frontend build / E2E (when applicable)
+
+The dashboard has two frontends (`CLAUDE.md` → frontend split):
+`server/frontend/admin/` (Vite + Svelte islands alongside Jinja2 + HTMX)
+and `server/frontend/app/` (SvelteKit `adapter-static` PWA). Both build at
+image-build time — there is **no Node runtime in the image**.
+
+For any UI-affecting issue:
+
+- Build the affected frontend the way CI does:
+  `cd server/frontend/<admin|app> && npm ci && npm run build`. The build
+  must succeed.
+- If (and only if) the frontend already has an E2E/test toolchain wired
+  up, write tests covering the intended behavior and the realistic edge
+  cases, and run them. The frontends are only lightly scaffolded today —
+  do not stand up a heavyweight Playwright harness as a side effect of an
+  unrelated ticket; that belongs to its own roadmap item.
+- `git status` after any frontend run — never commit `node_modules/`,
+  `build/`, `dist/`, or test artifacts.
+- Include up to 4 representative screenshots in the PR body when the
+  change is visual.
+
+## 9. Finalize
+
+```bash
+black server/src/ server/tests/ && ruff check server/src/ server/tests/ \
+  && mypy --strict server/src/ \
+  && pytest server/tests/ -m "not integration" --strict-markers -q \
+       --cov=dashboard --cov-fail-under=80
+gh pr ready <num>
+```
+
+If you touched a transport, packaging, or the Docker image, sanity-check
+that the `license-guard` workflow will still pass (no GPL binaries in the
+image) before marking ready.
+
+## 10. First-pass review via subagent
+
+Launch a review subagent (`subagent_type=general-purpose`, a capable
+model). Instruct it to:
+
+1. Try the repo's `/code-review` command flow, or do a manual deep review:
+   read the full diff (`gh pr diff <num>`), check tests, check `CLAUDE.md`
+   and `docs/` compliance — **especially the license-boundary rules** —
+   and produce file-level comments with explicit `path` + `line` + `body`.
+2. Pay specific attention to: any new `import` that crosses a GPL
+   boundary; any subprocess/REST boundary being collapsed; missing type
+   annotations; tests that assert too little; tamper-resistance scope
+   creep.
+3. Post comments via the GitHub MCP review tools or
+   `gh api repos/BenSeymourODB/linux-parental-controls-toolkit/pulls/<num>/comments`,
+   or return them verbatim for you to post — do not paraphrase.
+
+## 11. Address review
+
+For each review comment:
+
+- If valid: change, commit, push (the PR updates automatically).
+- If no change needed: post a threaded reply explaining why.
+
+Post a follow-up on every first-round comment so nothing is left
+mid-conversation.
+
+## 12. Cleanup & exit
+
+- **PR is ready-for-review and pushed:** leave the worktree intact for the
+  user to merge / for follow-up runs.
+- **Exiting early due to an unrecoverable blocker:**
+  - Post a comment on the issue summarizing what's blocked and what would
+    unblock it.
+  - Remove your stale `implement-issue claiming` marker (replace with a
+    status update) so the next run can pick up cleanly.
+  - Leave the worktree intact so the next run can continue — do not delete
+    partial work.
+  - Exit cleanly. Never force a state the next run cannot pick up.
+
+## Optional: project board
+
+If the roadmap project board (#2) has been set up with single-select
+fields (`Status`, `Priority`, …), discover the field and option IDs at
+runtime rather than hardcoding them — they are unique per project:
+
+```bash
+gh api graphql -f query='
+{ user(login: "BenSeymourODB") { projectV2(number: 2) {
+  id
+  fields(first: 50) { nodes {
+    ... on ProjectV2SingleSelectField { id name options { id name } }
+    ... on ProjectV2FieldCommon { id name }
+  } }
+} } }'
+```
+
+Then set a field with `updateProjectV2ItemFieldValue` using the IDs you
+just read. If the board has no such fields yet, skip this — the phase
+label and roadmap doc are sufficient for sequencing.
+
+## Scope & guardrails
+
+- If the chosen feature is too large for one session, scope to a
+  meaningful slice and clearly note deferred work in the PR body. Better to
+  ship a clean slice than a broken full feature.
+- Keep PRs small and focused on one roadmap item (`CLAUDE.md` → "Working
+  on this repo").
+- Never `--no-verify`, never force-push, never amend a published commit.
+- Respect every license boundary and the tamper-resistance ceiling above.
+
+Begin.

--- a/.claude/commands/review-issues.md
+++ b/.claude/commands/review-issues.md
@@ -1,0 +1,83 @@
+# Review issues
+
+Do a review of all open Issues on this repository. Identify blockers,
+co-dependencies, and synergies between the issues: which issues must be
+addressed first to let development on others proceed? Which issues aren't
+explicitly blocked but would become easier if others were developed and
+merged first? For each connection you identify, update the description of
+both issues tagging the connected issue.
+
+This repo is sequenced by roadmap phase ([`docs/roadmap.md`](../../docs/roadmap.md)),
+so anchor your analysis to the phases — but surface the finer-grained
+dependencies *within* and *across* phases that the phase labels alone
+don't capture.
+
+Where this guide shows `gh ...`, use the GitHub MCP tools
+(`mcp__github__*`) instead when your environment provides them; fall back
+to the `gh` CLI when running locally.
+
+## Instructions
+
+1. **Read `CLAUDE.md` and `docs/roadmap.md`** so your dependency reasoning
+   respects the intended architecture (e.g. the Settings loader and
+   logging config underpin the transports; the policy schema underpins the
+   API and UI; the event stream underpins the client notification work).
+
+2. **Fetch all open issues** using
+   `gh issue list --state open --json number,title,labels,body --limit 100`.
+
+3. **Analyze dependencies** across all issues. For each issue, identify:
+   - **Blockers**: issues that must be completed before this one can start
+     (e.g. the SQLite schema must exist before the JSON API can serve it;
+     the Settings loader must exist before transport config).
+   - **Enables**: issues this one unblocks once completed.
+   - **Synergies**: issues that share infrastructure, patterns, or a
+     design surface and benefit from coordinated development (e.g. all the
+     transport facades share the subprocess/REST boundary discipline; the
+     admin UI and PWA share the `/api/*` contract).
+   - **Benefits from**: issues that aren't strict blockers but would make
+     this one easier if done first.
+   - **Decision dependencies**: issues blocked on a `decision-needed`
+     ticket (e.g. the budget-timezone decision gates the policy schema).
+
+4. **Group into tiers** based on dependency depth:
+   - **Tier 0 (Foundation)**: no blockers, enables many others.
+   - **Tier 1**: depends only on Tier 0 or external factors.
+   - **Tier 2**: depends on Tier 1 issues.
+   - **Tier 3+**: highest dependency chains.
+   Cross-reference the tiers against the roadmap phases and call out any
+   place where an issue's phase label and its real dependency depth
+   disagree.
+
+5. **Identify synergy clusters**: groups of issues that share enough
+   infrastructure (or the same license boundary, the same transport, the
+   same UI surface) that they should be designed together even if
+   developed separately.
+
+6. **Write two documentation files**:
+   - `docs/issue-dependency-analysis.md` — full dependency graph with
+     tiers, a per-issue connection map, recommended implementation order,
+     and key synergy clusters. Cross-link to the relevant roadmap phase.
+   - `docs/issue-cross-reference-updates.md` — the exact markdown text to
+     append to each affected issue's description.
+
+7. **Update each affected issue** on GitHub:
+   - Append a "Cross-References" section to its description.
+   - Preserve the existing body and append the new section.
+   - Use `gh issue view <number> --json body -q .body` to read existing
+     content, then `gh issue edit <number> --body "<existing + new>"` to
+     update (or the equivalent GitHub MCP calls).
+   - The cross-reference section should tag connected issues and explain
+     the nature of each connection.
+
+8. **Report a summary** of all updates made.
+
+## Notes
+
+- This is primarily an **analysis + bookkeeping** task. Do not change any
+  source code or design docs other than the two analysis files above.
+- Be conservative about declaring hard blockers — reserve "blocked by" for
+  genuine ordering constraints, and use "benefits from" for soft ones.
+- If you spot a dependency that contradicts the roadmap's phase ordering,
+  flag it in `docs/issue-dependency-analysis.md` rather than silently
+  re-sequencing — the roadmap is a human-owned document.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ build/
 
 # Coverage
 .coverage
+
+# Agent worktrees (created by .claude/commands/implement-issue.md)
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Adapts the [`next-digital-wall-calendar`](https://github.com/BenSeymourODB/next-digital-wall-calendar) repo's `/implement-issue` command for this repository, and ports its cohesive code-review suite alongside it. Every command is rewritten for this project's stack and rules rather than copied verbatim.

## What's included (`.claude/commands/`)

| Command | Purpose |
| ------- | ------- |
| `/implement-issue` | Pick one eligible roadmap ticket and deliver it end-to-end: branch + worktree, plan, tests, the `black`/`ruff`/`mypy --strict`/`pytest` gate, a draft PR, a self-review pass, and review follow-up. |
| `/review-issues` | Blocker / enabler / synergy dependency analysis across open issues; writes `docs/issue-dependency-analysis.md` + `docs/issue-cross-reference-updates.md` and appends cross-reference sections to issues. |
| `/code-review` + 5 agents + `/code-review-fix` | Read-only cleanliness review that spawns five specialized agents, dedupes findings, files `code-review`-labelled issues, and a remediation executor that fixes them through the quality gate. |
| `README.md` | Documents the set, assumed conventions, and what was deliberately omitted. |

## Adaptation notes (calendar → this repo)

- **Stack:** Next.js/pnpm/TDD-React → Python/FastAPI/SQLite. Quality gate rewritten to the real CI commands (`black server/src/ server/tests/`, `ruff check`, `mypy --strict server/src/`, `pytest ... --cov=dashboard --cov-fail-under=80`); install via `pip install -e "server/[dev]"`.
- **Project's own rules baked in:** the `CLAUDE.md` license boundaries (no GPL imports, subprocess/REST isolation, no GPL binaries in the image) are now a first-class review category and a hard rule in `implement-issue`; the bounded tamper-resistance posture is an explicit guardrail. The five review agents were rewritten around the `dashboard.*` module split and transport facades instead of React/shadcn concerns.
- **Sequencing:** the calendar repo's dense project-board field IDs are replaced with this repo's actual model — roadmap phases (`docs/roadmap.md`) + `phase-N` labels + GitHub "Blocked by". `implement-issue` discovers any [project #2](https://github.com/users/BenSeymourODB/projects/2) field IDs at runtime instead of hardcoding the calendar's.
- **Tool-agnostic GitHub access:** commands prefer the GitHub MCP tools when available (Claude Code on the web) and fall back to `gh` locally.

## License-boundary note

N/A — documentation/tooling only; no `server/`, transport, or Docker image changes.

## Deliberately not ported

The calendar repo's `browser-qa` and `review-with-video` commands are tightly bound to a built SvelteKit/React UI driven through Playwright. This repo's frontends are only lightly scaffolded with no E2E toolchain yet, so those were skipped (with a note in the README) until the Phase 9 frontend work lands. `implement-issue` step 8 still covers the frontend-build checks that apply today.

## Notes

- `.claude/worktrees/` added to `.gitignore` (created per run by `implement-issue`).
- Branch was fast-forwarded to current `main` before adding these files, so the diff is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9M24xE9jQqS22giziYEvH)_