### PR TITLE
feat(dev): top-level docker-compose.yml for local development (#7)

### DIFF
--- a/.claude/plans/docker-compose-local-dev.md
+++ b/.claude/plans/docker-compose-local-dev.md
@@ -1,0 +1,50 @@
+# Plan — Top-level `docker-compose.yml` for local dev (#7)
+
+Roadmap: `docs/roadmap.md` → Phase 1 ("a basic `docker-compose.yml` example
+for local development"). Blocked-by #6 (image) and #10 (settings loader),
+both merged.
+
+## Goal
+
+One-command local bring-up of the dashboard, building the image from source
+so local changes are reflected, reading config from a gitignored `.env`
+(template `.env.example` already checked in), and persisting state to a host
+data directory.
+
+## Deliverables (acceptance criteria from #7)
+
+1. `docker-compose.yml` at the repo root with a single `dashboard` service.
+   - Builds the image from `./server` (context = `server/`, matching the
+     Dockerfile's build context — see `.github/workflows/ci.yml` →
+     `docker-build`). Local dev builds from source rather than pulling the
+     published GHCR image used in the production reference files in
+     `docs/server-deployment.md`.
+   - Mounts a host directory (`./data`) as the dashboard's `/data` volume
+     (the canonical state tree from `docs/server-deployment.md` → "Volume
+     layout"). `./data` is already covered by `.gitignore` (`/data/`).
+   - Reads env from `.env` via `env_file` with `required: false`, so
+     `docker compose up` works out of the box (the settings loader has safe
+     defaults: AdGuard `disabled`, `DATABASE_URL=/data/policy.sqlite`)
+     and picks up overrides once the user copies `.env.example` → `.env`.
+   - Publishes `8000:8000` (dashboard HTTP surface).
+   - `/healthz` healthcheck (the probe added in #5), run via Node's global
+     `fetch` (no curl in the `node:22-slim` runtime image).
+   - `restart: unless-stopped`.
+
+2. `README.md` — add a "Quick start (local development)" section.
+
+3. Guard test under `server/tests/` asserting the compose file's invariants
+   (service name, build context, `/data` mount, `8000` port, `env_file`,
+   and that no AdGuard sidecar leaked in — that's Phase 7, explicitly out of
+   scope per #7).
+
+## Out of scope (per #7)
+
+- AdGuard sidecar (Phase 7).
+- Integration-test compose file (already in `docs/testing.md`).
+
+## License-boundary note
+
+No transport or packaging changes. The compose file builds the existing
+`server/Dockerfile` (which already keeps GPL binaries out of the image) and
+adds no services that bundle GPL code. N/A for in-process linkage.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,38 @@ clients (initial target: **Linux Mint with Cinnamon**) enforce the policy
 locally using established open-source tools (Timekpr-nExT, ActivityWatch,
 e2guardian, AdGuard Home).
 
-> **Status:** Design phase. No implementation has landed yet. This repository
-> currently contains the architecture and licensing analyses that the
-> implementation will follow. See [`docs/roadmap.md`](docs/roadmap.md) for the
-> work breakdown and the [roadmap project](https://github.com/users/BenSeymourODB/projects/2)
-> for issue-level tracking.
+> **Status:** Early implementation (Phase 1). The architecture and licensing
+> analyses are complete and the dashboard skeleton is taking shape — a Fastify
+> app, settings loader, Docker image, and CI. Most features in
+> [`docs/roadmap.md`](docs/roadmap.md) are not built yet. See the roadmap for
+> the work breakdown and the
+> [roadmap project](https://github.com/users/BenSeymourODB/projects/2) for
+> issue-level tracking.
+
+## Quick start (local development)
+
+Run the dashboard from source with Docker Compose:
+
+```bash
+# (optional) override defaults — the dashboard runs without this file
+cp .env.example .env
+
+# build the image from ./server and start the dashboard
+docker compose up --build
+```
+
+The dashboard is then on <http://localhost:8000> (`GET /` serves a
+"hello, no policy yet" placeholder; `GET /healthz` is the liveness probe).
+Persistent state lives in a gitignored `./data` directory mounted at `/data`
+in the container (see [`docs/server-deployment.md`](docs/server-deployment.md)
+→ "Volume layout"). Configuration is read from `.env`; every setting and its
+default is documented in [`.env.example`](.env.example).
+
+This compose file builds from source for local development and deliberately
+omits DNS filtering (AdGuard Home is a Phase 7 concern). For production
+deployment on TrueNAS SCALE — using the published image and the AdGuard
+topologies — see the reference compose files in
+[`docs/server-deployment.md`](docs/server-deployment.md).
 
 ## What the product does
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+# Local-development bring-up for the dashboard.
+#
+#   cp .env.example .env   # optional — defaults work without it
+#   docker compose up --build
+#
+# This builds the image from source (server/) so local changes are picked up
+# on the next `--build`. It is NOT the production deployment: the reference
+# compose files in docs/server-deployment.md pull the published GHCR image and
+# cover the AdGuard topologies. DNS filtering (AdGuard Home) is a Phase 7
+# concern and intentionally absent here.
+services:
+  dashboard:
+    # Build context is server/, matching server/Dockerfile's expectations and
+    # the CI docker-build job (.github/workflows/ci.yml).
+    build:
+      context: ./server
+    image: linux-parental-controls-toolkit:dev
+    container_name: pct-dashboard
+    restart: unless-stopped
+    ports:
+      # Dashboard HTTP surface (docs/server-deployment.md → first-run step 5).
+      - "8000:8000"
+    # Canonical state tree (policy.sqlite, secrets/, ansible/, logs/) lives on
+    # the host under ./data so it survives container rebuilds. ./data is
+    # gitignored (/data/). docs/server-deployment.md → "Volume layout".
+    volumes:
+      - ./data:/data
+    # Config is parsed/validated by server/src/config.ts. The loader has safe
+    # defaults (AdGuard disabled, DATABASE_URL=/data/policy.sqlite), so .env is
+    # optional; copy .env.example → .env to override.
+    env_file:
+      - path: .env
+        required: false
+    # Liveness probe hits the /healthz route (#5). node:22-slim has no curl, so
+    # use Node's global fetch.
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://localhost:8000/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -30,7 +30,8 @@
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.45.0",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22"
@@ -6981,6 +6982,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/server/package.json
+++ b/server/package.json
@@ -44,7 +44,8 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.45.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "yaml": "^2.9.0"
   },
   "repository": {
     "type": "git",

--- a/server/tests/docker-compose.test.ts
+++ b/server/tests/docker-compose.test.ts
@@ -11,21 +11,30 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { z } from "zod";
 
 const composePath = fileURLToPath(new URL("../../docker-compose.yml", import.meta.url));
 
-interface ComposeService {
-  build?: { context?: string } | string;
-  ports?: string[];
-  volumes?: string[];
-  env_file?: ({ path?: string; required?: boolean } | string)[] | string;
-}
-interface ComposeFile {
-  services?: Record<string, ComposeService>;
-}
+// Validate the slice of the Compose schema this test asserts on, rather than
+// casting `parse()`'s `unknown` output — keeps the repo's "validate external
+// input with zod / no unchecked `as`" convention (CLAUDE.md → "Code conventions").
+const envFileEntrySchema = z.union([
+  z.string(),
+  z.object({ path: z.string().optional(), required: z.boolean().optional() }),
+]);
+const serviceSchema = z.object({
+  build: z.union([z.string(), z.object({ context: z.string().optional() })]).optional(),
+  ports: z.array(z.string()).optional(),
+  volumes: z.array(z.string()).optional(),
+  env_file: z.union([z.array(envFileEntrySchema), z.string()]).optional(),
+});
+const composeSchema = z.object({
+  services: z.record(z.string(), serviceSchema).optional(),
+});
+type ComposeService = z.infer<typeof serviceSchema>;
 
-function loadCompose(): ComposeFile {
-  return parse(readFileSync(composePath, "utf8")) as ComposeFile;
+function loadCompose(): z.infer<typeof composeSchema> {
+  return composeSchema.parse(parse(readFileSync(composePath, "utf8")));
 }
 
 /** The single `dashboard` service, with a clear failure if it is missing. */

--- a/server/tests/docker-compose.test.ts
+++ b/server/tests/docker-compose.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Guards the repo-root `docker-compose.yml` (the local-dev bring-up, #7).
+ *
+ * This file is infrastructure, not TypeScript, so the invariants the README
+ * Quick Start and the acceptance criteria depend on are asserted here: a
+ * single `dashboard` service built from `./server`, the `/data` mount, the
+ * `8000` port, and `.env` wiring — plus the explicit out-of-scope guarantee
+ * that no AdGuard (Phase 7) sidecar has crept in.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const composePath = fileURLToPath(new URL("../../docker-compose.yml", import.meta.url));
+
+interface ComposeService {
+  build?: { context?: string } | string;
+  ports?: string[];
+  volumes?: string[];
+  env_file?: ({ path?: string; required?: boolean } | string)[] | string;
+}
+interface ComposeFile {
+  services?: Record<string, ComposeService>;
+}
+
+function loadCompose(): ComposeFile {
+  return parse(readFileSync(composePath, "utf8")) as ComposeFile;
+}
+
+/** The single `dashboard` service, with a clear failure if it is missing. */
+function dashboardService(): ComposeService {
+  const service = loadCompose().services?.dashboard;
+  if (service === undefined) {
+    throw new Error("docker-compose.yml is missing the `dashboard` service");
+  }
+  return service;
+}
+
+describe("docker-compose.yml (local dev)", () => {
+  it("parses as valid YAML", () => {
+    expect(() => loadCompose()).not.toThrow();
+  });
+
+  it("defines exactly one service: dashboard (no AdGuard sidecar — Phase 7)", () => {
+    const compose = loadCompose();
+    expect(Object.keys(compose.services ?? {})).toEqual(["dashboard"]);
+  });
+
+  it("builds the image from ./server", () => {
+    const { build } = dashboardService();
+    const context = typeof build === "string" ? build : build?.context;
+    expect(context).toBe("./server");
+  });
+
+  it("publishes the dashboard HTTP port 8000", () => {
+    expect(dashboardService().ports).toContain("8000:8000");
+  });
+
+  it("mounts a host directory at /data", () => {
+    expect(dashboardService().volumes).toContain("./data:/data");
+  });
+
+  it("reads config from an optional .env file", () => {
+    const { env_file } = dashboardService();
+    const entries = Array.isArray(env_file) ? env_file : [env_file];
+    const dotEnv = entries.find((e) => (typeof e === "string" ? e === ".env" : e?.path === ".env"));
+    expect(dotEnv).toBeDefined();
+    // Optional so `docker compose up` works before the user copies .env.example.
+    if (typeof dotEnv === "object") {
+      expect(dotEnv.required).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add a repo-root `docker-compose.yml` for **local development**: a single `dashboard` service that builds the image from source (`./server`), publishes `8000:8000`, mounts a gitignored `./data` host directory at `/data` (the canonical state tree from `docs/server-deployment.md` → "Volume layout"), reads config from an optional `.env` (`env_file` `required: false`) so it runs out of the box on the settings-loader defaults, and adds a `/healthz` healthcheck.
- `README.md`: new "Quick start (local development)" section and a refresh of the stale "design phase" status note.
- Guard test (`server/tests/docker-compose.test.ts`) parses the compose file and asserts its invariants — including the out-of-scope guarantee that no AdGuard (Phase 7) sidecar leaked in.

## Plan

Linked plan: `.claude/plans/docker-compose-local-dev.md`
Roadmap: `docs/roadmap.md` → Phase 1 ("a basic `docker-compose.yml` example for local development"). Blocked-by #6 (image) and #10 (settings loader), both merged.

## New dependency

`yaml` (devDependency) — used only by the guard test to parse and assert the compose file's structure. No existing dependency parses YAML (the stack uses zod for JSON/env), and it is a `devDependency`, so `npm prune --omit=dev` keeps it out of the runtime image.

## License-boundary note

No transport or packaging changes to the image itself. The compose file builds the existing `server/Dockerfile` (which already keeps GPL binaries out of the image) and adds no services that bundle GPL code. AdGuard Home (GPL, Phase 7) is intentionally absent. N/A for in-process linkage.

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm test` all green (coverage 100% on `src/`, gate is 80%).
- [x] `docker compose config -q` validates the file and resolves the `./server` build context.
- [x] Guard test asserts: single `dashboard` service, build context `./server`, `8000:8000`, `./data:/data`, optional `.env` wiring.

## Out of scope (per #7)

- AdGuard sidecar (Phase 7).
- Integration-test compose file (already in `docs/testing.md`).

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYPegyzLhBmkWvNEuM1HYY)_