### PR TITLE
docs: clarify auth scope boundary and flag managed-auth-library evaluation

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -228,7 +228,12 @@ so chore/calendar completions can grant screen-time rewards.
 ## Phase 11 — Hardening and polish
 
 - Reverse-proxy + TLS instructions for non-LAN deployments.
-- Multi-admin / OIDC option.
+- Multi-admin / OIDC option. This is the first step beyond the
+  single-admin Argon2 model of Phase 2; evaluate a managed TypeScript
+  auth library (e.g. [Better-auth](https://www.better-auth.com/),
+  Fastify-compatible, Drizzle adapter) here rather than extending the
+  hand-rolled single-admin login. See `docs/server-deployment.md` →
+  "Authentication" and stretch epic #24 → #26.
 - Backup/restore utility script.
 - Documentation pass: per-feature how-tos.
 - Optional: tamper-resistance review and AppArmor hardening pass.

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -233,8 +233,26 @@ behind authentication.
 
 - The dashboard ships with single-admin local password auth (Argon2
   hash) suitable for a home deployment behind a LAN.
+- **Scope boundary (deliberate).** This is *one* admin login, not a user
+  system. The policy-model `User` is a supervised person, not an auth
+  principal (see [`architecture.md`](architecture.md) → "Policy model"
+  and [`adr/0002-client-dashboard-shell.md`](adr/0002-client-dashboard-shell.md)).
+  Phase 2 auth is intentionally minimal — verify a single Argon2id hash,
+  set a signed session cookie keyed on `PCT_SECRET_KEY`, guard the
+  routes — implemented with `argon2` plus a Fastify session plugin (see
+  issue #52). Do not pull in a multi-user auth framework for this;
+  accounts, roles, MFA, federation, and self-registration are explicitly
+  out of scope until the identity work below.
 - Future: optional OIDC integration so a household identity provider
-  (FreeIPA, Authentik) can be used.
+  (FreeIPA, Authentik) can be used. When that (Phase 11 multi-admin/OIDC)
+  or the larger centralised-identity work (stretch epic #24 → #26:
+  accounts, per-family roles, TOTP MFA, OIDC-as-RP, invite-co-parent)
+  is picked up, **evaluate a managed TypeScript auth library such as
+  [Better-auth](https://www.better-auth.com/) before hand-rolling** —
+  it is Fastify-compatible and has a Drizzle adapter, and that feature
+  set is exactly what such a library exists to provide. Reconcile its
+  managed tables with this repo's committed drizzle-kit migrations as
+  part of that evaluation.
 - Client SSH access uses a single dedicated key generated on first run;
   rotation is a one-click action in the dashboard that pushes a new key
   via the existing connection.


### PR DESCRIPTION
## What

Documents how authentication is defined across the repo and records two decisions that were previously only implicit:

1. **Scope boundary made explicit** in `docs/server-deployment.md` → "Authentication": Phase 2 auth is intentionally *one* admin login (a single Argon2id hash + signed session cookie via `argon2` + a Fastify session plugin), not a user system. The policy-model `User` is a supervised person, not an auth principal. Don't pull a multi-user framework in for this.
2. **Managed-auth-library pointer** in `docs/server-deployment.md` and `docs/roadmap.md` Phase 11: when the multi-admin/OIDC step or the centralised-identity stretch (#24 → #26) is picked up, evaluate a managed TypeScript auth library such as [Better-auth](https://www.better-auth.com/) (Fastify-compatible, Drizzle adapter) rather than hand-rolling accounts/roles/MFA/OIDC.

## Why

A review of the roadmap, `server-deployment.md`, `proposed-tech-stack.md`, ADR 0002, and the open auth issues (#52, #51, #49, stretch #24/#26) showed the auth model was spread across several docs with the *scope boundary* left implicit, and no recorded view on whether to adopt an auth framework. This pins both down so a future contributor neither over-builds Phase 2 nor re-implements an identity system by hand later.

## Companion issue notes

- #52 — recorded that the single-admin implementation should stay minimal (`argon2` + Fastify session), and why a framework is the wrong altitude there.
- #26 — recommended evaluating Better-auth when centralised identity is built, with a note to reconcile its managed tables against the repo's committed drizzle-kit migrations.

No code or behaviour changes; docs only.

https://claude.ai/code/session_01NSvjWYsEgeGWfmiLe2xE9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSvjWYsEgeGWfmiLe2xE9o)_