### PR TITLE
docs(roadmap): file Phase 2 issues and sequence Phases 1–2 by dependency

### DIFF
--- a/scripts/set-roadmap-dates.sh
+++ b/scripts/set-roadmap-dates.sh
@@ -3,8 +3,8 @@
 # set-roadmap-dates.sh
 #
 # Assigns "Start date" / "End date" on the GitHub Project
-# (users/BenSeymourODB/projects/2) for the Phase-1 roadmap issues,
-# spaced over 2026-06-16 .. 2026-07-12 in dependency order.
+# (users/BenSeymourODB/projects/2) for the Phase-1 and Phase-2 roadmap
+# issues, spaced over 2026-06-16 .. 2026-08-08 in dependency order.
 #
 # This exists because the Claude Code GitHub MCP tools cannot edit
 # Projects v2 fields; run it locally with the gh CLI instead.
@@ -32,9 +32,20 @@ START_FIELD="Start date"
 END_FIELD="End date"
 
 # issue-number <TAB> start-date <TAB> end-date  (YYYY-MM-DD)
+#
+# Dependency-ordered. Phase 1 is largely merged already; its rows are kept
+# for the historical record. Phase 2 is sequenced behind the two Phase-1
+# decisions that gate it — #17 (timezone → User.tz) and #34 (DATABASE_URL
+# contract) — both of which have no blockers of their own and should land
+# first. Critical path through Phase 2:
+#   (#17, #34) -> #48 schema -> #49 runtime DB -> #52 auth -> #51 CRUD -> #53 UI
+# with #50 (API foundation) running parallel to #48, #54 (stub push) after
+# #51, and #40 (static mount) any time before #53.
 read -r -d '' SCHEDULE <<'EOF' || true
+# --- Phase 1 (scaffolding; mostly merged) ---
 17	2026-06-16	2026-06-17
 5	2026-06-16	2026-06-19
+34	2026-06-17	2026-06-19
 10	2026-06-17	2026-06-20
 9	2026-06-20	2026-06-22
 13	2026-06-20	2026-06-24
@@ -45,6 +56,16 @@ read -r -d '' SCHEDULE <<'EOF' || true
 6	2026-06-29	2026-07-04
 15	2026-07-04	2026-07-07
 7	2026-07-07	2026-07-12
+# --- Phase 2 (policy store, JSON API, admin UI shell) ---
+40	2026-07-12	2026-07-14
+48	2026-07-14	2026-07-18
+50	2026-07-14	2026-07-17
+49	2026-07-18	2026-07-21
+39	2026-07-21	2026-07-23
+52	2026-07-21	2026-07-25
+51	2026-07-25	2026-07-31
+54	2026-07-31	2026-08-02
+53	2026-08-01	2026-08-08
 EOF
 
 echo "Resolving project $OWNER/projects/$PROJECT_NUMBER ..."
@@ -66,6 +87,7 @@ ITEMS_JSON=$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format js
 
 while IFS=$'\t' read -r ISSUE START END; do
   [[ -z "${ISSUE:-}" ]] && continue
+  [[ "${ISSUE}" == \#* ]] && continue   # skip section-header comment lines
   ITEM_ID=$(echo "$ITEMS_JSON" | jq -r --argjson n "$ISSUE" '.items[] | select(.content.number==$n) | .id')
   if [[ -z "$ITEM_ID" || "$ITEM_ID" == "null" ]]; then
     echo "Issue #$ISSUE is not on project $PROJECT_NUMBER yet — add it, then re-run. Skipping." >&2


### PR DESCRIPTION
## What

A review pass over the Phase 1 / Phase 2 roadmap issues. Phase 1 scaffolding is
essentially merged (the `/`+`/healthz` app #5, Dockerfile #6, compose #7,
drizzle scaffold #9, settings #10, pino #11, test helpers #12, frontend
scaffold #13), but **the substance of Phase 2 had no issues at all** — the
policy `schema.ts` is intentionally `export {}` and the `api`/`policy` modules
are stubs. This fills that gap and sequences both phases.

## New Phase-2 issues filed

- **#48** — Drizzle policy schema + first real table migration
- **#49** — Runtime SQLite connection (better-sqlite3 + Drizzle) + migrate-on-start
- **#50** — API foundation: zod DTOs, shared error envelope, validation plumbing
- **#51** — `/api/*` policy CRUD endpoints for the full policy model
- **#52** — Single-admin auth (Argon2) + signed session + **first-admin bootstrap**
- **#53** — SvelteKit admin UI (`/admin/*`): policy editors
- **#54** — Stub transport push (log-only) on policy change

## Un-owned blockers surfaced (not just roadmap bullets)

- **Runtime DB connection (#49)** — nothing currently opens `settings.databaseUrl`;
  #39 only deferred the *entrypoint* migration. #49 owns the live `app.db` and
  reconciles with #39 so they don't double-migrate.
- **API error/validation envelope (#50)** — the shared `/api/*` contract needs a
  consistent error shape before routes land, since the PWA and integrators
  depend on it too.
- **First-admin bootstrap (#52)** — the docs promise "single-admin local password
  auth" but never say how the initial password is set. #52 must define and
  document that path.

## Dependency order (this PR)

The only code change is `scripts/set-roadmap-dates.sh` (the documented mechanism
for setting the project's Start/End date fields, which the GitHub MCP tools
can't edit). It now carries both phases in dependency order:

```
(#17, #34) -> #48 -> #49 -> #52 -> #51 -> #53
              #50 ‖ #48,  #54 after #51,  #40 before #53
```

Each new issue and the two existing Phase-2 issues (#39, #40) got a
"Dependencies & blockers" section in the repo's house style; the two gating
Phase-1 decisions (#17 timezone, #34 `DATABASE_URL`) got comments resolving
their "forthcoming Phase 2 issue" references to #48/#49.

## Notes

- #17 and #34 are `decision-needed` and on the critical path — they have no
  blockers and should be resolved first. I have **not** decided them.
- #5 is effectively complete (its code is merged) but its issue is still open —
  worth closing, left untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_019FJ8ZTRHpC9uLNbEhdn5ns)_