### PR TITLE
design: HTML UI/UX mock-ups for admin, app, and client surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ server. See [`docs/client-install.md`](docs/client-install.md).
 | [`docs/client-install.md`](docs/client-install.md) | Client enrollment script design and Linux Mint specifics. |
 | [`docs/client-notifications.md`](docs/client-notifications.md) | Client-side toast/sound notifications, time-remaining cadence, grace period, and end-of-budget enforcement (`pct-client` agent design). |
 | [`docs/roadmap.md`](docs/roadmap.md) | Phased milestone plan; the basis for GitHub issues. |
-| [`docs/adr/`](docs/adr/) | Architecture decision records. ADR 0001 fixes the timezone strategy (UTC internally, server-default TZ with per-user overrides). |
+| [`docs/adr/`](docs/adr/) | Architecture decision records. ADR 0001 fixes the timezone strategy (UTC internally, server-default TZ with per-user overrides). ADR 0002 fixes the client "My Time" dashboard's data model (hybrid, agent-first) and rendering shell (installed-browser app mode, with Tauri v2 as the upgrade path). |
 | [`CLAUDE.md`](CLAUDE.md) | Guidance for AI coding agents working in this repo. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Local dev loop: setup, pre-commit hooks, the quality gate, tests, the frontend loop, and branch/PR conventions. |
 

--- a/design/README.md
+++ b/design/README.md
@@ -28,7 +28,7 @@ Open [`index.html`](index.html) for the gallery.
 | **App (PWA)** `/app` | [`app/parent-home.html`](app/parent-home.html) | All kids on one phone screen, quick-grant buttons, low-time alert | Phase 9 |
 | | [`app/grant.html`](app/grant.html) | Touch-first grant flow: who / what scope / how much / reason | Phase 9 + 10 |
 | | [`app/child-status.html`](app/child-status.html) | PIN-scoped per-child view: time left, limits, next transition, rewards | Phase 9 |
-| **Client** (supervised desktop) | [`client/dashboard.html`](client/dashboard.html) | **NEW** — the "My Time" desktop dashboard (see below) | *not yet on the roadmap — proposed here* |
+| **Client** (supervised desktop) | [`client/dashboard.html`](client/dashboard.html) | **NEW** — the "My Time" desktop dashboard (see below) | new phase · [#61] |
 | | [`client/notifications.html`](client/notifications.html) | Every toast / grace-countdown / lock / grant / offline state | Phase 8b · [`docs/client-notifications.md`](../docs/client-notifications.md) |
 
 [#53]: https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/53
@@ -112,25 +112,31 @@ interrupted — and without having to ask a parent.
   applet, or only-on-demand?
 - **How much history** to show a child (today only, this week, this month)?
 
-## Suggested roadmap / issue follow-ups
+## Roadmap / issue follow-ups (filed)
 
-These mock-ups surface work that isn't yet an issue. Candidates to file
-against the [roadmap project](https://github.com/users/BenSeymourODB/projects/2):
+These mock-ups surfaced work that is now tracked as issues against the
+[roadmap project](https://github.com/users/BenSeymourODB/projects/2):
 
-- **New — Phase 8d (proposed): supervised-user "My Time" dashboard.** Decide
-  the delivery vehicle (PWA-reuse vs. agent-hosted), then build the read-only
-  status view. Depends on Phase 5 (usage data) and Phase 8b (cached budget).
-- **Admin burndown & usage-timeline components** (Phase 5): the chart pieces in
-  `admin/user-detail.html` are their own deliverable once `UsageSample`
-  aggregation lands.
-- **Drag-to-order rule editor** (Phase 2, refines [#53]): the schedule/exception
-  list in `admin/policy-editor.html` needs ordering semantics ("first match
-  wins") nailed down in the policy model.
-- **Save-and-push diff preview** (Phase 4): the "preview diff" affordance in the
-  policy editor maps to the offline-queue / per-client diff in
-  `docs/architecture.md`.
-- **Parent low-time push notifications** (Phase 9): the alert banner in
+- **[#61] — New phase: supervised-user "My Time" dashboard.** Decide the
+  delivery vehicle (PWA-reuse vs. agent-hosted), then build the read-only
+  status view. Filed as its own phase; depends on Phase 5 (usage data),
+  Phase 8b (cached budget), and Phase 9 (the PWA child-status view it reuses).
+- **[#62] — Admin burndown & usage-timeline components** (Phase 5): the chart
+  pieces in `admin/user-detail.html`, once `UsageSample` aggregation lands.
+- **[#63] — Drag-to-order rule editor** (Phase 2, refines [#53]): the
+  schedule/exception list in `admin/policy-editor.html` needs ordering
+  semantics ("first match wins") nailed down in the policy model.
+- **[#64] — Save-and-push diff preview** (Phase 4): the "preview diff"
+  affordance in the policy editor maps to the offline-queue / per-client diff
+  in `docs/architecture.md`.
+- **[#65] — Parent low-time push notifications** (Phase 9): the alert banner in
   `app/parent-home.html` is the UI for the Web Push item already in the roadmap.
+
+[#61]: https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/61
+[#62]: https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/62
+[#63]: https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/63
+[#64]: https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/64
+[#65]: https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/65
 
 ## Conventions used in these files
 

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,141 @@
+# Design mock-ups
+
+Static, plain-HTML design studies for the three consumer surfaces of the
+Parental Controls Toolkit. They exist to settle **UX direction** before the
+SvelteKit (`/admin`, `/app`) and TypeScript desktop-app (client) work lands,
+and to give the roadmap and issue tracker something concrete to point at.
+
+> These are **mock-ups, not the product.** No build step, no framework, no
+> external assets, no real data — every file opens straight from `file://`.
+> Shared styling lives in [`assets/styles.css`](assets/styles.css); the real
+> surfaces are SvelteKit and a packaged TS app per
+> [`docs/proposed-tech-stack.md`](../docs/proposed-tech-stack.md). Where a
+> mock-up shows a chart it is hand-drawn SVG/CSS standing in for the eventual
+> live component, not a finished design spec.
+
+Open [`index.html`](index.html) for the gallery.
+
+## What's here
+
+| Surface | File | What it explores | Maps to |
+|---|---|---|---|
+| **Admin** `/admin` | [`admin/dashboard.html`](admin/dashboard.html) | All supervised users at a glance, live burndown rings, client/agent health, activity feed | Roadmap Phase 2 · [#53] |
+| | [`admin/user-detail.html`](admin/user-detail.html) | Per-user overall **burndown chart**, **ActivityWatch usage timeline**, per-activity budgets, today's schedule, grants affecting today | Phase 5 (telemetry views) |
+| | [`admin/policy-editor.html`](admin/policy-editor.html) | Budgets, activity groups, **drag-to-order** schedule/exception rules, notification + filter policy, save-and-push bar | Phase 2 · [#53] |
+| | [`admin/grants-ledger.html`](admin/grants-ledger.html) | Immutable grant ledger (admin + calendar sources, `source_ref`, expiry, revoke) + grant panel | Phase 10 · architecture "External integrations" |
+| | [`admin/clients.html`](admin/clients.html) | Enrolled machines, component health (Timekpr/AW/e2guardian/bridge/agent), offline + queued-change state, enrol-a-client flow | Phase 3 · architecture "Failure modes" |
+| | [`admin/integrations.html`](admin/integrations.html) | Calendar API tokens (scopes/rate), AdGuard mode selector, notification defaults | Phases 7 & 10 |
+| **App (PWA)** `/app` | [`app/parent-home.html`](app/parent-home.html) | All kids on one phone screen, quick-grant buttons, low-time alert | Phase 9 |
+| | [`app/grant.html`](app/grant.html) | Touch-first grant flow: who / what scope / how much / reason | Phase 9 + 10 |
+| | [`app/child-status.html`](app/child-status.html) | PIN-scoped per-child view: time left, limits, next transition, rewards | Phase 9 |
+| **Client** (supervised desktop) | [`client/dashboard.html`](client/dashboard.html) | **NEW** — the "My Time" desktop dashboard (see below) | *not yet on the roadmap — proposed here* |
+| | [`client/notifications.html`](client/notifications.html) | Every toast / grace-countdown / lock / grant / offline state | Phase 8b · [`docs/client-notifications.md`](../docs/client-notifications.md) |
+
+[#53]: https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/53
+
+## Design principles carried through every surface
+
+- **No surprises.** The supervised user can always see the rules in force and
+  what's coming next. This is the same philosophy as the warning cadence in
+  `docs/client-notifications.md`, extended to a persistent surface.
+- **Not punitive.** Framing is "time left", "earn more", "coming up" — never
+  "blocked / denied / violation". Consistent with the household framing in
+  `README.md` and `docs/client-install.md` ("Tamper resistance is deliberately
+  bounded").
+- **Orchestration, not enforcement, shows through.** The UI labels which
+  upstream tool does the work (Timekpr-nExT locks the session, e2guardian
+  filters, ActivityWatch supplies usage). We render **our own** views from
+  ActivityWatch's REST data rather than embedding AW's GPL UI in-process —
+  respecting the license boundaries in `docs/licensing-analysis.md`. The
+  client dashboard links out to AW's own UI for the deep dive.
+- **One API.** Every surface reads and writes the same `/api/*` contract; the
+  PWA and external integrators are first-class consumers, not afterthoughts
+  (`docs/architecture.md`).
+- **UTC inside, local at the edge.** Every "today / resets at midnight" string
+  is the user's *effective* timezone resolving a UTC instant, per
+  [ADR 0001](../docs/adr/0001-budget-timezone.md).
+
+## The new piece: a supervised-user client dashboard
+
+So far the client-side UX in the docs is **only** toast notifications
+(`docs/client-notifications.md`). That's the *interrupt* channel. These
+mock-ups propose a complementary *pull* channel: a small desktop app the child
+can open any time to answer "how am I doing?" without waiting to be
+interrupted — and without having to ask a parent.
+
+`client/dashboard.html` sketches **"My Time"**, presenting:
+
+1. **Time left right now** — a hero ring for overall screen time, plus a
+   plain-language "what's happening now" card (free time / school hours /
+   wind-down) and the next scheduled change.
+2. **Time left per app & category** — Games / YouTube / Social / School with
+   their own remaining time, colour-coded, so the child can self-budget ("I'll
+   stop Minecraft and save YouTube for later") instead of being surprised.
+3. **What you did today** — an ActivityWatch-style timeline rendered from the
+   same `UsageSample` data the admin sees, framed neutrally as *your own*
+   activity on *your own* device (transparency, not surveillance theatre).
+4. **This week** — a small bar chart against the daily limit to encourage
+   self-regulation over time.
+5. **Coming up today** — upcoming schedule transitions (Social unlocks,
+   wind-down, bedtime lock) so nothing arrives as a shock.
+6. **Rewards** — grants received and a nudge toward the family-calendar chores
+   that earn more time (the Phase 10 integrator, surfaced as a *positive*).
+7. **Status / "what's filtered" / "ask a parent"** — honest agent-connection
+   state, a gentle note that web filtering is on, and a low-friction path to
+   start a conversation rather than a workaround.
+
+### Why this is worth building
+
+- **Reduces conflict.** Most "you cut me off!" friction comes from opacity.
+  A glanceable dashboard turns the limit into a shared, visible fact.
+- **Teaches self-regulation.** Per-category budgets + a weekly trend let a
+  child plan their own time — the explicit goal of a *household* tool rather
+  than a lockdown tool.
+- **Cheap to build on what exists.** It reuses data already flowing for Phase
+  5 (ActivityWatch → `UsageSample`), the locally cached budget the Phase 8b
+  agent already holds, and the same `/api/*` contract. No new enforcement, no
+  new license surface.
+- **Fits the "no arms race" stance.** It deliberately shows *only the user's
+  own* data and offers *no* controls — viewing, never editing. Adjustments
+  stay with the parent on `/admin` or `/app`.
+
+### Open questions for the maintainer
+
+- **Delivery vehicle.** Three plausible options, in rough order of effort:
+  (a) reuse the Phase 9 `/app` PWA child-status view, opened in a kiosk
+  browser on the client — *cheapest, no new artifact*; (b) a thin wrapper
+  window in the existing `pct-client-agent` that loads that same web view
+  locally; (c) a fully native dashboard in the agent. The mock-up is drawn as
+  a desktop window but the content is identical to `app/child-status.html` on
+  purpose, so (a)/(b) stay open.
+- **Always-available vs. summoned.** Tray icon + "open My Time", a panel
+  applet, or only-on-demand?
+- **How much history** to show a child (today only, this week, this month)?
+
+## Suggested roadmap / issue follow-ups
+
+These mock-ups surface work that isn't yet an issue. Candidates to file
+against the [roadmap project](https://github.com/users/BenSeymourODB/projects/2):
+
+- **New — Phase 8d (proposed): supervised-user "My Time" dashboard.** Decide
+  the delivery vehicle (PWA-reuse vs. agent-hosted), then build the read-only
+  status view. Depends on Phase 5 (usage data) and Phase 8b (cached budget).
+- **Admin burndown & usage-timeline components** (Phase 5): the chart pieces in
+  `admin/user-detail.html` are their own deliverable once `UsageSample`
+  aggregation lands.
+- **Drag-to-order rule editor** (Phase 2, refines [#53]): the schedule/exception
+  list in `admin/policy-editor.html` needs ordering semantics ("first match
+  wins") nailed down in the policy model.
+- **Save-and-push diff preview** (Phase 4): the "preview diff" affordance in the
+  policy editor maps to the offline-queue / per-client diff in
+  `docs/architecture.md`.
+- **Parent low-time push notifications** (Phase 9): the alert banner in
+  `app/parent-home.html` is the UI for the Web Push item already in the roadmap.
+
+## Conventions used in these files
+
+- One shared stylesheet, design tokens as CSS custom properties.
+- Charts are inline SVG or CSS — no JS, no chart library, no network.
+- Sample names (Alice/Bob/Chloe, `mint-livingroom`) and figures are
+  illustrative and consistent across files.
+- Each file has a top "MOCK-UP" bar linking back to the gallery.

--- a/design/admin/clients.html
+++ b/design/admin/clients.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Admin · Clients</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .client-card { display:grid; grid-template-columns: 1fr; gap:14px; }
+  .kv { display:flex; justify-content:space-between; font-size:12.5px; padding:4px 0; border-bottom:1px dashed var(--border); }
+  .kv:last-child { border-bottom:none; }
+  .comp { display:flex; align-items:center; gap:8px; font-size:12.5px; padding:6px 0; }
+  .enrol { background:#0f1222; color:#cdd2e6; border-radius:12px; padding:18px 20px; }
+  .enrol code { display:block; background:#000; color:#9be7b6; padding:10px 12px; border-radius:8px; font-size:12px; margin-top:8px; overflow:auto; }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>Admin · Clients &amp; agents &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a></span></div>
+<div class="admin">
+  <nav class="admin-nav">
+    <div class="brand"><span class="logo">🛡️</span> ParentCtl</div>
+    <a href="dashboard.html"><span class="ic">▦</span> Overview</a>
+    <a href="user-detail.html"><span class="ic">👤</span> Users</a>
+    <a href="policy-editor.html"><span class="ic">⚖︎</span> Policies</a>
+    <a href="grants-ledger.html"><span class="ic">🎁</span> Grants</a>
+    <a class="active" href="clients.html"><span class="ic">🖥️</span> Clients</a>
+    <div class="nav-sec">Configure</div>
+    <a href="integrations.html"><span class="ic">🔌</span> Integrations</a>
+    <a href="integrations.html"><span class="ic">🔔</span> Notifications</a>
+    <a href="integrations.html"><span class="ic">🌐</span> DNS / AdGuard</a>
+  </nav>
+
+  <div class="admin-main">
+    <header class="admin-top">
+      <div><div class="crumb">Clients</div><h1>Enrolled machines</h1></div>
+      <button class="btn primary">＋ Enrol a client</button>
+    </header>
+
+    <div class="admin-content col gap-24">
+      <div class="grid" style="grid-template-columns:repeat(2,1fr);">
+
+        <!-- client 1 -->
+        <div class="card pad client-card">
+          <div class="row between ai-center">
+            <div class="row ai-center gap-8"><span style="font-size:22px;">🖥️</span><div><div style="font-weight:650;">mint-livingroom</div><div class="muted mono" style="font-size:11.5px;">192.168.1.24 · Linux Mint 21.3</div></div></div>
+            <span class="pill ok"><span class="dot"></span>live</span>
+          </div>
+          <div>
+            <div class="kv"><span class="muted">Supervised users</span><span>Alice (uid 1001), Bob (uid 1002)</span></div>
+            <div class="kv"><span class="muted">SSH</span><span class="mono">pct-agent@ · key OK · 8ms</span></div>
+            <div class="kv"><span class="muted">Last AW pull</span><span>2m ago · 41 samples</span></div>
+            <div class="kv"><span class="muted">Last Ansible apply</span><span>48m ago · no drift</span></div>
+          </div>
+          <div style="border-top:1px solid var(--border);padding-top:8px;">
+            <div class="section-title">Client components</div>
+            <div class="comp"><span class="pill ok" style="padding:1px 7px;"><span class="dot"></span></span> Timekpr-nExT <span class="muted">daemon active</span></div>
+            <div class="comp"><span class="pill ok" style="padding:1px 7px;"><span class="dot"></span></span> ActivityWatch <span class="muted">:5600 reachable (via tunnel)</span></div>
+            <div class="comp"><span class="pill ok" style="padding:1px 7px;"><span class="dot"></span></span> e2guardian + iptables redirect</div>
+            <div class="comp"><span class="pill ok" style="padding:1px 7px;"><span class="dot"></span></span> pct-client-bridge <span class="muted">WS connected · 0.4.1</span></div>
+            <div class="comp"><span class="pill ok" style="padding:1px 7px;"><span class="dot"></span></span> pct-client-agent <span class="muted">×2 user sessions</span></div>
+          </div>
+          <div class="row gap-8"><button class="btn sm">Re-apply config</button><button class="btn sm">Probe now</button><button class="btn ghost sm">Logs</button></div>
+        </div>
+
+        <!-- client 2 offline -->
+        <div class="card pad client-card" style="border-color:#efd99a;">
+          <div class="row between ai-center">
+            <div class="row ai-center gap-8"><span style="font-size:22px;">💻</span><div><div style="font-weight:650;">chloe-laptop</div><div class="muted mono" style="font-size:11.5px;">last seen 192.168.1.51 · Linux Mint 22</div></div></div>
+            <span class="pill warn"><span class="dot"></span>offline 3h</span>
+          </div>
+          <div>
+            <div class="kv"><span class="muted">Supervised users</span><span>Chloe (uid 1001)</span></div>
+            <div class="kv"><span class="muted">SSH</span><span class="mono" style="color:var(--amber);">unreachable — retrying</span></div>
+            <div class="kv"><span class="muted">Bridge</span><span style="color:var(--amber);">disconnected 3h ago</span></div>
+            <div class="kv"><span class="muted">Queued changes</span><span><span class="pill warn" style="padding:1px 8px;">1 pending</span> overall 1h→1h30</span></div>
+          </div>
+          <div class="card" style="background:var(--amber-soft);border-color:#efd99a;padding:10px 12px;font-size:12.5px;">
+            ⚠ Change queued — will replay on next successful SSH probe. The laptop keeps enforcing its last-known policy while offline (server is control plane, not data plane).
+          </div>
+          <div class="row gap-8"><button class="btn sm">Probe now</button><button class="btn ghost sm">View queued diff</button></div>
+        </div>
+      </div>
+
+      <!-- enrol flow -->
+      <div class="card">
+        <div class="card-head"><h3>＋ Enrol a new client</h3><span class="sub">one-time token · short TTL · single use</span></div>
+        <div class="card-body row" style="align-items:flex-start;">
+          <div class="grow col">
+            <div class="row gap-8 ai-center">
+              <span class="pill brand">1</span> Generate an enrolment token, scoped to the supervised user(s) you'll create.
+            </div>
+            <div class="row gap-8 ai-center"><span class="pill brand">2</span> Run the installer on the fresh Mint machine. It installs the GPL tools via <span class="mono">apt</span>, provisions <span class="mono">pct-agent</span>, drops the SSH key, and self-tests.</div>
+            <div class="row gap-8 ai-center"><span class="pill brand">3</span> The client POSTs to <span class="mono">/api/clients/enrol</span> and appears here.</div>
+          </div>
+          <div class="enrol" style="width:420px;flex:none;">
+            <div style="font-size:12px;color:#9097ad;">Run on the client (token expires in 15:00):</div>
+            <code>curl -fsSL https://parentalcontrols.lan/install-client.sh \
+  | sudo bash -s -- \
+    --enrolment-token PCT-9f2a-7c1e-d40b \
+    --supervised-user chloe</code>
+            <div class="row gap-8" style="margin-top:12px;"><button class="btn sm primary">Copy command</button><button class="btn sm" style="color:#cdd2e6;border-color:#3a4063;background:transparent;">Regenerate token</button></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/admin/dashboard.html
+++ b/design/admin/dashboard.html
@@ -1,0 +1,207 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Admin · Overview</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .kpis { display:grid; grid-template-columns: repeat(4,1fr); gap:16px; }
+  .users-grid { display:grid; grid-template-columns: repeat(2,1fr); gap:16px; }
+  .user-card { display:flex; flex-direction:column; gap:14px; }
+  .user-card .top { display:flex; align-items:center; gap:12px; }
+  .mini-budgets { display:flex; flex-direction:column; gap:9px; }
+  .mb-row { display:grid; grid-template-columns: 92px 1fr 58px; align-items:center; gap:10px; font-size:12.5px; }
+  .feed-item { display:flex; gap:11px; padding:11px 0; border-bottom:1px solid var(--border); font-size:13px; }
+  .feed-item:last-child { border-bottom:none; }
+  .feed-ic { width:30px; height:30px; border-radius:8px; display:grid; place-items:center; flex:none; font-size:14px; }
+  @media (max-width:1080px){ .kpis{grid-template-columns:repeat(2,1fr);} .users-grid{grid-template-columns:1fr;} }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>Admin · Overview &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a></span></div>
+<div class="admin">
+
+  <!-- ============ left nav ============ -->
+  <nav class="admin-nav">
+    <div class="brand"><span class="logo">🛡️</span> ParentCtl</div>
+    <a class="active" href="dashboard.html"><span class="ic">▦</span> Overview</a>
+    <a href="user-detail.html"><span class="ic">👤</span> Users</a>
+    <a href="policy-editor.html"><span class="ic">⚖︎</span> Policies</a>
+    <a href="grants-ledger.html"><span class="ic">🎁</span> Grants</a>
+    <a href="clients.html"><span class="ic">🖥️</span> Clients</a>
+    <div class="nav-sec">Configure</div>
+    <a href="integrations.html"><span class="ic">🔌</span> Integrations</a>
+    <a href="integrations.html"><span class="ic">🔔</span> Notifications</a>
+    <a href="integrations.html"><span class="ic">🌐</span> DNS / AdGuard</a>
+    <div class="spacer"></div>
+    <a href="#"><span class="ic">⚙︎</span> Settings</a>
+  </nav>
+
+  <!-- ============ main ============ -->
+  <div class="admin-main">
+    <header class="admin-top">
+      <div>
+        <div class="crumb">Household</div>
+        <h1>Overview</h1>
+      </div>
+      <div class="row ai-center">
+        <div class="search">🔍 <input placeholder="Search users, apps, domains…" /></div>
+        <button class="btn primary">＋ Grant time</button>
+        <div class="avatar av-c" title="Admin">P</div>
+      </div>
+    </header>
+
+    <div class="admin-content col gap-24">
+
+      <!-- KPIs -->
+      <div class="kpis">
+        <div class="card pad stat">
+          <div class="lbl">Supervised users</div>
+          <div class="num">3 <span style="font-size:14px;" class="muted">· 2 online</span></div>
+          <div class="row ai-center gap-8" style="margin-top:6px;"><span class="pill ok"><span class="dot"></span>Alice</span><span class="pill ok"><span class="dot"></span>Bob</span><span class="pill"><span class="dot"></span>Chloe</span></div>
+        </div>
+        <div class="card pad stat">
+          <div class="lbl">Time granted today</div>
+          <div class="num">+1h 15m</div>
+          <div class="muted" style="font-size:12px;margin-top:6px;">3 grants · 2 from 📅 calendar chores</div>
+        </div>
+        <div class="card pad stat">
+          <div class="lbl">Clients &amp; agents</div>
+          <div class="num">2<span class="muted" style="font-size:15px;">/3</span></div>
+          <div class="muted" style="font-size:12px;margin-top:6px;"><span class="pill warn"><span class="dot"></span>1 client offline</span></div>
+        </div>
+        <div class="card pad stat">
+          <div class="lbl">Web filtering</div>
+          <div class="num">On</div>
+          <div class="muted" style="font-size:12px;margin-top:6px;">e2guardian · AdGuard <span class="mono">external</span></div>
+        </div>
+      </div>
+
+      <div class="row" style="align-items:flex-start;">
+        <!-- Users -->
+        <div class="grow col">
+          <div class="row between ai-center">
+            <div class="section-title">Today · live burndown</div>
+            <div class="muted" style="font-size:12px;">timezone <span class="mono">America/New_York</span> · resets 00:00 · last AW pull 2m ago</div>
+          </div>
+          <div class="users-grid">
+
+            <!-- Alice -->
+            <div class="card pad user-card">
+              <div class="top">
+                <div class="avatar av-a">A</div>
+                <div class="grow">
+                  <div style="font-weight:650;">Alice <span class="muted" style="font-weight:400;font-size:12.5px;">· 11</span></div>
+                  <div class="muted" style="font-size:12px;">alice@mint-livingroom · <span class="pill ok" style="padding:1px 8px;"><span class="dot"></span>online</span></div>
+                </div>
+                <a class="btn sm" href="user-detail.html">Open</a>
+              </div>
+              <div class="row ai-center gap-24">
+                <div class="ring-wrap">
+                  <svg width="92" height="92" viewBox="0 0 92 92">
+                    <circle class="track" cx="46" cy="46" r="38" stroke-width="9"/>
+                    <circle class="value warn" cx="46" cy="46" r="38" stroke-width="9"
+                      stroke-dasharray="238.8" stroke-dashoffset="65.7" transform="rotate(-90 46 46)"/>
+                  </svg>
+                  <div class="ring-center"><div style="font-size:17px;font-weight:700;">35m</div><div class="muted" style="font-size:10px;">left today</div></div>
+                </div>
+                <div class="mini-budgets grow">
+                  <div class="mb-row"><span class="muted">Overall</span><div class="bar warn"><span style="width:72%"></span></div><span class="nowrap">1h25/2h</span></div>
+                  <div class="mb-row"><span class="muted">🎮 Games</span><div class="bar bad"><span style="width:94%"></span></div><span class="nowrap">3m left</span></div>
+                  <div class="mb-row"><span class="muted">▶️ YouTube</span><div class="bar ok"><span style="width:40%"></span></div><span class="nowrap">27m left</span></div>
+                  <div class="mb-row"><span class="muted">💬 Social</span><div class="bar"><span style="width:0%"></span></div><span class="nowrap">off (school)</span></div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Bob -->
+            <div class="card pad user-card">
+              <div class="top">
+                <div class="avatar av-b">B</div>
+                <div class="grow">
+                  <div style="font-weight:650;">Bob <span class="muted" style="font-weight:400;font-size:12.5px;">· 14</span></div>
+                  <div class="muted" style="font-size:12px;">bob@mint-livingroom · <span class="pill ok" style="padding:1px 8px;"><span class="dot"></span>online</span></div>
+                </div>
+                <a class="btn sm" href="user-detail.html">Open</a>
+              </div>
+              <div class="row ai-center gap-24">
+                <div class="ring-wrap">
+                  <svg width="92" height="92" viewBox="0 0 92 92">
+                    <circle class="track" cx="46" cy="46" r="38" stroke-width="9"/>
+                    <circle class="value ok" cx="46" cy="46" r="38" stroke-width="9"
+                      stroke-dasharray="238.8" stroke-dashoffset="143.3" transform="rotate(-90 46 46)"/>
+                  </svg>
+                  <div class="ring-center"><div style="font-size:17px;font-weight:700;">1h48</div><div class="muted" style="font-size:10px;">left today</div></div>
+                </div>
+                <div class="mini-budgets grow">
+                  <div class="mb-row"><span class="muted">Overall</span><div class="bar ok"><span style="width:40%"></span></div><span class="nowrap">1h12/3h</span></div>
+                  <div class="mb-row"><span class="muted">🎮 Games</span><div class="bar ok"><span style="width:30%"></span></div><span class="nowrap">1h05 left</span></div>
+                  <div class="mb-row"><span class="muted">▶️ YouTube</span><div class="bar warn"><span style="width:80%"></span></div><span class="nowrap">9m left</span></div>
+                  <div class="mb-row"><span class="muted">💻 School</span><div class="bar"><span style="width:25%;background:var(--sky)"></span></div><span class="nowrap">no limit</span></div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Chloe (offline) -->
+            <div class="card pad user-card" style="opacity:0.92;">
+              <div class="top">
+                <div class="avatar" style="background:#9aa2bd;">C</div>
+                <div class="grow">
+                  <div style="font-weight:650;">Chloe <span class="muted" style="font-weight:400;font-size:12.5px;">· 9</span></div>
+                  <div class="muted" style="font-size:12px;">chloe@chloe-laptop · <span class="pill warn" style="padding:1px 8px;"><span class="dot"></span>offline 3h</span></div>
+                </div>
+                <a class="btn sm" href="user-detail.html">Open</a>
+              </div>
+              <div class="row ai-center gap-24">
+                <div class="ring-wrap">
+                  <svg width="92" height="92" viewBox="0 0 92 92">
+                    <circle class="track" cx="46" cy="46" r="38" stroke-width="9"/>
+                    <circle class="value" cx="46" cy="46" r="38" stroke-width="9" style="stroke:var(--faint);"
+                      stroke-dasharray="238.8" stroke-dashoffset="179.1" transform="rotate(-90 46 46)"/>
+                  </svg>
+                  <div class="ring-center"><div style="font-size:17px;font-weight:700;">45m</div><div class="muted" style="font-size:10px;">left today</div></div>
+                </div>
+                <div class="mini-budgets grow">
+                  <div class="mb-row"><span class="muted">Overall</span><div class="bar"><span style="width:25%"></span></div><span class="nowrap">15m/1h</span></div>
+                  <div class="mb-row" style="color:var(--faint);"><span>last sync</span><div class="bar"><span style="width:100%;background:var(--surface-3)"></span></div><span class="nowrap">3h ago</span></div>
+                  <div class="muted" style="font-size:11.5px;">⚠ 1 policy change queued — will apply on reconnect</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- add user -->
+            <a class="card pad user-card center" style="display:grid;place-items:center;color:var(--muted);text-decoration:none;border-style:dashed;" href="#">
+              <div><div style="font-size:24px;">＋</div><div style="font-weight:600;">Add supervised user</div><div style="font-size:12px;">create a User, link a Linux account on a client</div></div>
+            </a>
+
+          </div>
+        </div>
+
+        <!-- right rail -->
+        <div class="col" style="width:330px;flex:none;">
+          <div class="card">
+            <div class="card-head"><h3>Recent activity</h3><a class="sub" href="grants-ledger.html">View all</a></div>
+            <div class="card-body" style="padding-top:4px;padding-bottom:8px;">
+              <div class="feed-item"><div class="feed-ic" style="background:var(--green-soft)">🎁</div><div><strong>+30m overall</strong> → Alice<br><span class="muted">📅 chore "clean room" · via calendar · 4m ago</span></div></div>
+              <div class="feed-item"><div class="feed-ic" style="background:var(--amber-soft)">⏳</div><div><strong>Games budget low</strong> · Alice 3m left<br><span class="muted">per-app warning cadence · 6m ago</span></div></div>
+              <div class="feed-item"><div class="feed-ic" style="background:var(--sky-soft)">✏️</div><div><strong>Policy changed</strong> · Bob YouTube 45m→60m<br><span class="muted">by admin · pushed to client · 22m ago</span></div></div>
+              <div class="feed-item"><div class="feed-ic" style="background:var(--red-soft)">🔒</div><div><strong>Session locked</strong> · Chloe overall budget reached<br><span class="muted">Timekpr-nExT · 3h ago</span></div></div>
+              <div class="feed-item"><div class="feed-ic" style="background:var(--surface-3)">🔌</div><div><strong>Client offline</strong> · chloe-laptop<br><span class="muted">bridge disconnected · 3h ago</span></div></div>
+            </div>
+          </div>
+
+          <div class="card pad col" style="gap:10px;">
+            <div class="section-title">Needs attention</div>
+            <div class="row ai-center gap-8"><span class="pill warn"><span class="dot"></span>1</span><span style="font-size:13px;">chloe-laptop offline — change queued</span></div>
+            <div class="row ai-center gap-8"><span class="pill info"><span class="dot"></span>1</span><span style="font-size:13px;">Calendar token unused 14 days</span></div>
+            <div class="row ai-center gap-8"><span class="pill ok"><span class="dot"></span>✓</span><span style="font-size:13px;">All AppArmor profiles applied</span></div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/admin/grants-ledger.html
+++ b/design/admin/grants-ledger.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Admin · Grant ledger</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .filters { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+  .seg { display:flex; background:var(--surface-3); border-radius:8px; padding:3px; }
+  .seg a { padding:5px 12px; border-radius:6px; font-size:12.5px; font-weight:600; color:var(--muted); }
+  .seg a.active { background:var(--surface); color:var(--text); box-shadow:var(--shadow); }
+  .src-cal { color:var(--grape); font-weight:600; }
+  .grant-panel { width:330px; flex:none; }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>Admin · Grant ledger (immutable) &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a></span></div>
+<div class="admin">
+  <nav class="admin-nav">
+    <div class="brand"><span class="logo">🛡️</span> ParentCtl</div>
+    <a href="dashboard.html"><span class="ic">▦</span> Overview</a>
+    <a href="user-detail.html"><span class="ic">👤</span> Users</a>
+    <a href="policy-editor.html"><span class="ic">⚖︎</span> Policies</a>
+    <a class="active" href="grants-ledger.html"><span class="ic">🎁</span> Grants</a>
+    <a href="clients.html"><span class="ic">🖥️</span> Clients</a>
+    <div class="nav-sec">Configure</div>
+    <a href="integrations.html"><span class="ic">🔌</span> Integrations</a>
+    <a href="integrations.html"><span class="ic">🔔</span> Notifications</a>
+    <a href="integrations.html"><span class="ic">🌐</span> DNS / AdGuard</a>
+  </nav>
+
+  <div class="admin-main">
+    <header class="admin-top">
+      <div><div class="crumb">Grants</div><h1>Grant ledger</h1></div>
+      <div class="row ai-center"><div class="search">🔍 <input placeholder="Search source_ref, reason…" /></div><button class="btn primary">＋ Grant time</button></div>
+    </header>
+
+    <div class="admin-content row" style="align-items:flex-start;">
+      <div class="grow col gap-24">
+
+        <div class="row gap-8" style="flex-wrap:wrap;">
+          <div class="card pad stat" style="flex:1;"><div class="lbl">Granted today</div><div class="num">+1h 15m</div></div>
+          <div class="card pad stat" style="flex:1;"><div class="lbl">Active grants</div><div class="num">3</div></div>
+          <div class="card pad stat" style="flex:1;"><div class="lbl">From calendar</div><div class="num src-cal">2</div></div>
+          <div class="card pad stat" style="flex:1;"><div class="lbl">Revoked (30d)</div><div class="num">1</div></div>
+        </div>
+
+        <div class="card">
+          <div class="card-head">
+            <div class="filters">
+              <div class="seg"><a class="active">All</a><a>Active</a><a>Expired</a><a>Revoked</a></div>
+              <span class="seg"><a class="active">Everyone</a><a>Alice</a><a>Bob</a></span>
+            </div>
+            <span class="sub">append-only · revocation = new row, never an edit</span>
+          </div>
+          <table class="tbl">
+            <thead><tr><th>When</th><th>User</th><th>Scope</th><th>Amount</th><th>Source</th><th>Reason / source_ref</th><th>Expires</th><th>State</th><th></th></tr></thead>
+            <tbody>
+              <tr>
+                <td class="nowrap">16 Jun 14:32</td>
+                <td><span class="pill brand" style="padding:1px 8px;">Alice</span></td>
+                <td>overall</td>
+                <td><strong>+30m</strong></td>
+                <td><span class="src-cal">📅 calendar</span></td>
+                <td>Cleaned room<br><span class="mono muted">calendar:chore:42a9c…</span></td>
+                <td class="nowrap">23:59</td>
+                <td><span class="pill ok"><span class="dot"></span>active</span></td>
+                <td><button class="btn ghost sm danger">revoke</button></td>
+              </tr>
+              <tr>
+                <td class="nowrap">16 Jun 12:10</td>
+                <td><span class="pill brand" style="padding:1px 8px;">Bob</span></td>
+                <td>activity · YouTube</td>
+                <td><strong>+45m</strong></td>
+                <td><span class="src-cal">📅 calendar</span></td>
+                <td>Finished homework<br><span class="mono muted">calendar:chore:7d11b…</span></td>
+                <td class="nowrap">23:59</td>
+                <td><span class="pill ok"><span class="dot"></span>active</span></td>
+                <td><button class="btn ghost sm danger">revoke</button></td>
+              </tr>
+              <tr>
+                <td class="nowrap">16 Jun 09:05</td>
+                <td><span class="pill brand" style="padding:1px 8px;">Alice</span></td>
+                <td>group · Games</td>
+                <td><strong>+15m</strong></td>
+                <td>👤 admin</td>
+                <td>“just because” <span class="muted">— Mum</span></td>
+                <td class="nowrap">23:59</td>
+                <td><span class="pill ok"><span class="dot"></span>active</span></td>
+                <td><button class="btn ghost sm danger">revoke</button></td>
+              </tr>
+              <tr style="opacity:0.6;">
+                <td class="nowrap">15 Jun 19:40</td>
+                <td><span class="pill" style="padding:1px 8px;">Bob</span></td>
+                <td>overall</td>
+                <td>+30m</td>
+                <td>👤 admin</td>
+                <td>movie night</td>
+                <td class="nowrap">15 Jun 23:59</td>
+                <td><span class="pill"><span class="dot"></span>expired</span></td>
+                <td></td>
+              </tr>
+              <tr style="opacity:0.6;">
+                <td class="nowrap">15 Jun 16:22</td>
+                <td><span class="pill" style="padding:1px 8px;">Alice</span></td>
+                <td>activity · YouTube</td>
+                <td><s>+20m</s></td>
+                <td><span class="src-cal">📅 calendar</span></td>
+                <td>duplicate chore submit<br><span class="mono muted">revoked 16:24 by admin</span></td>
+                <td class="nowrap">—</td>
+                <td><span class="pill bad"><span class="dot"></span>revoked</span></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="muted" style="font-size:12px;">Idempotency: a repeated <span class="mono">source_ref</span> from the calendar is a no-op, so a retried webhook never double-grants. See <span class="mono">docs/architecture.md</span> → External integrations.</p>
+      </div>
+
+      <!-- grant panel -->
+      <div class="card grant-panel">
+        <div class="card-head"><h3>＋ Grant time</h3></div>
+        <div class="card-body col">
+          <div class="col" style="gap:5px;"><label style="font-size:11.5px;font-weight:700;text-transform:uppercase;color:var(--faint);">User</label>
+            <div class="row gap-8"><button class="btn sm primary">Alice</button><button class="btn sm">Bob</button><button class="btn sm">Chloe</button></div>
+          </div>
+          <div class="col" style="gap:5px;"><label style="font-size:11.5px;font-weight:700;text-transform:uppercase;color:var(--faint);">Scope</label>
+            <select class="btn" style="width:100%;"><option>Overall screen time</option><option>Games (group)</option><option>YouTube (domain)</option></select>
+          </div>
+          <div class="col" style="gap:5px;"><label style="font-size:11.5px;font-weight:700;text-transform:uppercase;color:var(--faint);">Amount</label>
+            <div class="row gap-8"><button class="btn sm">+15m</button><button class="btn sm primary">+30m</button><button class="btn sm">+1h</button></div>
+          </div>
+          <div class="col" style="gap:5px;"><label style="font-size:11.5px;font-weight:700;text-transform:uppercase;color:var(--faint);">Expires</label>
+            <select class="btn" style="width:100%;"><option>End of today (23:59)</option><option>End of week</option></select>
+          </div>
+          <div class="col" style="gap:5px;"><label style="font-size:11.5px;font-weight:700;text-transform:uppercase;color:var(--faint);">Reason</label>
+            <input class="btn" style="width:100%;text-align:left;font-weight:400;" placeholder="optional note (shows in child's toast)" />
+          </div>
+          <button class="btn primary" style="justify-content:center;">Grant +30m to Alice</button>
+          <p class="muted" style="font-size:11.5px;">Recomputes today's budget, pushes via timekpra, and fires a <span class="mono">grant.applied</span> toast on Alice's desktop.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/admin/integrations.html
+++ b/design/admin/integrations.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Admin · Integrations &amp; DNS</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .mode { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; }
+  .mode .opt { border:1px solid var(--border); border-radius:11px; padding:14px; cursor:pointer; }
+  .mode .opt.sel { border-color:var(--primary); box-shadow:0 0 0 2px var(--primary-soft); }
+  .mode .opt h4 { font-size:14px; }
+  .mode .opt p { font-size:12px; color:var(--muted); margin-top:5px; }
+  .scope-chip { font-size:11px; padding:2px 8px; border-radius:6px; background:var(--surface-3); font-weight:600; color:var(--muted); }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>Admin · Integrations &amp; DNS &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a></span></div>
+<div class="admin">
+  <nav class="admin-nav">
+    <div class="brand"><span class="logo">🛡️</span> ParentCtl</div>
+    <a href="dashboard.html"><span class="ic">▦</span> Overview</a>
+    <a href="user-detail.html"><span class="ic">👤</span> Users</a>
+    <a href="policy-editor.html"><span class="ic">⚖︎</span> Policies</a>
+    <a href="grants-ledger.html"><span class="ic">🎁</span> Grants</a>
+    <a href="clients.html"><span class="ic">🖥️</span> Clients</a>
+    <div class="nav-sec">Configure</div>
+    <a class="active" href="integrations.html"><span class="ic">🔌</span> Integrations</a>
+    <a href="integrations.html"><span class="ic">🔔</span> Notifications</a>
+    <a href="integrations.html"><span class="ic">🌐</span> DNS / AdGuard</a>
+  </nav>
+
+  <div class="admin-main">
+    <header class="admin-top"><div><div class="crumb">Configure</div><h1>Integrations &amp; DNS</h1></div></header>
+
+    <div class="admin-content col gap-24">
+
+      <!-- Integration tokens -->
+      <div class="card">
+        <div class="card-head"><div><h3>🔌 External integration tokens</h3><div class="sub">scoped · revocable · rate-limited · all inbound traffic via /api/integrations/*</div></div><button class="btn primary sm">＋ New token</button></div>
+        <table class="tbl">
+          <thead><tr><th>Name</th><th>Scopes</th><th>Created</th><th>Last used</th><th>Rate</th><th>State</th><th></th></tr></thead>
+          <tbody>
+            <tr>
+              <td><strong>next-digital-wall-calendar</strong><div class="muted" style="font-size:11.5px;">family calendar · chore rewards</div></td>
+              <td><span class="scope-chip">grants:write</span> <span class="scope-chip">policy:read</span></td>
+              <td>02 Jun 2026</td>
+              <td>4m ago</td>
+              <td class="muted">12 / 60 min</td>
+              <td><span class="pill ok"><span class="dot"></span>active</span></td>
+              <td><button class="btn ghost sm danger">revoke</button></td>
+            </tr>
+            <tr style="opacity:0.6;">
+              <td><strong>home-assistant</strong><div class="muted" style="font-size:11.5px;">test token</div></td>
+              <td><span class="scope-chip">policy:read</span></td>
+              <td>20 May 2026</td>
+              <td>14 days ago</td>
+              <td class="muted">0 / 60 min</td>
+              <td><span class="pill warn"><span class="dot"></span>idle</span></td>
+              <td><button class="btn ghost sm danger">revoke</button></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="card-body" style="border-top:1px solid var(--border);background:var(--surface-2);font-size:12.5px;">
+          <strong>How the calendar grants time →</strong> <span class="muted">child completes a chore → calendar POSTs</span>
+          <span class="mono">/api/integrations/grants</span> <span class="muted">with a</span> <span class="mono">source_ref</span> <span class="muted">→ dashboard records a Grant, recomputes today, pushes via timekpra, toasts the child. Retries are idempotent.</span>
+        </div>
+      </div>
+
+      <!-- AdGuard / DNS -->
+      <div class="card">
+        <div class="card-head"><h3>🌐 DNS filtering · AdGuard Home</h3><span class="sub">PCT_ADGUARD_MODE</span></div>
+        <div class="card-body col">
+          <div class="mode">
+            <div class="opt"><h4>Disabled</h4><p>No DNS layer. e2guardian still does per-user HTTP/S filtering on the client.</p></div>
+            <div class="opt sel"><h4>External ✓</h4><p>Point at the AdGuard Home you already run. Writes confined to a <span class="mono">pct:</span>-prefixed client set.</p></div>
+            <div class="opt"><h4>Managed</h4><p>Dashboard fetches &amp; supervises AdGuard on first run into the data volume.</p></div>
+          </div>
+          <div class="row wrap gap-8" style="align-items:center;">
+            <span class="pill ok"><span class="dot"></span>reachable</span>
+            <span class="muted mono" style="font-size:12.5px;">https://adguard.lan · user pct-writer · v0.107</span>
+            <button class="btn sm">Test connection</button>
+          </div>
+          <div class="muted" style="font-size:12px;">Per-client domain blocklists with schedule support land in Phase 7. This surface shows where DNS rules end up so it's never a mystery.</div>
+        </div>
+      </div>
+
+      <!-- Notification defaults -->
+      <div class="card">
+        <div class="card-head"><h3>🔔 Notification defaults</h3><span class="sub">household-wide defaults · per-user override in the policy editor</span></div>
+        <div class="card-body row wrap gap-24">
+          <div class="stat"><div class="lbl">Default sound profile</div><div class="num" style="font-size:18px;">subtle</div></div>
+          <div class="stat"><div class="lbl">Default grace period</div><div class="num" style="font-size:18px;">15s</div></div>
+          <div class="stat"><div class="lbl">Parent push (Phase 9)</div><div class="num" style="font-size:18px;">on</div><div class="muted" style="font-size:11.5px;">“5 min left”, “time's up”</div></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/admin/policy-editor.html
+++ b/design/admin/policy-editor.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Admin · Policy editor</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .editor { display:grid; grid-template-columns: 1fr 1fr; gap:16px; align-items:start; }
+  .field { display:flex; flex-direction:column; gap:5px; }
+  .field label { font-size:11.5px; font-weight:700; text-transform:uppercase; letter-spacing:0.05em; color:var(--faint); }
+  .input, select.input { font:inherit; font-size:13.5px; padding:8px 11px; border:1px solid var(--border-strong); border-radius:8px; background:var(--surface); color:var(--text); }
+  .time { display:inline-flex; align-items:center; gap:6px; border:1px solid var(--border-strong); border-radius:8px; padding:5px 8px; font-weight:600; }
+  .time button { border:none; background:var(--surface-3); width:24px; height:24px; border-radius:6px; cursor:pointer; font-size:15px; line-height:1; }
+  .rule { display:grid; grid-template-columns: 22px 1fr auto; gap:11px; align-items:center; padding:11px; border:1px solid var(--border); border-radius:10px; background:var(--surface); }
+  .rule + .rule { margin-top:8px; }
+  .handle { cursor:grab; color:var(--faint); font-size:16px; text-align:center; }
+  .rule.dragging { box-shadow:var(--shadow-lg); border-color:var(--primary); opacity:0.95; }
+  .chip { display:inline-flex; align-items:center; gap:6px; padding:4px 9px; border-radius:7px; background:var(--surface-3); font-size:12px; font-weight:600; }
+  .chip .x { color:var(--faint); cursor:pointer; }
+  .pushbar { position:sticky; bottom:0; display:flex; align-items:center; justify-content:space-between; gap:14px; padding:13px 26px; background:#15182a; color:#dfe2f2; border-radius:12px; box-shadow:var(--shadow-lg); }
+  @media (max-width:1000px){ .editor{grid-template-columns:1fr;} }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>Admin · Policy editor &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a></span></div>
+<div class="admin">
+  <nav class="admin-nav">
+    <div class="brand"><span class="logo">🛡️</span> ParentCtl</div>
+    <a href="dashboard.html"><span class="ic">▦</span> Overview</a>
+    <a href="user-detail.html"><span class="ic">👤</span> Users</a>
+    <a class="active" href="policy-editor.html"><span class="ic">⚖︎</span> Policies</a>
+    <a href="grants-ledger.html"><span class="ic">🎁</span> Grants</a>
+    <a href="clients.html"><span class="ic">🖥️</span> Clients</a>
+    <div class="nav-sec">Configure</div>
+    <a href="integrations.html"><span class="ic">🔌</span> Integrations</a>
+    <a href="integrations.html"><span class="ic">🔔</span> Notifications</a>
+    <a href="integrations.html"><span class="ic">🌐</span> DNS / AdGuard</a>
+  </nav>
+
+  <div class="admin-main">
+    <header class="admin-top">
+      <div>
+        <div class="crumb">Policies / Alice</div>
+        <h1>Edit policy · <span class="row ai-center" style="display:inline-flex;gap:7px;"><span class="avatar av-a" style="width:26px;height:26px;font-size:11px;">A</span>Alice</span></h1>
+      </div>
+      <div class="row ai-center">
+        <span class="pill warn"><span class="dot"></span>3 unsaved changes</span>
+        <button class="btn">Discard</button>
+        <button class="btn primary">Save &amp; push</button>
+      </div>
+    </header>
+
+    <div class="admin-content col gap-24">
+      <div class="editor">
+
+        <!-- Budgets -->
+        <div class="card">
+          <div class="card-head"><h3>⏱ Time budgets</h3><span class="sub">policy baseline · grants add on top</span></div>
+          <div class="card-body col">
+            <div class="field">
+              <label>Overall screen time</label>
+              <div class="row ai-center wrap gap-8">
+                <div class="time"><button>−</button> 2h 00m <button>＋</button></div>
+                <select class="input"><option>daily</option><option>weekly</option><option>monthly</option></select>
+                <span class="muted" style="font-size:12px;">→ Timekpr-nExT</span>
+              </div>
+            </div>
+            <div style="border-top:1px solid var(--border);"></div>
+            <div class="field">
+              <label>🎮 Games <span class="muted" style="text-transform:none;font-weight:400;">(group)</span></label>
+              <div class="row ai-center wrap gap-8"><div class="time"><button>−</button> 1h 00m <button>＋</button></div><select class="input"><option>daily</option></select><span class="muted" style="font-size:12px;">→ PlayTime + agent close</span></div>
+            </div>
+            <div class="field">
+              <label>▶️ YouTube <span class="muted" style="text-transform:none;font-weight:400;">(domain)</span></label>
+              <div class="row ai-center wrap gap-8"><div class="time"><button>−</button> 45m <button>＋</button></div><select class="input"><option>daily</option></select></div>
+            </div>
+            <button class="btn sm" style="align-self:flex-start;">＋ Add activity budget</button>
+          </div>
+        </div>
+
+        <!-- Activity groups -->
+        <div class="card">
+          <div class="card-head"><h3>🗂 Activity groups</h3><span class="sub">app / app-group / domain / domain-group matchers</span></div>
+          <div class="card-body col">
+            <div class="field">
+              <label>🎮 Games</label>
+              <div class="row wrap gap-8"><span class="chip">Minecraft <span class="x">×</span></span><span class="chip">steam <span class="x">×</span></span><span class="chip">lutris <span class="x">×</span></span><span class="chip" style="background:var(--surface);border:1px dashed var(--border-strong);">＋ add app/domain</span></div>
+            </div>
+            <div class="field">
+              <label>💬 Social</label>
+              <div class="row wrap gap-8"><span class="chip">discord <span class="x">×</span></span><span class="chip">messenger.com <span class="x">×</span></span><span class="chip">tiktok.com <span class="x">×</span></span></div>
+            </div>
+            <div class="field">
+              <label>💻 School</label>
+              <div class="row wrap gap-8"><span class="chip">soffice.bin <span class="x">×</span></span><span class="chip">zoom <span class="x">×</span></span><span class="chip">*.khanacademy.org <span class="x">×</span></span></div>
+            </div>
+            <button class="btn sm" style="align-self:flex-start;">＋ New group</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Schedule rules (drag to order) -->
+      <div class="card">
+        <div class="card-head">
+          <div><h3>📅 Schedule &amp; exception rules</h3><div class="sub">evaluated top-to-bottom — drag to reorder; first match wins</div></div>
+          <button class="btn sm">＋ Add rule</button>
+        </div>
+        <div class="card-body">
+          <div class="rule dragging">
+            <span class="handle">⠿</span>
+            <div class="row ai-center wrap gap-8">
+              <span class="pill bad">deny</span> <strong>💬 Social</strong>
+              <span class="muted">on</span> <span class="chip">Mon–Fri</span> <span class="chip">08:00–15:00</span>
+              <span class="muted">— “no Discord during school”</span>
+            </div>
+            <div class="row gap-8"><button class="btn ghost sm">edit</button><button class="btn ghost sm">⋯</button></div>
+          </div>
+          <div class="rule">
+            <span class="handle">⠿</span>
+            <div class="row ai-center wrap gap-8">
+              <span class="pill ok">allow</span> <strong>▶️ YouTube</strong>
+              <span class="muted">on</span> <span class="chip">Sat–Sun</span> <span class="chip">until 11:00</span>
+              <span class="muted">— “weekend morning cartoons”</span>
+            </div>
+            <div class="row gap-8"><button class="btn ghost sm">edit</button><button class="btn ghost sm">⋯</button></div>
+          </div>
+          <div class="rule">
+            <span class="handle">⠿</span>
+            <div class="row ai-center wrap gap-8">
+              <span class="pill info">extend</span> <strong>Overall +30m</strong>
+              <span class="muted">on</span> <span class="chip">Fri</span> <span class="chip">17:00–20:00</span>
+              <span class="muted">— “movie night”</span>
+            </div>
+            <div class="row gap-8"><button class="btn ghost sm">edit</button><button class="btn ghost sm">⋯</button></div>
+          </div>
+          <div class="rule">
+            <span class="handle">⠿</span>
+            <div class="row ai-center wrap gap-8">
+              <span class="pill" style="background:#5b6480;color:#fff;">lock</span> <strong>Whole device</strong>
+              <span class="muted">at</span> <span class="chip">every day 21:00</span>
+              <span class="muted">— “bedtime” · expires never</span>
+            </div>
+            <div class="row gap-8"><button class="btn ghost sm">edit</button><button class="btn ghost sm">⋯</button></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Notification policy (Phase 8b) -->
+      <div class="editor">
+        <div class="card">
+          <div class="card-head"><h3>🔔 Notifications</h3><span class="sub">NotificationPolicy · pushed to pct-client-agent</span></div>
+          <div class="card-body col">
+            <div class="row between ai-center"><span>Toast notifications</span><span class="pill ok"><span class="dot"></span>enabled</span></div>
+            <div class="field"><label>Sound profile</label><select class="input"><option>subtle (default)</option><option>off</option><option>prominent</option></select></div>
+            <div class="field"><label>Grace period before lock / close</label><div class="time"><button>−</button> 15s <button>＋</button></div></div>
+            <div class="muted" style="font-size:12px;">Cadence: 15-min warnings &gt; 15m left, 5-min ≤15m, 1-min ≤5m, “time's up” at 0:00. <a href="policy-editor.html">Override per-budget…</a></div>
+          </div>
+        </div>
+        <div class="card">
+          <div class="card-head"><h3>🌐 Web filtering</h3><span class="sub">e2guardian filter group for this UID</span></div>
+          <div class="card-body col">
+            <div class="field"><label>Filter level</label><select class="input"><option>Children (strict)</option><option>Teen (moderate)</option><option>Custom list</option></select></div>
+            <div class="field"><label>Always-blocked domains</label><div class="row wrap gap-8"><span class="chip">adult-*<span class="x">×</span></span><span class="chip">gambling<span class="x">×</span></span></div></div>
+            <div class="row between ai-center"><span>DNS-level block (AdGuard)</span><span class="pill info"><span class="dot"></span>external mode</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- sticky push bar -->
+    <div style="padding:0 26px 22px;">
+      <div class="pushbar">
+        <div style="font-size:13px;">Changes affect <strong>Alice</strong> on <span class="mono">mint-livingroom</span>. Session limits push via <strong>SSH + timekpra</strong>; filter/group changes via <strong>Ansible</strong>.</div>
+        <div class="row gap-8"><button class="btn ghost" style="color:#cdd2e6;border-color:#3a4063;">Preview diff</button><button class="btn primary">Save &amp; push now</button></div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/admin/user-detail.html
+++ b/design/admin/user-detail.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Admin · Alice</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .tabs { display:flex; gap:4px; background:var(--surface-3); padding:4px; border-radius:10px; }
+  .tabs a { padding:6px 14px; border-radius:7px; font-size:13px; font-weight:600; color:var(--muted); }
+  .tabs a.active { background:var(--surface); color:var(--text); box-shadow:var(--shadow); }
+  .split { display:grid; grid-template-columns: 2fr 1fr; gap:16px; align-items:start; }
+  .budget-list .b { display:grid; grid-template-columns: 150px 1fr 96px; gap:12px; align-items:center; padding:10px 0; border-bottom:1px solid var(--border); }
+  .budget-list .b:last-child { border-bottom:none; }
+  .sched { position:relative; height:34px; background:var(--surface-2); border:1px solid var(--border); border-radius:8px; }
+  .sched .blk { position:absolute; top:4px; bottom:4px; border-radius:5px; font-size:10.5px; color:#fff; display:flex; align-items:center; padding:0 7px; font-weight:600; }
+  @media (max-width:1000px){ .split{grid-template-columns:1fr;} }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>Admin · User detail (burndown + ActivityWatch) &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a></span></div>
+<div class="admin">
+  <nav class="admin-nav">
+    <div class="brand"><span class="logo">🛡️</span> ParentCtl</div>
+    <a href="dashboard.html"><span class="ic">▦</span> Overview</a>
+    <a class="active" href="user-detail.html"><span class="ic">👤</span> Users</a>
+    <a href="policy-editor.html"><span class="ic">⚖︎</span> Policies</a>
+    <a href="grants-ledger.html"><span class="ic">🎁</span> Grants</a>
+    <a href="clients.html"><span class="ic">🖥️</span> Clients</a>
+    <div class="nav-sec">Configure</div>
+    <a href="integrations.html"><span class="ic">🔌</span> Integrations</a>
+    <a href="integrations.html"><span class="ic">🔔</span> Notifications</a>
+    <a href="integrations.html"><span class="ic">🌐</span> DNS / AdGuard</a>
+  </nav>
+
+  <div class="admin-main">
+    <header class="admin-top">
+      <div class="row ai-center">
+        <div class="avatar av-a lg">A</div>
+        <div>
+          <div class="crumb">Users / Alice</div>
+          <h1>Alice <span class="muted" style="font-size:13px;font-weight:400;">· 11 · <span class="mono">America/New_York</span> · alice@mint-livingroom</span></h1>
+        </div>
+      </div>
+      <div class="row ai-center">
+        <span class="pill ok"><span class="dot"></span>online · agent 0.4.1</span>
+        <button class="btn">＋ Grant time</button>
+        <a class="btn primary" href="policy-editor.html">Edit policy</a>
+      </div>
+    </header>
+
+    <div class="admin-content col gap-24">
+
+      <div class="row between ai-center">
+        <div class="tabs"><a class="active">Today</a><a>This week</a><a>This month</a></div>
+        <div class="muted" style="font-size:12px;">Mon 16 Jun · usage from ActivityWatch · last pull 2m ago · budgets reset 00:00 local</div>
+      </div>
+
+      <!-- top summary -->
+      <div class="split">
+        <div class="card">
+          <div class="card-head"><h3>Overall screen-time · burndown</h3><span class="sub">2h budget + 30m granted = 2h30 today</span></div>
+          <div class="card-body">
+            <!-- burndown SVG: remaining minutes over the day -->
+            <svg viewBox="0 0 640 190" width="100%" height="190" role="img" aria-label="Burndown chart">
+              <!-- gridlines -->
+              <g stroke="var(--border)" stroke-width="1">
+                <line x1="40" y1="20"  x2="620" y2="20"/>
+                <line x1="40" y1="63"  x2="620" y2="63"/>
+                <line x1="40" y1="106" x2="620" y2="106"/>
+                <line x1="40" y1="149" x2="620" y2="149"/>
+              </g>
+              <g fill="var(--faint)" font-size="10" text-anchor="end">
+                <text x="34" y="24">150m</text><text x="34" y="67">100m</text>
+                <text x="34" y="110">50m</text><text x="34" y="153">0</text>
+              </g>
+              <!-- ideal pace (straight) -->
+              <line x1="40" y1="20" x2="620" y2="149" stroke="var(--border-strong)" stroke-width="1.5" stroke-dasharray="4 4"/>
+              <!-- actual remaining (stepped, faster than ideal) area -->
+              <path d="M40,20 L150,20 L150,55 L260,55 L260,86 L360,86 L360,92 L470,92 L470,116 L520,116 L520,116 L560,124 L560,124 L600,124 L600,124"
+                    fill="none" stroke="var(--amber)" stroke-width="2.5"/>
+              <path d="M40,20 L150,20 L150,55 L260,55 L260,86 L360,86 L360,92 L470,92 L470,116 L520,116 L560,124 L600,124 L600,170 L40,170 Z"
+                    fill="var(--amber)" opacity="0.10"/>
+              <!-- grant bump marker -->
+              <line x1="360" y1="20" x2="360" y2="170" stroke="var(--green)" stroke-width="1" stroke-dasharray="3 3"/>
+              <circle cx="360" cy="92" r="4" fill="var(--green)"/>
+              <text x="366" y="40" fill="var(--green)" font-size="10" font-weight="700">+30m grant</text>
+              <!-- now marker -->
+              <circle cx="600" cy="124" r="4.5" fill="var(--amber)"/>
+              <text x="594" y="116" fill="var(--amber)" font-size="10" font-weight="700" text-anchor="end">now · 35m left</text>
+              <g fill="var(--faint)" font-size="10" text-anchor="middle">
+                <text x="40" y="184">07:00</text><text x="190" y="184">10:00</text>
+                <text x="340" y="184">13:00</text><text x="490" y="184">16:00</text><text x="620" y="184">19:00</text>
+              </g>
+            </svg>
+            <div class="row gap-24" style="margin-top:6px;font-size:12px;">
+              <span class="muted">— — ideal pace</span>
+              <span style="color:var(--amber);font-weight:600;">— actual remaining</span>
+              <span style="color:var(--green);">● grant</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="card pad col" style="gap:14px;">
+          <div class="row ai-center gap-24">
+            <div class="ring-wrap">
+              <svg width="116" height="116" viewBox="0 0 116 116">
+                <circle class="track" cx="58" cy="58" r="48" stroke-width="11"/>
+                <circle class="value warn" cx="58" cy="58" r="48" stroke-width="11"
+                  stroke-dasharray="301.6" stroke-dashoffset="82.9" transform="rotate(-90 58 58)"/>
+              </svg>
+              <div class="ring-center"><div style="font-size:22px;font-weight:700;">35m</div><div class="muted" style="font-size:10px;">of 2h30 left</div></div>
+            </div>
+            <div class="col" style="gap:8px;">
+              <div class="stat"><div class="num" style="font-size:20px;">1h 55m</div><div class="lbl">used today</div></div>
+              <span class="pill warn"><span class="dot"></span>72% consumed</span>
+              <span class="pill ok"><span class="dot"></span>+30m granted</span>
+            </div>
+          </div>
+          <div class="muted" style="font-size:12px;border-top:1px solid var(--border);padding-top:10px;">
+            Enforced by <strong>Timekpr-nExT</strong>. At 0:00 the agent shows a 15s grace countdown, then the session locks. A grant re-opens login automatically.
+          </div>
+        </div>
+      </div>
+
+      <!-- ActivityWatch timeline -->
+      <div class="card">
+        <div class="card-head">
+          <div><h3>Usage timeline</h3><div class="sub">normalised from ActivityWatch (aw-watcher-window + aw-watcher-afk) into UsageSample rows</div></div>
+          <div class="row gap-8" style="font-size:11.5px;color:var(--muted);align-items:center;">
+            <span class="row ai-center" style="gap:5px;"><span class="swatch c-games"></span>Games</span>
+            <span class="row ai-center" style="gap:5px;"><span class="swatch c-social"></span>Social</span>
+            <span class="row ai-center" style="gap:5px;"><span class="swatch c-school"></span>School</span>
+            <span class="row ai-center" style="gap:5px;"><span class="swatch c-web"></span>Web</span>
+            <span class="row ai-center" style="gap:5px;"><span class="swatch c-idle"></span>Idle / AFK</span>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="tl">
+            <div class="tl-row">
+              <span class="tl-label"><span class="swatch c-school"></span>School</span>
+              <div class="tl-track">
+                <span class="tl-seg c-school" style="left:4%;width:14%;" title="LibreOffice 08:00–10:00"></span>
+                <span class="tl-seg c-school" style="left:22%;width:7%;"></span>
+              </div>
+            </div>
+            <div class="tl-row">
+              <span class="tl-label"><span class="swatch c-web"></span>Web</span>
+              <div class="tl-track">
+                <span class="tl-seg c-web" style="left:20%;width:5%;"></span>
+                <span class="tl-seg c-web" style="left:52%;width:9%;" title="youtube.com"></span>
+                <span class="tl-seg c-web" style="left:74%;width:4%;"></span>
+              </div>
+            </div>
+            <div class="tl-row">
+              <span class="tl-label"><span class="swatch c-games"></span>Games</span>
+              <div class="tl-track">
+                <span class="tl-seg c-games" style="left:38%;width:11%;" title="Minecraft"></span>
+                <span class="tl-seg c-games" style="left:62%;width:18%;" title="Minecraft — budget exhausted here"></span>
+              </div>
+            </div>
+            <div class="tl-row">
+              <span class="tl-label"><span class="swatch c-idle"></span>Idle</span>
+              <div class="tl-track">
+                <span class="tl-seg c-idle" style="left:30%;width:7%;"></span>
+                <span class="tl-seg c-idle" style="left:49%;width:3%;"></span>
+                <span class="tl-seg c-idle" style="left:80%;width:6%;"></span>
+              </div>
+            </div>
+          </div>
+          <div class="tl-axis" style="margin-top:8px;">
+            <span></span>
+            <div class="ticks"><span>07:00</span><span>10:00</span><span>13:00</span><span>16:00</span><span>19:00</span><span>21:00</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- budgets + schedule -->
+      <div class="split">
+        <div class="card">
+          <div class="card-head"><h3>Per-activity budgets</h3><a class="sub" href="policy-editor.html">Edit</a></div>
+          <div class="card-body budget-list" style="padding-top:6px;padding-bottom:8px;">
+            <div class="b"><div><strong>🎮 Games</strong><div class="muted" style="font-size:11.5px;">group · Minecraft, Steam</div></div><div class="bar bad"><span style="width:94%"></span></div><div style="text-align:right;font-size:12px;"><strong>3m</strong> / 1h<br><span class="muted">daily</span></div></div>
+            <div class="b"><div><strong>▶️ YouTube</strong><div class="muted" style="font-size:11.5px;">domain · youtube.com</div></div><div class="bar ok"><span style="width:40%"></span></div><div style="text-align:right;font-size:12px;"><strong>27m</strong> / 45m<br><span class="muted">daily</span></div></div>
+            <div class="b"><div><strong>💬 Social</strong><div class="muted" style="font-size:11.5px;">group · Discord, Messenger</div></div><div class="bar"><span style="width:0%"></span></div><div style="text-align:right;font-size:12px;"><strong>blocked</strong><br><span class="muted">school hours</span></div></div>
+            <div class="b"><div><strong>💻 School</strong><div class="muted" style="font-size:11.5px;">group · LibreOffice, Zoom</div></div><div class="bar"><span style="width:30%;background:var(--sky)"></span></div><div style="text-align:right;font-size:12px;"><strong>no limit</strong><br><span class="muted">always allow</span></div></div>
+          </div>
+        </div>
+
+        <div class="card pad col">
+          <div class="section-title">Today's schedule</div>
+          <div class="sched">
+            <span class="blk" style="left:2%;width:30%;background:var(--sky);">School · Social off</span>
+            <span class="blk" style="left:33%;width:40%;background:var(--green);">Free time</span>
+            <span class="blk" style="left:74%;width:18%;background:var(--grape);">Wind-down</span>
+            <span class="blk" style="left:92%;width:6%;background:#5b6480;">🔒</span>
+          </div>
+          <div class="muted" style="font-size:11.5px;">07:00 → 21:00 · bedtime lock at 21:00</div>
+          <div style="border-top:1px solid var(--border);padding-top:10px;" class="col gap-8">
+            <div class="section-title">Grants affecting today</div>
+            <div class="row between" style="font-size:12.5px;"><span>📅 +30m overall <span class="muted">· chore: clean room</span></span><span class="muted">exp 23:59</span></div>
+            <a href="grants-ledger.html" style="font-size:12px;">View grant ledger →</a>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/app/child-status.html
+++ b/design/app/child-status.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>App · My time (child)</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .hero-ring { display:grid; place-items:center; padding:6px 0 4px; }
+  .cat { display:flex; align-items:center; gap:12px; padding:11px 0; border-bottom:1px solid var(--border); }
+  .cat:last-child { border-bottom:none; }
+  .cat .ic { width:34px;height:34px;border-radius:10px;display:grid;place-items:center;font-size:16px;background:var(--surface-3); }
+  .cat .bar2 { height:7px;border-radius:999px;background:var(--surface-3);overflow:hidden;margin-top:5px; }
+  .cat .bar2 span { display:block;height:100%;border-radius:999px; }
+  .next { background:var(--sky-soft); border-radius:12px; padding:11px 13px; font-size:13px; display:flex; gap:9px; align-items:center; }
+  .reward { background:var(--green-soft); border-radius:12px; padding:11px 13px; font-size:13px; }
+  .earn { border:1px dashed var(--border-strong); border-radius:12px; padding:13px; text-align:center; }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>App (PWA) · Child status (PIN-scoped) &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a></span></div>
+<div class="phone-stage">
+  <div class="phone">
+    <div class="notch"></div>
+    <div class="statusbar"><span>9:41</span><span>📶 🔋</span></div>
+    <div class="screen">
+      <div class="app-head row between ai-center">
+        <div><div class="muted" style="font-size:12px;">Signed in with PIN</div><h1>Hi, Alice 👋</h1></div>
+        <div class="avatar av-a lg">A</div>
+      </div>
+
+      <div class="card" style="padding:16px;">
+        <div class="hero-ring">
+          <div class="ring-wrap">
+            <svg width="160" height="160" viewBox="0 0 160 160"><circle class="track" cx="80" cy="80" r="66" stroke-width="14"/><circle class="value warn" cx="80" cy="80" r="66" stroke-width="14" stroke-dasharray="414.7" stroke-dashoffset="114" transform="rotate(-90 80 80)"/></svg>
+            <div class="ring-center"><div style="font-size:34px;font-weight:700;">35m</div><div class="muted" style="font-size:12px;">left today</div></div>
+          </div>
+        </div>
+        <p class="center muted" style="font-size:12.5px;">You've used 1h 55m of 2h 30m today. Resets at midnight 🌙</p>
+      </div>
+
+      <div class="next" style="margin-top:14px;">⏰ <div><strong>Bedtime lock at 21:00</strong><div class="muted" style="font-size:11.5px;">YouTube turns back on tomorrow at 11:00 (weekend)</div></div></div>
+
+      <div class="section-title" style="margin:18px 0 4px;">My limits today</div>
+      <div class="card" style="padding:4px 16px;">
+        <div class="cat"><div class="ic">🎮</div><div class="grow"><div style="font-weight:600;">Games</div><div class="bar2"><span style="width:94%;background:var(--red);"></span></div></div><div style="text-align:right;"><strong style="color:var(--red);">3m</strong><div class="muted" style="font-size:11px;">of 1h</div></div></div>
+        <div class="cat"><div class="ic">▶️</div><div class="grow"><div style="font-weight:600;">YouTube</div><div class="bar2"><span style="width:40%;background:var(--green);"></span></div></div><div style="text-align:right;"><strong>27m</strong><div class="muted" style="font-size:11px;">of 45m</div></div></div>
+        <div class="cat"><div class="ic">💬</div><div class="grow"><div style="font-weight:600;">Social <span class="pill" style="padding:0 7px;font-size:10px;">school hours</span></div><div class="bar2"><span style="width:0%;"></span></div></div><div style="text-align:right;"><strong class="muted">off</strong><div class="muted" style="font-size:11px;">till 15:00</div></div></div>
+        <div class="cat"><div class="ic">💻</div><div class="grow"><div style="font-weight:600;">School</div><div class="bar2"><span style="width:30%;background:var(--sky);"></span></div></div><div style="text-align:right;"><strong>∞</strong><div class="muted" style="font-size:11px;">no limit</div></div></div>
+      </div>
+
+      <div class="reward" style="margin-top:14px;">🎁 <strong>+30 min</strong> added today for <strong>cleaning your room</strong> — nice work!</div>
+
+      <div class="earn" style="margin-top:14px;">
+        <div style="font-size:13px;font-weight:600;">Want more time?</div>
+        <p class="muted" style="font-size:12px;margin:4px 0 10px;">Finish a chore in the Family Calendar to earn screen time.</p>
+        <a class="btn sm primary" href="#">Open chores →</a>
+      </div>
+      <p class="muted center" style="font-size:11px;margin-top:12px;">Questions about your limits? Talk to a parent 💬</p>
+    </div>
+
+    <div class="tabbar">
+      <a class="active"><span class="ti">📊</span>My time</a>
+      <a><span class="ti">📅</span>Schedule</a>
+      <a><span class="ti">🎁</span>Rewards</a>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/app/grant.html
+++ b/design/app/grant.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>App · Grant time</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .pick { display:flex; gap:10px; }
+  .pick .p { flex:1; border:1px solid var(--border); border-radius:14px; padding:12px; text-align:center; }
+  .pick .p.sel { border-color:var(--primary); box-shadow:0 0 0 2px var(--primary-soft); }
+  .opts { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+  .opt { border:1px solid var(--border); border-radius:12px; padding:12px 14px; font-weight:600; font-size:14px; }
+  .opt.sel { border-color:var(--primary); background:var(--primary-soft); color:var(--primary-600); }
+  .amt { display:flex; gap:10px; }
+  .amt .a { flex:1; border:1px solid var(--border); border-radius:14px; padding:16px 0; text-align:center; font-size:18px; font-weight:700; }
+  .amt .a.sel { border-color:var(--primary); background:var(--primary); color:#fff; }
+  .lbl2 { font-size:11.5px; font-weight:700; text-transform:uppercase; letter-spacing:0.05em; color:var(--faint); margin-bottom:8px; }
+  .grp { margin-top:18px; }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>App (PWA) · Grant time &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a> &nbsp;·&nbsp; <a href="parent-home.html">← home</a></span></div>
+<div class="phone-stage">
+  <div class="phone">
+    <div class="notch"></div>
+    <div class="statusbar"><span>9:41</span><span>📶 🔋</span></div>
+    <div class="screen">
+      <div class="app-head row ai-center gap-8"><a href="parent-home.html" style="font-size:20px;">‹</a><h1>Grant time</h1></div>
+
+      <div class="grp">
+        <div class="lbl2">Who</div>
+        <div class="pick">
+          <div class="p sel"><div class="avatar av-a" style="margin:0 auto 6px;">A</div><div style="font-weight:600;font-size:13px;">Alice</div></div>
+          <div class="p"><div class="avatar av-b" style="margin:0 auto 6px;">B</div><div style="font-weight:600;font-size:13px;">Bob</div></div>
+          <div class="p"><div class="avatar" style="background:#9aa2bd;margin:0 auto 6px;">C</div><div style="font-weight:600;font-size:13px;">Chloe</div></div>
+        </div>
+      </div>
+
+      <div class="grp">
+        <div class="lbl2">What time</div>
+        <div class="opts">
+          <div class="opt sel">⏱ Overall screen time</div>
+          <div class="opt">🎮 Games</div>
+          <div class="opt">▶️ YouTube</div>
+          <div class="opt">💬 Social</div>
+        </div>
+      </div>
+
+      <div class="grp">
+        <div class="lbl2">How much</div>
+        <div class="amt"><div class="a">+15m</div><div class="a sel">+30m</div><div class="a">+1h</div></div>
+      </div>
+
+      <div class="grp">
+        <div class="lbl2">Expires</div>
+        <div class="opts"><div class="opt sel">End of today</div><div class="opt">End of week</div></div>
+      </div>
+
+      <div class="grp">
+        <div class="lbl2">Reason (shows in Alice's toast)</div>
+        <div class="card" style="padding:12px;color:var(--muted);font-size:13.5px;">Helped with dinner 🍝</div>
+      </div>
+
+      <div class="card" style="margin-top:18px;padding:13px 15px;background:var(--green-soft);border-color:#b6e6c9;font-size:13px;">
+        ✓ Alice will have <strong>1h 05m</strong> overall today (35m + 30m). She'll get a toast: <em>“Mum granted you +30 minutes — Helped with dinner 🍝”</em>
+      </div>
+    </div>
+
+    <div style="padding:14px 18px calc(16px + env(safe-area-inset-bottom)); border-top:1px solid var(--border);">
+      <button class="btn primary" style="width:100%;justify-content:center;font-size:15px;padding:13px;">Grant +30m to Alice</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/app/parent-home.html
+++ b/design/app/parent-home.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>App · Parent home</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .kid { border:1px solid var(--border); border-radius:16px; padding:14px; margin-bottom:12px; box-shadow:var(--shadow); background:var(--surface); }
+  .kid .top { display:flex; align-items:center; gap:12px; }
+  .quick { display:flex; gap:8px; margin-top:12px; }
+  .quick .btn { flex:1; justify-content:center; }
+  .mini { display:flex; gap:10px; margin-top:10px; font-size:11.5px; }
+  .mini .m { flex:1; background:var(--surface-2); border-radius:9px; padding:7px 9px; }
+  .alert { background:var(--amber-soft); border:1px solid #efd99a; border-radius:12px; padding:11px 13px; font-size:12.5px; margin-bottom:14px; }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>App (PWA) · Parent home &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a> &nbsp;·&nbsp; <a href="grant.html">grant →</a> <a href="child-status.html">child view →</a></span></div>
+<div class="phone-stage">
+  <div class="phone">
+    <div class="notch"></div>
+    <div class="statusbar"><span>9:41</span><span>📶 🔋</span></div>
+    <div class="screen">
+      <div class="app-head row between ai-center">
+        <div><div class="muted" style="font-size:12px;">Home screen · installed PWA</div><h1>Family</h1></div>
+        <div class="avatar av-c">P</div>
+      </div>
+
+      <div class="alert">⚠ <strong>Alice</strong> has <strong>3 min</strong> of Games left. <a href="grant.html">Add time?</a></div>
+
+      <!-- Alice -->
+      <div class="kid">
+        <div class="top">
+          <div class="avatar av-a lg">A</div>
+          <div class="grow"><div style="font-weight:650;">Alice</div><div class="muted" style="font-size:12px;"><span class="pill ok" style="padding:1px 8px;"><span class="dot"></span>online · living room</span></div></div>
+          <div class="ring-wrap">
+            <svg width="64" height="64" viewBox="0 0 64 64"><circle class="track" cx="32" cy="32" r="26" stroke-width="7"/><circle class="value warn" cx="32" cy="32" r="26" stroke-width="7" stroke-dasharray="163.4" stroke-dashoffset="45" transform="rotate(-90 32 32)"/></svg>
+            <div class="ring-center"><div style="font-size:14px;font-weight:700;">35m</div></div>
+          </div>
+        </div>
+        <div class="mini">
+          <div class="m"><div class="muted">🎮 Games</div><strong style="color:var(--red);">3m left</strong></div>
+          <div class="m"><div class="muted">▶️ YouTube</div><strong>27m left</strong></div>
+          <div class="m"><div class="muted">Overall</div><strong>35m left</strong></div>
+        </div>
+        <div class="quick"><a class="btn sm" href="grant.html">+15m</a><a class="btn sm primary" href="grant.html">+30m</a><a class="btn sm" href="grant.html">⋯</a></div>
+      </div>
+
+      <!-- Bob -->
+      <div class="kid">
+        <div class="top">
+          <div class="avatar av-b lg">B</div>
+          <div class="grow"><div style="font-weight:650;">Bob</div><div class="muted" style="font-size:12px;"><span class="pill ok" style="padding:1px 8px;"><span class="dot"></span>online · living room</span></div></div>
+          <div class="ring-wrap">
+            <svg width="64" height="64" viewBox="0 0 64 64"><circle class="track" cx="32" cy="32" r="26" stroke-width="7"/><circle class="value ok" cx="32" cy="32" r="26" stroke-width="7" stroke-dasharray="163.4" stroke-dashoffset="98" transform="rotate(-90 32 32)"/></svg>
+            <div class="ring-center"><div style="font-size:13px;font-weight:700;">1h48</div></div>
+          </div>
+        </div>
+        <div class="mini">
+          <div class="m"><div class="muted">🎮 Games</div><strong>1h05 left</strong></div>
+          <div class="m"><div class="muted">▶️ YouTube</div><strong style="color:var(--amber);">9m left</strong></div>
+          <div class="m"><div class="muted">Overall</div><strong>1h48 left</strong></div>
+        </div>
+        <div class="quick"><a class="btn sm" href="grant.html">+15m</a><a class="btn sm primary" href="grant.html">+30m</a><a class="btn sm" href="grant.html">⋯</a></div>
+      </div>
+
+      <!-- Chloe offline -->
+      <div class="kid" style="opacity:0.85;">
+        <div class="top">
+          <div class="avatar" style="background:#9aa2bd;width:46px;height:46px;font-size:16px;">C</div>
+          <div class="grow"><div style="font-weight:650;">Chloe</div><div class="muted" style="font-size:12px;"><span class="pill warn" style="padding:1px 8px;"><span class="dot"></span>offline · 45m left when locked</span></div></div>
+        </div>
+        <div class="quick"><a class="btn sm" href="grant.html">+15m</a><a class="btn sm" href="grant.html">+30m</a><a class="btn sm" href="child-status.html">View</a></div>
+      </div>
+
+      <p class="muted center" style="font-size:11px;margin-top:6px;">Pull to refresh · last synced 2m ago</p>
+    </div>
+
+    <div class="tabbar">
+      <a class="active"><span class="ti">🏠</span>Family</a>
+      <a href="grant.html"><span class="ti">🎁</span>Grant</a>
+      <a href="child-status.html"><span class="ti">📊</span>Activity</a>
+      <a><span class="ti">⚙️</span>Settings</a>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/assets/styles.css
+++ b/design/assets/styles.css
@@ -1,0 +1,308 @@
+/*
+ * Shared design tokens + components for the Parental Controls Toolkit
+ * design mock-ups. Hand-written CSS only — no build step, no framework,
+ * no external assets — so every mock-up opens straight from file://.
+ *
+ * These mock-ups are intentionally static and approximate. They exist to
+ * settle UX direction and feed the roadmap (see design/README.md); the
+ * real surfaces are SvelteKit (/admin, /app) and a TypeScript desktop
+ * app (client), per docs/proposed-tech-stack.md.
+ */
+
+:root {
+  /* palette */
+  --bg: #f4f5fb;
+  --surface: #ffffff;
+  --surface-2: #f7f8fc;
+  --surface-3: #eef0f8;
+  --border: #e3e6f0;
+  --border-strong: #cfd4e6;
+  --text: #1c2030;
+  --muted: #646b85;
+  --faint: #9097ad;
+
+  --primary: #4f46e5;
+  --primary-600: #4338ca;
+  --primary-soft: #ecebfd;
+  --teal: #0d9488;
+  --teal-soft: #d6f3ee;
+
+  --green: #1f9d57;
+  --green-soft: #d9f3e3;
+  --amber: #c98a00;
+  --amber-soft: #fbeecb;
+  --red: #d4453b;
+  --red-soft: #fbe1df;
+  --sky: #2570c4;
+  --sky-soft: #dcebfb;
+  --grape: #8b3fc7;
+  --grape-soft: #f0e2fb;
+
+  --radius: 14px;
+  --radius-sm: 9px;
+  --shadow: 0 1px 2px rgba(20, 24, 48, 0.06), 0 8px 24px rgba(20, 24, 48, 0.06);
+  --shadow-lg: 0 12px 40px rgba(20, 24, 48, 0.14);
+  --font: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, sans-serif;
+  --mono: "SFMono-Regular", ui-monospace, "JetBrains Mono", Menlo, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1, h2, h3, h4 { margin: 0; font-weight: 650; letter-spacing: -0.01em; }
+p { margin: 0; }
+
+.mono { font-family: var(--mono); font-size: 0.85em; }
+.muted { color: var(--muted); }
+.faint { color: var(--faint); }
+.center { text-align: center; }
+.nowrap { white-space: nowrap; }
+.grow { flex: 1; }
+
+/* ---------- mock-up scaffolding ---------- */
+.mock-note {
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--amber-soft);
+  border: 1px solid #efd99a;
+  border-radius: 8px;
+  padding: 6px 12px;
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+.mock-bar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 16px;
+  background: #15182a;
+  color: #cdd2e6;
+  font-size: 12.5px;
+}
+.mock-bar a { color: #aeb6f5; }
+.mock-bar .tag { background: #2a2f4a; padding: 2px 9px; border-radius: 999px; font-weight: 600; }
+
+/* ---------- generic layout helpers ---------- */
+.row { display: flex; gap: 16px; }
+.row.wrap { flex-wrap: wrap; }
+.col { display: flex; flex-direction: column; gap: 16px; }
+.between { justify-content: space-between; }
+.ai-center { align-items: center; }
+.gap-8 { gap: 8px; }
+.gap-24 { gap: 24px; }
+.grid { display: grid; gap: 16px; }
+
+/* ---------- cards ---------- */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+.card.pad { padding: 18px 20px; }
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 15px 20px;
+  border-bottom: 1px solid var(--border);
+}
+.card-head h3 { font-size: 15px; }
+.card-head .sub { font-size: 12px; color: var(--muted); }
+.card-body { padding: 18px 20px; }
+
+.section-title { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--faint); font-weight: 700; }
+
+/* ---------- pills / badges ---------- */
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--surface-3);
+  color: var(--muted);
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.pill .dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+.pill.ok { background: var(--green-soft); color: #157c43; }
+.pill.warn { background: var(--amber-soft); color: #93660a; }
+.pill.bad { background: var(--red-soft); color: #ab332b; }
+.pill.info { background: var(--sky-soft); color: #1c5697; }
+.pill.brand { background: var(--primary-soft); color: var(--primary-600); }
+.pill.grape { background: var(--grape-soft); color: #6c2ba0; }
+
+/* ---------- buttons ---------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font: inherit;
+  font-size: 13.5px;
+  font-weight: 600;
+  padding: 8px 15px;
+  border-radius: 9px;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn:hover { background: var(--surface-2); text-decoration: none; }
+.btn.primary { background: var(--primary); border-color: var(--primary); color: #fff; }
+.btn.primary:hover { background: var(--primary-600); }
+.btn.ghost { border-color: transparent; background: transparent; color: var(--muted); }
+.btn.ghost:hover { background: var(--surface-3); }
+.btn.sm { padding: 5px 11px; font-size: 12.5px; }
+.btn.danger { color: var(--red); border-color: #eab4af; }
+
+/* ---------- tables ---------- */
+table.tbl { width: 100%; border-collapse: collapse; font-size: 13.5px; }
+table.tbl th {
+  text-align: left;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--faint);
+  font-weight: 700;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+table.tbl td { padding: 11px 12px; border-bottom: 1px solid var(--border); vertical-align: middle; }
+table.tbl tr:last-child td { border-bottom: none; }
+table.tbl tr:hover td { background: var(--surface-2); }
+
+/* ---------- avatars ---------- */
+.avatar {
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  font-weight: 700; font-size: 13px;
+  color: #fff;
+  flex: none;
+}
+.avatar.lg { width: 46px; height: 46px; font-size: 16px; }
+.av-a { background: linear-gradient(135deg, #6366f1, #8b5cf6); }
+.av-b { background: linear-gradient(135deg, #0ea5a3, #14b8a6); }
+.av-c { background: linear-gradient(135deg, #f59e0b, #ef7c3a); }
+
+/* ---------- progress bars ---------- */
+.bar { height: 9px; border-radius: 999px; background: var(--surface-3); overflow: hidden; }
+.bar > span { display: block; height: 100%; border-radius: 999px; background: var(--primary); }
+.bar.ok > span { background: var(--green); }
+.bar.warn > span { background: var(--amber); }
+.bar.bad > span { background: var(--red); }
+.bar.thin { height: 6px; }
+
+/* ---------- SVG ring (donut) ---------- */
+.ring-wrap { position: relative; display: inline-grid; place-items: center; }
+.ring-wrap .ring-center { position: absolute; text-align: center; line-height: 1.05; }
+svg .track { fill: none; stroke: var(--surface-3); }
+svg .value { fill: none; stroke: var(--primary); stroke-linecap: round; transition: none; }
+svg .value.ok { stroke: var(--green); }
+svg .value.warn { stroke: var(--amber); }
+svg .value.bad { stroke: var(--red); }
+
+/* ---------- timeline (ActivityWatch-style) ---------- */
+.tl { display: flex; flex-direction: column; gap: 9px; }
+.tl-row { display: grid; grid-template-columns: 96px 1fr; align-items: center; gap: 12px; }
+.tl-label { font-size: 12.5px; color: var(--muted); display: flex; align-items: center; gap: 7px; }
+.tl-track { position: relative; height: 22px; background: var(--surface-2); border-radius: 6px; border: 1px solid var(--border); }
+.tl-seg { position: absolute; top: 3px; bottom: 3px; border-radius: 4px; opacity: 0.92; }
+.tl-axis { display: grid; grid-template-columns: 96px 1fr; gap: 12px; font-size: 10.5px; color: var(--faint); }
+.tl-axis .ticks { display: flex; justify-content: space-between; }
+
+.swatch { width: 10px; height: 10px; border-radius: 3px; flex: none; }
+.c-games { background: #8b5cf6; }
+.c-social { background: #ef7c3a; }
+.c-school { background: #14b8a6; }
+.c-web { background: #2570c4; }
+.c-other { background: #94a0bd; }
+.c-idle { background: #d4d8e6; }
+
+/* ---------- KPI stat ---------- */
+.stat .num { font-size: 26px; font-weight: 700; letter-spacing: -0.02em; }
+.stat .lbl { font-size: 12px; color: var(--muted); }
+
+/* ============================================================
+ * Admin shell — desktop app chrome with left nav
+ * ============================================================ */
+.admin { display: grid; grid-template-columns: 232px 1fr; min-height: 100vh; }
+.admin-nav { background: #161a2e; color: #c7cce2; padding: 18px 14px; display: flex; flex-direction: column; gap: 4px; }
+.admin-nav .brand { display: flex; align-items: center; gap: 9px; padding: 6px 8px 16px; font-weight: 700; color: #fff; font-size: 15px; }
+.admin-nav .brand .logo { width: 26px; height: 26px; border-radius: 7px; background: linear-gradient(135deg,#6366f1,#0d9488); display:grid; place-items:center; font-size:14px; }
+.admin-nav .nav-sec { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; color: #6f76a0; margin: 14px 8px 4px; }
+.admin-nav a { display: flex; align-items: center; gap: 10px; padding: 8px 10px; border-radius: 8px; color: #c7cce2; font-size: 13.5px; font-weight: 500; }
+.admin-nav a:hover { background: #232845; text-decoration: none; }
+.admin-nav a.active { background: var(--primary); color: #fff; }
+.admin-nav a .ic { width: 18px; text-align: center; opacity: 0.9; }
+.admin-nav .spacer { flex: 1; }
+.admin-main { display: flex; flex-direction: column; min-width: 0; }
+.admin-top { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 26px; background: var(--surface); border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 20; }
+.admin-top h1 { font-size: 18px; }
+.admin-top .crumb { font-size: 12.5px; color: var(--faint); }
+.admin-content { padding: 24px 26px 56px; }
+.search { display:flex; align-items:center; gap:8px; background: var(--surface-2); border:1px solid var(--border); border-radius:9px; padding:7px 12px; color: var(--muted); font-size:13px; min-width: 240px; }
+.search input { border:none; background:transparent; outline:none; font:inherit; color:var(--text); width:100%; }
+
+/* ============================================================
+ * Phone shell — PWA mock-up frame
+ * ============================================================ */
+.phone-stage { min-height: 100vh; display: grid; place-items: center; padding: 32px 16px; background:
+  radial-gradient(1200px 600px at 50% -10%, #e9eafb, transparent), var(--bg); }
+.phone { width: 390px; max-width: 100%; height: 800px; background: var(--surface); border-radius: 40px; box-shadow: var(--shadow-lg); border: 1px solid var(--border); overflow: hidden; display: flex; flex-direction: column; position: relative; }
+.phone .statusbar { display:flex; justify-content:space-between; align-items:center; padding: 12px 24px 6px; font-size: 12px; font-weight:600; color: var(--text); }
+.phone .notch { position:absolute; top:10px; left:50%; transform:translateX(-50%); width:120px; height:24px; background:#0c0e18; border-radius:0 0 16px 16px; }
+.phone .screen { flex:1; overflow-y: auto; padding: 8px 18px 18px; }
+.phone .tabbar { display:flex; justify-content:space-around; padding: 10px 8px calc(10px + env(safe-area-inset-bottom)); border-top: 1px solid var(--border); background: var(--surface); }
+.phone .tabbar a { display:flex; flex-direction:column; align-items:center; gap:3px; font-size:10.5px; color: var(--faint); }
+.phone .tabbar a.active { color: var(--primary); }
+.phone .tabbar .ti { font-size:18px; }
+.app-head { padding: 6px 2px 14px; }
+.app-head h1 { font-size: 22px; }
+
+/* ============================================================
+ * Client desktop window shell (Cinnamon-ish)
+ * ============================================================ */
+.desk-stage { min-height: 100vh; padding: 28px 18px; background:
+  linear-gradient(160deg,#2b3252,#1c2138 60%, #141829);
+  display: grid; place-items: start center; }
+.win { width: min(1080px, 100%); background: var(--surface); border-radius: 12px; overflow: hidden; box-shadow: var(--shadow-lg); border: 1px solid #0e1120; }
+.win-bar { display:flex; align-items:center; gap:10px; padding: 9px 14px; background: #20243a; color:#e7e9f6; }
+.win-bar .traffic { display:flex; gap:7px; }
+.win-bar .traffic i { width:12px; height:12px; border-radius:50%; display:block; }
+.win-bar .title { font-size: 13px; font-weight:600; display:flex; align-items:center; gap:8px; }
+.win-bar .spacer { flex:1; }
+.win-body { display:grid; grid-template-columns: 200px 1fr; min-height: 560px; }
+.win-nav { background: var(--surface-2); border-right:1px solid var(--border); padding:16px 12px; display:flex; flex-direction:column; gap:3px; }
+.win-nav a { display:flex; align-items:center; gap:10px; padding:9px 11px; border-radius:9px; font-size:13.5px; color:var(--muted); font-weight:550; }
+.win-nav a:hover { background: var(--surface-3); text-decoration:none; }
+.win-nav a.active { background: var(--primary-soft); color: var(--primary-600); }
+.win-content { padding: 22px 26px 30px; overflow-y:auto; }
+
+@media (max-width: 720px){
+  .admin { grid-template-columns: 1fr; }
+  .admin-nav { flex-direction: row; flex-wrap: wrap; }
+  .win-body { grid-template-columns: 1fr; }
+  .win-nav { flex-direction: row; flex-wrap: wrap; border-right:none; border-bottom:1px solid var(--border); }
+}

--- a/design/client/dashboard.html
+++ b/design/client/dashboard.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Client · My Time</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .hero { display:grid; grid-template-columns: auto 1fr; gap:24px; align-items:center; }
+  .now-card { border-radius:14px; padding:16px 18px; background:linear-gradient(135deg,var(--primary-soft),var(--teal-soft)); }
+  .cat-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:12px; }
+  .cat { display:flex; align-items:center; gap:12px; border:1px solid var(--border); border-radius:12px; padding:12px; }
+  .cat .ic { width:38px;height:38px;border-radius:11px;display:grid;place-items:center;font-size:18px;background:var(--surface-3);flex:none; }
+  .cat .bar2 { height:7px;border-radius:999px;background:var(--surface-3);overflow:hidden;margin-top:6px; }
+  .cat .bar2 span { display:block;height:100%;border-radius:999px; }
+  .week { display:flex; align-items:flex-end; gap:10px; height:120px; padding-top:8px; }
+  .week .d { flex:1; display:flex; flex-direction:column; align-items:center; gap:6px; height:100%; justify-content:flex-end; }
+  .week .col2 { width:60%; border-radius:6px 6px 0 0; position:relative; }
+  .week .budget-line { width:80%; height:2px; background:var(--border-strong); }
+  .next-list .n { display:flex; gap:11px; padding:10px 0; border-bottom:1px dashed var(--border); font-size:13px; }
+  .next-list .n:last-child { border-bottom:none; }
+  .nt { width:26px;height:26px;border-radius:8px;display:grid;place-items:center;flex:none;font-size:13px; }
+  .reward { background:var(--green-soft); border-radius:12px; padding:12px 14px; font-size:13px; display:flex; gap:9px; }
+  .statusrow { display:flex; align-items:center; gap:14px; flex-wrap:wrap; font-size:12px; color:var(--muted); border-top:1px solid var(--border); padding-top:14px; }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>Client · supervised-user desktop dashboard (NEW) &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a> &nbsp;·&nbsp; <a href="notifications.html">toasts →</a></span></div>
+
+<div class="desk-stage">
+  <div class="win">
+    <!-- window titlebar -->
+    <div class="win-bar">
+      <div class="traffic"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i></div>
+      <div class="title">🛡️ My Time <span class="muted" style="color:#9aa2c6;font-weight:400;">— Parental Controls</span></div>
+      <div class="spacer"></div>
+      <span class="pill ok" style="background:#26405e;color:#9be7b6;"><span class="dot"></span>connected</span>
+    </div>
+
+    <div class="win-body">
+      <!-- left nav -->
+      <nav class="win-nav">
+        <a class="active">⏱ Today</a>
+        <a>📈 This week</a>
+        <a>📅 Schedule</a>
+        <a>🎁 Rewards</a>
+        <a>🌐 What's filtered</a>
+        <div class="grow"></div>
+        <a>❓ Help</a>
+      </nav>
+
+      <!-- content -->
+      <div class="win-content col gap-24">
+
+        <!-- HERO: time left now + what's happening -->
+        <div class="hero">
+          <div class="ring-wrap">
+            <svg width="150" height="150" viewBox="0 0 150 150">
+              <circle class="track" cx="75" cy="75" r="62" stroke-width="13"/>
+              <circle class="value warn" cx="75" cy="75" r="62" stroke-width="13" stroke-dasharray="389.6" stroke-dashoffset="107" transform="rotate(-90 75 75)"/>
+            </svg>
+            <div class="ring-center"><div style="font-size:32px;font-weight:700;">35m</div><div class="muted" style="font-size:11px;">screen time<br>left today</div></div>
+          </div>
+          <div class="col" style="gap:12px;">
+            <div>
+              <h2 style="font-size:21px;">Hi Alice 👋 — you've got <span style="color:var(--amber);">35 minutes</span> left today</h2>
+              <p class="muted" style="font-size:13px;margin-top:3px;">Used 1h 55m of 2h 30m. Your time resets at midnight. You'll get a heads-up at 15, 5, and 1 minute left.</p>
+            </div>
+            <div class="now-card row ai-center between">
+              <div><div class="section-title" style="color:var(--primary-600);">Right now</div><div style="font-weight:650;margin-top:2px;">🟢 Free time</div><div class="muted" style="font-size:12px;">Games &amp; YouTube allowed · Social is off during school hours</div></div>
+              <div class="center"><div style="font-size:12px;" class="muted">next change</div><strong>15:00</strong></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- per-app / per-category budgets -->
+        <div>
+          <div class="row between ai-center" style="margin-bottom:10px;"><div class="section-title">Time left by app &amp; category</div><span class="muted" style="font-size:11.5px;">live · updated from your activity</span></div>
+          <div class="cat-grid">
+            <div class="cat">
+              <div class="ic">🎮</div>
+              <div class="grow"><div class="row between"><strong>Games</strong><span style="color:var(--red);font-weight:700;">3m left</span></div><div class="bar2"><span style="width:94%;background:var(--red);"></span></div><div class="muted" style="font-size:11px;margin-top:4px;">Minecraft, Steam · 57m of 1h used</div></div>
+            </div>
+            <div class="cat">
+              <div class="ic">▶️</div>
+              <div class="grow"><div class="row between"><strong>YouTube</strong><span style="color:var(--green);font-weight:700;">27m left</span></div><div class="bar2"><span style="width:40%;background:var(--green);"></span></div><div class="muted" style="font-size:11px;margin-top:4px;">18m of 45m used</div></div>
+            </div>
+            <div class="cat">
+              <div class="ic">💬</div>
+              <div class="grow"><div class="row between"><strong>Social</strong><span class="muted" style="font-weight:700;">off</span></div><div class="bar2"><span style="width:100%;background:var(--surface-3);"></span></div><div class="muted" style="font-size:11px;margin-top:4px;">Discord, TikTok · back on at 15:00</div></div>
+            </div>
+            <div class="cat">
+              <div class="ic">💻</div>
+              <div class="grow"><div class="row between"><strong>School</strong><span style="color:var(--sky);font-weight:700;">no limit</span></div><div class="bar2"><span style="width:30%;background:var(--sky);"></span></div><div class="muted" style="font-size:11px;margin-top:4px;">LibreOffice, Zoom, Khan Academy</div></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- today's timeline (rendered from ActivityWatch data) -->
+        <div class="card">
+          <div class="card-head"><div><h3>What you did today</h3><div class="sub">your own activity, on your device</div></div>
+            <div class="row gap-8" style="font-size:11px;color:var(--muted);">
+              <span class="row ai-center" style="gap:5px;"><span class="swatch c-school"></span>School</span>
+              <span class="row ai-center" style="gap:5px;"><span class="swatch c-web"></span>Web</span>
+              <span class="row ai-center" style="gap:5px;"><span class="swatch c-games"></span>Games</span>
+              <span class="row ai-center" style="gap:5px;"><span class="swatch c-idle"></span>Away</span>
+            </div>
+          </div>
+          <div class="card-body">
+            <div class="tl">
+              <div class="tl-row"><span class="tl-label"><span class="swatch c-school"></span>School</span><div class="tl-track"><span class="tl-seg c-school" style="left:4%;width:14%;"></span><span class="tl-seg c-school" style="left:22%;width:7%;"></span></div></div>
+              <div class="tl-row"><span class="tl-label"><span class="swatch c-web"></span>Web / YT</span><div class="tl-track"><span class="tl-seg c-web" style="left:20%;width:5%;"></span><span class="tl-seg c-web" style="left:52%;width:9%;"></span></div></div>
+              <div class="tl-row"><span class="tl-label"><span class="swatch c-games"></span>Games</span><div class="tl-track"><span class="tl-seg c-games" style="left:38%;width:11%;"></span><span class="tl-seg c-games" style="left:62%;width:18%;"></span></div></div>
+              <div class="tl-row"><span class="tl-label"><span class="swatch c-idle"></span>Away</span><div class="tl-track"><span class="tl-seg c-idle" style="left:30%;width:7%;"></span><span class="tl-seg c-idle" style="left:80%;width:6%;"></span></div></div>
+            </div>
+            <div class="tl-axis" style="margin-top:8px;"><span></span><div class="ticks"><span>7am</span><span>10am</span><span>1pm</span><span>4pm</span><span>7pm</span><span>9pm</span></div></div>
+            <p class="muted" style="font-size:11px;margin-top:10px;">Powered by ActivityWatch on this computer. <a href="#">Open the full ActivityWatch view →</a></p>
+          </div>
+        </div>
+
+        <!-- this week + what's coming -->
+        <div class="row" style="align-items:stretch;">
+          <div class="card pad grow">
+            <div class="section-title">This week</div>
+            <div class="week">
+              <div class="d"><div class="col2" style="height:55%;background:var(--green);"></div><span class="muted" style="font-size:10px;">M</span></div>
+              <div class="d"><div class="col2" style="height:70%;background:var(--green);"></div><span class="muted" style="font-size:10px;">T</span></div>
+              <div class="d"><div class="col2" style="height:48%;background:var(--green);"></div><span class="muted" style="font-size:10px;">W</span></div>
+              <div class="d"><div class="col2" style="height:62%;background:var(--green);"></div><span class="muted" style="font-size:10px;">T</span></div>
+              <div class="d"><div class="col2" style="height:95%;background:var(--amber);"></div><span style="font-size:10px;font-weight:700;">F</span></div>
+              <div class="d"><div class="col2" style="height:30%;background:var(--surface-3);"></div><span class="muted" style="font-size:10px;">S</span></div>
+              <div class="d"><div class="col2" style="height:30%;background:var(--surface-3);"></div><span class="muted" style="font-size:10px;">S</span></div>
+            </div>
+            <p class="muted" style="font-size:11.5px;margin-top:8px;">Daily limit ~2h. You're a bit over today — nearly all used up. 💪</p>
+          </div>
+
+          <div class="card pad" style="width:320px;flex:none;">
+            <div class="section-title">Coming up today</div>
+            <div class="next-list">
+              <div class="n"><span class="nt" style="background:var(--sky-soft);">💬</span><div><strong>Social unlocks</strong> at 15:00<div class="muted" style="font-size:11px;">Discord &amp; TikTok become available</div></div></div>
+              <div class="n"><span class="nt" style="background:var(--grape-soft);">🌙</span><div><strong>Wind-down</strong> at 19:00<div class="muted" style="font-size:11px;">calmer apps only</div></div></div>
+              <div class="n"><span class="nt" style="background:#e6e8f0;">🔒</span><div><strong>Bedtime lock</strong> at 21:00<div class="muted" style="font-size:11px;">you'll get warnings before</div></div></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- rewards + earn more -->
+        <div class="reward">🎁 <div><strong>+30 minutes</strong> added today for <strong>cleaning your room</strong>. <a href="#">See all rewards →</a><div class="muted" style="font-size:11.5px;">Finish chores in the Family Calendar to earn more screen time.</div></div></div>
+
+        <!-- status footer -->
+        <div class="statusrow">
+          <span class="pill ok"><span class="dot"></span>Agent connected</span>
+          <span>Last updated just now</span>
+          <span>·</span>
+          <span>🌐 Some websites are filtered to keep things safe — <a href="#">what's filtered?</a></span>
+          <span class="grow"></span>
+          <span>Need more time or think a limit is wrong? <a href="#">Ask a parent</a></span>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/design/client/notifications.html
+++ b/design/client/notifications.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Client · Toasts &amp; countdown</title>
+<link rel="stylesheet" href="../assets/styles.css" />
+<style>
+  .toast-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:18px; max-width:840px; margin:0 auto; }
+  .case { display:flex; flex-direction:column; gap:8px; }
+  .case .cap { color:#c7cce2; font-size:12.5px; }
+  .case .cap .mono { color:#9be7b6; }
+  /* a Cinnamon/libnotify-ish toast */
+  .toast { width:100%; background:#1c2030; color:#eef0f8; border:1px solid #2c3350; border-radius:13px; padding:13px 14px; box-shadow:var(--shadow-lg); display:flex; gap:12px; }
+  .toast .ic { width:40px;height:40px;border-radius:11px;display:grid;place-items:center;font-size:20px;flex:none; }
+  .toast .body { flex:1; min-width:0; }
+  .toast .t { font-weight:650; font-size:14px; }
+  .toast .d { font-size:12.5px; color:#aab2cf; margin-top:2px; }
+  .toast .app { font-size:11px; color:#7d86a8; margin-top:8px; display:flex; justify-content:space-between; }
+  .toast .actions { display:flex; gap:8px; margin-top:10px; }
+  .toast .tbtn { font:inherit; font-size:12px; font-weight:600; padding:5px 11px; border-radius:7px; border:1px solid #3a4063; background:#262c45; color:#dfe2f2; cursor:pointer; }
+  .toast .tbtn.go { background:var(--primary); border-color:var(--primary); color:#fff; }
+  .gauge { height:6px; border-radius:999px; background:#2c3350; overflow:hidden; margin-top:10px; }
+  .gauge span { display:block; height:100%; border-radius:999px; }
+  .big-count { font-size:30px; font-weight:800; letter-spacing:-0.02em; line-height:1; }
+  .header { max-width:840px; margin:0 auto 22px; color:#dfe2f2; }
+</style>
+</head>
+<body>
+<div class="mock-bar"><span class="tag">MOCK-UP</span><span>Client · notification states &nbsp;·&nbsp; <a href="../index.html">↑ all mock-ups</a> &nbsp;·&nbsp; <a href="dashboard.html">← My Time dashboard</a></span></div>
+
+<div class="desk-stage" style="display:block;padding:34px 18px 60px;">
+  <div class="header">
+    <span class="pill" style="background:#26405e;color:#9be7b6;">pct-client-agent</span>
+    <h1 style="margin-top:10px;font-size:22px;">Toast &amp; countdown states</h1>
+    <p style="color:#aab2cf;font-size:13.5px;max-width:70ch;margin-top:6px;">
+      Rendered through Cinnamon's own notification stack (<span class="mono" style="color:#9be7b6;">gdbus</span> / <span class="mono" style="color:#9be7b6;">notify-send</span>),
+      sound via <span class="mono" style="color:#9be7b6;">canberra-gtk-play</span>. The escalating cadence, grace countdown, and force-close behaviour are specified in
+      <span class="mono" style="color:#9be7b6;">docs/client-notifications.md</span>. These are the exact moments the supervised user actually sees.
+    </p>
+  </div>
+
+  <div class="toast-grid">
+
+    <!-- routine 15-min -->
+    <div class="case">
+      <div class="cap">Routine warning · &gt;15m left · interval 15m · sound <span class="mono">subtle</span></div>
+      <div class="toast">
+        <div class="ic" style="background:#2b3550;">⏳</div>
+        <div class="body"><div class="t">30 minutes of screen time left</div><div class="d">Heads up — your time resets at midnight.</div><div class="app"><span>My Time</span><span>now</span></div></div>
+      </div>
+    </div>
+
+    <!-- 5-min -->
+    <div class="case">
+      <div class="cap">≤5m left · interval 1m · sound <span class="mono">dialog-warning</span></div>
+      <div class="toast">
+        <div class="ic" style="background:#4a3a1e;color:#ffd479;">⚠️</div>
+        <div class="body"><div class="t">5 minutes left — start wrapping up</div><div class="d">Save your work so nothing is lost.</div><div class="app"><span>My Time</span><span>now</span></div></div>
+      </div>
+    </div>
+
+    <!-- coalesced multi-budget -->
+    <div class="case">
+      <div class="cap">Coalesced — two budgets cross a boundary together</div>
+      <div class="toast">
+        <div class="ic" style="background:#4a3a1e;color:#ffd479;">⚠️</div>
+        <div class="body"><div class="t">YouTube and Games both have 5 minutes left</div><div class="d">One alert instead of two, to avoid spam.</div><div class="app"><span>My Time</span><span>now</span></div></div>
+      </div>
+    </div>
+
+    <!-- per-app time's up + grace countdown -->
+    <div class="case">
+      <div class="cap">Per-app budget hit 0:00 · grace countdown (updates each second) · <span class="mono">enforce.force_close</span> after grace</div>
+      <div class="toast">
+        <div class="ic" style="background:#4a2420;color:#ff9b91;">🎮</div>
+        <div class="body">
+          <div class="t">Time's up for Games — save and quit!</div>
+          <div class="d">Minecraft will close in</div>
+          <div class="big-count" style="color:#ff9b91;">0:11</div>
+          <div class="gauge"><span style="width:73%;background:var(--red);"></span></div>
+          <div class="actions"><button class="tbtn">Save &amp; quit now</button></div>
+          <div class="app"><span>My Time · keeps reappearing until done</span><span>now</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- overall time's up -> session lock -->
+    <div class="case">
+      <div class="cap">Overall screen-time hit 0:00 · <span class="mono">enforce.session_lock</span> via Timekpr-nExT after grace</div>
+      <div class="toast">
+        <div class="ic" style="background:#2b2f44;">🔒</div>
+        <div class="body">
+          <div class="t">Screen time is up for today</div>
+          <div class="d">Your session will lock in <strong>0:08</strong>. You can log back in when you have more time, or after midnight.</div>
+          <div class="gauge"><span style="width:53%;background:#8a93b8;"></span></div>
+          <div class="app"><span>Timekpr-nExT + My Time</span><span>now</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- grant arrived (happy path) -->
+    <div class="case">
+      <div class="cap">Server event <span class="mono">grant.applied</span> · sound <span class="mono">complete</span> · dismisses any countdown</div>
+      <div class="toast" style="border-color:#2f6b46;">
+        <div class="ic" style="background:#1f5236;color:#9be7b6;">🎁</div>
+        <div class="body"><div class="t">Mum granted you +30 minutes</div><div class="d">“Cleaned room (chore reward)” — keep going!</div><div class="app"><span>My Time</span><span>now</span></div></div>
+      </div>
+    </div>
+
+    <!-- policy changed -->
+    <div class="case">
+      <div class="cap">Server event <span class="mono">policy.changed</span></div>
+      <div class="toast">
+        <div class="ic" style="background:#1e3a52;color:#8ec5ff;">✏️</div>
+        <div class="body"><div class="t">Your YouTube limit is now 1 hour</div><div class="d">Updated by a parent.</div><div class="app"><span>My Time</span><span>now</span></div></div>
+      </div>
+    </div>
+
+    <!-- lockout cleared -->
+    <div class="case">
+      <div class="cap">Server event <span class="mono">lockout.cleared</span> · shown on any device you're logged into</div>
+      <div class="toast" style="border-color:#2f6b46;">
+        <div class="ic" style="background:#1f5236;color:#9be7b6;">🔓</div>
+        <div class="body"><div class="t">More time! You can log back in.</div><div class="d">A grant restored your screen time.</div><div class="app"><span>My Time</span><span>now</span></div></div>
+      </div>
+    </div>
+
+    <!-- offline indicator (failure mode) -->
+    <div class="case">
+      <div class="cap">Degraded mode · bridge offline · enforcement continues on cached budget</div>
+      <div class="toast" style="opacity:0.92;">
+        <div class="ic" style="background:#3a3320;color:#e6cf8a;">📡</div>
+        <div class="body"><div class="t">Working offline</div><div class="d">Can't reach the server right now. Your time limits still work using the last known settings.</div><div class="app"><span>My Time</span><span>persistent</span></div></div>
+      </div>
+    </div>
+
+    <!-- bedtime heads up -->
+    <div class="case">
+      <div class="cap">Schedule transition heads-up (from local schedule cache)</div>
+      <div class="toast">
+        <div class="ic" style="background:#2f244a;color:#d3b6ff;">🌙</div>
+        <div class="body"><div class="t">Bedtime lock in 10 minutes</div><div class="d">The computer will lock at 21:00. Time to wrap up!</div><div class="app"><span>My Time</span><span>20:50</span></div></div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</body>
+</html>

--- a/design/index.html
+++ b/design/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Design mock-ups · Parental Controls Toolkit</title>
+<link rel="stylesheet" href="assets/styles.css" />
+<style>
+  .wrap { max-width: 1040px; margin: 0 auto; padding: 40px 24px 80px; }
+  .hero h1 { font-size: 30px; }
+  .hero p { color: var(--muted); max-width: 64ch; margin-top: 10px; }
+  .surface-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 10px; }
+  .tile { display: block; padding: 16px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--surface); }
+  .tile:hover { border-color: var(--border-strong); text-decoration: none; box-shadow: var(--shadow); }
+  .tile .nm { font-weight: 650; color: var(--text); }
+  .tile .ds { font-size: 12.5px; color: var(--muted); margin-top: 3px; }
+  .surface-head { display: flex; align-items: baseline; gap: 10px; margin: 34px 0 12px; }
+  .surface-head h2 { font-size: 18px; }
+  .legend { display: flex; gap: 16px; flex-wrap: wrap; font-size: 12.5px; color: var(--muted); }
+  @media (max-width: 760px){ .surface-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="mock-bar">
+  <span class="tag">MOCK-UP</span>
+  <span>Static HTML design studies — not the shipping product. See <a href="../README.md">repo README</a> &amp; <code>design/README.md</code>.</span>
+</div>
+
+<div class="wrap">
+  <div class="hero">
+    <span class="pill brand">Parental Controls Toolkit</span>
+    <h1 style="margin-top:12px;">UI / UX design mock-ups</h1>
+    <p>
+      Three consumer surfaces feed one Fastify dashboard and one policy store
+      (see <code>docs/architecture.md</code>). These plain-HTML studies explore
+      what each surface should look like and feel like before the SvelteKit and
+      desktop-app work lands. The supervised-user <strong>client dashboard</strong>
+      is new territory — proposed here for the first time and written up in
+      <code>design/README.md</code>.
+    </p>
+  </div>
+
+  <div class="surface-head">
+    <h2>1 · Admin</h2><span class="pill info">/admin · desktop · SvelteKit</span>
+    <span class="muted" style="font-size:12.5px;">Roadmap Phase 2 / 5 / 10</span>
+  </div>
+  <div class="surface-grid">
+    <a class="tile" href="admin/dashboard.html"><div class="nm">Overview dashboard</div><div class="ds">All supervised users at a glance, live burndown, client &amp; agent health.</div></a>
+    <a class="tile" href="admin/user-detail.html"><div class="nm">User detail</div><div class="ds">Per-user burndown charts + ActivityWatch usage timeline + budgets.</div></a>
+    <a class="tile" href="admin/policy-editor.html"><div class="nm">Policy editor</div><div class="ds">Budgets, schedules, activity groups, drag-to-order rules.</div></a>
+    <a class="tile" href="admin/grants-ledger.html"><div class="nm">Grant ledger</div><div class="ds">Immutable record of every grant; grant time; revoke.</div></a>
+    <a class="tile" href="admin/clients.html"><div class="nm">Clients</div><div class="ds">Enrolled machines, agent liveness, enrol-a-client flow.</div></a>
+    <a class="tile" href="admin/integrations.html"><div class="nm">Integrations &amp; DNS</div><div class="ds">Calendar API tokens, AdGuard mode, notification defaults.</div></a>
+  </div>
+
+  <div class="surface-head">
+    <h2>2 · App (PWA)</h2><span class="pill grape">/app · mobile · SvelteKit PWA</span>
+    <span class="muted" style="font-size:12.5px;">Roadmap Phase 9</span>
+  </div>
+  <div class="surface-grid">
+    <a class="tile" href="app/parent-home.html"><div class="nm">Parent home</div><div class="ds">All kids on one phone screen; tap to grant time fast.</div></a>
+    <a class="tile" href="app/grant.html"><div class="nm">Grant time</div><div class="ds">Touch-friendly: pick child, scope, amount, reason.</div></a>
+    <a class="tile" href="app/child-status.html"><div class="nm">Child status</div><div class="ds">PIN-scoped view of just my own time left today.</div></a>
+  </div>
+
+  <div class="surface-head">
+    <h2>3 · Client</h2><span class="pill ok">supervised desktop · Cinnamon · TS app</span>
+    <span class="muted" style="font-size:12.5px;">NEW — proposed, see README</span>
+  </div>
+  <div class="surface-grid">
+    <a class="tile" href="client/dashboard.html"><div class="nm">My Time (dashboard)</div><div class="ds">The new piece: what the child sees — time left across apps/categories, today's timeline, schedule, rewards.</div></a>
+    <a class="tile" href="client/notifications.html"><div class="nm">Toasts &amp; countdown</div><div class="ds">The notification states from docs/client-notifications.md.</div></a>
+  </div>
+
+  <div class="card pad" style="margin-top:36px;">
+    <div class="section-title">Design principles carried through every surface</div>
+    <div class="legend" style="margin-top:12px;">
+      <span>🟢 <strong>No surprises</strong> — the child can always see the rules and what's coming.</span>
+      <span>🤝 <strong>Not punitive</strong> — framed as "time left", "earn more", never "blocked / denied".</span>
+      <span>🔭 <strong>Orchestration, not enforcement</strong> — UI reflects upstream tools, doesn't reinvent them.</span>
+      <span>📱 <strong>One API</strong> — every surface reads/writes the same <code>/api/*</code> contract.</span>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/adr/0002-client-dashboard-shell.md
+++ b/docs/adr/0002-client-dashboard-shell.md
@@ -1,0 +1,139 @@
+# ADR 0002 — Client "My Time" dashboard: data model and rendering shell
+
+- **Status:** Accepted (2026-06-16)
+- **Issue:** [#61](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/61)
+- **Phase:** new phase (sequenced after Phase 9); depends on Phase 5
+  (usage data), Phase 8b (`pct-client-agent` + cached budget), and Phase 9
+  (the `/app` child-status Svelte view it reuses)
+
+## Context
+
+The supervised-user client dashboard ("My Time", proposed in
+[#61](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/61)
+and mocked up under [`design/client/`](../../design/client/dashboard.html))
+is a read-only desktop surface a child can open any time to see how much
+time they have left, what they've used, what's coming up, and what rewards
+they've earned. It complements the toast/interrupt channel in
+[`client-notifications.md`](../client-notifications.md) with a pull channel.
+
+Two questions had to be answered before it can be built:
+
+1. **Where does the data come from** — the authoritative server `/api/*`,
+   or the local `pct-client-agent`?
+2. **What renders the UI** on the Linux Mint / Cinnamon desktop, given the
+   firm constraint that we will **not** build a second UI implementation —
+   it must render the *same* SvelteKit (Svelte 5, `adapter-static`) build
+   that the Phase 9 `/app` child-status view produces.
+
+### Constraints carried in from elsewhere
+
+- **One UI codebase.** The client dashboard reuses the Phase 9 Svelte
+  child-status component; no GTK/native re-implementation.
+- **Lean client install.** The agent is shipped as a `.deb` that bundles
+  its own Node runtime (`client-notifications.md`); we don't want to add a
+  full Chromium per app, nor a *second* managed runtime.
+- **License discipline.** Consistent with
+  [`licensing-analysis.md`](../licensing-analysis.md): a permissive shell,
+  WebKitGTK reached by *dynamic* link (LGPL — fine), no GPL static linkage,
+  no proprietary-engine lock-in.
+- **Bounded tamper posture** (`CLAUDE.md`, `client-install.md`): the surface
+  is read-only and must not become a new attack/escalation surface.
+- **Must work during a server/network outage** and update *live* (time
+  ticking down) — the server is a control plane, not a data plane
+  (`architecture.md` → "Failure modes").
+
+## Decision
+
+### 1. Data model — hybrid, agent-first for the live view
+
+The dashboard reads from **both** sources, by responsibility:
+
+- **Live "time left / today's usage"** comes from the **local agent**,
+  which already caches the authoritative budget (policy + active grants,
+  pushed by the server) and already polls `aw-server` on `localhost:5600`
+  to compute remaining time for the warning cadence. Reusing that means the
+  dashboard ticks live and keeps working offline, with no new
+  budget-computation logic and no per-user server round-trip.
+- **Richer/historical views** (this week, this month, the rewards/grant
+  ledger) come from the server **`/api/*`** when it is reachable, and
+  degrade gracefully when it is not (today's data still renders from the
+  agent).
+
+The agent therefore exposes a **localhost-only, uid-scoped, read-only**
+data endpoint. It is bound to loopback, scoped to the requesting Linux UID
+(the same per-user isolation model as the `/run/pct/<uid>.sock` channel in
+`client-notifications.md`), and serves only the current user's data — a
+child can never read another user's budget. All timestamps remain UTC;
+the budget window is the user's effective timezone per
+[ADR 0001](0001-budget-timezone.md).
+
+### 2. Authentication — from the Linux session, not a PIN
+
+On the client the user is already authenticated as a Linux user. The agent
+maps `linux-uid → User` and authorises the local read directly; the Phase 9
+PIN is **not** re-prompted on the client. (The PIN remains the auth model
+for the `/app` PWA when accessed from a phone.)
+
+### 3. Rendering shell — Tier 0 now, Tauri v2 as the upgrade path
+
+A staged choice, recorded after the survey in
+[#61 (research comment)](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/61#issuecomment-4722719125):
+
+- **MVP (Tier 0): the installed browser in app mode.** A `.desktop`
+  launcher opens the user's installed browser against the agent's localhost
+  URL — Chromium-family `--app=http://127.0.0.1:<port>` yields a chromeless
+  window. No new runtime, language, or bundled binary; reuses the Svelte
+  build verbatim; license-clean; available as soon as the Phase 9 view
+  exists. This validates the whole hybrid model cheaply.
+- **Upgrade path: [Tauri v2](https://v2.tauri.app/).** When we want a
+  branded, single-instance, tray-integrated app window, adopt Tauri v2: a
+  thin Rust frame around the **system WebKitGTK 4.1** already present on the
+  targets, MIT/Apache-2.0, whose bundler emits a `.deb` directly. The UI
+  stays 100% the one Svelte codebase (Rust is only the frame), so the
+  "no second UI implementation" rule holds.
+- **Stay-in-Node fallback:** if we prefer the agent process to own the
+  window without adding a Rust toolchain,
+  [`webview-nodejs`](https://github.com/Winterreisender/webview-nodejs)
+  (a NAPI binding to system WebKitGTK) is the option, accepting its
+  smaller bus factor and DIY packaging.
+
+## Consequences
+
+- **Agent gains a local read API.** `pct-client-agent` exposes a
+  loopback-bound, uid-scoped, read-only HTTP (and/or WS for live updates)
+  endpoint serving cached budget + `localhost:5600`-derived usage. This is
+  new client surface and must be covered by the bounded-tamper review.
+- **Client apt dependency.** The installer pins `libwebkit2gtk-4.1-0`
+  (Mint 22 / Ubuntu 24.04 ship 4.1 as primary; Mint 21 / Ubuntu 22.04
+  carry it in-repo). Relevant to both Tier 0 (browser already pulls it in)
+  and a future Tauri build.
+- **CI/toolchain.** Tier 0 adds nothing. Adopting Tauri later introduces
+  **Rust** as the first non-Node/non-Python toolchain in the repo and a
+  WebKitGTK build dependency in CI — a deliberate, deferred decision, not
+  an MVP cost.
+- **Offline behaviour is explicit:** today's live data always renders from
+  the agent; week/month/rewards render only when the server is reachable
+  and otherwise show a clear "available when online" state.
+- **No new enforcement and no new license surface** are introduced by the
+  dashboard itself; it is viewing-only. All adjustment controls stay on
+  `/admin` and `/app`.
+
+## Alternatives not chosen
+
+- **Server-`/api`-only data** was rejected: it would not tick live without
+  a browser-facing push/poll mechanism, would not work during an outage,
+  and would need per-user server auth on a device where the user is already
+  locally authenticated. The agent already computes "time remaining," so
+  reusing it is both more robust and less code.
+- **A native (GTK) UI** (e.g. a Photino/InfiniFrame .NET shell, or hand-
+  written GTK) was rejected: it duplicates the UI → a second implementation
+  to keep in sync (violates the core constraint), and .NET would add a
+  second managed runtime to the `.deb`.
+- **Bundling a full browser engine (Electron / NW.js / QtWebEngine)** was
+  rejected: ~100–150 MB and heavy per-window RAM for a read-only widget —
+  exactly the "full browser runtime" we set out to avoid.
+- **Non-standard engines (Sciter, Ultralight)** were rejected: a partial or
+  proprietary HTML/CSS engine would not render our Svelte build faithfully
+  (a porting effort) and/or carries license lock-in.
+- **Re-prompting the Phase 9 PIN on the client** was rejected as needless
+  friction where the OS session already authenticates the user.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -233,6 +233,31 @@ so chore/calendar completions can grant screen-time rewards.
 - Documentation pass: per-feature how-tos.
 - Optional: tamper-resistance review and AppArmor hardening pass.
 
+## Phase 12 — Supervised-user "My Time" client dashboard
+
+Goal: a read-only desktop surface the supervised user can open any time to
+see how much time they have left (overall + per app/category), what they
+did today, what's coming up, and what rewards they've earned — the
+complement to the toast/interrupt channel in
+[`client-notifications.md`](client-notifications.md).
+
+Depends on Phase 5 (usage data), Phase 8b (`pct-client-agent` + cached
+budget), and Phase 9 (reuses the `/app` child-status Svelte view); it can
+land alongside Phase 10/11 rather than strictly last. Tracked in
+[#61](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/61);
+data model and rendering-shell decisions are fixed in
+[`docs/adr/0002-client-dashboard-shell.md`](adr/0002-client-dashboard-shell.md).
+
+- Agent exposes a localhost-only, uid-scoped, **read-only** data endpoint
+  (cached budget + `localhost:5600` usage), so the view ticks live and
+  works offline; `/api/*` supplies week/month/rewards history when online.
+- Auth from the Linux session (`linux-uid → User`), not the Phase 9 PIN.
+- Rendering shell: installed-browser app mode for the MVP, with Tauri v2
+  as the upgrade path (per ADR 0002).
+- Read-only — all adjustment controls stay on `/admin` and `/app`; no new
+  enforcement, no new license surface. Designed in
+  [`design/client/dashboard.html`](../design/client/dashboard.html).
+
 ## Out of scope (for now)
 
 - Non-Linux **enforcement** clients (macOS, Windows, Chromebook). The


### PR DESCRIPTION
## What

A new `design/` folder of plain-HTML design studies (no build, no framework, no external assets — open straight from `file://`) for the three consumer surfaces in `docs/architecture.md`. The goal is to settle **UX direction** before the SvelteKit / desktop-app work lands, and to give the roadmap and issues something concrete to point at.

Start at `design/index.html` (gallery) or read `design/README.md`.

## Surfaces covered

**Admin (`/admin`, Phase 2 / 5 / 10)**
- `dashboard.html` — all supervised users at a glance, live burndown rings, client/agent health, activity feed
- `user-detail.html` — per-user overall **burndown chart** + **ActivityWatch usage timeline** + per-activity budgets + today's schedule + grants
- `policy-editor.html` — budgets, activity groups, **drag-to-order** schedule/exception rules, notification + filter policy, save-and-push bar
- `grants-ledger.html` — immutable grant ledger (admin + calendar sources, `source_ref`, expiry, revoke)
- `clients.html` — enrolled machines, per-component health, offline + queued-change states, enrol-a-client flow
- `integrations.html` — calendar API tokens, AdGuard mode selector, notification defaults

**App / PWA (`/app`, Phase 9)**
- `parent-home.html` — all kids on one phone, quick-grant, low-time alert
- `grant.html` — touch-first grant flow
- `child-status.html` — PIN-scoped per-child status

**Client (supervised desktop)**
- `dashboard.html` — **NEW:** a proposed read-only "My Time" dashboard (time left per app/category, today's activity timeline, weekly trend, upcoming schedule, rewards). This is the part not previously discussed — rationale, delivery-vehicle options, and open questions are in `design/README.md`.
- `notifications.html` — every toast / grace-countdown / session-lock / grant / offline state from `docs/client-notifications.md`

## Design notes

- Honours the license boundaries (`docs/licensing-analysis.md`): views are rendered from **ActivityWatch REST data**, not by embedding AW's GPL UI; the client dashboard links out to AW's own UI for the deep dive.
- Carries the household, non-punitive framing from `README.md` / `docs/client-install.md` ("time left" / "earn more", never "blocked/denied"; viewing only on the client, never editing).
- Charts are hand-drawn inline SVG/CSS — illustrative stand-ins, not finished component specs.

## Follow-ups proposed (see `design/README.md`)

- **New Phase 8d (proposed):** supervised-user "My Time" dashboard — decide PWA-reuse vs. agent-hosted, then build the read-only view (depends on Phase 5 usage data + Phase 8b cached budget).
- Admin burndown & usage-timeline components (Phase 5).
- Drag-to-order rule editor semantics (refines #53).
- Save-and-push diff preview (Phase 4).
- Parent low-time push notifications UI (Phase 9).

## Notes

- Docs/mock-ups only — no code paths, dependencies, or license surface touched.
- No screenshots: the remote environment has no browser, so files were validated structurally (tag balance, all internal links + CSS paths resolve) rather than rendered.

https://claude.ai/code/session_01JSHjaU6bVVMqdmRsWmZpXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSHjaU6bVVMqdmRsWmZpXL)_