### PR TITLE
feat(api): /api foundation — zod DTOs, error envelope, validation plumbing (#50)

### DIFF
--- a/.claude/plans/issue-50-api-foundation.md
+++ b/.claude/plans/issue-50-api-foundation.md
@@ -1,0 +1,70 @@
+# Issue #50 — API foundation: zod DTOs, shared error envelope, validation plumbing
+
+Phase 2 (`docs/roadmap.md`). Establish the `/api/*` conventions **once**,
+before policy routes (#51), auth (#52), and the admin UI (#53) land, so both
+built-in frontends and external integrators share one stable contract.
+
+No live DB required — this is the contract layer.
+
+## Decisions
+
+- **Error envelope:** the small `{ error: { code, message, details } }` shape
+  (one of the two the issue offered), not RFC 9457 `problem+json`. Simpler to
+  type with zod, trivial for the SvelteKit frontend to narrow on, and the
+  `details` array surfaces structured zod issues instead of a stack trace.
+- **Validation hook:** a Fastify-native **custom validator compiler** that runs
+  `schema.safeParse(data)` for any route part (`body`/`querystring`/`params`/
+  `headers`) given a zod schema. On failure it returns an `ApiValidationError`
+  carrying the `ZodError` so the error handler can render `details`.
+- **Type inference, zero new deps:** a ~6-line custom `ZodTypeProvider`
+  (`FastifyTypeProvider`) so handlers infer `request.body`/`request.query` from
+  the zod schema — no `as` casts, no hand-written interfaces, and no
+  `fastify-type-provider-zod` dependency (an existing primitive, `zod` +
+  Fastify's own type-provider hook, already covers it).
+- **Encapsulation:** the envelope/validation/not-found conventions are installed
+  inside the encapsulated `/api` plugin only, so `/`, `/healthz`, `/admin`,
+  `/app` behaviour is untouched.
+- **DTO export path:** `server/src/api/` (re-exported from `api/index.ts`), per
+  `CLAUDE.md`. Documented in `docs/architecture.md` → API conventions.
+
+## Files
+
+- `server/src/api/errors.ts` — `ApiError`, `ApiValidationError`,
+  `errorEnvelopeSchema` + `ErrorEnvelope`/`ErrorDetail` types, `zodIssuesToDetails`.
+- `server/src/api/validation.ts` — `ZodTypeProvider`, `zodValidatorCompiler`,
+  `apiErrorHandler`, `apiNotFoundHandler`, `installApiConventions(scope)`.
+- `server/src/api/meta.ts` — `metaResponseSchema` + `MetaResponse`, the
+  `GET /api/meta` route (proves the wiring).
+- `server/src/api/plugin.ts` — `apiPlugin` + `registerApi(app)`.
+- `server/src/api/index.ts` — keeps `moduleName = "api"` (package-layout test),
+  re-exports the public types + `registerApi`.
+- `server/src/web/app.ts` — call `registerApi(app)`.
+- `docs/architecture.md` — short "API conventions" subsection (export path,
+  envelope shape, validation).
+
+## Tests (`server/tests/api/`)
+
+- `errors.test.ts` — envelope schema round-trips; `zodIssuesToDetails`;
+  `ApiError`/`ApiValidationError` fields.
+- `validation.test.ts` — the validator compiler returns `{value}`/`{error}`;
+  the `ZodTypeProvider` inference (type-level, compile check).
+- `plugin.test.ts` — a real Fastify app via `installApiConventions` + probe
+  routes exercises: valid body passes & infers; malformed body → 400 envelope
+  with `details` (not a stack trace); malformed JSON → 400 envelope; thrown
+  `ApiError` → mapped status + envelope; unexpected throw → 500 generic
+  envelope (no leak); unknown `/api/*` → 404 envelope. Plus `GET /api/meta`
+  via `buildApp().inject()`.
+
+## Phases
+
+1. Primitives (`errors.ts`, `validation.ts`) + unit tests. Push → draft PR.
+2. `/api` plugin + meta route + wire into `buildApp` + docs + integration
+   tests. Push → mark ready.
+
+## Out of scope / deferred
+
+- Policy CRUD routes (#51), auth (#52), admin UI (#53).
+- Static-wildcard vs `/api` 404 precedence when the frontend build is mounted
+  is #59's domain (SPA fallback); the `/api` not-found envelope is active in
+  every config where no static `GET /*` is mounted (dev/CI/tests + until a
+  build is present).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,6 +276,37 @@ calendar that a budget was exceeded) is out of scope for now but stays
 open: same pattern, the dashboard would hold a per-integration outbound
 webhook URL.
 
+## API conventions
+
+The `/api/*` surface is the single contract for both built-in frontends
+and external integrators, so its conventions are fixed once (issue #50)
+and every later route — policy CRUD, auth, integrations — builds on them.
+
+- **DTOs live in `server/src/api/`** as zod schemas; consumers import the
+  **inferred** types (`z.infer`) re-exported from `server/src/api/index.ts`.
+  This is the documented import surface for the SvelteKit frontend — there
+  are no hand-maintained interfaces and no runtime coupling between
+  frontend and backend.
+- **Request validation** is a zod-aware Fastify validator compiler: a route
+  declares `schema: { body, querystring, params, headers }` as zod schemas,
+  and a custom `ZodTypeProvider` infers the handler's `request.*` types from
+  them. Invalid input never reaches a handler.
+- **One error envelope.** Every `/api/*` error is serialized as
+  `{ "error": { "code", "message", "details"? } }`. `code` is a stable
+  machine-readable string (`validation_error`, `not_found`, …); `details`
+  carries one structured entry per rejected field for validation failures.
+  Unexpected errors collapse to a generic `internal_error` 500 — the real
+  error is logged, never leaked to the client. (We chose this small shape
+  over RFC 9457 `problem+json` for ease of typing and frontend consumption;
+  the envelope is itself a zod schema, `errorEnvelopeSchema`.)
+- **Encapsulation.** The validation hook, error handler, and not-found
+  handler are installed inside the `/api` plugin scope only, so `/`,
+  `/healthz`, and the static `/admin`·`/app` mounts keep their own
+  behaviour.
+
+`GET /api/meta` (`{ name, apiVersion }`) is the trivial route that proves
+the prefix and conventions are mounted.
+
 ## Failure modes the design must handle
 
 - **Client offline at policy-change time** — queue the change; replay on

--- a/server/src/api/errors.ts
+++ b/server/src/api/errors.ts
@@ -1,0 +1,111 @@
+/**
+ * The shared `/api/*` error envelope and the error types that render into it.
+ *
+ * Every error that leaves the JSON API uses one shape so both built-in
+ * frontends and external integrators can narrow on it without parsing prose or
+ * a stack trace (`CLAUDE.md` → "the single contract for both frontends **and**
+ * for external integrations"). We use the small `{ error: { code, message,
+ * details } }` form rather than RFC 9457 `problem+json`: it is trivial to type
+ * with zod, trivial for the SvelteKit frontend to narrow on, and `details`
+ * carries structured zod issues instead of an opaque 500.
+ *
+ * License boundary: none touched — plain TypeScript + zod.
+ */
+import { z } from "zod";
+
+/**
+ * One structured problem in an {@link ErrorEnvelope}. For validation failures
+ * this is one zod issue: `path` is the dotted location in the rejected input
+ * (empty for the root), `code` is zod's issue code (e.g. `invalid_type`).
+ */
+export const errorDetailSchema = z.object({
+  path: z.string(),
+  message: z.string(),
+  code: z.string().optional(),
+});
+
+/** A single structured problem; see {@link errorDetailSchema}. */
+export type ErrorDetail = z.infer<typeof errorDetailSchema>;
+
+/** The envelope every `/api/*` error response is serialized as. */
+export const errorEnvelopeSchema = z.object({
+  error: z.object({
+    /** Stable, machine-readable code (e.g. `validation_error`, `not_found`). */
+    code: z.string(),
+    /** Human-readable summary; safe to surface in a UI. */
+    message: z.string(),
+    /** Present for validation errors; one entry per rejected field. */
+    details: z.array(errorDetailSchema).optional(),
+  }),
+});
+
+/** The inferred shape of an `/api/*` error response. */
+export type ErrorEnvelope = z.infer<typeof errorEnvelopeSchema>;
+
+/**
+ * Map a {@link z.ZodError} to the envelope's `details` array — one entry per
+ * issue, with the path rendered as a dotted string (`budget.seconds`).
+ */
+export function zodIssuesToDetails(error: z.ZodError): ErrorDetail[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.map(String).join("."),
+    message: issue.message,
+    code: issue.code,
+  }));
+}
+
+/**
+ * An error a route raises deliberately to produce a specific HTTP status and
+ * envelope (e.g. a 404 for a missing policy row, a 409 for a conflict). The
+ * `/api` error handler serializes it via {@link toEnvelope}.
+ */
+export class ApiError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+  readonly details: ErrorDetail[] | undefined;
+
+  constructor(statusCode: number, code: string, message: string, details?: ErrorDetail[]) {
+    super(message);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+    this.code = code;
+    this.details = details;
+  }
+
+  /** Render this error as the wire envelope. */
+  toEnvelope(): ErrorEnvelope {
+    const inner: ErrorEnvelope["error"] = { code: this.code, message: this.message };
+    if (this.details !== undefined) {
+      inner.details = this.details;
+    }
+    return { error: inner };
+  }
+}
+
+/**
+ * Raised by the zod validator compiler when a request part fails validation.
+ * Carries the originating {@link z.ZodError} so the error handler can render
+ * structured `details`; `httpPart` records which part (`body`, `querystring`,
+ * …) was rejected. Always maps to HTTP 400.
+ */
+export class ApiValidationError extends Error {
+  readonly statusCode = 400;
+  readonly zodError: z.ZodError;
+  readonly httpPart: string | undefined;
+
+  constructor(zodError: z.ZodError, httpPart?: string) {
+    super(
+      httpPart === undefined
+        ? "Request validation failed"
+        : `Request ${httpPart} failed validation`,
+    );
+    this.name = "ApiValidationError";
+    this.zodError = zodError;
+    this.httpPart = httpPart;
+  }
+
+  /** The rejected fields as envelope `details`. */
+  toDetails(): ErrorDetail[] {
+    return zodIssuesToDetails(this.zodError);
+  }
+}

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -1,2 +1,24 @@
-/** JSON API: zod DTOs and routes shared by both frontends and external integrators. */
+/**
+ * JSON API: zod DTOs and routes shared by both frontends and external
+ * integrators.
+ *
+ * This barrel is the documented import surface for the SvelteKit frontend and
+ * for any code that needs the API contract: the inferred request/response
+ * types (`z.infer`) and the shared error envelope live here, alongside
+ * {@link registerApi} for mounting the routes. See `docs/architecture.md` →
+ * "API conventions".
+ */
 export const moduleName = "api";
