### PR TITLE
feat(web): structured pino logging configuration (#11)

### DIFF
--- a/.claude/plans/structured-logging.md
+++ b/.claude/plans/structured-logging.md
@@ -1,0 +1,48 @@
+# Plan — Structured logging configuration (issue #11)
+
+Roadmap: `docs/roadmap.md` → Phase 1. Blocked by #5 (Fastify app factory)
+and #10 (settings loader, `PCT_LOG_LEVEL`) — both merged to `main`.
+
+## Goal
+
+One opinionated pino setup configured once in `buildApp()`, establishing the
+conventions every later log source follows (Phase 4 transport audit logs,
+Phase 6 Ansible output capture, Phase 8b event broadcaster).
+
+## Acceptance criteria → implementation
+
+1. **Shared pino options; level from `PCT_LOG_LEVEL`; pretty only on demand.**
+   - `src/web/logger.ts` → `buildLoggerOptions(settings, stream?)` returns the
+     Fastify `logger` option: `{ level }` by default (JSON), `pino-pretty`
+     transport only when `settings.logPretty` is set, an explicit `stream`
+     (test seam) taking precedence.
+   - Add `logPretty` (from `PCT_LOG_PRETTY`) to the settings schema in
+     `config.ts` using `z.stringbool()` (env-var-safe boolean).
+   - `pino-pretty` added as a **dev-only** dependency (ships nowhere near the
+     runtime image; pino itself is already inside Fastify — no new runtime dep).
+2. **Request-ID on every request-scoped line.**
+   - Fastify constructed with `requestIdHeader: "x-request-id"` (honour inbound
+     header) and `genReqId: genRequestId` (UUID fallback). `reqId` propagates
+     to `request.log` automatically.
+3. **Named child loggers for non-request sources.**
+   - `componentLogger(app, component)` → `app.log.child({ component })`. The
+     convention is documented in the module header; concrete sources arrive in
+     later phases.
+4. **ESLint `no-console` for `src/`.**
+   - Scoped rule block in `eslint.config.js`.
+5. **Unit test asserts request-ID propagation.**
+   - `tests/web/logging.test.ts`: inject with/without `X-Request-Id`, capture
+     the log stream, assert the `reqId` field; plus `componentLogger`,
+     `buildLoggerOptions`, and `genRequestId` coverage.
+
+## Wiring
+
+- `buildApp(options?: { settings?, loggerStream? })` — defaults settings to
+  `loadSettings()`. `main.ts` passes the already-parsed settings (no double
+  parse). Existing route test passes a silent-level settings object so test
+  output stays clean (assertions unchanged).
+
+## License boundary
+
+N/A — no transport/subprocess/REST/Docker changes. `pino-pretty` is an
+MIT dev-only dependency.

--- a/server/eslint.config.js
+++ b/server/eslint.config.js
@@ -16,4 +16,12 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // #11: non-request log sources use a named child logger (componentLogger),
+    // never console.*. Scoped to src/ so tests/config keep their console use.
+    files: ["src/**/*.ts"],
+    rules: {
+      "no-console": "error",
+    },
+  },
 );

--- a/server/frontend/README.md
+++ b/server/frontend/README.md
@@ -31,6 +31,29 @@ serves it at `/admin` and `/app` (the static mount lands with #6 / Phase 2).
 `server/frontend/.gitignore`) — it is a build artefact, produced at
 image-build time, never committed.
 
