### PR TITLE
feat(policy): runtime SQLite connection + app.db, migrated on boot (#49)

### DIFF
--- a/.claude/plans/49-runtime-sqlite-connection.md
+++ b/.claude/plans/49-runtime-sqlite-connection.md
@@ -1,0 +1,82 @@
+# Plan — #49 Runtime SQLite connection (better-sqlite3 + Drizzle) and migrate-on-start
+
+Roadmap: `docs/roadmap.md` → Phase 2. Blocks #51 (CRUD over `app.db`), #52
+(admin credential persistence). Builds on merged #48 (schema + first
+migration), #34 (`DATABASE_URL` contract), #12 (`testDb()`), #9 (drizzle
+scaffold).
+
+## Goal
+
+Wire a **live** `better-sqlite3` + drizzle-orm connection into the running
+app. Today `buildApp()` never opens `settings.databaseUrl`; the only DB handle
+that exists is the in-memory `testDb()` test helper. Give routes and the
+policy service one shared `app.db` handle, migrated on boot, closed cleanly on
+shutdown.
+
+## Key decisions
+
+1. **Migrate in-process on boot, not in the entrypoint.** `createDb()` applies
+   the committed migrations via drizzle-orm's `better-sqlite3` migrator (which
+   reads the SQL the Dockerfile already copies to `/app/drizzle`). This keeps
+   `drizzle-kit` (a dev dependency) out of the runtime image, per #39's
+   Phase-2 note, and means the entrypoint does **not** also migrate — so the
+   two can never double-migrate or disagree on the path (AC #4). The migrator
+   is idempotent (drizzle's `__drizzle_migrations` journal). This is a change
+   to a documented step, so `docs/server-deployment.md` first-run step 1 and
+   the `docker-entrypoint.sh` comment are updated in this PR.
+
+2. **`databaseUrl` is consumed as-is** — the settings loader (#34) already
+   strips a leading `file:` to a bare path, which is what `better-sqlite3`
+   wants. `createDb` does no further URL handling.
+
+3. **`buildApp` owns the DB it creates.** When no `db` is injected, `buildApp`
+   calls `createDb(settings)` and closes that handle on `app.close()`. When a
+   `db` is injected (tests via `buildTestApp`), the injector owns its lifecycle
+   and `buildApp` does not close it — no double-close.
+
+## Phases
+
+### Phase 1 — `createDb()` + the typed `PolicyDb` handle (+ tests, docs)
+
+- New `server/src/policy/db.ts`:
+  - `createDb(settings, options?)`: opens `settings.databaseUrl`, sets
+    `PRAGMA journal_mode = WAL` and `PRAGMA foreign_keys = ON`, wraps in
+    drizzle with the full `schema`, applies migrations, returns the handle.
+  - `export type PolicyDb` = `BetterSQLite3Database<typeof schema>` with the
+    `$client` better-sqlite3 handle exposed (mirrors `TestDb`).
+  - Migrations folder resolved relative to the module (`../../drizzle`), which
+    is `<root>/drizzle` both from `src/policy/` (tests) and `dist/policy/`
+    (image) — same trick the test helper and `migrations.test.ts` use. An
+    `options.migrationsFolder` override keeps it testable.
+- Tests `server/tests/policy/db.test.ts`: opens against a real temp file
+  (WAL pragma is meaningful on-disk), asserts `foreign_keys = ON`,
+  `journal_mode = wal`, the full schema is materialised, FK violations are
+  rejected, and re-opening the same file is a no-op (no re-migrate).
+- Docs: `docs/server-deployment.md` first-run step 1 + `docker-entrypoint.sh`
+  comment — migration runs in-process at server boot, not via `drizzle-kit` in
+  the entrypoint.
+
+### Phase 2 — `app.db` decorator wiring (+ tests, docs)
+
+- `server/src/web/app.ts`: add `db?: PolicyDb` to `BuildAppOptions`; module-
+  augment `FastifyInstance` with `db: PolicyDb`; decorate; create-and-own when
+  not injected; `onClose` closes only an owned handle.
+- `tests/helpers/app.ts`: pass the bundled `db` through to `buildApp` (drops
+  the forward-compat note).
+- Update the three direct-`buildApp` route/logging/frontend tests to inject a
+  `testDb()` so they don't try to open `/data/policy.sqlite`.
+- `tests/web/app.test.ts` (or a new `tests/web/db.test.ts`): assert `app.db` is
+  decorated, usable (insert + select a `users` row), and that an owned handle
+  is closed on `app.close()` while an injected one is left open.
+- Docs: drop the Phase-1 status caveat in `docs/testing.md` (lines ~215-219).
+
+## Quality gate (run from `server/` after each phase)
+
+`npm run format` · `npm run lint:fix` · `npm run typecheck` · `npm test`
+(coverage ≥ 80 %; `src/policy` target 90 %).
+
+## License-boundary note
+
+No GPL linkage: better-sqlite3 (MIT) and drizzle-orm (Apache-2.0) only. No new
+dependency. No change to the image's GPL posture (migrations SQL already
+shipped; no new binaries).

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -76,10 +76,17 @@ the same file whichever form you set.
 
 ## First-run setup
 
-On container start, the entrypoint runs these steps idempotently:
+On container start, the entrypoint and the Node server run these steps
+idempotently:
 
-1. **Schema migration** — apply the committed drizzle-kit migrations
-   against `/data/policy.sqlite`.
+1. **Schema migration** — the Node server applies the committed migrations
+   **in-process on boot**, against `/data/policy.sqlite`, using drizzle-orm's
+   `better-sqlite3` migrator (not `drizzle-kit`, which stays a build-time-only
+   dev dependency and is never shipped in the runtime image). The migrator is
+   idempotent — it tracks applied migrations in its own journal — so the
+   entrypoint itself runs no migration step, and the runtime and migrations
+   always open the same `DATABASE_URL` file with no double-migration hazard
+   (issues #49, #39).
 2. **Ansible bootstrap** — if `/data/ansible/venv` is missing, create it
    and `pip install ansible-core` (downloaded from PyPI at runtime, not
    from the image). Sync `playbooks/` from the image.
@@ -267,7 +274,7 @@ the image.
 
 ## Upgrade path
 
-`docker pull` a newer image tag and restart. The entrypoint's migration
-step applies any new drizzle-kit migrations. The Ansible venv inside
+`docker pull` a newer image tag and restart. The server applies any new
+migrations in-process on boot (see "First-run setup" step 1). The Ansible venv inside
 `/data/ansible/venv` is pinned per image release; upgrades reconcile it
 on first start under the new tag.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -212,11 +212,12 @@ it("grant endpoint is idempotent by source_ref", async () => {
 });
 ```
 
-> **Phase-1 status:** `buildApp()` does not yet take a `db` option — the
-> runtime DB connection is wired in Phase 2 (the `DATABASE_URL` contract,
-> issue #34, and first-run schema migration, issue #39). Until then
-> `buildTestApp()` creates and returns the `db` alongside the app; the
-> pass-through into `buildApp` lands with that Phase-2 work.
+`buildApp()` takes an optional `db` (#49): when omitted it opens and migrates
+one from `settings` via `createDb()` and closes it on `app.close()`; when
+injected (as `buildTestApp()` does with `testDb()`) the app uses that handle
+and leaves closing it to the provider. So `app.db`, the `db` returned by
+`buildTestApp()`, and the handle you passed in are all the same object, and
+`close()` tears down the app and then the database.
 
 ---
 

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -6,10 +6,17 @@
 # "Backup and restore"), so setup only ever reconciles that volume.
 #
 # In scope today: ensure the documented /data volume layout exists, then
-# exec the compiled Node server. The heavier first-run steps each land with
-# their roadmap phase and are tracked in the follow-up issue linked from the
-# PR that introduced this script:
-#   - Schema migration (drizzle-kit migrations -> policy.sqlite)  [Phase 2]
+# exec the compiled Node server.
+#
+# Schema migration is deliberately NOT an entrypoint step: the Node server
+# applies the committed migrations in-process on boot via drizzle-orm's
+# better-sqlite3 migrator (#49), so the runtime image never ships drizzle-kit
+# and the entrypoint and runtime can't double-migrate. See
+# docs/server-deployment.md -> "First-run setup" step 1.
+#
+# The remaining heavier first-run steps each land with their roadmap phase and
+# are tracked in the follow-up issue linked from the PR that introduced this
+# script:
 #   - Ansible venv bootstrap (pip install ansible-core)           [Phase 6]
 #   - AdGuard Home fetch / supervise (managed mode)               [Phase 7]
 #   - SSH key bootstrap (generate id_ed25519)                     [Phase 4]

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -8,7 +8,7 @@
  *
  * This file is excluded from the coverage gate (vitest.config.ts): it is a
  * thin bootstrap whose only job is to validate settings, build the app,
- * and listen.
+ * install shutdown signal handlers, and listen.
  */
 import { loadSettings } from "./config.js";
 import { buildApp } from "./web/app.js";
@@ -21,6 +21,22 @@ async function main(): Promise<void> {
   // settings feed the logger (#11) and transports in later phases.
   const settings = loadSettings();
   const app = buildApp({ settings });
+
+  // On `docker stop` (SIGTERM) or Ctrl-C (SIGINT), close the app so Fastify's
+  // onClose hooks run — notably closing the policy-store handle the app owns
+  // (#49), flushing the WAL cleanly rather than leaning on crash recovery.
+  for (const signal of ["SIGTERM", "SIGINT"] as const) {
+    process.once(signal, () => {
+      void app.close().then(
+        () => process.exit(0),
+        (err: unknown) => {
+          app.log.error(err);
+          process.exit(1);
+        },
+      );
+    });
+  }
+
   try {
     await app.listen({ host: HOST, port: PORT });
   } catch (err) {

--- a/server/src/policy/db.ts
+++ b/server/src/policy/db.ts
@@ -80,8 +80,14 @@ export function createDb(
   sqlite.pragma("journal_mode = WAL");
   sqlite.pragma("foreign_keys = ON");
 
-  const db = drizzle(sqlite, { schema });
-  migrate(db, { migrationsFolder: options.migrationsFolder ?? DEFAULT_MIGRATIONS_FOLDER });
+  const db: PolicyDb = drizzle(sqlite, { schema });
+  try {
+    migrate(db, { migrationsFolder: options.migrationsFolder ?? DEFAULT_MIGRATIONS_FOLDER });
+  } catch (err) {
+    // Don't leak the open handle if migration fails (corrupt/locked file).
+    sqlite.close();
+    throw err;
+  }
 
-  return db as PolicyDb;
+  return db;
 }

--- a/server/src/policy/db.ts
+++ b/server/src/policy/db.ts
@@ -1,0 +1,87 @@
+/**
+ * Live policy-store connection (better-sqlite3 + Drizzle).
+ *
+ * This is the runtime counterpart to the in-memory `testDb()` helper
+ * (`tests/helpers/db.ts`, #12): where that opens a hermetic `:memory:`
+ * database for unit tests, `createDb()` opens the real file the dashboard
+ * persists to (`settings.databaseUrl`) and hands the app one shared Drizzle
+ * handle (#49). The CRUD routes (#51) and auth (#52) read and write through
+ * this single connection.
+ *
+ * **Migrate-on-boot, in-process.** `createDb()` applies the committed
+ * migrations under `server/drizzle/` with drizzle-orm's `better-sqlite3`
+ * migrator. The migrator runs in-process at server start rather than from
+ * `docker-entrypoint.sh`, so the runtime image never ships `drizzle-kit` (a
+ * dev dependency) — see the Phase-2 note on #39 and
+ * `docs/server-deployment.md` → "First-run setup". The migrator is
+ * idempotent (it tracks applied migrations in its own `__drizzle_migrations`
+ * journal), so re-running it on an already-migrated file is a no-op and there
+ * is no double-migration hazard.
+ *
+ * License boundary: better-sqlite3 (MIT) and drizzle-orm (Apache-2.0) are
+ * permissively licensed and linked in-process freely; no GPL component is
+ * involved here.
+ */
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Database from "better-sqlite3";
+import { drizzle, type BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+
+import type { Settings } from "../config.js";
+import * as schema from "./schema.js";
+
+/**
+ * The committed migrations folder, resolved relative to this module rather
+ * than the process cwd. From `src/policy/` (tests, run from TypeScript) and
+ * from `dist/policy/` (the image, where the Dockerfile copies `drizzle/` to
+ * `/app/drizzle`) this is the same `<root>/drizzle` directory — the same
+ * approach `tests/helpers/db.ts` and `tests/policy/migrations.test.ts` use.
+ */
+const DEFAULT_MIGRATIONS_FOLDER = resolve(dirname(fileURLToPath(import.meta.url)), "../../drizzle");
+
+/**
+ * A migrated, file-backed Drizzle database, typed against the full policy
+ * {@link schema}. The underlying better-sqlite3 handle is reachable via
+ * `.$client` (e.g. `db.$client.close()` on shutdown) — mirroring `TestDb`.
+ */
+export type PolicyDb = BetterSQLite3Database<typeof schema> & {
+  $client: Database.Database;
+};
+
+/** Options for {@link createDb}. */
+export interface CreateDbOptions {
+  /**
+   * Override the migrations folder. Defaults to the committed `server/drizzle`
+   * resolved relative to this module; tests point it at a fixture when needed.
+   */
+  migrationsFolder?: string;
+}
+
+/**
+ * Open the policy store at `settings.databaseUrl`, apply migrations, and
+ * return a typed Drizzle handle.
+ *
+ * `databaseUrl` is already a bare filesystem path: the settings loader (#34)
+ * strips any leading `file:` so drizzle-kit and the runtime always open the
+ * same file. WAL is enabled so reads don't block the dashboard's writes, and
+ * `foreign_keys` is turned on (SQLite leaves it off per-connection by default)
+ * so the schema's referential integrity is actually enforced at runtime.
+ */
+export function createDb(
+  settings: Pick<Settings, "databaseUrl">,
+  options: CreateDbOptions = {},
+): PolicyDb {
+  const sqlite = new Database(settings.databaseUrl);
+  // WAL: concurrent readers don't block the writer (the dashboard reads usage
+  // while pushing policy). foreign_keys: SQLite defaults this OFF per
+  // connection, so the schema's FK constraints only bite once we set it.
+  sqlite.pragma("journal_mode = WAL");
+  sqlite.pragma("foreign_keys = ON");
+
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: options.migrationsFolder ?? DEFAULT_MIGRATIONS_FOLDER });
+
+  return db as PolicyDb;
+}

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -12,8 +12,20 @@
  */
 import Fastify, { type FastifyInstance } from "fastify";
 import { loadSettings, type Settings } from "../config.js";
+import { createDb, type PolicyDb } from "../policy/db.js";
 import { registerFrontend } from "./frontend.js";
 import { REQUEST_ID_HEADER, buildLoggerOptions, genRequestId, type LogStream } from "./logger.js";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    /**
+     * The shared policy-store connection (#49). Routes and the policy service
+     * read and write through this single Drizzle handle. Created from settings
+     * (migrated on boot) unless one is injected via {@link BuildAppOptions.db}.
+     */
+    db: PolicyDb;
+  }
+}
 
 /** Options for {@link buildApp}. */
 export interface BuildAppOptions {
@@ -24,6 +36,13 @@ export interface BuildAppOptions {
    * precedence over the `pino-pretty` transport.
    */
   loggerStream?: LogStream;
+  /**
+   * Inject a policy-store handle (tests pass the in-memory `testDb()`). When
+   * omitted, {@link buildApp} opens and migrates one from `settings` via
+   * {@link createDb} and owns its lifecycle — closing it on `app.close()`. An
+   * injected handle is left open; its owner closes it.
+   */
+  db?: PolicyDb;
 }
 
 /**
@@ -42,6 +61,16 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
     // Either way the id is bound to every request-scoped log line as `reqId`.
     requestIdHeader: REQUEST_ID_HEADER,
     genReqId: genRequestId,
+  });
+
+  // Open (and migrate) the policy store unless a handle was injected. buildApp
+  // owns only the handle it creates: that one is closed on shutdown; an
+  // injected handle's lifecycle belongs to its provider (no double-close).
+  const db = options.db ?? createDb(settings);
+  const ownsDb = options.db === undefined;
+  app.decorate("db", db);
+  app.addHook("onClose", async () => {
+    if (ownsDb) db.$client.close();
   });
 
   app.get("/", async (_request, reply) => {

--- a/server/tests/helpers/app.test.ts
+++ b/server/tests/helpers/app.test.ts
@@ -27,11 +27,13 @@ describe("buildTestApp helper", () => {
     await close();
   });
 
-  it("accepts a caller-supplied db", async () => {
+  it("accepts a caller-supplied db and wires it through to app.db", async () => {
     const db = testDb();
-    const { db: bundled, close } = buildTestApp({ db });
+    const { app, db: bundled, close } = buildTestApp({ db });
 
+    // The returned db, the injected db, and app.db are all the same handle.
     expect(bundled).toBe(db);
+    expect(app.db).toBe(db);
 
     await close();
   });

--- a/server/tests/helpers/app.ts
+++ b/server/tests/helpers/app.ts
@@ -7,11 +7,10 @@
  * holding the policy DB the routes will read — see `docs/testing.md` →
  * "HTTP routes".
  *
- * Forward-compat note: the Phase-1 {@link buildApp} does not yet accept a
- * `db` option — the runtime DB connection is wired in Phase 2 (see #34/#39).
- * Until then the db is created and returned alongside the app; once
- * `buildApp` gains a `db` option this helper passes it through. Bundling both
- * here means Phase 2 / Phase 4 tests don't each re-derive the wiring.
+ * The in-memory `db` is passed through to {@link buildApp} (#49), so
+ * `app.db` and the returned `db` are the same handle; `close()` closes the
+ * app and then the database. Bundling both here means policy / route tests
+ * don't each re-derive the wiring.
  */
 import type { FastifyInstance } from "fastify";
 
@@ -53,6 +52,9 @@ export function buildTestApp(options: BuildTestAppOptions = {}): TestApp {
   const app = buildApp({
     settings: loadSettings({ PCT_LOG_LEVEL: "silent" }),
     ...options.appOptions,
+    // Inject the bundled db last so app.db is the handle this helper returns,
+    // regardless of any db passed via appOptions.
+    db,
   });
 
   return {

--- a/server/tests/helpers/db.ts
+++ b/server/tests/helpers/db.ts
@@ -14,8 +14,11 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import Database from "better-sqlite3";
-import { drizzle, type BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+
+import type { PolicyDb } from "../../src/policy/db.js";
+import * as schema from "../../src/policy/schema.js";
 
 // Resolve the committed migrations folder relative to this file rather than
 // the process cwd, so the helper works regardless of where the runner is
@@ -23,12 +26,12 @@ import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 const migrationsFolder = resolve(dirname(fileURLToPath(import.meta.url)), "../../drizzle");
 
 /**
- * A migrated in-memory Drizzle database. The underlying better-sqlite3 handle
- * is reachable via `.$client` (e.g. `db.$client.close()` to free it).
+ * A migrated in-memory Drizzle database. Typed identically to the runtime
+ * {@link PolicyDb} (same schema) so it can be injected into `buildApp` via
+ * `buildTestApp`; the underlying better-sqlite3 handle is reachable via
+ * `.$client` (e.g. `db.$client.close()` to free it).
  */
-export type TestDb = BetterSQLite3Database<Record<string, never>> & {
-  $client: Database.Database;
-};
+export type TestDb = PolicyDb;
 
 /**
  * Build a fresh in-memory policy database with all migrations applied.
@@ -39,7 +42,10 @@ export type TestDb = BetterSQLite3Database<Record<string, never>> & {
  */
 export function testDb(): TestDb {
   const sqlite = new Database(":memory:");
-  const db = drizzle(sqlite);
+  // Schema-typed (like createDb) so app.db and the injected test handle share
+  // one type; in-memory ignores WAL, and foreign_keys is left at SQLite's
+  // default here since hermetic unit tests opt into FK checks when they need them.
+  const db = drizzle(sqlite, { schema });
   migrate(db, { migrationsFolder });
-  return db;
+  return db as PolicyDb;
 }

--- a/server/tests/helpers/db.ts
+++ b/server/tests/helpers/db.ts
@@ -44,8 +44,10 @@ export function testDb(): TestDb {
   const sqlite = new Database(":memory:");
   // Schema-typed (like createDb) so app.db and the injected test handle share
   // one type; in-memory ignores WAL, and foreign_keys is left at SQLite's
-  // default here since hermetic unit tests opt into FK checks when they need them.
-  const db = drizzle(sqlite, { schema });
+  // default here since hermetic unit tests opt into FK checks when they need
+  // them. Once CRUD routes land (#51), consider enabling foreign_keys here so
+  // route tests over app.db catch referential bugs the way runtime does.
+  const db: PolicyDb = drizzle(sqlite, { schema });
   migrate(db, { migrationsFolder });
-  return db as PolicyDb;
+  return db;
 }

--- a/server/tests/policy/db.test.ts
+++ b/server/tests/policy/db.test.ts
@@ -96,6 +96,14 @@ describe("createDb", () => {
     expect(rows[0]?.createdAt).toBeInstanceOf(Date);
   });
 
+  it("propagates a migration failure instead of returning a half-open handle", () => {
+    // Point at a folder with no migration journal so the migrator throws; the
+    // open sqlite handle is closed in createDb's catch rather than leaked.
+    expect(() =>
+      createDb({ databaseUrl: dbPath }, { migrationsFolder: join(dir, "no-such-migrations") }),
+    ).toThrow();
+  });
+
   it("is idempotent: reopening an existing file re-applies no migrations and keeps data", () => {
     const first = openDb();
     first.insert(users).values({ displayName: "Bob" }).run();

--- a/server/tests/policy/db.test.ts
+++ b/server/tests/policy/db.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the live policy-store connection {@link createDb} (#49).
+ *
+ * Unlike the in-memory `testDb()` helper, these exercise a real file-backed
+ * database in a temp dir: WAL mode is only meaningful on disk, and reopening
+ * the same file is what proves migrate-on-boot is idempotent. Each test gets
+ * its own temp directory and closes the handle so nothing leaks between runs.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createDb, type PolicyDb } from "../../src/policy/db.js";
+import { users } from "../../src/policy/schema.js";
+
+describe("createDb", () => {
+  let dir: string;
+  let dbPath: string;
+  const open = new Set<PolicyDb>();
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pct-db-"));
+    dbPath = join(dir, "policy.sqlite");
+  });
+
+  afterEach(() => {
+    for (const db of open) db.$client.close();
+    open.clear();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Open a tracked handle so afterEach always closes it (and frees the file). */
+  function openDb(path = dbPath): PolicyDb {
+    const db = createDb({ databaseUrl: path });
+    open.add(db);
+    return db;
+  }
+
+  /** Read a SQLite PRAGMA's scalar value off the underlying handle. */
+  function pragma(db: PolicyDb, name: string): unknown {
+    return db.$client.pragma(name, { simple: true });
+  }
+
+  it("creates the database file and materialises the full policy schema", () => {
+    const db = openDb();
+
+    const tableNames = db.$client
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' " +
+          "AND name NOT LIKE 'sqlite_%' AND name != '__drizzle_migrations' ORDER BY name",
+      )
+      .pluck()
+      .all();
+
+    expect(tableNames).toContain("users");
+    expect(tableNames).toContain("grants");
+    expect(tableNames).toContain("notification_policies");
+  });
+
+  it("enables WAL journaling and foreign-key enforcement", () => {
+    const db = openDb();
+
+    // WAL is only honoured on a file-backed database, which is why this test
+    // uses a temp file rather than the in-memory testDb() helper.
+    expect(String(pragma(db, "journal_mode")).toLowerCase()).toBe("wal");
+    expect(pragma(db, "foreign_keys")).toBe(1);
+  });
+
+  it("enforces foreign keys at runtime", () => {
+    const db = openDb();
+
+    // users_on_clients.user_id / client_id are NOT NULL FKs; with
+    // foreign_keys=ON, inserting a row referencing absent parents must throw.
+    expect(() =>
+      db.$client
+        .prepare(
+          "INSERT INTO users_on_clients (user_id, client_id, linux_username, linux_uid) " +
+            "VALUES (999, 999, 'ghost', 1000)",
+        )
+        .run(),
+    ).toThrow(/FOREIGN KEY/i);
+  });
+
+  it("round-trips a row through the typed Drizzle handle", () => {
+    const db = openDb();
+
+    db.insert(users).values({ displayName: "Alice" }).run();
+    const rows = db.select().from(users).all();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.displayName).toBe("Alice");
+    // tz defaults to NULL ("inherit the server default"); createdAt is set.
+    expect(rows[0]?.tz).toBeNull();
+    expect(rows[0]?.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("is idempotent: reopening an existing file re-applies no migrations and keeps data", () => {
+    const first = openDb();
+    first.insert(users).values({ displayName: "Bob" }).run();
+    const appliedAfterFirst = first.$client
+      .prepare("SELECT count(*) FROM __drizzle_migrations")
+      .pluck()
+      .get();
+    first.$client.close();
+    open.delete(first);
+
+    // Reopen the same path: migrate-on-boot must be a no-op (same journal
+    // count) and the previously written row must still be there.
+    const second = openDb();
+    const appliedAfterSecond = second.$client
+      .prepare("SELECT count(*) FROM __drizzle_migrations")
+      .pluck()
+      .get();
+
+    expect(appliedAfterSecond).toBe(appliedAfterFirst);
+    expect(second.select().from(users).all()).toHaveLength(1);
+  });
+});

--- a/server/tests/web/app.test.ts
+++ b/server/tests/web/app.test.ts
@@ -1,29 +1,37 @@
 /**
- * Route tests for the minimal Phase 1 app.
+ * Route + wiring tests for the minimal app.
  *
- * Uses Fastify's `app.inject()` — no sockets, no port binding — per
- * docs/testing.md → "HTTP routes".
+ * Uses `buildTestApp()` (silent logger + bundled in-memory db) and Fastify's
+ * `app.inject()` — no sockets, no port binding — per docs/testing.md →
+ * "HTTP routes".
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { FastifyInstance } from "fastify";
+
 import { buildApp } from "../../src/web/app.js";
 import { loadSettings } from "../../src/config.js";
+import { buildTestApp, type TestApp } from "../helpers/app.js";
+import { testDb } from "../helpers/db.js";
+import { users } from "../../src/policy/schema.js";
 
 describe("web app routes", () => {
-  let app: FastifyInstance;
+  let harness: TestApp;
 
   beforeEach(() => {
     // Silent logger keeps route-test output clean; logging behaviour itself
     // is covered in logging.test.ts.
-    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "silent" }) });
+    harness = buildTestApp();
   });
 
   afterEach(async () => {
-    await app.close();
+    await harness.close();
   });
 
   it("GET / returns the placeholder landing page", async () => {
-    const res = await app.inject({ method: "GET", url: "/" });
+    const res = await harness.app.inject({ method: "GET", url: "/" });
 
     expect(res.statusCode).toBe(200);
     expect(res.body).toBe("hello, no policy yet");
@@ -31,15 +39,64 @@ describe("web app routes", () => {
   });
 
   it("GET /healthz reports ok", async () => {
-    const res = await app.inject({ method: "GET", url: "/healthz" });
+    const res = await harness.app.inject({ method: "GET", url: "/healthz" });
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ status: "ok" });
   });
 
   it("unknown routes 404", async () => {
-    const res = await app.inject({ method: "GET", url: "/nope" });
+    const res = await harness.app.inject({ method: "GET", url: "/nope" });
 
     expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("app.db decorator (#49)", () => {
+  it("decorates the app with the injected policy db and serves reads/writes", () => {
+    const db = testDb();
+    const app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "silent" }), db });
+
+    // The decorator is the exact handle that was injected...
+    expect(app.db).toBe(db);
+    // ...and it is a live, migrated connection routes can query.
+    app.db.insert(users).values({ displayName: "Carol" }).run();
+    expect(app.db.select().from(users).all()).toHaveLength(1);
+
+    db.$client.close();
+  });
+
+  it("leaves an injected db open on app.close() (its owner closes it)", async () => {
+    const db = testDb();
+    const app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "silent" }), db });
+
+    await app.close();
+
+    // better-sqlite3 marks a closed handle `open: false`; an injected handle
+    // must still be open after app.close() so its provider owns the lifecycle.
+    expect(db.$client.open).toBe(true);
+    db.$client.close();
+  });
+
+  it("opens, migrates, and owns a db from settings when none is injected", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pct-app-db-"));
+    const dbPath = join(dir, "policy.sqlite");
+    try {
+      // No `db` injected: buildApp calls createDb(settings) and owns the handle.
+      const app = buildApp({
+        settings: loadSettings({ PCT_LOG_LEVEL: "silent", DATABASE_URL: dbPath }),
+      });
+
+      // The owned handle is a live, migrated connection.
+      app.db.insert(users).values({ displayName: "Dave" }).run();
+      expect(app.db.select().from(users).all()).toHaveLength(1);
+
+      // ...and closing the app closes the handle it owns.
+      const client = app.db.$client;
+      await app.close();
+      expect(client.open).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/server/tests/web/frontend.test.ts
+++ b/server/tests/web/frontend.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { FastifyInstance } from "fastify";
 import { buildApp } from "../../src/web/app.js";
 import { loadSettings } from "../../src/config.js";
+import { testDb, type TestDb } from "../helpers/db.js";
 
 const ADMIN_HTML = "<!doctype html><title>admin</title><div id=admin-marker>";
 const APP_HTML = "<!doctype html><title>app</title><div id=app-marker>";
@@ -32,17 +33,21 @@ function makeFixtureBuild(): string {
 
 describe("frontend static mount (build present)", () => {
   let app: FastifyInstance;
+  let db: TestDb;
   let root: string;
 
   beforeEach(() => {
     root = makeFixtureBuild();
+    db = testDb();
     app = buildApp({
       settings: loadSettings({ PCT_LOG_LEVEL: "silent", PCT_FRONTEND_ROOT: root }),
+      db,
     });
   });
 
   afterEach(async () => {
     await app.close();
+    db.$client.close();
     rmSync(root, { recursive: true, force: true });
   });
 
@@ -121,10 +126,12 @@ describe("frontend static mount (build present)", () => {
 
 describe("frontend static mount (build absent)", () => {
   let app: FastifyInstance;
+  let db: TestDb;
   const missingRoot = join(tmpdir(), "pct-frontend-does-not-exist-40");
 
   afterEach(async () => {
     await app.close();
+    db.$client.close();
   });
 
   it("warns and skips the mount without blocking startup", async () => {
@@ -134,9 +141,11 @@ describe("frontend static mount (build absent)", () => {
         lines.push(JSON.parse(msg) as Record<string, unknown>);
       },
     };
+    db = testDb();
     app = buildApp({
       settings: loadSettings({ PCT_LOG_LEVEL: "warn", PCT_FRONTEND_ROOT: missingRoot }),
       loggerStream: stream,
+      db,
     });
 
     // The surfaces 404 because nothing is mounted...

--- a/server/tests/web/logging.test.ts
+++ b/server/tests/web/logging.test.ts
@@ -10,6 +10,7 @@ import type { FastifyInstance } from "fastify";
 import { buildApp } from "../../src/web/app.js";
 import { buildLoggerOptions, componentLogger, genRequestId } from "../../src/web/logger.js";
 import { loadSettings } from "../../src/config.js";
+import { testDb, type TestDb } from "../helpers/db.js";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
@@ -31,14 +32,21 @@ function collectStream(): {
 
 describe("request-id logging", () => {
   let app: FastifyInstance;
+  let db: TestDb;
 
   afterEach(async () => {
     await app.close();
+    db.$client.close();
   });
 
   it("honours an inbound X-Request-Id on request-scoped log lines", async () => {
     const { stream, lines } = collectStream();
-    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "info" }), loggerStream: stream });
+    db = testDb();
+    app = buildApp({
+      settings: loadSettings({ PCT_LOG_LEVEL: "info" }),
+      loggerStream: stream,
+      db,
+    });
 
     await app.inject({
       method: "GET",
@@ -55,7 +63,12 @@ describe("request-id logging", () => {
 
   it("generates a UUID request id when no header is present", async () => {
     const { stream, lines } = collectStream();
-    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "info" }), loggerStream: stream });
+    db = testDb();
+    app = buildApp({
+      settings: loadSettings({ PCT_LOG_LEVEL: "info" }),
+      loggerStream: stream,
+      db,
+    });
 
     await app.inject({ method: "GET", url: "/healthz" });
 
@@ -66,7 +79,12 @@ describe("request-id logging", () => {
 
   it("componentLogger binds a component field to non-request log lines", async () => {
     const { stream, lines } = collectStream();
-    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "info" }), loggerStream: stream });
+    db = testDb();
+    app = buildApp({
+      settings: loadSettings({ PCT_LOG_LEVEL: "info" }),
+      loggerStream: stream,
+      db,
+    });
 
     componentLogger(app, "transport/ssh").info("ssh command issued");
 


### PR DESCRIPTION
## Summary

- Add `createDb(settings)` in `server/src/policy/db.ts`: opens the policy store at `settings.databaseUrl`, enables `journal_mode=WAL` + `foreign_keys=ON`, wraps it in a Drizzle handle typed against the full schema, and applies the committed migrations **in-process on boot** via drizzle-orm's `better-sqlite3` migrator.
- Expose it as a Fastify `app.db` decorator: `buildApp` opens & owns a handle from settings (closed on `app.close()`) unless one is injected — the test seam `buildTestApp` injects an in-memory `testDb()`, whose lifecycle stays with the provider (no double-close).
- Documents the migrate-on-boot decision and reconciles the deferred #39 entrypoint "schema migration" step so the entrypoint and runtime never double-migrate or disagree on the path.

## Plan

Linked plan: `.claude/plans/49-runtime-sqlite-connection.md`
Roadmap: `docs/roadmap.md` → Phase 2

## Key decision (documented in-PR)

Migrations run **in-process at server boot**, not from `docker-entrypoint.sh`. This keeps `drizzle-kit` (a dev dependency) out of the runtime image — the migrator reads the SQL the Dockerfile already copies to `/app/drizzle` — and is idempotent via drizzle's own `__drizzle_migrations` journal. Captured in `docs/server-deployment.md` → "First-run setup" step 1, the `docker-entrypoint.sh` comment, and `docs/testing.md`.

## License-boundary note

No GPL linkage: only better-sqlite3 (MIT) and drizzle-orm (Apache-2.0), both already dependencies — **no new dependency added**. No change to the image's GPL posture (the migration SQL was already shipped; no new binaries). No transport/REST boundary touched.

## Test plan

- [x] `createDb` against a real temp file: schema materialised, `WAL` + `foreign_keys` pragmas set, runtime FK enforcement, typed round-trip, idempotent reopen (no re-migration, data preserved).
- [x] `app.db` is the injected handle and serves typed reads/writes; an injected handle stays open after `app.close()`, an owned handle is closed.
- [x] `buildTestApp` wires the bundled `testDb()` through to `app.db`.
- [x] Existing route/logging/frontend tests updated to inject an in-memory db.
- [x] Full gate from `server/`: `format:check` · `lint` · `typecheck` · `test` (109 tests, coverage ≥ 80%; `db.ts` 100%).

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Knr4yrWuQZWvLWtKgX4nrA)_