### PR TITLE
test: shared test helpers — testDb, buildTestApp, mockSubprocess (#12)

### DIFF
--- a/.claude/plans/issue-12-shared-test-helpers.md
+++ b/.claude/plans/issue-12-shared-test-helpers.md
@@ -1,0 +1,53 @@
+# Issue #12 — Shared test helpers (`server/tests/helpers/`)
+
+Roadmap: Phase 1 groundwork. Land the helpers `docs/testing.md` already
+documents so Phase 2 / Phase 4 PRs don't each re-invent them. Prerequisites
+#5 (`buildApp()`) and #9 (drizzle migrations scaffold) are merged on `main`.
+
+## Helpers
+
+1. **`tests/helpers/db.ts` — `testDb()`**
+   - Fresh in-memory better-sqlite3 DB, `drizzle()`-wrapped, with the
+     committed migrations applied via `drizzle-orm/better-sqlite3/migrator`.
+   - Resolve the migrations folder relative to the helper file (not cwd),
+     mirroring `tests/policy/migrations.test.ts`, so it is runner-cwd
+     independent.
+   - Phase-1 journal is empty (no tables yet); the migrator only provisions
+     its bookkeeping table. The helper keeps working unchanged once Phase 2
+     adds real tables.
+   - Returns the Drizzle db directly (matching the documented
+     `buildApp({ db: testDb() })` contract); the underlying handle is
+     reachable via `db.$client` for explicit `.close()`.
+
+2. **`tests/helpers/app.ts` — `buildTestApp()`**
+   - Wraps `buildApp()` (#5) with a silent logger and bundles a `testDb()`.
+   - Returns `{ app, db, close() }`; `close()` shuts the Fastify app and the
+     in-memory DB so route tests stay hermetic.
+   - Forward-compatible: `buildApp()` does not yet accept a `db` option (that
+     runtime DB wiring lands in Phase 2 — see #34/#39). For now the db is
+     created and returned alongside the app; the pass-through into `buildApp`
+     lands with the Phase-2 connection work. Documented in the helper.
+
+3. **`tests/helpers/subprocess.ts` — `mockSubprocess()`**
+   - Wraps the `vi.mock("node:child_process")` pattern from
+     `docs/testing.md` → "Mock patterns by layer". Provides `vi.fn()` mocks
+     for `execFile`/`spawn`, the `module` object to hand back from the mock
+     factory, and `execFileCalls()` / `spawnCalls()` recorders that normalise
+     `.mock.calls` into `{ command, args }`. Used by Phase-4 transport tests.
+   - Intended usage: `const sp = vi.hoisted(() => mockSubprocess()); vi.mock("node:child_process", () => sp.module);`
+
+## Tests
+
+One smoke test per helper under `tests/helpers/` confirming wiring:
+`db.test.ts` (migrations apply, bookkeeping table exists), `app.test.ts`
+(`app.inject()` hits `/healthz`, db is usable, `close()` works),
+`subprocess.test.ts` (a mocked `execFile` call is intercepted and recorded).
+
+Helpers live under `tests/` so they are excluded from coverage
+(`include: ["src/**"]`); the smoke tests keep the gate green without
+touching `src/`.
+
+## License-boundary note
+
+N/A — test-only helpers. `mockSubprocess` reinforces the subprocess boundary
+(it never invokes a real GPL binary). No transport/packaging/image changes.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -173,34 +173,32 @@ Test the following error cases for every REST client:
 
 ### Policy model
 
-Use an in-memory SQLite database via a shared helper. better-sqlite3
-supports `:memory:` natively, and the Drizzle migrations run against it
-in milliseconds:
+Use an in-memory SQLite database via the shared `testDb()` helper
+(`tests/helpers/db.ts`). better-sqlite3 supports `:memory:` natively, and the
+Drizzle migrations run against it in milliseconds:
 
 ```ts
-import Database from "better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { testDb } from "../helpers/db.js";
 
-export function testDb() {
-  const sqlite = new Database(":memory:");
-  const db = drizzle(sqlite);
-  migrate(db, { migrationsFolder: "drizzle" });
-  return db;
-}
+const db = testDb(); // fresh :memory: database with all migrations applied
 ```
 
+The helper resolves the committed migrations folder relative to itself (not
+the process cwd), so it works regardless of where the runner is invoked from.
+The underlying handle is reachable via `db.$client` (e.g. `db.$client.close()`).
 This keeps policy tests hermetic and fast — no file I/O, no leftover state.
 
 ### HTTP routes
 
-Use Fastify's built-in injection — no sockets, no port binding:
+Use Fastify's built-in injection — no sockets, no port binding. The
+`buildTestApp()` helper (`tests/helpers/app.ts`) builds the app with a silent
+logger and bundles a `testDb()`:
 
 ```ts
-import { buildApp } from "../src/web/app.js";
+import { buildTestApp } from "../helpers/app.js";
 
 it("grant endpoint is idempotent by source_ref", async () => {
-  const app = await buildApp({ db: testDb() });
+  const { app, db, close } = buildTestApp();
   const payload = { user: "alice", seconds: 1800, source_ref: "chore-abc-001" };
 
   const r1 = await app.inject({ method: "POST", url: "/api/grants", headers: authHeaders, payload });
@@ -209,8 +207,16 @@ it("grant endpoint is idempotent by source_ref", async () => {
   expect(r1.statusCode).toBe(201);
   expect(r2.statusCode).toBe(200); // idempotent: same grant, not a new one
   expect(r1.json().id).toBe(r2.json().id);
+
+  await close(); // closes the app and the in-memory db
 });
 ```
+
+> **Phase-1 status:** `buildApp()` does not yet take a `db` option — the
+> runtime DB connection is wired in Phase 2 (the `DATABASE_URL` contract,
+> issue #34, and first-run schema migration, issue #39). Until then
+> `buildTestApp()` creates and returns the `db` alongside the app; the
+> pass-through into `buildApp` lands with that Phase-2 work.
 
 ---
 

--- a/server/tests/helpers/app.test.ts
+++ b/server/tests/helpers/app.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildTestApp } from "./app.js";
+import { testDb } from "./db.js";
 
 describe("buildTestApp helper", () => {
   it("builds an injectable app paired with a migrated db", async () => {
@@ -27,7 +28,7 @@ describe("buildTestApp helper", () => {
   });
 
   it("accepts a caller-supplied db", async () => {
-    const db = (await import("./db.js")).testDb();
+    const db = testDb();
     const { db: bundled, close } = buildTestApp({ db });
 
     expect(bundled).toBe(db);

--- a/server/tests/helpers/app.test.ts
+++ b/server/tests/helpers/app.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Smoke test for the {@link buildTestApp} helper: it returns a working
+ * Fastify instance (exercised via `app.inject()`), a usable migrated DB, and
+ * a `close()` that tears both down.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildTestApp } from "./app.js";
+
+describe("buildTestApp helper", () => {
+  it("builds an injectable app paired with a migrated db", async () => {
+    const { app, db, close } = buildTestApp();
+
+    const res = await app.inject({ method: "GET", url: "/healthz" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: "ok" });
+
+    // The bundled db is migrated and queryable.
+    const row = db.$client
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '__drizzle_migrations'",
+      )
+      .get();
+    expect(row).not.toBeUndefined();
+
+    await close();
+  });
+
+  it("accepts a caller-supplied db", async () => {
+    const db = (await import("./db.js")).testDb();
+    const { db: bundled, close } = buildTestApp({ db });
+
+    expect(bundled).toBe(db);
+
+    await close();
+  });
+});

--- a/server/tests/helpers/app.ts
+++ b/server/tests/helpers/app.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared Fastify test-app helper.
+ *
+ * `buildTestApp()` constructs the real {@link buildApp} instance (#5) with a
+ * silent logger and bundles a fresh {@link testDb}, so HTTP-route tests can
+ * exercise the app via `app.inject()` (no sockets, no port binding) while
+ * holding the policy DB the routes will read — see `docs/testing.md` →
+ * "HTTP routes".
+ *
+ * Forward-compat note: the Phase-1 {@link buildApp} does not yet accept a
+ * `db` option — the runtime DB connection is wired in Phase 2 (see #34/#39).
+ * Until then the db is created and returned alongside the app; once
+ * `buildApp` gains a `db` option this helper passes it through. Bundling both
+ * here means Phase 2 / Phase 4 tests don't each re-derive the wiring.
+ */
+import type { FastifyInstance } from "fastify";
+
+import { loadSettings } from "../../src/config.js";
+import { buildApp, type BuildAppOptions } from "../../src/web/app.js";
+import { testDb, type TestDb } from "./db.js";
+
+/** A test app paired with its in-memory policy database. */
+export interface TestApp {
+  /** The configured Fastify instance; drive it with `app.inject()`. */
+  app: FastifyInstance;
+  /** The in-memory policy database (migrations applied). */
+  db: TestDb;
+  /** Close the Fastify app and the underlying in-memory database. */
+  close(): Promise<void>;
+}
+
+/** Options for {@link buildTestApp}. */
+export interface BuildTestAppOptions {
+  /** Override the in-memory policy DB (defaults to a fresh {@link testDb}). */
+  db?: TestDb;
+  /**
+   * Extra {@link buildApp} options (e.g. a custom `settings` or a
+   * `loggerStream` to capture log output). The default settings use a silent
+   * log level to keep test output clean.
+   */
+  appOptions?: BuildAppOptions;
+}
+
+/**
+ * Build a Fastify test app wired to an in-memory policy database.
+ *
+ * Defaults to a silent logger so route assertions aren't drowned in log
+ * lines; pass `appOptions` to override (logging behaviour itself is covered
+ * in `tests/web/logging.test.ts`).
+ */
+export function buildTestApp(options: BuildTestAppOptions = {}): TestApp {
+  const db = options.db ?? testDb();
+  const app = buildApp({
+    settings: loadSettings({ PCT_LOG_LEVEL: "silent" }),
+    ...options.appOptions,
+  });
+
+  return {
+    app,
+    db,
+    close: async () => {
+      await app.close();
+      db.$client.close();
+    },
+  };
+}

--- a/server/tests/helpers/db.test.ts
+++ b/server/tests/helpers/db.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Smoke test for the {@link testDb} helper: a fresh in-memory database has
+ * the migrations applied and is independent per call.
+ */
+import { describe, expect, it } from "vitest";
+
+import { testDb } from "./db.js";
+
+describe("testDb helper", () => {
+  it("applies the migrations to a fresh in-memory database", () => {
+    const db = testDb();
+
+    // The migrator always provisions its bookkeeping table once the journal
+    // has been read — proof the migrations folder was found and applied.
+    const row = db.$client
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '__drizzle_migrations'",
+      )
+      .get();
+    expect(row).not.toBeUndefined();
+
+    db.$client.close();
+  });
+
+  it("returns an independent database on each call", () => {
+    const a = testDb();
+    const b = testDb();
+
+    expect(a.$client).not.toBe(b.$client);
+
+    a.$client.close();
+    b.$client.close();
+  });
+});

--- a/server/tests/helpers/db.ts
+++ b/server/tests/helpers/db.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared test database helper.
+ *
+ * `testDb()` returns a fresh, in-memory better-sqlite3 database wrapped by
+ * Drizzle with the committed migrations applied. Policy-layer unit tests use
+ * it for hermetic, fast (no file I/O, no leftover state) coverage — see
+ * `docs/testing.md` → "Mock patterns by layer → Policy model".
+ *
+ * Phase 1 ships an empty migration journal (no tables yet), so the migrator
+ * only provisions its bookkeeping table. The helper keeps working unchanged
+ * once Phase 2 adds real tables on top of the scaffold (#9).
+ */
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Database from "better-sqlite3";
+import { drizzle, type BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+
+// Resolve the committed migrations folder relative to this file rather than
+// the process cwd, so the helper works regardless of where the runner is
+// invoked from — same approach as tests/policy/migrations.test.ts.
+const migrationsFolder = resolve(dirname(fileURLToPath(import.meta.url)), "../../drizzle");
+
+/**
+ * A migrated in-memory Drizzle database. The underlying better-sqlite3 handle
+ * is reachable via `.$client` (e.g. `db.$client.close()` to free it).
+ */
+export type TestDb = BetterSQLite3Database<Record<string, never>> & {
+  $client: Database.Database;
+};
+
+/**
+ * Build a fresh in-memory policy database with all migrations applied.
+ *
+ * Each call is an independent `:memory:` database, so tests never share
+ * state. Close the underlying handle with `db.$client.close()` when done (or
+ * let it be reclaimed at process exit for short-lived unit tests).
+ */
+export function testDb(): TestDb {
+  const sqlite = new Database(":memory:");
+  const db = drizzle(sqlite);
+  migrate(db, { migrationsFolder });
+  return db;
+}

--- a/server/tests/helpers/subprocess.test.ts
+++ b/server/tests/helpers/subprocess.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Smoke test for the {@link mockSubprocess} helper: a `vi.mock`-ed
+ * `node:child_process` routes `execFile`/`spawn` through the helper's mocks
+ * and the recorders normalise the captured invocations.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockSubprocess } from "./subprocess.js";
+
+// `mock`-prefixed so the hoisted `vi.mock` factory below may reference it.
+const mockCp = mockSubprocess();
+vi.mock("node:child_process", () => mockCp.module);
+
+// Deferred import so the mock is registered before the module resolves —
+// the canonical wiring documented in subprocess.ts.
+const { execFile, spawn } = await import("node:child_process");
+
+describe("mockSubprocess helper", () => {
+  beforeEach(() => mockCp.reset());
+
+  it("intercepts execFile and records the command and args", () => {
+    execFile("timekpra", ["--settimelimitforday", "alice", "7200"]);
+
+    expect(mockCp.execFileCalls()).toEqual([
+      { command: "timekpra", args: ["--settimelimitforday", "alice", "7200"] },
+    ]);
+  });
+
+  it("records spawn calls and an argument-less invocation as []", () => {
+    spawn("ansible-playbook", ["site.yml"]);
+    spawn("true");
+
+    expect(mockCp.spawnCalls()).toEqual([
+      { command: "ansible-playbook", args: ["site.yml"] },
+      { command: "true", args: [] },
+    ]);
+  });
+
+  it("reset() clears recorded calls", () => {
+    execFile("timekpra", ["--version"]);
+    expect(mockCp.execFileCalls().length).toBeGreaterThan(0);
+
+    mockCp.reset();
+
+    expect(mockCp.execFileCalls()).toEqual([]);
+  });
+});

--- a/server/tests/helpers/subprocess.ts
+++ b/server/tests/helpers/subprocess.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared subprocess-mock helper.
+ *
+ * Phase-4 transport unit tests must never invoke a real `timekpra` or
+ * `ansible-playbook` (the GPL tools are driven only as subprocesses across a
+ * process boundary — see `CLAUDE.md` → "License boundaries"). This helper
+ * wraps the `vi.mock("node:child_process")` pattern from `docs/testing.md` →
+ * "Mock patterns by layer → Transport — subprocess": it supplies the
+ * `execFile`/`spawn` mock functions, the `module` object to hand back from
+ * the mock factory, and recorders that normalise the captured invocations
+ * for assertion.
+ *
+ * `vi.mock` is hoisted above imports, so its factory cannot reference an
+ * imported helper directly (the import isn't initialised yet) and `vi.hoisted`
+ * can only see `vi` itself — not `mockSubprocess`. Instead, assign the mock to
+ * a `mock`-prefixed top-level binding (which Vitest allows the factory to
+ * reference) and load anything that imports `node:child_process` — the code
+ * under test, or `node:child_process` itself — via a top-level `await import`,
+ * so the factory runs after the mock exists:
+ *
+ * ```ts
+ * import { mockSubprocess } from "../helpers/subprocess.js";
+ *
+ * const mockCp = mockSubprocess();
+ * vi.mock("node:child_process", () => mockCp.module);
+ *
+ * // Deferred import so the mock is registered before the module resolves.
+ * const { setDailyLimit } = await import("../../src/transport/ssh/index.js");
+ *
+ * it("invokes timekpra with the right arguments", async () => {
+ *   await setDailyLimit({ user: "alice", seconds: 7200 });
+ *   expect(mockCp.execFileCalls()).toEqual([
+ *     { command: "timekpra", args: ["--settimelimitforday", "alice", "7200"] },
+ *   ]);
+ * });
+ * ```
+ */
+import { vi, type Mock } from "vitest";
+
+/** A captured subprocess invocation, reduced to the bits tests assert on. */
+export interface RecordedCall {
+  /** The executable name/path (first argument to `execFile`/`spawn`). */
+  command: string;
+  /** The positional CLI arguments, or `[]` when none were passed. */
+  args: string[];
+}
+
+/** A configured `node:child_process` mock plus its recorders. */
+export interface SubprocessMock {
+  /** Mock for `child_process.execFile`. */
+  execFile: Mock;
+  /** Mock for `child_process.spawn`. */
+  spawn: Mock;
+  /** Object to return from `vi.mock("node:child_process", () => …)`. */
+  module: { execFile: Mock; spawn: Mock };
+  /** Recorded `execFile` invocations, in call order. */
+  execFileCalls(): RecordedCall[];
+  /** Recorded `spawn` invocations, in call order. */
+  spawnCalls(): RecordedCall[];
+  /** Clear recorded calls and any configured implementations. */
+  reset(): void;
+}
+
+/** Normalise a mock's raw `.mock.calls` into `{ command, args }` records. */
+function toRecordedCalls(mock: Mock): RecordedCall[] {
+  return mock.mock.calls.map((call): RecordedCall => {
+    const command = call[0] as unknown;
+    const maybeArgs = call[1] as unknown;
+    return {
+      command: String(command),
+      args: Array.isArray(maybeArgs) ? maybeArgs.map((arg: unknown) => String(arg)) : [],
+    };
+  });
+}
+
+/**
+ * Create a `node:child_process` mock that records `execFile`/`spawn` calls.
+ *
+ * Call this inside `vi.hoisted` and hand `module` to `vi.mock` — see the
+ * module docstring for the canonical wiring.
+ */
+export function mockSubprocess(): SubprocessMock {
+  const execFile = vi.fn();
+  const spawn = vi.fn();
+
+  return {
+    execFile,
+    spawn,
+    module: { execFile, spawn },
+    execFileCalls: () => toRecordedCalls(execFile),
+    spawnCalls: () => toRecordedCalls(spawn),
+    reset: () => {
+      execFile.mockReset();
+      spawn.mockReset();
+    },
+  };
+}

--- a/server/tests/helpers/subprocess.ts
+++ b/server/tests/helpers/subprocess.ts
@@ -76,8 +76,9 @@ function toRecordedCalls(mock: Mock): RecordedCall[] {
 /**
  * Create a `node:child_process` mock that records `execFile`/`spawn` calls.
  *
- * Call this inside `vi.hoisted` and hand `module` to `vi.mock` — see the
- * module docstring for the canonical wiring.
+ * Assign the result to a `mock`-prefixed top-level binding and hand `module`
+ * to `vi.mock("node:child_process", …)` — see the module docstring for the
+ * canonical wiring (and why `vi.hoisted` can't be used here).
  */
 export function mockSubprocess(): SubprocessMock {
   const execFile = vi.fn();


### PR DESCRIPTION
## Summary

- Add the shared Vitest helpers `docs/testing.md` already documents, so Phase 2 / Phase 4 PRs don't each re-invent them:
  - `tests/helpers/db.ts` — `testDb()`: a fresh in-memory better-sqlite3 + Drizzle database with the committed migrations applied (folder resolved relative to the helper, so it's runner-cwd independent). Phase-1 journal is empty; keeps working unchanged once Phase 2 adds tables.
  - `tests/helpers/app.ts` — `buildTestApp()`: wraps `buildApp()` (#5) with a silent logger and bundles a `testDb()`, returning `{ app, db, close() }` for hermetic `app.inject()` route tests.
  - `tests/helpers/subprocess.ts` — `mockSubprocess()`: wraps the `vi.mock("node:child_process")` pattern, exposing `execFile`/`spawn` mocks, the factory `module`, and `execFileCalls()`/`spawnCalls()` recorders normalised to `{ command, args }`.
- One smoke test per helper confirming wiring. Helpers live under `tests/` so they're excluded from the coverage `include` (`src/**`); the gate stays green (42 tests, 100% lines / 96% branches).

## Plan

Linked plan: `.claude/plans/issue-12-shared-test-helpers.md`
Roadmap: `docs/roadmap.md` → Phase 1 (groundwork)

## Notes

- **`buildApp()` does not yet accept a `db` option.** The runtime DB connection is wired in Phase 2 (tracked by #34 — `DATABASE_URL` contract — and #39 — first-run schema migration). Until then `buildTestApp()` creates and returns the db alongside the app; the pass-through into `buildApp` lands with that Phase-2 work. This is documented inline in the helper. No new follow-up issue is needed — the deferred wiring is already covered by #34/#39.
- **Subprocess mock wiring.** `vi.mock` is hoisted above imports and `vi.hoisted` can't reference an imported helper, so the documented pattern assigns the mock to a `mock`-prefixed top-level binding (which Vitest permits the factory to reference) and loads the module-under-test via a top-level `await import`. The helper's docstring and the smoke test both demonstrate this.

## License-boundary note

N/A — test-only helpers, no transport/packaging/image changes. `mockSubprocess` reinforces the subprocess boundary (transport unit tests never invoke a real GPL binary).

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm test` all green (42 tests; coverage 100% lines / 96% branches — above the 80% gate).
- [x] Each helper covered by a co-located smoke test (`db.test.ts`, `app.test.ts`, `subprocess.test.ts`).

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YH5Gm9upwPzVHBNzr9QJBe)_