### PR TITLE
feat(policy): drizzle-kit migration scaffolding (#9)

### DIFF
--- a/server/drizzle.config.ts
+++ b/server/drizzle.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "drizzle-kit";
+
+/**
+ * drizzle-kit configuration for the policy store.
+ *
+ * - `dialect: "sqlite"` with the better-sqlite3 driver (matches the runtime
+ *   in `server/src/policy`).
+ * - `schema` points at the (Phase-1-empty) policy schema; tables land in
+ *   Phase 2 and each one is followed by `npm run db:generate`.
+ * - `out` is the committed migrations folder consumed by CI's `migrations`
+ *   job (`.github/workflows/integration.yml`) and by `testDb()` in the test
+ *   helpers (#12).
+ *
+ * `DATABASE_URL` follows the libsql `file:` convention used across the
+ * deployment docs and CI; better-sqlite3 wants a bare filesystem path, so the
+ * scheme is stripped here. Phase 2's settings loader owns the runtime
+ * connection; this config is a drizzle-kit-only concern (generate/migrate/
+ * check), so it reads the env directly.
+ */
+const databaseUrl = process.env.DATABASE_URL ?? "file:./policy.sqlite";
+const dbPath = databaseUrl.replace(/^file:/, "");
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./src/policy/schema.ts",
+  out: "./drizzle",
+  dbCredentials: {
+    url: dbPath,
+  },
+});

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -1,0 +1,1 @@
+{"version":"7","dialect":"sqlite","entries":[]}

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:check": "drizzle-kit check",
     "test": "vitest run --coverage",
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },

--- a/server/src/policy/schema.ts
+++ b/server/src/policy/schema.ts
@@ -1,0 +1,16 @@
+/**
+ * Drizzle schema for the policy store (SQLite).
+ *
+ * Intentionally empty in Phase 1: this module exists so `drizzle.config.ts`
+ * has a schema target and the migrations pipeline (`drizzle-kit generate` /
+ * `migrate` / `check`) is wired and exercised by CI before any tables exist.
+ *
+ * The policy tables — `User`, `Client`, `UserOnClient`, `Activity`,
+ * `ActivityGroup`, `Budget`, `Schedule`, `Exception`, `Grant`,
+ * `IntegrationToken` (see `docs/architecture.md` → "Policy model") — land in
+ * Phase 2 on top of this scaffold. Each table added here is followed by
+ * `npm run db:generate` to emit the next migration under `server/drizzle/`.
+ */
+
+// No table definitions yet. Phase 2 adds `sqliteTable(...)` exports here.
+export {};

--- a/server/tests/policy/migrations.test.ts
+++ b/server/tests/policy/migrations.test.ts
@@ -30,6 +30,15 @@ function migrationTableExists(sqlite: Database.Database): boolean {
   return row !== undefined;
 }
 
+/** How many migrations the migrator believes it has applied. */
+function appliedMigrationCount(sqlite: Database.Database): number {
+  const value = sqlite.prepare("SELECT count(*) FROM __drizzle_migrations").pluck().get();
+  if (typeof value !== "number") {
+    throw new Error(`expected a numeric count, got ${typeof value}`);
+  }
+  return value;
+}
+
 describe("policy migrations", () => {
   it("applies all migrations to an empty database", () => {
     const sqlite = new Database(":memory:");
@@ -48,7 +57,13 @@ describe("policy migrations", () => {
     const db = drizzle(sqlite);
 
     migrate(db, { migrationsFolder });
+    const countAfterFirst = appliedMigrationCount(sqlite);
+
     expect(() => migrate(db, { migrationsFolder })).not.toThrow();
+    // Re-applying must not record any additional migrations — the journal's
+    // bookkeeping count is unchanged. (Phase-1 empty journal: stays 0; the
+    // assertion keeps holding once Phase 2 adds real migrations.)
+    expect(appliedMigrationCount(sqlite)).toBe(countAfterFirst);
 
     sqlite.close();
   });

--- a/server/tests/policy/migrations.test.ts
+++ b/server/tests/policy/migrations.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Exercises the committed drizzle-kit migrations against a fresh in-memory
+ * SQLite database — the runtime counterpart to the `drizzle-kit check` drift
+ * gate that CI's `migrations` job runs (`.github/workflows/integration.yml`).
+ *
+ * Phase 1 ships an empty migration journal (no tables yet); these tests
+ * pin the invariants the scaffold must keep as Phase 2 adds real tables:
+ * applying all migrations to an empty DB succeeds, and re-applying is a
+ * no-op. See `docs/testing.md` → "Policy module — what to test".
+ */
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { describe, expect, it } from "vitest";
+
+// Resolve the committed migrations folder relative to this file so the test
+// is independent of the working directory the runner is invoked from.
+const migrationsFolder = resolve(dirname(fileURLToPath(import.meta.url)), "../../drizzle");
+
+/** Drizzle records applied migrations in this bookkeeping table. */
+function migrationTableExists(sqlite: Database.Database): boolean {
+  const row = sqlite
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '__drizzle_migrations'",
+    )
+    .get();
+  return row !== undefined;
+}
+
+describe("policy migrations", () => {
+  it("applies all migrations to an empty database", () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+
+    expect(() => migrate(db, { migrationsFolder })).not.toThrow();
+    // The migrator always provisions its bookkeeping table, even with an
+    // empty journal — proof the folder was read and the pipeline ran.
+    expect(migrationTableExists(sqlite)).toBe(true);
+
+    sqlite.close();
+  });
+
+  it("is a no-op when re-applied to an already-migrated database", () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+
+    migrate(db, { migrationsFolder });
+    expect(() => migrate(db, { migrationsFolder })).not.toThrow();
+
+    sqlite.close();
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -14,5 +14,11 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts", "vitest.integration.config.ts"]
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts",
+    "drizzle.config.ts",
+    "vitest.config.ts",
+    "vitest.integration.config.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- `server/drizzle.config.ts` — SQLite dialect, schema at `src/policy/schema.ts`, migrations out to `server/drizzle/`. Reads `DATABASE_URL` (libsql `file:` convention) and strips the scheme for better-sqlite3. This is what makes CI's `migrations` job (`.github/workflows/integration.yml`) stop skipping.
- `server/src/policy/schema.ts` — empty Phase-1 schema module; the policy tables land in Phase 2 on top of this scaffold.
- `server/drizzle/meta/_journal.json` — empty migration journal so `drizzle-kit migrate` / `check` and the runtime migrator (used by the future `testDb()` in #12) all have a valid, no-op pipeline to run.
- `tests/policy/migrations.test.ts` — applying all migrations to a fresh in-memory DB succeeds; re-applying is a no-op (per `docs/testing.md` → "Policy module — what to test").
- `db:generate` / `db:migrate` / `db:check` npm scripts; `drizzle.config.ts` added to the typecheck `include`.

## Plan

Roadmap: `docs/roadmap.md` → Phase 1. No `.claude/plans/` file was needed — the issue's acceptance criteria are self-contained. Unblocks #12 (`testDb()` applies these migrations) and the Phase 2 schema work.

## Deviation from the acceptance criteria (empty migration, not a generated `.sql`)

The issue asks for an "initial migration **generated by `drizzle-kit generate`**". With a genuinely empty schema this is not possible the way the criterion imagines, and I want this flagged rather than papered over:

- `drizzle-kit generate` on an empty schema emits nothing (`No schema changes, nothing to migrate 😴`) — there is no DDL to produce.
- `drizzle-kit generate --custom` does produce a `0000_*.sql` file, but it is statement-less, and `drizzle-kit migrate` then **fails** (exit 1) trying to apply a migration with zero statements.
- An **empty journal** (`{"version":"7","dialect":"sqlite","entries":[]}`) is the honest, working representation of "no tables yet": `drizzle-kit migrate` succeeds, re-running is a no-op, and `drizzle-kit check` reports no drift. When Phase 2 adds the first table, `npm run db:generate` writes `0000_*.sql` + its snapshot and appends the journal entry as normal.

This matches the issue's own "Semantic change from the Alembic version" framing (drizzle-kit has no down-migrations / round-trip). All the *functional* acceptance criteria hold:

- [x] `server/drizzle.config.ts` points at the schema + `server/drizzle/`, SQLite dialect
- [x] empty Drizzle schema module at `server/src/policy/schema.ts`
- [x] `drizzle-kit migrate` succeeds against a fresh DB; re-running is a no-op
- [x] `drizzle-kit check` reports no drift
- [x] CI `migrations` job no longer skips (`drizzle.config.ts` now exists)

## License-boundary note

N/A — no transport, subprocess, REST, or Docker-image changes. No new runtime dependencies (`drizzle-orm` and `drizzle-kit` were already in `package.json`).

## Test plan

- [x] `migrate` applies to a fresh in-memory DB and provisions `__drizzle_migrations`
- [x] re-applying `migrate` is a no-op (no throw)
- [x] `drizzle-kit migrate` + `drizzle-kit check` both exit 0 with `DATABASE_URL=file:./ci_migration_test.sqlite` (the CI env)
- [x] `format:check && lint && typecheck && test` green; coverage gate (80%) satisfied (100% aggregate)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfAiq8Q3TrjRjYt2NhLVDt)_