### PR TITLE
feat(server): multi-stage Dockerfile for the dashboard image (#6)

### DIFF
--- a/.claude/plans/dockerfile-dashboard-image.md
+++ b/.claude/plans/dockerfile-dashboard-image.md
@@ -1,0 +1,81 @@
+# Plan: `server/Dockerfile` for the dashboard image (#6)
+
+Roadmap: `docs/roadmap.md` → Phase 1. Unblocks #7 (local dev compose).
+
+## Goal
+
+Add `server/Dockerfile` so CI's `docker-build` and `license-guard` jobs
+stop skipping and the dashboard ships as a single multi-stage Node 22
+image with **no GPL binaries** inside it.
+
+## Acceptance criteria (from the issue)
+
+- Multi-stage `node:22-slim` build:
+  - builder stage: `npm ci`, `npm run build`, plus the `server/frontend/`
+    SvelteKit build.
+  - runtime stage receives only `dist/`, production `node_modules`, and
+    the static frontend output.
+- Runtime installs the distro `python3-venv` (PSF, **not** GPL) solely so
+  first-run setup can create the isolated Ansible venv in `/data`.
+- Default `CMD`/entrypoint runs the compiled server (`node dist/main.js`)
+  via an entrypoint that performs first-run setup.
+- Image builds green in CI's `docker-build` job.
+- `license-guard.yml` passes (no `ansible*`/`timekpr*`/`e2guardian*`/
+  `adguardhome` binaries in the image).
+- `/data` mount point documented.
+
+## Design
+
+Build context is `server/` (per `.github/workflows/ci.yml` →
+`docker-build`: `docker buildx build … server/`). `server/frontend/` is
+inside that context.
+
+Three stages, all `node:22-slim`:
+
+1. **`frontend-builder`** — `npm ci` + `npm run build` in
+   `server/frontend/`; emits prerendered static assets to `build/`
+   (`admin.html`, `app.html`, `_app/…`).
+2. **`builder`** — install throwaway build tools (`python3`, `make`,
+   `g++`) so `better-sqlite3` compiles even when no prebuilt binary
+   matches; `npm ci`; `npm run build` (tsc → `dist/`); then
+   `npm prune --omit=dev` so the already-compiled production
+   `node_modules` (with the native `better-sqlite3` binding) can be
+   copied as-is — no recompile in the runtime stage. Build tools live
+   only in this throwaway stage, never the final image.
+3. **`runtime`** — `python3-venv` via apt (first-run Ansible venv);
+   copy `node_modules`, `dist/`, `drizzle/`, `package.json` from
+   `builder` and `build/` from `frontend-builder`; copy the entrypoint;
+   `EXPOSE 8000`, `VOLUME /data`, `ENTRYPOINT` → entrypoint → `node
+   dist/main.js`.
+
+### Entrypoint (`server/docker-entrypoint.sh`)
+
+Idempotent, runs on every start. In-scope now: ensure the documented
+`/data` volume layout exists, then `exec node dist/main.js`. The heavier
+first-run steps are deferred to their roadmap phases and tracked in a
+follow-up issue:
+
+- Schema migration (drizzle-kit migrations → `policy.sqlite`) — Phase 2
+  (the runtime DB connection lands then; see #34).
+- Ansible venv bootstrap (`pip install ansible-core`) — Phase 6.
+- AdGuard Home fetch/supervise (managed mode) — Phase 7.
+- SSH key bootstrap (`id_ed25519`) — Phase 4.
+
+## Deferred (tracked by follow-up issues, linked from the PR)
+
+- **Container first-run setup** (migration / Ansible venv / AdGuard fetch
+  / SSH keygen in the entrypoint).
+- **Serve the SvelteKit build via `@fastify/static`** at `/admin` and
+  `/app` (Phase 2, with the real UI). The image already carries the build
+  output; only the live mount is deferred. `server/frontend/README.md`
+  updated so it no longer couples the mount to #6.
+
+## Validation
+
+- Frontend build locally: `cd server/frontend && npm ci && npm run build`
+  (done — emits `build/`).
+- Backend gate: `npm run format:check && npm run lint && npm run
+  typecheck && npm test`.
+- Image build + license-guard: validated in CI (local Docker cannot pull
+  the base-image blobs under this environment's network policy). Monitor
+  the `docker-build` and `license-guard` jobs after pushing.

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -10,6 +10,12 @@ coverage/
 .eslintcache
 *.tsbuildinfo
 
+# Frontend build / cache (the frontend-builder stage runs its own npm ci
+# and SvelteKit build; never ship the host's local artefacts)
+frontend/node_modules/
+frontend/build/
+frontend/.svelte-kit/
+
 # Tests (built image runs them in CI, not at runtime)
 tests/
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,94 @@
+# syntax=docker/dockerfile:1
+#
+# Dashboard image — single multi-stage Node 22 build (#6).
+#
+# The published image is *dashboard code only*. It deliberately contains
+# NO GPL binaries: Ansible is installed into an isolated venv inside the
+# /data volume on first run, AdGuard Home is fetched at runtime (managed
+# mode) or pointed at an external instance, and the client-side GPL tools
+# (Timekpr-nExT, e2guardian, ActivityWatch) live on the client. See
+# docs/server-deployment.md and docs/licensing-analysis.md, enforced by
+# .github/workflows/license-guard.yml.
+#
+# Build context is server/ (see .github/workflows/ci.yml → docker-build),
+# so server/frontend/ is in scope for the frontend build stage.
+
+# ---------------------------------------------------------------------------
+# Stage 1: build the SvelteKit frontend (/admin + /app) to static assets.
+# adapter-static prerenders every route into frontend/build/.
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS frontend-builder
+WORKDIR /app/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: compile the TypeScript backend and resolve production deps.
+#
+# python3/make/g++ are installed only in this throwaway stage so
+# better-sqlite3's native binding compiles even when no prebuilt binary
+# matches the target. They never reach the runtime image.
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS builder
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json tsconfig.build.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# Strip dev dependencies in place, leaving the already-compiled native
+# better-sqlite3 binding so the runtime stage can copy node_modules as-is
+# (no recompile, no build tools in the final image).
+RUN npm prune --omit=dev
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime. Compiled output + production node_modules + static
+# frontend, plus a stock python3 (python3-venv, PSF-licensed — NOT GPL)
+# used solely by first-run setup to create the isolated Ansible venv in
+# the /data volume. No dashboard code is Python.
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS runtime
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3-venv \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+# Production dependencies and compiled backend.
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+# package.json gives Node "type": "module" for ESM resolution of dist/.
+COPY --from=builder /app/package.json ./package.json
+# Committed drizzle-kit migrations, reconciled into /data on start (Phase 2).
+# Copied straight from the build context (not the builder stage, which only
+# carries the TypeScript sources it compiles).
+COPY drizzle ./drizzle
+
+# Prerendered frontend (served at /admin and /app once the static mount
+# lands in Phase 2; carried in the image now so the asset path is settled).
+COPY --from=frontend-builder /app/frontend/build ./frontend
+
+# First-run setup + server launch.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Canonical policy store, Ansible venv, AdGuard payload, logs, secrets.
+VOLUME ["/data"]
+
+# Dashboard HTTP surface (docs/server-deployment.md → first-run step 5).
+EXPOSE 8000
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Dashboard container entrypoint — first-run setup, then launch the server.
+#
+# Runs on every container start and is idempotent (safe to re-run): the
+# entire deployable state lives under /data (docs/server-deployment.md →
+# "Backup and restore"), so setup only ever reconciles that volume.
+#
+# In scope today: ensure the documented /data volume layout exists, then
+# exec the compiled Node server. The heavier first-run steps each land with
+# their roadmap phase and are tracked in the follow-up issue linked from the
+# PR that introduced this script:
+#   - Schema migration (drizzle-kit migrations -> policy.sqlite)  [Phase 2]
+#   - Ansible venv bootstrap (pip install ansible-core)           [Phase 6]
+#   - AdGuard Home fetch / supervise (managed mode)               [Phase 7]
+#   - SSH key bootstrap (generate id_ed25519)                     [Phase 4]
+set -eu
+
+DATA_DIR="${PCT_DATA_DIR:-/data}"
+
+# Reconcile the documented volume layout (docs/server-deployment.md ->
+# "Volume layout"). Cheap and idempotent; the subdirectories are where the
+# deferred first-run steps above will write.
+mkdir -p \
+  "${DATA_DIR}/secrets/ssh" \
+  "${DATA_DIR}/ansible/playbooks" \
+  "${DATA_DIR}/adguard" \
+  "${DATA_DIR}/logs"
+
+echo "pct-dashboard: data volume ready at ${DATA_DIR}; starting server"
+
+# exec so the Node process becomes PID 1 and receives signals directly.
+exec node dist/main.js

--- a/server/frontend/README.md
+++ b/server/frontend/README.md
@@ -24,8 +24,10 @@ server/frontend/build/
 `adapter-static` is configured with `strict: true`, so the build fails if any
 route is not prerenderable — the runtime image is a plain static file server
 for these assets and has **no Node frontend toolchain**. The Docker builder
-stage (#6) runs this build; the Fastify `web` module mounts `build/` and
-serves it at `/admin` and `/app` (the static mount lands with #6 / Phase 2).
+stage (#6) runs this build and copies the output into the runtime image
+(under `/app/frontend`); the Fastify `web` module will mount `build/` and
+serve it at `/admin` and `/app` (the live static mount lands in Phase 2 with
+the real UI).
 
 `build/` is git-ignored (by both the repo-root `.gitignore` and the local
 `server/frontend/.gitignore`) — it is a build artefact, produced at
@@ -38,7 +40,7 @@ prerenders everything to static HTML/JS/CSS, so there is nothing to "wire
 pino into" on the frontend itself. The only server that ever handles an
 `/admin` or `/app` request is Fastify.
 
-When the `web` module mounts `build/` via `@fastify/static` (#6 / Phase 2),
+When the `web` module mounts `build/` via `@fastify/static` (Phase 2),
 those static-asset requests flow through the **same** request logging the
 backend already configures (`server/src/web/logger.ts`, #11) — no
 frontend-specific logging setup is needed or wanted:


### PR DESCRIPTION
## Summary

- Add `server/Dockerfile`: a single multi-stage `node:22-slim` build so CI's
  `docker-build` and `license-guard` jobs stop skipping. `frontend-builder`
  runs the SvelteKit build; `builder` compiles the TypeScript backend and
  prunes to production deps (the native `better-sqlite3` binding is compiled in
  the throwaway builder and copied as-is, so no build tools reach the runtime
  image); `runtime` carries only `dist/`, prod `node_modules`, drizzle
  migrations, and the prerendered frontend.
- Runtime installs `python3-venv` (PSF-licensed, **not** GPL) solely so
  first-run setup can create the isolated Ansible venv in `/data`.
- `server/docker-entrypoint.sh` reconciles the documented `/data` volume
  layout, then `exec`s the compiled server (`node dist/main.js`) as PID 1.
- `.dockerignore` excludes frontend build/cache artefacts; `server/frontend/README.md`
  no longer couples the live `@fastify/static` mount to #6.

## Plan

Linked plan: `.claude/plans/dockerfile-dashboard-image.md`
Roadmap: `docs/roadmap.md` → Phase 1

## License-boundary note

No GPL binaries are bundled in the image. Ansible stays in the `/data` venv
(first run), AdGuard Home is fetched at runtime / external / disabled, and the
client-side GPL tools live on the client. The only interpreter added to the
runtime image is a stock `python3` (via `python3-venv`, PSF). The throwaway
`builder` stage installs `python3/make/g++` to compile `better-sqlite3`, but
those never reach the final image. `license-guard.yml` enforces this.

## Deferred work (tracked)

- **#39** — container first-run setup in the entrypoint (schema migration /
  Ansible venv / AdGuard fetch / SSH keygen), each landing with its phase.
- **#40** — serve the SvelteKit build via `@fastify/static` at `/admin` and
  `/app` (Phase 2, with the real UI). The image already carries the build
  output; only the live mount is deferred.

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm test`
      green (35 tests, coverage 100% lines / 96% branches — above the 80% gate).
- [x] `cd server/frontend && npm ci && npm run build` succeeds (emits
      `build/admin.html`, `build/app.html`, `build/_app/…`).
- [x] `cd server && npm run build` emits `dist/main.js` (the runtime entrypoint).
- [x] CI `docker-build` builds the image green (local Docker can't pull the
      base-image blobs under this environment's network policy — validated in CI).
- [ ] CI `license-guard` confirms no GPL binaries in the image.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDnHDcvn2JX2jmiqEsBRjL)_