+
+export { registerApi, apiPlugin } from "./plugin.js";
+export {
+  ApiError,
+  ApiValidationError,
+  errorDetailSchema,
+  errorEnvelopeSchema,
+  zodIssuesToDetails,
+  type ErrorDetail,
+  type ErrorEnvelope,
+} from "./errors.js";
+export { metaResponseSchema, type MetaResponse } from "./meta.js";
+export type { ZodTypeProvider } from "./validation.js";

--- a/server/src/api/meta.ts
+++ b/server/src/api/meta.ts
@@ -1,0 +1,31 @@
+/**
+ * `GET /api/meta` — a trivial, dependency-free route that proves the `/api`
+ * prefix and the validation/envelope conventions are wired (issue #50). It
+ * also models the response-DTO pattern the policy routes (#51) will follow:
+ * the shape is a zod schema, and the handler's return type is the inferred
+ * type, so the contract has one source of truth.
+ *
+ * License boundary: none touched.
+ */
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+
+import type { ZodTypeProvider } from "./validation.js";
+
+/** Response shape of `GET /api/meta`. */
+export const metaResponseSchema = z.object({
+  /** Service identifier; matches the package name. */
+  name: z.string(),
+  /** Major version of the `/api/*` contract. Bumped on breaking changes. */
+  apiVersion: z.number().int().positive(),
+});
+
+/** The inferred `GET /api/meta` response type, shared with the frontend. */
+export type MetaResponse = z.infer<typeof metaResponseSchema>;
+
+const META: MetaResponse = { name: "dashboard", apiVersion: 1 };
+
+/** Register `GET /meta` on the given (already `/api`-prefixed) scope. */
+export function registerMetaRoute(scope: FastifyInstance): void {
+  scope.withTypeProvider<ZodTypeProvider>().get("/meta", async (): Promise<MetaResponse> => META);
+}

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -1,0 +1,23 @@
+/**
+ * The `/api` Fastify plugin: one encapsulated scope that installs the shared
+ * validation/envelope conventions and mounts the JSON routes. Mounting it
+ * under the `/api` prefix keeps the conventions (and any future policy/auth/
+ * integration routes) from touching `/`, `/healthz`, `/admin`, or `/app`.
+ *
+ * License boundary: none touched.
+ */
+import type { FastifyInstance, FastifyPluginAsync } from "fastify";
+
+import { registerMetaRoute } from "./meta.js";
+import { installApiConventions } from "./validation.js";
+
+/** The encapsulated `/api` plugin: conventions first, then routes. */
+export const apiPlugin: FastifyPluginAsync = async (scope) => {
+  installApiConventions(scope);
+  registerMetaRoute(scope);
+};
+
+/** Mount the JSON API under `/api` on the given app. */
+export function registerApi(app: FastifyInstance): void {
+  app.register(apiPlugin, { prefix: "/api" });
+}

--- a/server/src/api/validation.ts
+++ b/server/src/api/validation.ts
@@ -1,0 +1,123 @@
+/**
+ * Validation plumbing for the `/api/*` surface: a zod-aware Fastify validator
+ * compiler, the error/not-found handlers that render the shared envelope, and
+ * a type provider so route handlers infer their input types from zod schemas.
+ *
+ * These primitives are installed once, inside the encapsulated `/api` plugin
+ * (see `plugin.ts`), so the conventions never leak onto `/`, `/healthz`,
+ * `/admin`, or `/app`. They are also exported individually so tests can wire
+ * them onto a throwaway scope with probe routes and exercise the exact runtime
+ * Fastify uses.
+ *
+ * Why no `fastify-type-provider-zod` dependency: the only thing that library
+ * adds over the few lines here is the same `FastifyTypeProvider` mapping plus
+ * a serializer compiler we do not want (we keep response shaping at the TS/DTO
+ * level, not runtime JSON-schema serialization). zod + Fastify's own
+ * type-provider hook already cover the inference we need.
+ *
+ * License boundary: none touched — plain TypeScript + zod + Fastify.
+ */
+import type {
+  FastifyError,
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  FastifySchemaCompiler,
+  FastifyTypeProvider,
+} from "fastify";
+import { z } from "zod";
+
+import { ApiError, ApiValidationError, type ErrorEnvelope } from "./errors.js";
+
+/**
+ * Fastify type provider that infers a route's `body`/`querystring`/`params`/
+ * `headers` types from the zod schema declared for that part, so handlers read
+ * `request.body` as `z.infer<typeof bodySchema>` with no `as` cast. Apply it
+ * per scope with `scope.withTypeProvider<ZodTypeProvider>()` before declaring
+ * routes.
+ */
+export interface ZodTypeProvider extends FastifyTypeProvider {
+  validator: this["schema"] extends z.ZodType ? z.output<this["schema"]> : unknown;
+  serializer: this["schema"] extends z.ZodType ? z.input<this["schema"]> : unknown;
+}
+
+/**
+ * Validator compiler that treats each route-part `schema` as a zod schema and
+ * runs `safeParse`. On success Fastify replaces the request part with the
+ * parsed (and coerced/defaulted) value; on failure it throws the returned
+ * {@link ApiValidationError}, which the error handler maps to a 400 envelope.
+ */
+export const zodValidatorCompiler: FastifySchemaCompiler<z.ZodType> =
+  ({ schema, httpPart }) =>
+  (data: unknown) => {
+    const result = schema.safeParse(data);
+    if (result.success) {
+      return { value: result.data };
+    }
+    return { error: new ApiValidationError(result.error, httpPart) };
+  };
+
+/**
+ * Error handler for the `/api` scope. Maps our own error types to their
+ * envelope, passes through framework 4xx client errors (e.g. malformed JSON)
+ * as a 400-class envelope, and collapses anything unexpected to a generic 500
+ * that leaks neither message nor stack — the real error is logged instead.
+ */
+export function apiErrorHandler(
+  error: FastifyError,
+  request: FastifyRequest,
+  reply: FastifyReply,
+): void {
+  if (error instanceof ApiValidationError) {
+    const envelope: ErrorEnvelope = {
+      error: { code: "validation_error", message: error.message, details: error.toDetails() },
+    };
+    reply.code(400).send(envelope);
+    return;
+  }
+
+  if (error instanceof ApiError) {
+    reply.code(error.statusCode).send(error.toEnvelope());
+    return;
+  }
+
+  const status = error.statusCode ?? 500;
+  if (status >= 400 && status < 500) {
+    // A framework client error (bad JSON, unsupported media type, …). Its
+    // message is about the request, so it is safe to surface.
+    const envelope: ErrorEnvelope = {
+      error: { code: error.code ?? "bad_request", message: error.message },
+    };
+    reply.code(status).send(envelope);
+    return;
+  }
+
+  // Unexpected: log the real error (with stack) and return a generic envelope.
+  request.log.error({ err: error }, "unhandled API error");
+  const envelope: ErrorEnvelope = {
+    error: { code: "internal_error", message: "Internal Server Error" },
+  };
+  reply.code(500).send(envelope);
+}
+
+/** Not-found handler for the `/api` scope: a 404 in the shared envelope. */
+export function apiNotFoundHandler(request: FastifyRequest, reply: FastifyReply): void {
+  const envelope: ErrorEnvelope = {
+    error: {
+      code: "not_found",
+      message: `Route ${request.method} ${request.url} not found`,
+    },
+  };
+  reply.code(404).send(envelope);
+}
+
+/**
+ * Install the `/api` conventions on a scope: the zod validator compiler, the
+ * envelope error handler, and the envelope not-found handler. Encapsulated to
+ * the scope it is called on, so it does not affect routes outside `/api`.
+ */
+export function installApiConventions(scope: FastifyInstance): void {
+  scope.setValidatorCompiler(zodValidatorCompiler);
+  scope.setErrorHandler(apiErrorHandler);
+  scope.setNotFoundHandler(apiNotFoundHandler);
+}

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -7,10 +7,12 @@
  *
  * Beyond the Phase 1 slice — a "hello, no policy yet" landing route and a
  * `/healthz` probe, plus the shared pino logging configuration (#11) — this
- * now also mounts the prerendered SvelteKit build at `/admin` and `/app`
- * (#40). The policy/api/integrations mounts land in later phases.
+ * now also mounts the JSON API at `/api` (#50) and the prerendered SvelteKit
+ * build at `/admin` and `/app` (#40). The policy/integrations routes land on
+ * top of the `/api` conventions in later phases.
  */
 import Fastify, { type FastifyInstance } from "fastify";
+import { registerApi } from "../api/index.js";
 import { loadSettings, type Settings } from "../config.js";
 import { registerFrontend } from "./frontend.js";
 import { REQUEST_ID_HEADER, buildLoggerOptions, genRequestId, type LogStream } from "./logger.js";
@@ -51,6 +53,11 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   app.get("/healthz", async () => {
     return { status: "ok" };
   });
+
+  // Mount the JSON API at /api (#50). Encapsulated: the zod validation hook,
+  // the shared error envelope, and the /api not-found envelope apply only
+  // within this prefix, leaving /, /healthz, /admin and /app untouched.
+  registerApi(app);
 
   // Serve the prerendered SvelteKit build at /admin and /app (#40). Skipped
   // (with a warning) when the build directory is absent, so /, /healthz, and

--- a/server/tests/api/errors.test.ts
+++ b/server/tests/api/errors.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the shared `/api` error envelope and error types.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  ApiError,
+  ApiValidationError,
+  errorEnvelopeSchema,
+  zodIssuesToDetails,
+} from "../../src/api/errors.js";
+
+describe("errorEnvelopeSchema", () => {
+  it("accepts an envelope with details", () => {
+    const parsed = errorEnvelopeSchema.parse({
+      error: {
+        code: "validation_error",
+        message: "Request body failed validation",
+        details: [{ path: "seconds", message: "Expected number", code: "invalid_type" }],
+      },
+    });
+    expect(parsed.error.details).toHaveLength(1);
+  });
+
+  it("accepts an envelope without details", () => {
+    const parsed = errorEnvelopeSchema.parse({
+      error: { code: "not_found", message: "nope" },
+    });
+    expect(parsed.error.details).toBeUndefined();
+  });
+
+  it("rejects a payload missing the error code", () => {
+    const result = errorEnvelopeSchema.safeParse({ error: { message: "x" } });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("zodIssuesToDetails", () => {
+  it("renders each issue as a dotted-path detail", () => {
+    const schema = z.object({ budget: z.object({ seconds: z.number() }) });
+    const result = schema.safeParse({ budget: { seconds: "nope" } });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const details = zodIssuesToDetails(result.error);
+    expect(details).toEqual([
+      { path: "budget.seconds", message: expect.any(String), code: "invalid_type" },
+    ]);
+  });
+
+  it("renders a root-level issue with an empty path", () => {
+    const result = z.string().safeParse(42);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const [detail] = zodIssuesToDetails(result.error);
+    expect(detail?.path).toBe("");
+  });
+});
+
+describe("ApiError", () => {
+  it("carries status/code and renders an envelope without details", () => {
+    const err = new ApiError(404, "not_found", "User not found");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.statusCode).toBe(404);
+    expect(err.toEnvelope()).toEqual({
+      error: { code: "not_found", message: "User not found" },
+    });
+  });
+
+  it("includes details in the envelope when provided", () => {
+    const err = new ApiError(409, "conflict", "Already exists", [
+      { path: "name", message: "taken" },
+    ]);
+    expect(err.toEnvelope().error.details).toEqual([{ path: "name", message: "taken" }]);
+  });
+});
+
+describe("ApiValidationError", () => {
+  it("is a 400 and names the rejected http part", () => {
+    const result = z.object({ a: z.number() }).safeParse({ a: "x" });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const err = new ApiValidationError(result.error, "body");
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toBe("Request body failed validation");
+    expect(err.toDetails()).toHaveLength(1);
+  });
+
+  it("falls back to a generic message when the part is unknown", () => {
+    const result = z.number().safeParse("x");
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const err = new ApiValidationError(result.error);
+    expect(err.message).toBe("Request validation failed");
+    expect(err.httpPart).toBeUndefined();
+  });
+});

--- a/server/tests/api/plugin.test.ts
+++ b/server/tests/api/plugin.test.ts
@@ -1,0 +1,146 @@
+/**
+ * End-to-end tests for the `/api` conventions against a real Fastify instance.
+ *
+ * The conventions (zod validator compiler, envelope error handler, envelope
+ * not-found handler) are installed via the same `installApiConventions` the
+ * production plugin uses, then a set of probe routes exercises each path:
+ * valid input, validation failure, malformed JSON, a deliberate `ApiError`,
+ * an unexpected throw, and an unknown route. `GET /api/meta` is checked
+ * through the real `buildApp()` to prove the prefix is mounted.
+ *
+ * Uses `app.inject()` — no sockets — per docs/testing.md → "HTTP routes".
+ */
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ApiError } from "../../src/api/errors.js";
+import { installApiConventions, type ZodTypeProvider } from "../../src/api/validation.js";
+import { buildApp } from "../../src/web/app.js";
+import { loadSettings } from "../../src/config.js";
+
+const bodySchema = z.object({ seconds: z.number().int().positive() });
+const querySchema = z.object({ n: z.coerce.number().int() });
+
+/** Mirror of the production plugin plus deliberately-failing probe routes. */
+const probePlugin: FastifyPluginAsync = async (scope) => {
+  installApiConventions(scope);
+  const typed = scope.withTypeProvider<ZodTypeProvider>();
+
+  // Type inference: `request.body.seconds` / `request.query.n` are `number`
+  // with no cast — this only compiles because the type provider is applied.
+  typed.post("/echo", { schema: { body: bodySchema } }, async (request) => ({
+    doubled: request.body.seconds * 2,
+  }));
+  typed.get("/query", { schema: { querystring: querySchema } }, async (request) => ({
+    n: request.query.n,
+  }));
+
+  scope.get("/boom-api", async () => {
+    throw new ApiError(403, "forbidden", "no entry");
+  });
+  scope.get("/boom-500", async () => {
+    throw new Error("kaboom");
+  });
+};
+
+describe("/api conventions", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    await app.register(probePlugin, { prefix: "/api" });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("passes valid input through and infers its type", async () => {
+    const res = await app.inject({ method: "POST", url: "/api/echo", payload: { seconds: 30 } });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ doubled: 60 });
+  });
+
+  it("coerces and validates the querystring", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/query?n=5" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ n: 5 });
+  });
+
+  it("rejects an invalid body with a 400 envelope of structured details", async () => {
+    const res = await app.inject({ method: "POST", url: "/api/echo", payload: { seconds: -1 } });
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.error.code).toBe("validation_error");
+    expect(body.error.message).toContain("body");
+    expect(body.error.details[0].path).toBe("seconds");
+    // The response is the envelope, never a stack trace.
+    expect(res.body).not.toContain("at ");
+  });
+
+  it("rejects malformed JSON with a 400 envelope, not a 500", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/echo",
+      payload: "{ not json",
+      headers: { "content-type": "application/json" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(typeof res.json().error.code).toBe("string");
+    expect(typeof res.json().error.message).toBe("string");
+  });
+
+  it("maps a thrown ApiError to its status and envelope", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/boom-api" });
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toEqual({ error: { code: "forbidden", message: "no entry" } });
+  });
+
+  it("collapses an unexpected throw to a generic 500 with no leak", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/boom-500" });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({
+      error: { code: "internal_error", message: "Internal Server Error" },
+    });
+    expect(res.body).not.toContain("kaboom");
+  });
+
+  it("returns the envelope for an unknown /api route", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/does-not-exist" });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+  });
+});
+
+describe("GET /api/meta (via buildApp)", () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "silent" }) });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("is mounted and returns the meta DTO", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/meta" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ name: "dashboard", apiVersion: 1 });
+  });
+
+  it("serves the /api 404 envelope for unknown api routes", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/nope" });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+  });
+
+  it("leaves the non-api 404 behaviour unchanged", async () => {
+    const res = await app.inject({ method: "GET", url: "/nope" });
+    expect(res.statusCode).toBe(404);
+    // Not the api envelope — the default Fastify 404 shape.
+    expect(res.json().error).not.toBe("not_found");
+  });
+});

