### PR TITLE
ci: start aw-server from pinned upstream release instead of phantom image

### DIFF
--- a/.claude/plans/issue-20-activitywatch-ci-image.md
+++ b/.claude/plans/issue-20-activitywatch-ci-image.md
@@ -1,0 +1,77 @@
+# Issue #20 — ActivityWatch integration job pulls a non-existent Docker image
+
+## Problem
+
+`.github/workflows/integration.yml` → `activitywatch` job runs
+`docker run -d activitywatch/activitywatch:latest`. That image does not
+exist on Docker Hub — ActivityWatch publishes no official container image,
+so the step fails with `pull access denied`. `docs/testing.md` repeats the
+mistake with a different non-existent image (`activitywatch/aw-server:latest`)
+in its local Docker Compose recipe. The job is currently dormant (it guards
+on the presence of `*.int.test.ts` files, per the #19 fix), but the broken
+bootstrap must be corrected before the first real ActivityWatch transport
+tests land.
+
+## Decision
+
+Adopt the issue's **Option 1** (run a real `aw-server` under our control),
+refined to use the upstream **prebuilt release** rather than building the
+Rust crate from source:
+
+- Download the pinned `activitywatch-vX.Y.Z-linux-x86_64.zip` from the
+  upstream GitHub release. The bundle contains the headless
+  `aw-server-rust` binary.
+- Pin both the **version** (`v0.13.2`) and the archive **SHA-256** so the
+  artifact is reproducible and under our control (mitigates the "community
+  image may disappear/change" risk the issue calls out for Option 2).
+- Extract just `activitywatch/aw-server-rust/aw-server-rust`, run it
+  headless (`--host --port --dbpath --no-legacy-import`), and wait on
+  `GET /api/0/info`.
+- We talk to it over its **REST API only** — no source-level integration,
+  no GPL boundary crossed (aw-server is MPL-2.0 regardless; it is a
+  test-time external service, never bundled in the dashboard image).
+
+Verified locally: the v0.13.2 bundle's `aw-server-rust` starts headless and
+serves `{"hostname":...,"version":"v0.13.2 (rust)",...}` on
+`/api/0/info`.
+
+## Why not the other options
+
+- **Option 2 (community image, pinned digest):** still depends on a
+  third-party publisher; the release bundle + checksum gives the same
+  pinning guarantee from the upstream project itself.
+- **Option 3 (spawn from a Vitest `globalSetup`):** `vitest.integration.config.ts`
+  is shared by the AdGuard and SSH integration jobs too, so an
+  unconditional global setup would start aw-server for unrelated tests.
+  Keeping the bootstrap in the job step mirrors how the `adguard` and
+  `ssh-transport` jobs already own their service bootstrap.
+
+## Changes
+
+1. `scripts/start-aw-server.sh` — single source of truth: download (cached),
+   checksum-verify, extract, launch headless, health-poll `/api/0/info`.
+   Env-overridable: `AW_VERSION`, `AW_SHA256`, `AW_HOST`, `AW_PORT`,
+   `AW_CACHE`. shellcheck-clean.
+2. `.github/workflows/integration.yml` — `activitywatch` job's
+   "Start ActivityWatch server" step calls the script instead of the broken
+   `docker run`; the #20 NOTE comment in the job header is replaced with a
+   one-line description of the resolved approach.
+3. `docs/testing.md` — replace the non-existent `activitywatch/aw-server:latest`
+   compose service with the native `scripts/start-aw-server.sh` recipe
+   (aw-server has no image), keeping AdGuard + ssh-target on Compose.
+
+## Tests / verification
+
+- shellcheck on `scripts/start-aw-server.sh` (run manually; CI's shellcheck
+  job is scoped to `client/`).
+- Manual end-to-end: download → checksum → extract → run → `/api/0/info`
+  200, confirmed in the implementing session.
+- Full TS quality gate (`format:check`, `lint`, `typecheck`, `test`) stays
+  green — no `server/` source touched.
+
+## Deferred
+
+The acceptance criterion "job runs to completion on a PR that lands real
+ActivityWatch transport tests" can only be fully exercised once those
+`*.int.test.ts` files exist (a later phase). This PR makes the bootstrap
+correct and verified so that future PR is unblocked.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,11 +12,11 @@ jobs:
   activitywatch:
     name: ActivityWatch REST client
     runs-on: ubuntu-22.04
-    # Starts a real aw-server via docker run (not a service container) so the
-    # step can be skipped gracefully when the transport tests don't exist yet.
-    # NOTE (issue #20): activitywatch/activitywatch is not a published Docker
-    # Hub image; the bootstrap below must be fixed before the first real
-    # ActivityWatch integration tests land.
+    # ActivityWatch publishes no official Docker image (issue #20), so we
+    # download the pinned upstream release bundle, checksum-verify it, and run
+    # the headless aw-server-rust binary directly via scripts/start-aw-server.sh.
+    # The step is still guarded so it skips gracefully until the transport
+    # tests exist.
     steps:
       - uses: actions/checkout@v4
 
@@ -44,14 +44,10 @@ jobs:
 
       - name: Start ActivityWatch server
         if: steps.check.outputs.run == 'true'
-        run: |
-          docker run -d --name activitywatch \
-            -p 5600:5600 \
-            activitywatch/activitywatch:latest
-          for i in $(seq 1 20); do
-            curl -sf http://localhost:5600/api/0/info && break
-            sleep 3
-          done
+        run: scripts/start-aw-server.sh
+        env:
+          AW_HOST: 127.0.0.1
+          AW_PORT: 5600
 
       - name: Integration tests — ActivityWatch transport
         if: steps.check.outputs.run == 'true'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,8 +15,17 @@ jobs:
     # ActivityWatch publishes no official Docker image (issue #20), so we
     # download the pinned upstream release bundle, checksum-verify it, and run
     # the headless aw-server-rust binary directly via scripts/start-aw-server.sh.
+    # The ~200 MB archive is cached across runs (actions/cache, keyed on
+    # version + checksum) so only the first run on a given pin actually
+    # downloads; the script's own checksum guard then skips the fetch.
     # The step is still guarded so it skips gracefully until the transport
     # tests exist.
+    env:
+      AW_VERSION: v0.13.2
+      AW_SHA256: 8f62b10babf8a8f108cbdf7267c02fbc1ce2a970fa9535f230b3416b803e3360
+      AW_CACHE: ${{ github.workspace }}/.aw-cache
+      AW_HOST: 127.0.0.1
+      AW_PORT: 5600
     steps:
       - uses: actions/checkout@v4
 
@@ -42,12 +51,20 @@ jobs:
         if: steps.check.outputs.run == 'true'
         run: cd server && npm ci
 
+      # Persist the downloaded archive across runs. The key includes the
+      # checksum, so a version/pin bump misses the cache and re-downloads;
+      # an unchanged pin restores the zip and start-aw-server.sh skips the
+      # fetch via its own checksum guard.
+      - name: Cache aw-server release archive
+        if: steps.check.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.AW_CACHE }}/activitywatch-${{ env.AW_VERSION }}-linux-x86_64.zip
+          key: aw-server-${{ runner.os }}-${{ env.AW_VERSION }}-${{ env.AW_SHA256 }}
+
       - name: Start ActivityWatch server
         if: steps.check.outputs.run == 'true'
         run: scripts/start-aw-server.sh
-        env:
-          AW_HOST: 127.0.0.1
-          AW_PORT: 5600
 
       - name: Integration tests — ActivityWatch transport
         if: steps.check.outputs.run == 'true'

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -344,17 +344,18 @@ For each public method of the SSH transport (e.g. `setDailyLimit`,
 
 ## Integration tests — local reproduction
 
-Each integration job can be reproduced locally with Docker Compose. Save the
-snippet below as `docker-compose.integration.yml` in the repo root (do not
-commit it; it is a local dev aid only):
+Each integration job can be reproduced locally. The AdGuard Home and SSH
+targets run as Docker containers; ActivityWatch does **not** (the project
+publishes no official image — see issue #20), so its server is started
+natively from the pinned upstream release by `scripts/start-aw-server.sh`,
+exactly as the CI job does.
+
+Save the snippet below as `docker-compose.integration.yml` in the repo root
+(do not commit it; it is a local dev aid only):
 
 ```yaml
 # docker-compose.integration.yml — local integration test environment
 services:
-  activitywatch:
-    image: activitywatch/aw-server:latest
-    ports: ["5600:5600"]
-
   adguardhome:
     image: adguard/adguardhome:latest
     ports: ["3000:3000", "53:53/udp"]
@@ -369,7 +370,11 @@ services:
 Start the services:
 
 ```bash
+# Containerised targets (AdGuard Home + SSH):
 docker compose -f docker-compose.integration.yml up -d
+
+# ActivityWatch aw-server (native, downloaded + checksum-verified):
+scripts/start-aw-server.sh
 ```
 
 Run the integration tests:

--- a/scripts/start-aw-server.sh
+++ b/scripts/start-aw-server.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# start-aw-server.sh — start a headless ActivityWatch aw-server for integration
+# tests.
+#
+# ActivityWatch publishes no official Docker image (see issue #20), so instead
+# of pulling a non-existent / community image we download the pinned upstream
+# release bundle, verify its SHA-256, extract the headless aw-server-rust
+# binary, launch it, and wait until its REST API answers. We only ever talk to
+# aw-server over its REST API — no source-level or in-process integration — so
+# no license boundary is crossed (it is a test-time external service, never
+# bundled in the dashboard image).
+#
+# Everything is pinned and overridable via the environment:
+#   AW_VERSION   upstream release tag                (default v0.13.2)
+#   AW_SHA256    expected SHA-256 of the linux zip   (default matches v0.13.2)
+#   AW_HOST      address aw-server binds to          (default 127.0.0.1)
+#   AW_PORT      port aw-server listens on           (default 5600)
+#   AW_CACHE     download/extract cache directory    (default $RUNNER_TEMP or /tmp/aw-cache)
+#
+# On success the script prints the base URL of the running server and leaves it
+# running in the background. Intended to be sourced/called once per CI job step.
+
+set -euo pipefail
+
+AW_VERSION="${AW_VERSION:-v0.13.2}"
+AW_SHA256="${AW_SHA256:-8f62b10babf8a8f108cbdf7267c02fbc1ce2a970fa9535f230b3416b803e3360}"
+AW_HOST="${AW_HOST:-127.0.0.1}"
+AW_PORT="${AW_PORT:-5600}"
+AW_CACHE="${AW_CACHE:-${RUNNER_TEMP:-/tmp/aw-cache}}"
+
+archive_name="activitywatch-${AW_VERSION}-linux-x86_64.zip"
+download_url="https://github.com/ActivityWatch/activitywatch/releases/download/${AW_VERSION}/${archive_name}"
+zip_path="${AW_CACHE}/${archive_name}"
+extract_dir="${AW_CACHE}/${AW_VERSION}"
+binary_path="${extract_dir}/activitywatch/aw-server-rust/aw-server-rust"
+db_dir="${AW_CACHE}/db-${AW_VERSION}"
+
+log() { printf '[start-aw-server] %s\n' "$*" >&2; }
+
+mkdir -p "${AW_CACHE}"
+
+# Download (cached): skip if a previously downloaded archive already matches the
+# expected checksum, so re-runs on a warm cache don't re-fetch ~200 MB.
+if [ -f "${zip_path}" ] && echo "${AW_SHA256}  ${zip_path}" | sha256sum --check --status; then
+  log "Using cached archive ${zip_path}"
+else
+  log "Downloading ${download_url}"
+  curl --fail --location --silent --show-error --output "${zip_path}" "${download_url}"
+fi
+
+# Verify checksum (always, even on a cache hit guard failure above).
+log "Verifying SHA-256"
+echo "${AW_SHA256}  ${zip_path}" | sha256sum --check --status
+
+# Extract just the headless server binary.
+log "Extracting aw-server-rust"
+rm -rf "${extract_dir}"
+mkdir -p "${extract_dir}"
+unzip -q -o "${zip_path}" "activitywatch/aw-server-rust/aw-server-rust" -d "${extract_dir}"
+chmod +x "${binary_path}"
+
+# Launch headless. --no-legacy-import keeps it from probing for an
+# aw-server-python database that does not exist on a CI runner.
+rm -rf "${db_dir}"
+mkdir -p "${db_dir}"
+log "Starting aw-server-rust on ${AW_HOST}:${AW_PORT}"
+"${binary_path}" \
+  --host "${AW_HOST}" \
+  --port "${AW_PORT}" \
+  --dbpath "${db_dir}/db.sqlite" \
+  --no-legacy-import \
+  >"${AW_CACHE}/aw-server.log" 2>&1 &
+
+# Health-poll the REST API.
+base_url="http://${AW_HOST}:${AW_PORT}"
+for _ in $(seq 1 30); do
+  if curl --fail --silent "${base_url}/api/0/info" >/dev/null; then
+    log "aw-server is up at ${base_url}"
+    echo "${base_url}"
+    exit 0
+  fi
+  sleep 1
+done
+
+log "aw-server did not become ready in time; last log lines:"
+tail -n 20 "${AW_CACHE}/aw-server.log" >&2 || true
+exit 1


### PR DESCRIPTION
## What

Fixes the `activitywatch` job in `.github/workflows/integration.yml`, which ran `docker run -d activitywatch/activitywatch:latest` — an image that does not exist on Docker Hub. ActivityWatch publishes no official container image, so the step failed with `pull access denied`. `docs/testing.md` repeated the same mistake with a different phantom image (`activitywatch/aw-server:latest`) in its local Compose recipe.

Closes #20.

## Approach

Adopts the issue's **Option 1** (run a real `aw-server` under our control), refined to use the upstream **prebuilt release** rather than building the Rust crate from source:

- New `scripts/start-aw-server.sh`: downloads the pinned `activitywatch-v0.13.2-linux-x86_64.zip` from the upstream GitHub release, verifies its SHA-256, extracts the headless `aw-server-rust` binary, launches it (`--host --port --dbpath --no-legacy-import`), and health-polls `GET /api/0/info`.
- Version (`v0.13.2`) and archive SHA-256 are pinned and env-overridable (`AW_VERSION`, `AW_SHA256`, `AW_HOST`, `AW_PORT`, `AW_CACHE`), so the artifact is reproducible and under our control — addressing the "community image may disappear/change" risk the issue flags for Option 2.
- We talk to aw-server over its REST API only — no source-level integration, no license boundary crossed. It is a test-time external service, never bundled in the dashboard image.

The job's skip guard (only runs when `*.int.test.ts` files exist) is unchanged, so this stays dormant until the first real ActivityWatch transport tests land — at which point the bootstrap is correct and ready.

### Why not the other options
- **Option 2 (community image, pinned digest):** still depends on a third-party publisher; the release bundle + checksum gives the same pinning guarantee from the upstream project itself.
- **Option 3 (spawn from a Vitest `globalSetup`):** the integration Vitest config is shared by the AdGuard and SSH jobs, so an unconditional global setup would start aw-server for unrelated tests. Keeping the bootstrap in the job step mirrors how the `adguard` and `ssh-transport` jobs own their own service bootstrap.

## Changes
1. `scripts/start-aw-server.sh` — download (cached) → checksum-verify → extract → launch headless → health-poll. shellcheck-clean.
2. `.github/workflows/integration.yml` — the `activitywatch` job's "Start ActivityWatch server" step calls the script; the `#20` NOTE comment is replaced with a description of the resolved approach.
3. `docs/testing.md` — replaces the non-existent `activitywatch/aw-server:latest` Compose service with the native `scripts/start-aw-server.sh` recipe (AdGuard + ssh-target stay on Compose).

## Verification
- `shellcheck scripts/start-aw-server.sh` — clean.
- Manual end-to-end in the implementing environment: download → SHA-256 verify → extract → run → `GET /api/0/info` returns `200` with `{"version":"v0.13.2 (rust)",...}`.
- No `server/` source touched, so the TS quality gate is unaffected.

## Deferred
The acceptance criterion "job runs to completion on a PR that lands real ActivityWatch transport tests" can only be fully exercised once those `*.int.test.ts` files exist (a later phase). This PR makes the bootstrap correct and verified so that future work is unblocked.

https://claude.ai/code/session_01GmjxLzRpqivBFogPEyHHki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmjxLzRpqivBFogPEyHHki)_