### PR TITLE
feat(web): minimal Fastify app with / and /healthz (#5)

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,0 +1,27 @@
+/**
+ * Process entrypoint: build the Fastify app and bind it to a socket.
+ *
+ * The build (`server/Dockerfile`, #6) runs the compiled output as
+ * `node dist/main.js`. Listening on 0.0.0.0 makes the dashboard reachable
+ * from outside the container. The bind host/port become configurable via
+ * the settings loader (#10); 8000 is the documented default for now.
+ *
+ * This file is excluded from the coverage gate (vitest.config.ts): it is a
+ * thin bootstrap whose only job is to call buildApp() and listen.
+ */
+import { buildApp } from "./web/app.js";
+
+const HOST = "0.0.0.0";
+const PORT = 8000;
+
+async function main(): Promise<void> {
+  const app = buildApp();
+  try {
+    await app.listen({ host: HOST, port: PORT });
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -1,0 +1,33 @@
+/**
+ * Fastify app composition.
+ *
+ * `buildApp()` is a factory (not a module-level singleton) so tests can
+ * construct isolated instances and exercise routes via `app.inject()`
+ * without binding a socket — see docs/testing.md → "HTTP routes".
+ *
+ * This is the minimal Phase 1 slice: a "hello, no policy yet" landing
+ * route and a `/healthz` probe. Logging configuration (pino, request
+ * IDs) lands in #11; the policy/api/integrations mounts land in later
+ * phases.
+ */
+import Fastify, { type FastifyInstance } from "fastify";
+
+/**
+ * Build and configure a Fastify instance.
+ *
+ * The logger is disabled here; #11 owns the shared pino configuration
+ * that the rest of the app will follow.
+ */
+export function buildApp(): FastifyInstance {
+  const app = Fastify({ logger: false });
+
+  app.get("/", async (_request, reply) => {
+    return reply.type("text/plain").send("hello, no policy yet");
+  });
+
+  app.get("/healthz", async () => {
+    return { status: "ok" };
+  });
+
+  return app;
+}

--- a/server/tests/web/app.test.ts
+++ b/server/tests/web/app.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Route tests for the minimal Phase 1 app.
+ *
+ * Uses Fastify's `app.inject()` — no sockets, no port binding — per
+ * docs/testing.md → "HTTP routes".
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../../src/web/app.js";
+
+describe("web app routes", () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("GET / returns the placeholder landing page", async () => {
+    const res = await app.inject({ method: "GET", url: "/" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe("hello, no policy yet");
+    expect(res.headers["content-type"]).toContain("text/plain");
+  });
+
+  it("GET /healthz reports ok", async () => {
+    const res = await app.inject({ method: "GET", url: "/healthz" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: "ok" });
+  });
+
+  it("unknown routes 404", async () => {
+    const res = await app.inject({ method: "GET", url: "/nope" });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**"],
+      // src/main.ts is a thin bootstrap (build app + listen); its socket
+      // bind can't run under the unit harness. The app it builds is fully
+      // covered via buildApp() in tests/web/app.test.ts.
+      exclude: ["src/main.ts"],
       thresholds: {
         lines: 80,
         branches: 80,


### PR DESCRIPTION
## Summary

- `buildApp()` factory in `server/src/web/app.ts` returning a configured Fastify instance (factory style so tests build isolated instances and exercise routes via `app.inject()` — no sockets, no port binding).
- `server/src/main.ts` entrypoint binding the app to `0.0.0.0:8000` and compiling to `dist/main.js` (the entrypoint the Dockerfile in #6 will run).
- `GET /` → `200`, `text/plain` body `"hello, no policy yet"`.
- `GET /healthz` → `200`, `{"status":"ok"}`.

## Plan

Roadmap: `docs/roadmap.md` → Phase 1 ("minimal Fastify app that serves a 'hello, no policy yet' page"). No `.claude/plans/` file was needed — the issue's acceptance criteria are self-contained.

## Scope notes / deferred work

- **Logging** is intentionally left at `logger: false`. Configuring the shared pino logger + request IDs in `buildApp()` is **#11**, which builds directly on this factory.
- **Bind host/port** are constants here; making them configurable is the settings-loader work in **#10**.
- `src/main.ts` is excluded from the coverage gate (it's a thin bootstrap whose socket bind can't run under the unit harness); the app it builds is fully covered via `buildApp()`. Coverage stays at 100%.

## License-boundary note

N/A — no transport, subprocess, REST, or Docker-image changes in this PR. No new runtime dependencies (Fastify was already in `package.json`).

## Test plan

- [x] `GET /` returns `200` + `text/plain` `"hello, no policy yet"`
- [x] `GET /healthz` returns `200` + `{"status":"ok"}`
- [x] Unknown route returns `404`
- [x] Tests use `app.inject()` (no sockets/ports)
- [x] `npm run format:check && npm run lint && npm run typecheck && npm test` all green; coverage gate (80%) satisfied at 100%
- [x] `npm run build` emits `dist/main.js`

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCu4rhBGLgaiVcG7KScofh)_