--- a/server/tests/api/plugin.test.ts
+++ b/server/tests/api/plugin.test.ts
@@ -39,6 +39,11 @@ const probePlugin: FastifyPluginAsync = async (scope) => {
   scope.get("/boom-api", async () => {
     throw new ApiError(403, "forbidden", "no entry");
   });
+  scope.get("/boom-4xx", async () => {
+    // A framework-style 4xx error with no `.code` — exercises the
+    // `?? "bad_request"` fallback in the error handler.
+    throw Object.assign(new Error("teapot"), { statusCode: 418 });
+  });
   scope.get("/boom-500", async () => {
     throw new Error("kaboom");
   });
@@ -98,6 +103,12 @@ describe("/api conventions", () => {
     expect(res.json()).toEqual({ error: { code: "forbidden", message: "no entry" } });
   });
 
+  it("passes a code-less 4xx error through as bad_request", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/boom-4xx" });
+    expect(res.statusCode).toBe(418);
+    expect(res.json()).toEqual({ error: { code: "bad_request", message: "teapot" } });
+  });
+
   it("collapses an unexpected throw to a generic 500 with no leak", async () => {
     const res = await app.inject({ method: "GET", url: "/api/boom-500" });
     expect(res.statusCode).toBe(500);
@@ -140,7 +151,9 @@ describe("GET /api/meta (via buildApp)", () => {
   it("leaves the non-api 404 behaviour unchanged", async () => {
     const res = await app.inject({ method: "GET", url: "/nope" });
     expect(res.statusCode).toBe(404);
-    // Not the api envelope — the default Fastify 404 shape.
-    expect(res.json().error).not.toBe("not_found");
+    // The default Fastify 404 has `error` as the string "Not Found"; the /api
+    // envelope would make it the object `{ code, message }`. Asserting the
+    // string proves the /api conventions did not leak outside the prefix.
+    expect(res.json().error).toBe("Not Found");
   });
 });

--- a/server/tests/api/validation.test.ts
+++ b/server/tests/api/validation.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the zod validator compiler. The error handler, not-found
+ * handler, and type-provider inference are exercised end-to-end against a real
+ * Fastify instance in `plugin.test.ts`.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ApiValidationError } from "../../src/api/errors.js";
+import { zodValidatorCompiler } from "../../src/api/validation.js";
+
+const schema = z.object({ seconds: z.number().int().positive() });
+
+describe("zodValidatorCompiler", () => {
+  it("returns the parsed value for valid input", () => {
+    const validate = zodValidatorCompiler({
+      schema,
+      method: "POST",
+      url: "/x",
+      httpPart: "body",
+    });
+    const result = validate({ seconds: 30 });
+    expect(result).toEqual({ value: { seconds: 30 } });
+  });
+
+  it("returns an ApiValidationError carrying the http part for invalid input", () => {
+    const validate = zodValidatorCompiler({
+      schema,
+      method: "POST",
+      url: "/x",
+      httpPart: "body",
+    });
+    const result = validate({ seconds: -1 });
+    // Fastify types the result as a wide union; narrow to the error branch.
+    if (typeof result !== "object" || result === null || !("error" in result)) {
+      throw new Error("expected an error result");
+    }
+    const error = result.error;
+    expect(error).toBeInstanceOf(ApiValidationError);
+    if (!(error instanceof ApiValidationError)) throw new Error("expected ApiValidationError");
+    expect(error.httpPart).toBe("body");
+    expect(error.toDetails()[0]?.path).toBe("seconds");
+  });
+});


### PR DESCRIPTION
## Summary

- Establish the `/api/*` conventions **once** (Phase 2), before policy routes (#51), auth (#52), and the admin UI (#53) build on them — needs no live DB.
- Shared error envelope `{ error: { code, message, details? } }` as a zod schema, with `ApiError` (deliberate status) and `ApiValidationError` (carries the `ZodError` → structured `details`).
- A zod-aware Fastify **validator compiler** + a ~6-line `ZodTypeProvider` so handlers infer `request.body`/`request.query` types from the schema. Encapsulated `/api` plugin (validation hook + envelope error/not-found handlers apply only within the prefix); `GET /api/meta` proves the mount. DTOs/types re-exported from `server/src/api/index.ts`.

## Plan

Linked plan: `.claude/plans/issue-50-api-foundation.md`
Roadmap: `docs/roadmap.md` → Phase 2

## License-boundary note

N/A — pure TypeScript + zod + Fastify. No GPL code imported, no GPL binaries added to the image, no transport/packaging change. **No new dependencies**: rather than add `fastify-type-provider-zod`, the inference is a ~6-line `FastifyTypeProvider` over the existing `zod` + Fastify's own type-provider hook (and we deliberately avoid that library's serializer compiler, keeping response shaping at the TS/DTO level).

## Design notes

- **Envelope shape:** chose the small `{ error: { code, message, details } }` (one of the two the issue offered) over RFC 9457 `problem+json` — easier to type with zod and to narrow on in Svelte; `details` surfaces structured zod issues instead of a stack trace. Unexpected errors collapse to a generic `internal_error` 500 (real error logged, never leaked).
- **Encapsulation:** conventions are installed inside the `/api` plugin scope only — `/`, `/healthz`, `/admin`, `/app` behaviour is unchanged (a test asserts the non-API 404 is untouched).
- Documented in `docs/architecture.md` → "API conventions" (the `server/src/api/` export path is the frontend's import surface).

## Test plan

- [x] Envelope schema round-trips (with/without `details`); rejects a missing `code`.
- [x] `zodIssuesToDetails` renders dotted paths + root path; `ApiError`/`ApiValidationError` fields.
- [x] Validator compiler returns `{ value }` / `{ error: ApiValidationError }` with the http part.
- [x] End-to-end on a real Fastify instance: valid input + **type inference**, invalid body → 400 envelope with `details` (no stack trace), malformed JSON → 400 (not 500), thrown `ApiError` → mapped status, unexpected throw → generic 500 with no leak, unknown `/api/*` → 404 envelope.
- [x] `GET /api/meta` mounted via real `buildApp()`; non-API 404 unchanged.
- [x] `format:check`, `lint`, `typecheck`, `npm test` green; coverage 100% / 97% branch (gate 80%).

## Deferred / out of scope

- Policy CRUD (#51), auth (#52), admin UI (#53) build on this layer.
- When a frontend build is mounted, `@fastify/static`'s `GET /*` wildcard would catch unknown `/api/*` before the scoped not-found handler; resolving that precedence is #59's domain (SPA fallback). The `/api` 404 envelope is active in every config without a static mount (dev/CI/tests + until a build is present).

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzXNLQbWdhhyVZwhGxjf92)_