### PR TITLE
feat(web): serve the SvelteKit build at /admin and /app (#40)

### DIFF
--- a/.claude/plans/issue-40-serve-sveltekit-static-mount.md
+++ b/.claude/plans/issue-40-serve-sveltekit-static-mount.md
@@ -1,0 +1,81 @@
+# Issue #40 — Serve the SvelteKit build via `@fastify/static` at `/admin` and `/app`
+
+Roadmap: `docs/roadmap.md` → Phase 2.
+
+## Goal
+
+Wire the Fastify `web` module to serve the prerendered SvelteKit build
+(`adapter-static` output) at the `/admin` and `/app` surfaces, plus its
+shared `_app/…` assets, without shadowing the existing `GET /`
+("hello, no policy yet") or `/healthz` routes.
+
+## Constraints from the issue + repo conventions
+
+- `@fastify/static` is already a dependency — no new dep.
+- Asset root must be **configurable** (default the in-image `/app/frontend`
+  path the Dockerfile copies the build into) so unit tests can point the
+  mount at a fixture directory.
+- Static-asset requests flow through the existing pino request logging
+  (`web/logger.ts`, #11). Any helper logs via the component child logger,
+  never `console.*`.
+- `GET /` and unknown routes behave as today.
+- `adapter-static` (prerender entries `/admin`, `/app`) emits
+  `build/admin.html`, `build/app.html`, shared `build/_app/…`, and static
+  files (e.g. `favicon.png`).
+- License boundary: N/A — pure Node/Fastify static serving, no GPL touch.
+
+## Design
+
+### 1. Config (`src/config.ts`)
+Add `frontendRoot: z.string().min(1).default("/app/frontend")`, sourced from
+`PCT_FRONTEND_ROOT`. Default matches the Dockerfile copy target
+(`COPY --from=frontend-builder /app/frontend/build ./frontend`, WORKDIR
+`/app`).
+
+### 2. Frontend plugin (`src/web/frontend.ts`)
+A small Fastify plugin `registerFrontend(app, settings)`:
+- If `settings.frontendRoot` does not exist on disk, log a warning via
+  `componentLogger(app, "web/frontend")` and **skip** the mount. This keeps
+  `buildApp()` usable in dev/CI where no build is present (the existing tests
+  call `buildApp()` with the default `/app/frontend`, which won't exist), and
+  matches reality: the runtime image always has the build.
+- Otherwise register an encapsulated plugin that:
+  - `register(fastifyStatic, { root, prefix: "/", index: false })` so shared
+    assets (`/_app/*`, `/favicon.png`, …) are served at the root, and
+    `reply.sendFile` is decorated in that scope.
+  - adds `GET /admin` (+ `/admin/`) → `reply.sendFile("admin.html")` and
+    `GET /app` (+ `/app/`) → `reply.sendFile("app.html")`.
+
+Route precedence: the static plugin registers the wildcard `GET /*`; the
+exact `GET /` and `GET /healthz` on the parent app win over it, so the landing
+page and probe are unaffected. The explicit `/admin` / `/app` routes win over
+the wildcard too. `index: false` stops `@fastify/static` from registering its
+own `GET /` (which would collide).
+
+### 3. Wire into `buildApp()`
+Call `registerFrontend(app, settings)` after the `/` and `/healthz` routes.
+`app.register(...)` is queued and resolved at `ready()`/`inject()` time, so
+`buildApp()` stays synchronous.
+
+## Tests (`tests/web/frontend.test.ts`)
+Build a temp fixture dir (`admin.html`, `app.html`, `_app/immutable/x.js`,
+`favicon.png`), point `PCT_FRONTEND_ROOT` at it, and assert via `app.inject()`:
+- `GET /admin` → 200, `text/html`, admin marker in body.
+- `GET /app` → 200, `text/html`, app marker.
+- `GET /_app/immutable/x.js` → 200, asset content.
+- `GET /favicon.png` → 200.
+- `GET /` → still `hello, no policy yet` (not shadowed).
+- `GET /healthz` → ok.
+- `GET /nope` → 404.
+- Missing-root case: `PCT_FRONTEND_ROOT` at a nonexistent path → `buildApp()`
+  works, `GET /admin` → 404, `GET /` still works, and a `web/frontend` warning
+  is emitted (capture via `loggerStream`).
+
+## Docs
+- `.env.example`: document `PCT_FRONTEND_ROOT`.
+- `server/frontend/README.md`: mark the static mount as landed.
+- `docs/server-deployment.md`: note the mount if env vars are listed there.
+
+## Out of scope (deferred)
+- Real `/admin` editors and `/app` PWA screens (#53 / Phase 9).
+- E2E/Playwright harness (own roadmap item).

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@
 # so drizzle-kit and the runtime always open the same file.
 # DATABASE_URL=/data/policy.sqlite
 
+# Filesystem root of the prerendered SvelteKit build served at /admin and
+# /app. Defaults to the in-image path the Dockerfile copies the build into;
+# override only for local dev (e.g. point at server/frontend/build). If the
+# path is absent the mount is skipped and those surfaces 404.
+# PCT_FRONTEND_ROOT=/app/frontend
+
 # pino log level: trace | debug | info | warn | error | fatal | silent
 # PCT_LOG_LEVEL=info
 

--- a/server/frontend/README.md
+++ b/server/frontend/README.md
@@ -25,9 +25,16 @@ server/frontend/build/
 route is not prerenderable — the runtime image is a plain static file server
 for these assets and has **no Node frontend toolchain**. The Docker builder
 stage (#6) runs this build and copies the output into the runtime image
-(under `/app/frontend`); the Fastify `web` module will mount `build/` and
-serve it at `/admin` and `/app` (the live static mount lands in Phase 2 with
-the real UI).
+(under `/app/frontend`); the Fastify `web` module mounts that directory via
+`@fastify/static` and serves it at `/admin` and `/app` (the live static mount
+landed in Phase 2, #40 — see `server/src/web/frontend.ts`).
+
+The mount root is `PCT_FRONTEND_ROOT` (default `/app/frontend`), so local dev
+can point it at `server/frontend/build`. The slash-free surface URLs
+(`/admin`, `/app`) serve `admin.html` / `app.html`; the trailing-slash forms
+redirect to them so the pages' relative asset paths (`./_app/…`) resolve
+correctly. If the directory is absent the mount is skipped (the surfaces 404)
+rather than failing startup. `/` and `/api/*` stay owned by the backend.
 
 `build/` is git-ignored (by both the repo-root `.gitignore` and the local
 `server/frontend/.gitignore`) — it is a build artefact, produced at
@@ -40,10 +47,10 @@ prerenders everything to static HTML/JS/CSS, so there is nothing to "wire
 pino into" on the frontend itself. The only server that ever handles an
 `/admin` or `/app` request is Fastify.
 
-When the `web` module mounts `build/` via `@fastify/static` (Phase 2),
-those static-asset requests flow through the **same** request logging the
-backend already configures (`server/src/web/logger.ts`, #11) — no
-frontend-specific logging setup is needed or wanted:
+The `web` module mounts `build/` via `@fastify/static` (#40), so those
+static-asset requests flow through the **same** request logging the backend
+already configures (`server/src/web/logger.ts`, #11) — no frontend-specific
+logging setup is needed or wanted:
 
 - Each request carries a `reqId` (an inbound `X-Request-Id` header is
   honoured, otherwise a UUID is generated), so a request for an `/admin`

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -65,6 +65,15 @@ const settingsSchema = z
      * so the default and any `file:`-prefixed value are both normalized.
      */
     databaseUrl: z.string().min(1).default("/data/policy.sqlite").transform(stripFileScheme),
+    /**
+     * Filesystem root of the prerendered SvelteKit build served at `/admin`
+     * and `/app` (#40). Defaults to the in-image path the Dockerfile copies
+     * the `adapter-static` output into (`COPY … ./frontend` under WORKDIR
+     * `/app`). Overridable via `PCT_FRONTEND_ROOT` so dev and tests can point
+     * the mount at a different directory; if the path is absent the mount is
+     * skipped (the surfaces 404) rather than failing startup.
+     */
+    frontendRoot: z.string().min(1).default("/app/frontend"),
     /** Drives pino's level (see #11). */
     logLevel: z.enum(LOG_LEVELS).default("info"),
     /**
@@ -125,6 +134,7 @@ export class SettingsError extends Error {
 export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
   const result = settingsSchema.safeParse({
     databaseUrl: env.DATABASE_URL,
+    frontendRoot: env.PCT_FRONTEND_ROOT,
     logLevel: env.PCT_LOG_LEVEL,
     logPretty: env.PCT_LOG_PRETTY,
     secretKey: env.PCT_SECRET_KEY,

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -5,12 +5,14 @@
  * construct isolated instances and exercise routes via `app.inject()`
  * without binding a socket — see docs/testing.md → "HTTP routes".
  *
- * This is the minimal Phase 1 slice: a "hello, no policy yet" landing
- * route and a `/healthz` probe, plus the shared pino logging configuration
- * (#11). The policy/api/integrations mounts land in later phases.
+ * Beyond the Phase 1 slice — a "hello, no policy yet" landing route and a
+ * `/healthz` probe, plus the shared pino logging configuration (#11) — this
+ * now also mounts the prerendered SvelteKit build at `/admin` and `/app`
+ * (#40). The policy/api/integrations mounts land in later phases.
  */
 import Fastify, { type FastifyInstance } from "fastify";
 import { loadSettings, type Settings } from "../config.js";
+import { registerFrontend } from "./frontend.js";
 import { REQUEST_ID_HEADER, buildLoggerOptions, genRequestId, type LogStream } from "./logger.js";
 
 /** Options for {@link buildApp}. */
@@ -49,6 +51,11 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   app.get("/healthz", async () => {
     return { status: "ok" };
   });
+
+  // Serve the prerendered SvelteKit build at /admin and /app (#40). Skipped
+  // (with a warning) when the build directory is absent, so /, /healthz, and
+  // unknown routes are unaffected.
+  registerFrontend(app, settings);
 
   return app;
 }

--- a/server/src/web/frontend.ts
+++ b/server/src/web/frontend.ts
@@ -1,0 +1,96 @@
+/**
+ * Serve the prerendered SvelteKit build at the `/admin` and `/app` surfaces
+ * (#40).
+ *
+ * The frontend is one SvelteKit project built with `adapter-static`
+ * (`server/frontend/`, see `CLAUDE.md` → frontend split). Its prerender
+ * crawler is pointed at `/admin` and `/app`, so the build emits:
+ *
+ * - `admin.html` and `app.html` — the two surface entry pages,
+ * - `_app/…` — the shared, hashed JS/CSS chunks both pages reference,
+ * - any files under `static/` (e.g. `favicon.png`).
+ *
+ * `@fastify/static` serves files by URL path, so the hashed assets and static
+ * files map one-to-one (`GET /_app/immutable/x.js` → `<root>/_app/immutable/x.js`).
+ * The two extensionless surface URLs do not, so they get explicit routes that
+ * send the matching `*.html`. `/` and `/healthz` (and, in a later phase,
+ * `/api/*`) stay owned by the backend: the exact and more-specific routes win
+ * over the static plugin's `GET /*` wildcard, and `index: false` stops the
+ * plugin from registering its own `GET /` (which would collide with the
+ * landing route).
+ *
+ * The prerendered pages reference their assets with **relative** URLs
+ * (`./_app/…`), which only resolve to `/_app/…` when the document is served at
+ * the canonical, slash-free surface URL. So the trailing-slash form redirects
+ * to the canonical one (a permanent 308) rather than serving the same HTML
+ * under a base path that would make every asset 404 in the browser. This also
+ * matches the frontend's `trailingSlash: 'never'` default.
+ *
+ * Static-asset requests flow through the same pino request logging the app
+ * already configures (`./logger.ts`, #11) — there is no frontend-specific
+ * logger. The only non-request line here is a startup warning, emitted via the
+ * shared component child logger rather than `console.*`.
+ *
+ * License boundary: none touched — this is plain Fastify static file serving.
+ */
+import { existsSync } from "node:fs";
+import fastifyStatic from "@fastify/static";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import type { Settings } from "../config.js";
+import { componentLogger } from "./logger.js";
+
+/** Maps each served surface URL to its prerendered entry page. */
+const SURFACES: readonly { url: string; page: string }[] = [
+  { url: "/admin", page: "admin.html" },
+  { url: "/app", page: "app.html" },
+];
+
+/**
+ * Mount the prerendered frontend build at `/admin` and `/app`.
+ *
+ * If `settings.frontendRoot` does not exist (dev/CI without a build, or a
+ * misconfigured deployment), the mount is skipped with a warning and the
+ * surfaces 404 — startup is never blocked on the presence of build output.
+ * The runtime image always carries the build, so this is the normal path
+ * there; tests point `frontendRoot` at a fixture directory.
+ */
+export function registerFrontend(app: FastifyInstance, settings: Settings): void {
+  const root = settings.frontendRoot;
+
+  if (!existsSync(root)) {
+    componentLogger(app, "web/frontend").warn(
+      { frontendRoot: root },
+      "frontend build not found; /admin and /app will 404 until it is present",
+    );
+    return;
+  }
+
+  // Encapsulate the static plugin and the surface routes in one scope so the
+  // `reply.sendFile` decoration the plugin adds is visible to the routes that
+  // use it. Route registration itself stays global, so the surfaces remain
+  // reachable from the parent app.
+  app.register(async (scope) => {
+    await scope.register(fastifyStatic, {
+      root,
+      prefix: "/",
+      // The landing route owns `GET /`; let the surface routes below own the
+      // two HTML entry points. `index: false` keeps the plugin from claiming
+      // either.
+      index: false,
+    });
+
+    for (const { url, page } of SURFACES) {
+      // Canonical URL: serve the prerendered entry page.
+      scope.get(
+        url,
+        (_request: FastifyRequest, reply: FastifyReply): FastifyReply => reply.sendFile(page),
+      );
+      // Trailing-slash form: redirect to the canonical URL so the page's
+      // relative asset paths resolve against `/` rather than `/<surface>/`.
+      scope.get(
+        `${url}/`,
+        (_request: FastifyRequest, reply: FastifyReply): FastifyReply => reply.redirect(url, 308),
+      );
+    }
+  });
+}

--- a/server/src/web/frontend.ts
+++ b/server/src/web/frontend.ts
@@ -87,10 +87,12 @@ export function registerFrontend(app: FastifyInstance, settings: Settings): void
       );
       // Trailing-slash form: redirect to the canonical URL so the page's
       // relative asset paths resolve against `/` rather than `/<surface>/`.
-      scope.get(
-        `${url}/`,
-        (_request: FastifyRequest, reply: FastifyReply): FastifyReply => reply.redirect(url, 308),
-      );
+      // Preserve any query string so client-side state survives the redirect.
+      scope.get(`${url}/`, (request: FastifyRequest, reply: FastifyReply): FastifyReply => {
+        const queryStart = request.url.indexOf("?");
+        const target = queryStart === -1 ? url : url + request.url.slice(queryStart);
+        return reply.redirect(target, 308);
+      });
     }
   });
 }

--- a/server/tests/web/frontend.test.ts
+++ b/server/tests/web/frontend.test.ts
@@ -72,10 +72,28 @@ describe("frontend static mount (build present)", () => {
     expect(appSurface.headers["location"]).toBe("/app");
   });
 
-  it("serves shared _app assets at their hashed path", async () => {
+  it("redirects the trailing-slash form preserving the query string", async () => {
+    const res = await app.inject({ method: "GET", url: "/admin/?tab=users" });
+    expect(res.statusCode).toBe(308);
+    expect(res.headers["location"]).toBe("/admin?tab=users");
+  });
+
+  it("serves shared _app assets with a JS content-type", async () => {
     const res = await app.inject({ method: "GET", url: "/_app/immutable/chunk.js" });
     expect(res.statusCode).toBe(200);
     expect(res.body).toBe(CHUNK_JS);
+    expect(res.headers["content-type"]).toContain("javascript");
+  });
+
+  it("answers HEAD on a surface URL", async () => {
+    const res = await app.inject({ method: "HEAD", url: "/admin" });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/html");
+  });
+
+  it("404s a non-GET method on a surface URL", async () => {
+    const res = await app.inject({ method: "POST", url: "/admin" });
+    expect(res.statusCode).toBe(404);
   });
 
   it("serves root-level static files (e.g. favicon.png)", async () => {
@@ -130,8 +148,10 @@ describe("frontend static mount (build absent)", () => {
     expect(landing.statusCode).toBe(200);
     expect(landing.body).toBe("hello, no policy yet");
 
-    const warning = lines.find((l) => l.component === "web/frontend" && typeof l.msg === "string");
+    const warning = lines.find((l) => l.component === "web/frontend");
     expect(warning).toBeDefined();
+    expect(warning?.level).toBe(40); // pino "warn"
     expect(warning?.frontendRoot).toBe(missingRoot);
+    expect(warning?.msg).toContain("not found");
   });
 });

--- a/server/tests/web/frontend.test.ts
+++ b/server/tests/web/frontend.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Static-mount tests for the SvelteKit build surfaces (#40).
+ *
+ * Builds a throwaway fixture directory shaped like `adapter-static` output
+ * (`admin.html`, `app.html`, a hashed `_app/…` chunk, a static file) and
+ * points `PCT_FRONTEND_ROOT` at it, then exercises the mount via
+ * `app.inject()` — no sockets, per docs/testing.md → "HTTP routes".
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../../src/web/app.js";
+import { loadSettings } from "../../src/config.js";
+
+const ADMIN_HTML = "<!doctype html><title>admin</title><div id=admin-marker>";
+const APP_HTML = "<!doctype html><title>app</title><div id=app-marker>";
+const CHUNK_JS = "export const x = 1; // hashed _app chunk";
+const FAVICON = "fake-png-bytes";
+
+/** Write a fixture directory shaped like the prerendered build output. */
+function makeFixtureBuild(): string {
+  const root = mkdtempSync(join(tmpdir(), "pct-frontend-"));
+  writeFileSync(join(root, "admin.html"), ADMIN_HTML);
+  writeFileSync(join(root, "app.html"), APP_HTML);
+  writeFileSync(join(root, "favicon.png"), FAVICON);
+  mkdirSync(join(root, "_app", "immutable"), { recursive: true });
+  writeFileSync(join(root, "_app", "immutable", "chunk.js"), CHUNK_JS);
+  return root;
+}
+
+describe("frontend static mount (build present)", () => {
+  let app: FastifyInstance;
+  let root: string;
+
+  beforeEach(() => {
+    root = makeFixtureBuild();
+    app = buildApp({
+      settings: loadSettings({ PCT_LOG_LEVEL: "silent", PCT_FRONTEND_ROOT: root }),
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("serves admin.html as HTML at /admin", async () => {
+    const res = await app.inject({ method: "GET", url: "/admin" });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/html");
+    expect(res.body).toContain("admin-marker");
+  });
+
+  it("serves app.html as HTML at /app", async () => {
+    const res = await app.inject({ method: "GET", url: "/app" });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/html");
+    expect(res.body).toContain("app-marker");
+  });
+
+  it("redirects the trailing-slash form to the canonical surface URL", async () => {
+    // The pages reference assets relatively (`./_app/…`); a redirect keeps the
+    // browser at the slash-free URL so those resolve to `/_app/…`, not 404.
+    const admin = await app.inject({ method: "GET", url: "/admin/" });
+    expect(admin.statusCode).toBe(308);
+    expect(admin.headers["location"]).toBe("/admin");
+
+    const appSurface = await app.inject({ method: "GET", url: "/app/" });
+    expect(appSurface.statusCode).toBe(308);
+    expect(appSurface.headers["location"]).toBe("/app");
+  });
+
+  it("serves shared _app assets at their hashed path", async () => {
+    const res = await app.inject({ method: "GET", url: "/_app/immutable/chunk.js" });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe(CHUNK_JS);
+  });
+
+  it("serves root-level static files (e.g. favicon.png)", async () => {
+    const res = await app.inject({ method: "GET", url: "/favicon.png" });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe(FAVICON);
+  });
+
+  it("does not shadow the backend's own routes", async () => {
+    const landing = await app.inject({ method: "GET", url: "/" });
+    expect(landing.statusCode).toBe(200);
+    expect(landing.body).toBe("hello, no policy yet");
+    expect(landing.headers["content-type"]).toContain("text/plain");
+
+    const health = await app.inject({ method: "GET", url: "/healthz" });
+    expect(health.statusCode).toBe(200);
+    expect(health.json()).toEqual({ status: "ok" });
+  });
+
+  it("404s an asset that does not exist in the build", async () => {
+    const res = await app.inject({ method: "GET", url: "/nope" });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("frontend static mount (build absent)", () => {
+  let app: FastifyInstance;
+  const missingRoot = join(tmpdir(), "pct-frontend-does-not-exist-40");
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("warns and skips the mount without blocking startup", async () => {
+    const lines: Record<string, unknown>[] = [];
+    const stream = {
+      write(msg: string) {
+        lines.push(JSON.parse(msg) as Record<string, unknown>);
+      },
+    };
+    app = buildApp({
+      settings: loadSettings({ PCT_LOG_LEVEL: "warn", PCT_FRONTEND_ROOT: missingRoot }),
+      loggerStream: stream,
+    });
+
+    // The surfaces 404 because nothing is mounted...
+    const admin = await app.inject({ method: "GET", url: "/admin" });
+    expect(admin.statusCode).toBe(404);
+
+    // ...but the backend's own routes still work.
+    const landing = await app.inject({ method: "GET", url: "/" });
+    expect(landing.statusCode).toBe(200);
+    expect(landing.body).toBe("hello, no policy yet");
+
+    const warning = lines.find((l) => l.component === "web/frontend" && typeof l.msg === "string");
+    expect(warning).toBeDefined();
+    expect(warning?.frontendRoot).toBe(missingRoot);
+  });
+});


### PR DESCRIPTION
## Summary

- Mount the prerendered `adapter-static` frontend build via `@fastify/static` so the `/admin` and `/app` surfaces are served by the Fastify process — the seam the real Phase-2 admin UI (#53) plugs into.
- `registerFrontend(app, settings)` serves `admin.html` / `app.html` at the slash-free surface URLs and the shared `_app/…` assets + static files at the root, leaving `GET /` and `/healthz` (and future `/api/*`) owned by the backend. Trailing-slash forms `308`-redirect (preserving the query string) to the canonical URL so the pages' **relative** asset paths (`./_app/…`) resolve against `/` rather than `/<surface>/` (where they would 404 in the browser).
- Asset root is configurable via `PCT_FRONTEND_ROOT` (default the in-image `/app/frontend` the Dockerfile copies the build into); an absent path skips the mount with a warning rather than failing startup, keeping `buildApp()` usable in dev/CI without a build.

## Plan

Linked plan: `.claude/plans/issue-40-serve-sveltekit-static-mount.md`
Roadmap: `docs/roadmap.md` → Phase 2

## License-boundary note

N/A — no transport or packaging changes. This is plain Fastify static file serving of our own SvelteKit output; no GPL code is imported and no binaries are added to the image. `@fastify/static` was already a project dependency, so no new dependency is introduced.

## Implementation notes

- The prerendered pages emit asset references as **relative** URLs (`./_app/…`), verified by building the frontend (`npm run build` → `build/admin.html`, `build/app.html`, `build/_app/…`). That is why the trailing-slash form redirects to the canonical URL instead of serving the same HTML under a `/<surface>/` base path.
- `index: false` on `@fastify/static` stops it from registering its own `GET /`, which would collide with the existing landing route.
- The static mount is encapsulated in a child plugin scope so the `reply.sendFile` decoration is visible to the surface routes; route registration stays global so the surfaces remain reachable.

## Test plan

- [x] `GET /admin`, `GET /app` → 200 `text/html`, correct page body (fixture build dir).
- [x] Shared `/_app/…` chunks (with JS content-type) and root-level static files (`favicon.png`) served.
- [x] `GET /admin/` and `GET /app/` → `308` redirect to the canonical URL, preserving the query string.
- [x] `HEAD /admin` → 200; non-GET method on a surface → `404`.
- [x] `GET /`, `GET /healthz` unaffected; unknown asset → `404`.
- [x] Build-absent: `buildApp()` works, surfaces `404`, a `web/frontend` warn line is logged, backend routes still work.
- [x] `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (coverage 80% gate) all green; `frontend.ts` at 100%.
- [x] Frontend build (`cd server/frontend && npm ci && npm run build`) succeeds and emits the expected output.

## Deferred work

- **#59** — SPA fallback for deep `/admin/*` / `/app/*` routes on hard refresh. Not relevant until #53 introduces client-side navigation with multiple views; tracked separately so it isn't lost.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)