+## Request logging
+
+This project ships **no SvelteKit server runtime** — `adapter-static`
+prerenders everything to static HTML/JS/CSS, so there is nothing to "wire
+pino into" on the frontend itself. The only server that ever handles an
+`/admin` or `/app` request is Fastify.
+
+When the `web` module mounts `build/` via `@fastify/static` (#6 / Phase 2),
+those static-asset requests flow through the **same** request logging the
+backend already configures (`server/src/web/logger.ts`, #11) — no
+frontend-specific logging setup is needed or wanted:
+
+- Each request carries a `reqId` (an inbound `X-Request-Id` header is
+  honoured, otherwise a UUID is generated), so a request for an `/admin`
+  asset is traceable end to end.
+- Any custom plugin or hook added around the static mount must log via
+  `request.log` (never `console.*`, which ESLint forbids in `src/`); any
+  non-request helper takes a child logger via `componentLogger(app, "...")`.
+
+Browser-side diagnostics (`console` inside a Svelte component) are a separate
+concern from server logs; if we ever want them captured server-side, that
+belongs behind a `/api` telemetry route, not a second logger.
+
 ## Local development
 
 ```bash

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -26,6 +26,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "drizzle-kit": "^0.31.5",
         "eslint": "^9.37.0",
+        "pino-pretty": "^13.1.3",
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.45.0",
@@ -2757,6 +2758,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2824,6 +2832,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -3339,6 +3357,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -3419,6 +3444,13 @@
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -3735,6 +3767,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3946,6 +3985,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -4463,6 +4512,44 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pino-std-serializers": {

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "drizzle-kit": "^0.31.5",
     "eslint": "^9.37.0",
+    "pino-pretty": "^13.1.3",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.45.0",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -46,6 +46,13 @@ const settingsSchema = z
     databaseUrl: z.string().min(1).default("/data/policy.sqlite"),
     /** Drives pino's level (see #11). */
     logLevel: z.enum(LOG_LEVELS).default("info"),
+    /**
+     * Enable the human-readable `pino-pretty` transport for local dev (#11).
+     * `z.stringbool()` parses the usual env truthy/falsy strings
+     * (`true`/`false`, `1`/`0`, `yes`/`no`, …); defaults off so production
+     * stays JSON.
+     */
+    logPretty: z.stringbool().default(false),
     /** Signs sessions / integration tokens (consumed in later phases). */
     secretKey: z.string().min(1).optional(),
     adguard: adguardSchema,
@@ -98,6 +105,7 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
   const result = settingsSchema.safeParse({
     databaseUrl: env.DATABASE_URL,
     logLevel: env.PCT_LOG_LEVEL,
+    logPretty: env.PCT_LOG_PRETTY,
     secretKey: env.PCT_SECRET_KEY,
     adguard: {
       mode: env.PCT_ADGUARD_MODE ?? "disabled",

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -19,8 +19,8 @@ const PORT = 8000;
 async function main(): Promise<void> {
   // Fail fast on a bad environment before binding a socket. The parsed
   // settings feed the logger (#11) and transports in later phases.
-  loadSettings();
-  const app = buildApp();
+  const settings = loadSettings();
+  const app = buildApp({ settings });
   try {
     await app.listen({ host: HOST, port: PORT });
   } catch (err) {

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -6,20 +6,41 @@
  * without binding a socket — see docs/testing.md → "HTTP routes".
  *
  * This is the minimal Phase 1 slice: a "hello, no policy yet" landing
- * route and a `/healthz` probe. Logging configuration (pino, request
- * IDs) lands in #11; the policy/api/integrations mounts land in later
- * phases.
+ * route and a `/healthz` probe, plus the shared pino logging configuration
+ * (#11). The policy/api/integrations mounts land in later phases.
  */
 import Fastify, { type FastifyInstance } from "fastify";
+import { loadSettings, type Settings } from "../config.js";
+import { REQUEST_ID_HEADER, buildLoggerOptions, genRequestId, type LogStream } from "./logger.js";
+
+/** Options for {@link buildApp}. */
+export interface BuildAppOptions {
+  /** Parsed settings; defaults to {@link loadSettings} reading `process.env`. */
+  settings?: Settings;
+  /**
+   * Test seam: capture log output via a pino destination stream. Takes
+   * precedence over the `pino-pretty` transport.
+   */
+  loggerStream?: LogStream;
+}
 
 /**
  * Build and configure a Fastify instance.
  *
- * The logger is disabled here; #11 owns the shared pino configuration
- * that the rest of the app will follow.
+ * The logger follows the shared conventions in `./logger.ts` (#11): JSON by
+ * default at `PCT_LOG_LEVEL`, an inbound `X-Request-Id` honoured with a UUID
+ * fallback, and `reqId` bound to every request-scoped log line.
  */
-export function buildApp(): FastifyInstance {
-  const app = Fastify({ logger: false });
+export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
+  const settings = options.settings ?? loadSettings();
+
+  const app = Fastify({
+    logger: buildLoggerOptions(settings, options.loggerStream),
+    // Honour an inbound X-Request-Id; genReqId supplies the UUID fallback.
+    // Either way the id is bound to every request-scoped log line as `reqId`.
+    requestIdHeader: REQUEST_ID_HEADER,
+    genReqId: genRequestId,
+  });
 
   app.get("/", async (_request, reply) => {
     return reply.type("text/plain").send("hello, no policy yet");

--- a/server/src/web/logger.ts
+++ b/server/src/web/logger.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared pino/logging configuration for the Fastify app (issue #11).
+ *
+ * One opinionated setup, configured once in `buildApp()`, so the log sources
+ * that arrive in later phases — transport audit logs (Phase 4), Ansible
+ * output capture (Phase 6), the event-stream broadcaster (Phase 8b) — all
+ * follow the same conventions:
+ *
+ * - **JSON by default.** Fastify's built-in logger *is* pino, so there is no
+ *   new runtime dependency. The level comes from `PCT_LOG_LEVEL` (via the
+ *   settings loader). The human-readable `pino-pretty` transport is used only
+ *   when `PCT_LOG_PRETTY` is enabled for local dev — it is a dev-only
+ *   dependency and never ships in the runtime image.
+ * - **A `reqId` on every request-scoped line.** An inbound `X-Request-Id`
+ *   header is honoured; otherwise a UUID is generated ({@link genRequestId}).
+ *   Route handlers must log via `request.log` (never a module-level logger)
+ *   so the field propagates.
+ * - **Named child loggers for non-request sources.** Subprocess runners,
+ *   croner jobs, and the WebSocket broadcaster take a child logger via
+ *   {@link componentLogger} rather than constructing their own pino instance
+ *   or reaching for `console.*` (which ESLint `no-console` forbids in `src/`).
+ */
+import { randomUUID } from "node:crypto";
+import type { FastifyBaseLogger, FastifyInstance, FastifyServerOptions } from "fastify";
+import type { Settings } from "../config.js";
+
+/**
+ * Request-ID header, lower-cased to match Fastify's normalised header keys.
+ * Wired into Fastify's `requestIdHeader` so an inbound value becomes the
+ * request id; {@link genRequestId} supplies the fallback.
+ */
+export const REQUEST_ID_HEADER = "x-request-id";
+
+/**
+ * Minimal pino destination: anything with a line-oriented `write`.
+ *
+ * Declared locally (rather than importing pino's `DestinationStream`) so the
+ * module depends only on the pino that ships inside Fastify — no direct,
+ * transitive pino import. Used as a test seam to capture log output.
+ */
+export interface LogStream {
+  write(msg: string): void;
+}
+
+/** Fallback request id when no inbound `X-Request-Id` header is present. */
+export function genRequestId(): string {
+  return randomUUID();
+}
+
+// `NonNullable` because the project runs with `exactOptionalPropertyTypes`:
+// Fastify's `logger` option is not `| undefined`, so neither is our return.
+type LoggerOption = NonNullable<FastifyServerOptions["logger"]>;
+
+/**
+ * Build the Fastify `logger` option from settings.
+ *
+ * @param settings - parsed app settings (`logLevel`, `logPretty`).
+ * @param stream - optional pino destination; a test seam for capturing log
+ *   output. When supplied it takes precedence over the pretty transport (the
+ *   two cannot be combined).
+ */
+export function buildLoggerOptions(settings: Settings, stream?: LogStream): LoggerOption {
+  const level = settings.logLevel;
+
+  if (stream !== undefined) {
+    return { level, stream };
+  }
+
+  if (settings.logPretty) {
+    return {
+      level,
+      transport: {
+        target: "pino-pretty",
+        options: { translateTime: "SYS:standard", ignore: "pid,hostname" },
+      },
+    };
+  }
+
+  return { level };
+}
+
+/**
+ * Named child logger for a non-request log source.
+ *
+ * Use this instead of constructing a new pino instance or reaching for
+ * `console.*`: `const log = componentLogger(app, "transport/ssh")`. Every line
+ * the returned logger emits carries the `component` field.
+ */
+export function componentLogger(app: FastifyInstance, component: string): FastifyBaseLogger {
+  return app.log.child({ component });
+}

--- a/server/tests/web/app.test.ts
+++ b/server/tests/web/app.test.ts
@@ -7,12 +7,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { FastifyInstance } from "fastify";
 import { buildApp } from "../../src/web/app.js";
+import { loadSettings } from "../../src/config.js";
 
 describe("web app routes", () => {
   let app: FastifyInstance;
 
   beforeEach(() => {
-    app = buildApp();
+    // Silent logger keeps route-test output clean; logging behaviour itself
+    // is covered in logging.test.ts.
+    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "silent" }) });
   });
 
   afterEach(async () => {

--- a/server/tests/web/logging.test.ts
+++ b/server/tests/web/logging.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Logging configuration tests (#11).
+ *
+ * Captures the pino output via a destination stream (the `loggerStream` test
+ * seam on `buildApp`) and asserts request-ID propagation, the `pino-pretty`
+ * opt-in, and the `componentLogger` convention.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../../src/web/app.js";
+import { buildLoggerOptions, componentLogger, genRequestId } from "../../src/web/logger.js";
+import { loadSettings } from "../../src/config.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** Collect JSON log lines pino writes to the destination stream. */
+function collectStream(): {
+  stream: { write(msg: string): void };
+  lines: Record<string, unknown>[];
+} {
+  const lines: Record<string, unknown>[] = [];
+  return {
+    stream: {
+      write(msg: string) {
+        lines.push(JSON.parse(msg) as Record<string, unknown>);
+      },
+    },
+    lines,
+  };
+}
+
+describe("request-id logging", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("honours an inbound X-Request-Id on request-scoped log lines", async () => {
+    const { stream, lines } = collectStream();
+    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "info" }), loggerStream: stream });
+
+    await app.inject({
+      method: "GET",
+      url: "/healthz",
+      headers: { "x-request-id": "calendar-webhook-42" },
+    });
+
+    const requestLines = lines.filter((l) => l.reqId !== undefined);
+    expect(requestLines.length).toBeGreaterThan(0);
+    for (const line of requestLines) {
+      expect(line.reqId).toBe("calendar-webhook-42");
+    }
+  });
+
+  it("generates a UUID request id when no header is present", async () => {
+    const { stream, lines } = collectStream();
+    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "info" }), loggerStream: stream });
+
+    await app.inject({ method: "GET", url: "/healthz" });
+
+    const requestLine = lines.find((l) => l.reqId !== undefined);
+    expect(requestLine).toBeDefined();
+    expect(requestLine?.reqId).toMatch(UUID_RE);
+  });
+
+  it("componentLogger binds a component field to non-request log lines", async () => {
+    const { stream, lines } = collectStream();
+    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "info" }), loggerStream: stream });
+
+    componentLogger(app, "transport/ssh").info("ssh command issued");
+
+    const line = lines.find((l) => l.component === "transport/ssh");
+    expect(line).toBeDefined();
+    expect(line?.msg).toBe("ssh command issued");
+    // A component logger is for non-request sources, so it carries no reqId.
+    expect(line?.reqId).toBeUndefined();
+  });
+});
+
+describe("buildLoggerOptions", () => {
+  it("defaults to JSON at the configured level", () => {
+    expect(buildLoggerOptions(loadSettings({ PCT_LOG_LEVEL: "warn" }))).toEqual({ level: "warn" });
+  });
+
+  it("uses the pino-pretty transport when logPretty is enabled", () => {
+    expect(buildLoggerOptions(loadSettings({ PCT_LOG_PRETTY: "true" }))).toMatchObject({
+      level: "info",
+      transport: { target: "pino-pretty" },
+    });
+  });
+
+  it("prefers an explicit stream over the pretty transport", () => {
+    const { stream } = collectStream();
+    expect(buildLoggerOptions(loadSettings({ PCT_LOG_PRETTY: "true" }), stream)).toEqual({
+      level: "info",
+      stream,
+    });
+  });
+});
+
+describe("genRequestId", () => {
+  it("returns unique UUIDs", () => {
+    const a = genRequestId();
+    const b = genRequestId();
+    expect(a).toMatch(UUID_RE);
+    expect(b).toMatch(UUID_RE);
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

- Configure Fastify's built-in pino logger once in `buildApp()` and establish the conventions later log sources follow (Phase 4 transport audit logs, Phase 6 Ansible output capture, Phase 8b event broadcaster).
- **JSON by default** at `PCT_LOG_LEVEL`; the human-readable `pino-pretty` transport is an opt-in (`PCT_LOG_PRETTY`) and a **dev-only** dependency.
- **`reqId` on every request-scoped line**: an inbound `X-Request-Id` header is honoured (`requestIdHeader`), with a UUID fallback (`genReqId`).
- **`componentLogger(app, name)`** for non-request sources instead of bespoke pino instances; **ESLint `no-console`** now enforced for `src/`.

## Plan

Linked plan: `.claude/plans/structured-logging.md`
Roadmap: `docs/roadmap.md` → Phase 1

## Implementation notes

- `buildApp` now takes an options object (`{ settings?, loggerStream? }`), forward-compatible with the `buildApp({ db })` shape in `docs/testing.md`. `main.ts` passes the already-parsed settings so the environment is parsed once. `loggerStream` is a small test seam for capturing log output.
- `logPretty` (`PCT_LOG_PRETTY`) added to the settings schema via `z.stringbool()` — env-var-safe boolean parsing (`true`/`false`, `1`/`0`, `yes`/`no`), defaulting off so production stays JSON.
- This branch was merged up with `main` to pick up the SvelteKit scaffold (#13/#36) that landed mid-flight; `server/frontend/README.md` gains a short **Request logging** note explaining that `adapter-static` has no server runtime, so the static `/admin` + `/app` surfaces simply inherit this request logging when Fastify mounts them (#6 / Phase 2) — no second logger.

## New dependency

- `pino-pretty` (dev-only, MIT). pino itself ships **inside Fastify** (no new runtime dependency); `pino-pretty` is the official transport for the local-dev pretty mode the acceptance criteria call for, used only when `PCT_LOG_PRETTY` is enabled. It never ships in the runtime image. The pre-existing `npm audit` advisories (`@fastify/static`, dev/build toolchain) are unaffected by this change.

## License-boundary note

N/A — no transport, subprocess, REST, or Docker-image changes. No GPL code or binaries introduced; pino is consumed only through Fastify (no direct pino import), and `pino-pretty` is MIT and dev-only.

## Test plan

- [x] `tests/web/logging.test.ts`: inbound `X-Request-Id` propagates to `reqId`; missing header generates a UUID `reqId`; `componentLogger` binds `component` (and carries no `reqId`); `buildLoggerOptions` default/pretty/stream branches; `genRequestId` uniqueness.
- [x] Existing route tests still pass (built with a silent logger to keep output clean — assertions unchanged).
- [x] `npm run format:check && npm run lint && npm run typecheck && npm test` all green from `server/` (coverage 100% lines/functions, 96% branches — above the 80% gate).

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)