### PR TITLE
docs: decide timezone strategy — UTC internally, per-user TZ overrides (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ server. See [`docs/client-install.md`](docs/client-install.md).
 | [`docs/client-install.md`](docs/client-install.md) | Client enrollment script design and Linux Mint specifics. |
 | [`docs/client-notifications.md`](docs/client-notifications.md) | Client-side toast/sound notifications, time-remaining cadence, grace period, and end-of-budget enforcement (`pct-client` agent design). |
 | [`docs/roadmap.md`](docs/roadmap.md) | Phased milestone plan; the basis for GitHub issues. |
+| [`docs/adr/`](docs/adr/) | Architecture decision records. ADR 0001 fixes the timezone strategy (UTC internally, server-default TZ with per-user overrides). |
 | [`CLAUDE.md`](CLAUDE.md) | Guidance for AI coding agents working in this repo. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Local dev loop: setup, pre-commit hooks, the quality gate, tests, the frontend loop, and branch/PR conventions. |
 

--- a/docs/adr/0001-budget-timezone.md
+++ b/docs/adr/0001-budget-timezone.md
@@ -1,0 +1,108 @@
+# ADR 0001 — Timezone strategy for daily budget rollover
+
+- **Status:** Accepted (2026-06-16)
+- **Issue:** [#17](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/17)
+- **Phase:** 1 (decision); affects Phase 2 (`User` schema and every budget query)
+
+## Context
+
+"How much time does Alice have left **today**?" only has a precise answer
+once we pick a timezone. Daily, weekly, and monthly budget windows all
+roll over at a wall-clock boundary, so the answer to "when does *today*
+end" is load-bearing for every budget rollup, burndown view, and
+enforcement decision. The decision touches the `User` schema, so it has
+to land before the Phase 2 schema work ([#48](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/48)).
+
+Three options were on the table (issue #17):
+
+- **A. Single server TZ via env var** (e.g. `PCT_TZ=America/New_York`).
+  Simplest; sufficient for a single-household, single-timezone
+  deployment, but cannot express a child or parent in a different zone.
+- **B. Per-user TZ column** on `User`. Flexible (kids in different
+  timezones, a travelling parent) but every budget rollup has to honour
+  it.
+- **C. UTC everywhere internally, surface in a configured display TZ.**
+  Cleanly separates storage from presentation, but does not by itself
+  answer "when does *today* end" — that is a policy question layered on
+  top of storage.
+
+These options are not mutually exclusive: A and B are about *which*
+timezone defines a user's day; C is about *how timestamps are stored*.
+
+## Decision
+
+Adopt **C as the storage rule and B as the budget-window rule, with A as
+the default source for B**:
+
+1. **UTC everywhere internally.** Every timestamp the server persists,
+   computes with, logs, or puts on the wire (`UsageSample.started_at` /
+   `ended_at`, `Grant.granted_at` / `expires_at`, audit-log entries,
+   `last_seen`, event-stream payloads, the JSON API) is UTC. Storage and
+   computation never depend on a local-time interpretation.
+
+2. **A server-default timezone, with per-user overrides.** The server
+   carries a default IANA timezone (`PCT_DEFAULT_TZ`, e.g.
+   `America/New_York`). Each `User` gets a nullable `tz` column; when it
+   is `NULL` the user inherits the server default. The user's *effective*
+   timezone is `User.tz ?? PCT_DEFAULT_TZ`.
+
+3. **The effective timezone defines budget windows.** "Today", "this
+   week", and "this month" — i.e. when a daily/weekly/monthly budget
+   rolls over — are computed by converting the relevant UTC instants into
+   the user's effective timezone and taking the local calendar boundary.
+   The budget window is the only place local time enters the computation;
+   everything underneath stays UTC.
+
+4. **TZ is a presentation/windowing concern, never a storage format.**
+   Frontends and integrators receive UTC instants (ISO 8601 with a `Z`
+   offset) plus the user's effective timezone, and render local time
+   client-side. The server does not store local-time strings.
+
+### Explicitly deferred
+
+A user **changing timezone mid-window** — e.g. moving house or going on
+vacation partway through a day of usage — is out of scope for this
+decision. Changing `User.tz` (or `PCT_DEFAULT_TZ`) takes effect from the
+next window boundary; the behaviour of the in-flight day is unspecified
+and may shift a budget boundary under the user. This edge case is tracked
+in [#56](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/56)
+and is acceptable for the target single-household deployment.
+
+## Consequences
+
+- **Schema:** `User` gains a nullable `tz` column (IANA name, e.g.
+  `America/New_York`). The Phase 2 schema issue ([#48](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/48))
+  defines it; the policy-model sketch in
+  [`architecture.md`](../architecture.md) is updated to match.
+- **Config:** a new `PCT_DEFAULT_TZ` server setting (IANA name) supplies
+  the default for users without an override. It must validate as a real
+  IANA zone at startup.
+- **Budget queries:** every daily/weekly/monthly rollup resolves the
+  user's effective timezone and computes the window boundary in it. This
+  is the one local-time-aware step; it should live in a single shared
+  helper so the rule is applied consistently (burndown views,
+  enforcement checks, grant expiry).
+- **Grants:** `Grant.expires_at` stays UTC. A grant that "expires at end
+  of day" is computed by the issuer (or the dashboard) as the UTC instant
+  of the user's local end-of-day; storage stays UTC.
+- **Validation:** timezone inputs (`PCT_DEFAULT_TZ`, `User.tz`) are
+  validated against the IANA database (available via
+  `Intl.supportedValuesOf('timeZone')` on Node 22) before they cross into
+  typed code, per the zod-at-the-boundary convention in `CLAUDE.md`.
+- **Clock skew** (see [`architecture.md`](../architecture.md) → "Failure
+  modes"): unchanged in substance — clients NTP-sync and the server
+  reconciles against client-reported `UsageSample` end-times — but the
+  reconciliation is now unambiguous because both sides agree on UTC.
+
+## Alternatives not chosen
+
+- **A alone** was rejected because it cannot represent a child or parent
+  in a different timezone, and retrofitting per-user zones later would
+  touch the same `User` schema and every budget query we are designing
+  now — cheaper to add the nullable column up front.
+- **B alone** (no UTC storage rule) was rejected because mixing
+  local-time storage with per-user zones makes reconciliation against
+  client telemetry and audit reasoning error-prone. C is what makes B
+  safe.
+- **Full mid-window TZ migration support** was rejected as scope for now;
+  see "Explicitly deferred".

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,11 @@ entities (final schema lives in `server/src/policy/schema.ts`
 once implementation begins):
 
 ```
-User          (id, display_name)
+User          (id, display_name, tz?)
+              --  tz is a nullable IANA timezone (e.g. America/New_York);
+              --  NULL means "inherit the server default" (PCT_DEFAULT_TZ).
+              --  The user's effective TZ defines daily/weekly/monthly
+              --  budget rollover. See docs/adr/0001-budget-timezone.md.
 Client        (id, hostname, ssh_user, enrolled_at, last_seen)
 UserOnClient  (user_id, client_id, linux_username, linux_uid)
 
@@ -141,6 +145,23 @@ NotificationPolicy (user_id, enabled, sound_profile,
                   experience; pushed to the client and cached there
                   (see docs/client-notifications.md)
 ```
+
+### Timezones and budget rollover
+
+All timestamps are stored, computed, logged, and transmitted in **UTC** —
+`UsageSample` times, `Grant` times, audit entries, `last_seen`, and the
+JSON API / event-stream payloads. Local time enters in exactly one place:
+deciding when a daily/weekly/monthly budget *rolls over*. That boundary is
+computed in the user's **effective timezone** — `User.tz` if set,
+otherwise the server default `PCT_DEFAULT_TZ` — so "how much does Alice
+have left today?" has a precise answer without ever storing local-time
+strings.
+
+The mid-window case (a user changing timezone partway through a day, e.g.
+moving house or on vacation) is deliberately out of scope; changing `tz`
+takes effect from the next window boundary. The full rationale, the
+options weighed, and this deferral are in
+[`docs/adr/0001-budget-timezone.md`](adr/0001-budget-timezone.md).
 
 Key derived views the dashboard renders:
 
@@ -263,6 +284,10 @@ webhook URL.
   means no consumption credited, not punitive deduction).
 - **Clock skew** — clients NTP-sync; budgets compute on the server clock
   but reconcile with `UsageSample` end-times reported by the client.
+  Both sides agree on UTC, so reconciliation is unambiguous; only the
+  budget *rollover* boundary is interpreted in the user's effective
+  timezone (see "Timezones and budget rollover" above and
+  [`docs/adr/0001-budget-timezone.md`](adr/0001-budget-timezone.md)).
 - **Tamper attempt on client** — periodic Ansible re-application of the
   desired state reverts unauthorised edits. Audit log records each
   reversion.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -48,7 +48,10 @@ and, later, the PWA and external integrators).
 
 - Implement the SQLite schema for `User`, `Client`, `UserOnClient`,
   `Activity`, `ActivityGroup`, `Budget`, `Schedule`, `Exception`,
-  `Grant`, `IntegrationToken`.
+  `Grant`, `IntegrationToken`. `User` carries a nullable `tz` column
+  (timezone strategy decided in
+  [`docs/adr/0001-budget-timezone.md`](adr/0001-budget-timezone.md);
+  UTC internally, server-default TZ with per-user overrides).
 - drizzle-kit migrations.
 - Single-admin local password auth (Argon2) for the admin UI.
 - **`/api/*` JSON endpoints** for the full policy model (the admin UI


### PR DESCRIPTION
## What

Resolves the timezone-strategy decision in #17 and records it as an ADR.

**Decision:** UTC everywhere internally; daily/weekly/monthly budget
rollover is computed in the user's **effective** timezone — `User.tz` if
set, otherwise a server default `PCT_DEFAULT_TZ`. This combines Option C
(UTC storage) as the storage rule with Option B (per-user TZ) as the
budget-window rule, defaulting from Option A (single server TZ).

The edge case of a user **changing timezone mid-window** (moving house, or
travelling part-way through a day) is explicitly deferred and tracked in
#56.

## Changes

- **`docs/adr/0001-budget-timezone.md`** (new) — the decision, the options
  weighed, consequences, and the explicit deferral. Establishes the
  `docs/adr/` convention.
- **`docs/architecture.md`** — adds the nullable `tz` column to the `User`
  sketch in the policy model, a new "Timezones and budget rollover"
  subsection, and a clock-skew cross-reference.
- **`docs/roadmap.md`** — notes the `tz` column on the Phase 2 `User`
  schema work (#48 can now proceed against a decided strategy).
- **`README.md`** — lists `docs/adr/` in the documentation index.

## Acceptance criteria (from #17)

- [x] Decision recorded in an ADR (`docs/adr/0001-budget-timezone.md`).
- [x] Policy-model sketch in `architecture.md` updated to add a `tz`
  column on `User` (Option B is part of the decision).
- [x] The Phase 2 `User` schema issue (#48) can link to this decision.

Docs-only change; no code paths touched.

Closes #17

https://claude.ai/code/session_01EBybKriHyMdkZVgt3f2wDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBybKriHyMdkZVgt3f2wDK)_