### PR TITLE
fix(config): normalize file: scheme in DATABASE_URL (#34)

### DIFF
--- a/.claude/plans/issue-34-database-url-contract.md
+++ b/.claude/plans/issue-34-database-url-contract.md
@@ -1,0 +1,45 @@
+# Issue #34 — Reconcile the `DATABASE_URL` contract
+
+## Problem
+
+Two Phase-1 contracts disagree on the shape of `DATABASE_URL`:
+
+- **`file:` (libsql) form** — CI `integration.yml` (`migrations` job) sets
+  `DATABASE_URL: file:./ci_migration_test.sqlite`, and `drizzle.config.ts`
+  defaults to `file:./policy.sqlite` and **strips** the `file:` scheme
+  because `better-sqlite3` wants a bare filesystem path.
+- **bare-path form** — `server/src/config.ts` (`loadSettings`) stores the
+  value **verbatim** (default `/data/policy.sqlite`); `.env.example` shows a
+  bare path.
+
+Nothing breaks today (no live `better-sqlite3` consumer), but in Phase 2 the
+runtime opens the DB from `settings.databaseUrl`. `better-sqlite3` does not
+understand `file:` URIs, so an operator following the CI/#33 convention
+(`DATABASE_URL=file:/data/policy.sqlite`) would have migrations and the
+runtime point at **different files**.
+
+## Decision — Option 1 (the issue's recommendation)
+
+Normalize a leading `file:` scheme in the settings loader so both forms
+resolve to the same `better-sqlite3` path. Mirror the exact strip
+`drizzle.config.ts` already uses (`/^file:/`) so the two stay in lockstep.
+`drizzle.config.ts` and CI are left untouched.
+
+## Changes
+
+1. `server/src/config.ts` — strip a leading `file:` from `databaseUrl` via a
+   zod `.transform` (runs after `.default`, so the default and any
+   `file:`-prefixed value both normalize). Keep the field a plain `string`.
+2. `server/tests/config.test.ts` — add cases: `file:./policy.sqlite` →
+   `./policy.sqlite`, `file:/data/policy.sqlite` → `/data/policy.sqlite`,
+   bare path unchanged, default unchanged.
+3. `server/.env.example` — one-line note that a `file:` prefix is accepted
+   and stripped, so the CI/drizzle `file:` form and a bare path are
+   equivalent.
+4. `docs/server-deployment.md` — document the single `DATABASE_URL` contract
+   in the Volume-layout / database paragraph.
+
+## Out of scope
+
+- Touching `drizzle.config.ts` or CI (Option 1 deliberately leaves them).
+- Wiring the runtime `better-sqlite3` connection (Phase 2, #39).

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,10 @@
 # Parsed and validated by server/src/config.ts (loadSettings). All values
 # below are the defaults; uncomment and change only what you need.
 
-# Path to the SQLite policy store (better-sqlite3 / Drizzle).
+# Path to the SQLite policy store (better-sqlite3 / Drizzle). A bare path
+# and the libsql `file:` URL form (e.g. file:/data/policy.sqlite, used by CI
+# and drizzle.config.ts) are equivalent: the loader strips a leading `file:`
+# so drizzle-kit and the runtime always open the same file.
 # DATABASE_URL=/data/policy.sqlite
 
 # pino log level: trace | debug | info | warn | error | fatal | silent

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -65,6 +65,15 @@ The dashboard's database schema, the read-only copy of playbooks shipped
 inside the image, and the drizzle-kit SQL migrations all live in the
 image and are reconciled into `/data` on each start.
 
+`DATABASE_URL` points at the policy store and defaults to
+`/data/policy.sqlite`. It accepts two interchangeable forms: a bare
+filesystem path (`/data/policy.sqlite`) and the libsql `file:` URL form
+(`file:/data/policy.sqlite`, the form CI's migration job and
+`drizzle.config.ts` use). `better-sqlite3` only understands bare paths, so
+both the settings loader and `drizzle.config.ts` strip a leading `file:` —
+drizzle-kit (migrate/check) and the runtime connection therefore always open
+the same file whichever form you set.
+
 ## First-run setup
 
 On container start, the entrypoint runs these steps idempotently:

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -18,6 +18,22 @@ import { z } from "zod";
 const LOG_LEVELS = ["trace", "debug", "info", "warn", "error", "fatal", "silent"] as const;
 
 /**
+ * Normalize a `DATABASE_URL` value to a bare filesystem path.
+ *
+ * `DATABASE_URL` is accepted in two interchangeable forms: a bare path
+ * (`/data/policy.sqlite`, as `.env.example` and the deployment docs show)
+ * and the libsql `file:` URL form (`file:/data/policy.sqlite`, as CI's
+ * `migrations` job and `drizzle.config.ts` use). `better-sqlite3` only
+ * understands bare paths, so we strip a leading `file:` here exactly the way
+ * `drizzle.config.ts` does — keeping drizzle-kit (generate/migrate/check) and
+ * the runtime connection pointed at the same file regardless of which form an
+ * operator picked. See issue #34.
+ */
+function stripFileScheme(databaseUrl: string): string {
+  return databaseUrl.replace(/^file:/, "");
+}
+
+/**
  * AdGuard Home integration, keyed on `PCT_ADGUARD_MODE`.
  *
  * The loader assembles a nested object from the flat `PCT_ADGUARD_*` env
@@ -42,8 +58,13 @@ const adguardSchema = z.discriminatedUnion("mode", [
 
 const settingsSchema = z
   .object({
-    /** Path to the SQLite policy store (better-sqlite3 / Drizzle). */
-    databaseUrl: z.string().min(1).default("/data/policy.sqlite"),
+    /**
+     * Path to the SQLite policy store (better-sqlite3 / Drizzle). Accepts a
+     * bare path or a `file:` URL; both normalize to a bare filesystem path
+     * (see {@link stripFileScheme}). The `.transform` runs after `.default`,
+     * so the default and any `file:`-prefixed value are both normalized.
+     */
+    databaseUrl: z.string().min(1).default("/data/policy.sqlite").transform(stripFileScheme),
     /** Drives pino's level (see #11). */
     logLevel: z.enum(LOG_LEVELS).default("info"),
     /**

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -30,6 +30,33 @@ describe("loadSettings", () => {
     expect(settings.secretKey).toBe("s3cret");
   });
 
+  // DATABASE_URL is accepted as a bare path or a libsql `file:` URL; both
+  // must resolve to the same bare better-sqlite3 path so drizzle-kit (CI /
+  // drizzle.config.ts) and the runtime connection never diverge. See #34.
+  describe("DATABASE_URL normalization", () => {
+    it("strips a file: scheme from an absolute path", () => {
+      expect(loadSettings({ DATABASE_URL: "file:/data/policy.sqlite" }).databaseUrl).toBe(
+        "/data/policy.sqlite",
+      );
+    });
+
+    it("strips a file: scheme from a relative path (the CI form)", () => {
+      expect(loadSettings({ DATABASE_URL: "file:./ci_migration_test.sqlite" }).databaseUrl).toBe(
+        "./ci_migration_test.sqlite",
+      );
+    });
+
+    it("leaves a bare path untouched", () => {
+      expect(loadSettings({ DATABASE_URL: "/srv/policy.sqlite" }).databaseUrl).toBe(
+        "/srv/policy.sqlite",
+      );
+    });
+
+    it("normalizes the default the same way (bare, no scheme to strip)", () => {
+      expect(loadSettings({}).databaseUrl).toBe("/data/policy.sqlite");
+    });
+  });
+
   it("rejects an invalid log level", () => {
     expect(() => loadSettings({ PCT_LOG_LEVEL: "verbose" })).toThrow(SettingsError);
   });


### PR DESCRIPTION
## Summary

- Normalize a leading `file:` scheme in the settings loader (`loadSettings`), mirroring the exact strip `drizzle.config.ts` already does, so `DATABASE_URL`'s two interchangeable forms — bare path (`/data/policy.sqlite`, used by `.env.example`/docs) and the libsql `file:` URL (`file:/data/policy.sqlite`, used by CI's migration job and `drizzle.config.ts`) — resolve to the same `better-sqlite3` path.
- Without this, Phase 2's runtime DB connection would open `settings.databaseUrl` verbatim; an operator following the CI/drizzle `file:` convention would have **migrations and the runtime point at different files**.
- `drizzle.config.ts` and CI are deliberately left untouched (Option 1 in the issue); `.env.example` and `docs/server-deployment.md` now document the single contract, and a unit test covers the `file:`-prefixed forms.

## Plan

Linked plan: `.claude/plans/issue-34-database-url-contract.md`
Roadmap: docs/roadmap.md → Phase 1 (groundwork, settling a contract before Phase 2 opens the runtime DB connection)

## Decision

The issue laid out three options; this implements **Option 1** (its recommendation): it's the smallest change, leaves the already-merged `drizzle.config.ts`/CI convention untouched, and makes the single source of truth (the settings loader) robust to both forms. No new dependency.

## License-boundary note

N/A — no transport or packaging changes. Pure config-parsing + docs; `better-sqlite3`/Drizzle relationship and the GPL process boundaries are unaffected.

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm test` all green (45 tests; `config.ts` 100% coverage, overall above the 80% gate).
- [x] New `DATABASE_URL normalization` cases: `file:`-absolute → bare, `file:`-relative (the CI form) → bare, bare path unchanged, default unchanged.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019MpjEVwK1CTz5wj4k8xKSi)_