### PR TITLE
feat(auth): single-admin Argon2id auth + signed session + first-admin bootstrap (#52)

### DIFF
--- a/.claude/plans/issue-52-single-admin-auth.md
+++ b/.claude/plans/issue-52-single-admin-auth.md
@@ -1,0 +1,79 @@
+# Issue #52 — Single-admin auth (Argon2id) + signed session + first-admin bootstrap
+
+Roadmap: Phase 2. Blocked by #48/#49/#50 (all closed). Unblocks #51 (policy
+routes sit behind this guard) and #53 (admin UI login).
+
+## Scope (deliberately minimal — see owner note on #52)
+
+One admin login. The policy-model `User` is a supervised person, **not** an
+auth principal. No multi-user framework, no roles/MFA/federation (those are
+Phase 11 / stretch #24→#26). Just: Argon2id hash, a signed session cookie
+keyed on `PCT_SECRET_KEY`, login/logout/session endpoints, a reusable guard,
+and a documented first-admin bootstrap.
+
+## Decisions
+
+- **Storage:** new `admin_credentials` singleton table (`CHECK (id = 1)`), so
+  the schema itself guarantees at most one admin. Stores only the Argon2id
+  hash. New drizzle migration `0001_*`.
+- **Hashing:** `argon2` (Argon2id). Mandated by the issue and already named in
+  `docs/server-deployment.md`'s runtime dependency list. No existing dep does
+  password hashing.
+- **Session:** `@fastify/cookie` signed cookie. Payload is a non-secret
+  base64url(JSON) `{ sub, iat }` signed with `PCT_SECRET_KEY` (HMAC via
+  cookie-signature). `httpOnly`, `sameSite=strict`, `path=/`. TTL enforced
+  both by cookie `maxAge` and an `iat`-age check in the guard. Chosen over
+  `@fastify/secure-session` (no payload secrecy needed — the only datum is
+  "this is the admin") and over a JWT lib (overkill for one signed marker).
+- **Bootstrap:** `PCT_ADMIN_USERNAME` + `PCT_ADMIN_PASSWORD` consumed on first
+  run (an `onReady` hook) to seed the admin row, hashed immediately. Idempotent
+  (no-op if an admin row already exists). If unset and no admin exists, log a
+  warning and leave login disabled until configured. Documented in
+  `docs/server-deployment.md` → "Authentication". Standard path for the
+  Docker/homelab single-admin target; not contentious, so not split to
+  `decision-needed`.
+- **Module:** new `server/src/auth/` (per-responsibility, like `transport/*`).
+  Auth DTO types are re-exported from `api/index.ts` so the frontend's import
+  surface stays `server/src/api`. `CLAUDE.md` module split + `architecture.md`
+  updated to document the module.
+- **Unconfigured (`PCT_SECRET_KEY` unset):** auth endpoints and the guard
+  return `503 auth_not_configured` in the envelope (cannot sign a session
+  without the key). Real deployments set the key; tests set it.
+
+## Wiring
+
+- `registerApi(app, settings)` → `apiPlugin(scope, { settings })`.
+- Inside `apiPlugin`: `installApiConventions(scope)` → `await
+  registerAuth(scope, settings)` → `registerMetaRoute(scope)`.
+- `registerAuth` (encapsulated to `/api`): register `@fastify/cookie`,
+  `decorate("requireAdmin", …)`, add the `onReady` bootstrap hook, register
+  `/auth/login|logout|session` routes. Future #51 policy routes use
+  `scope.requireAdmin`.
+
+## Files
+
+- `src/auth/passwords.ts` — `hashPassword` / `verifyPassword` (Argon2id) + a
+  constant dummy hash for constant-time-ish unknown-user verification.
+- `src/auth/session.ts` — issue/clear/read the signed session cookie; TTL.
+- `src/auth/credentials.ts` — `findAdmin`, `bootstrapAdmin`.
+- `src/auth/rate-limit.ts` — minimal in-memory per-IP failed-login limiter.
+- `src/auth/guard.ts` — `makeRequireAdmin` preHandler + `requireAdmin` augmentation.
+- `src/auth/routes.ts` — `POST /auth/login`, `POST /auth/logout`, `GET /auth/session`.
+- `src/auth/dtos.ts` — `loginRequestSchema`, `sessionResponseSchema`.
+- `src/auth/index.ts` — `registerAuth` orchestrator + barrel.
+- `src/policy/schema.ts` (+ migration), `src/config.ts`, `src/api/plugin.ts`,
+  `src/api/index.ts`, `src/web/app.ts`, `.env.example`, docs.
+
+## Tests (coverage gate 80%, `include: src/**`)
+
+- `tests/auth/passwords.test.ts` — hash is argon2id; verify true/false; dummy verify false.
+- `tests/auth/session.test.ts` — round-trip; tamper rejected; expired rejected.
+- `tests/auth/credentials.test.ts` — seeds when empty+env; no-op when admin exists; warns when env missing (testDb).
+- `tests/auth/rate-limit.test.ts` — under/over limit; window reset; success resets.
+- `tests/api/auth.test.ts` (buildTestApp) — login ok sets cookie; wrong pw/unknown user → 401; missing field → 400;
+  guard rejects anon → 401 + allows valid cookie; logout clears; session whoami anon/auth; 429 after N failures; 503 when unconfigured.
+
+## Phases
+
+1. Schema + migration + config + bootstrap/credentials + passwords (+ tests).
+2. Session + guard + routes + api wiring + docs (+ tests).

--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,19 @@
 # pino log level: trace | debug | info | warn | error | fatal | silent
 # PCT_LOG_LEVEL=info
 
-# Signs sessions / integration tokens (used in later phases). Set a long
-# random value in any real deployment.
+# Signs the admin session cookie (and, later, integration tokens). Set a long
+# random value in any real deployment — until it is set, login and the admin
+# guard fail closed with 503 (a session cannot be signed without it).
 # PCT_SECRET_KEY=
+
+# First-admin bootstrap (single-admin auth). On first run, if no admin exists
+# and BOTH of these are set, the admin login is seeded from them: the password
+# is Argon2id-hashed immediately and the plaintext is never stored. Seeding is
+# idempotent (a restart never reseeds), so you can drop PCT_ADMIN_PASSWORD from
+# the environment after the first successful start. See docs/server-deployment.md
+# → "Authentication".
+# PCT_ADMIN_USERNAME=admin
+# PCT_ADMIN_PASSWORD=change-me-on-first-run
 
 # --- AdGuard Home (optional DNS filtering) ----------------------------------
 # Mode: disabled (default) | external | managed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,9 @@ full reasoning.
     at `/admin` and `/app`, hosts `/integrations`
   - `api/` — zod DTOs, JSON routes used by both frontends and by
     external integrations
+  - `auth/` — single-admin authentication: Argon2id hashing, the signed
+    session cookie, the `requireAdmin` guard, and first-admin bootstrap
+    (wired into the `/api` scope; auth DTO types re-exported from `api/`)
   - `policy/` — Drizzle schema, policy model, DB access, grant ledger
   - `integrations/` — external-system inbound APIs (e.g. the
     family-calendar rewards endpoint; see `docs/architecture.md`)

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -246,10 +246,31 @@ behind authentication.
   and [`adr/0002-client-dashboard-shell.md`](adr/0002-client-dashboard-shell.md)).
   Phase 2 auth is intentionally minimal — verify a single Argon2id hash,
   set a signed session cookie keyed on `PCT_SECRET_KEY`, guard the
-  routes — implemented with `argon2` plus a Fastify session plugin (see
+  routes — implemented with `argon2` plus `@fastify/cookie` (see
   issue #52). Do not pull in a multi-user auth framework for this;
   accounts, roles, MFA, federation, and self-registration are explicitly
   out of scope until the identity work below.
+- **First-admin bootstrap.** On first run, if no admin credential exists
+  yet and **both** `PCT_ADMIN_USERNAME` and `PCT_ADMIN_PASSWORD` are set,
+  the dashboard seeds the single admin row from them. The password is
+  Argon2id-hashed immediately on seeding and the plaintext is never
+  stored; only the hash is persisted (in the `admin_credentials` table,
+  a singleton enforced by a `CHECK (id = 1)` constraint). Seeding is
+  idempotent — once an admin exists it is never reseeded or overwritten,
+  so you can drop `PCT_ADMIN_PASSWORD` from the environment after the
+  first successful start. If the variables are absent and no admin
+  exists, the dashboard logs a warning and login stays disabled until an
+  admin is configured. Until `PCT_SECRET_KEY` is set the auth endpoints
+  and the admin guard fail closed with `503 auth_not_configured` (a
+  session cannot be signed without it), so set a long random
+  `PCT_SECRET_KEY` in any real deployment.
+- **Session cookie.** The session is a signed (`PCT_SECRET_KEY`),
+  `HttpOnly`, `SameSite=Strict` cookie carrying a small non-secret
+  payload; it expires after 7 days. `SameSite=Strict` closes off CSRF
+  against the cookie-authenticated mutating routes. The cookie is not
+  marked `Secure` (the default LAN deployment is plain HTTP on port
+  8000); when terminating TLS at a reverse proxy, that proxy is the
+  appropriate place to enforce HTTPS.
 - Future: optional OIDC integration so a household identity provider
   (FreeIPA, Authentik) can be used. When that (Phase 11 multi-admin/OIDC)
   or the larger centralised-identity work (stretch epic #24 → #26:

--- a/server/drizzle/0001_sparkling_talkback.sql
+++ b/server/drizzle/0001_sparkling_talkback.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `admin_credentials` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`username` text NOT NULL,
+	`password_hash` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	CONSTRAINT "admin_credentials_singleton_check" CHECK("admin_credentials"."id" = 1)
+);

--- a/server/drizzle/meta/0001_snapshot.json
+++ b/server/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1048 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "12d906c3-b2d3-4bba-ad3c-4ae7cc7a56fc",
+  "prevId": "f3d5548f-d172-4223-92ce-ee19c786f714",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matcher": {
+          "name": "matcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "activities_kind_check": {
+          "name": "activities_kind_check",
+          "value": "\"activities\".\"kind\" in ('app', 'app_group', 'domain', 'domain_group')"
+        }
+      }
+    },
+    "activities_to_groups": {
+      "name": "activities_to_groups",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activities_to_groups_activity_id_activities_id_fk": {
+          "name": "activities_to_groups_activity_id_activities_id_fk",
+          "tableFrom": "activities_to_groups",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activities_to_groups_group_id_activity_groups_id_fk": {
+          "name": "activities_to_groups_group_id_activity_groups_id_fk",
+          "tableFrom": "activities_to_groups",
+          "tableTo": "activity_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activities_to_groups_activity_id_group_id_pk": {
+          "columns": [
+            "activity_id",
+            "group_id"
+          ],
+          "name": "activities_to_groups_activity_id_group_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_groups": {
+      "name": "activity_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "activity_groups_name_unique": {
+          "name": "activity_groups_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "admin_credentials": {
+      "name": "admin_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "admin_credentials_singleton_check": {
+          "name": "admin_credentials_singleton_check",
+          "value": "\"admin_credentials\".\"id\" = 1"
+        }
+      }
+    },
+    "budgets": {
+      "name": "budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seconds_allowed": {
+          "name": "seconds_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "budgets_user_scope_window_idx": {
+          "name": "budgets_user_scope_window_idx",
+          "columns": [
+            "user_id",
+            "scope",
+            "window"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "budgets_scope_check": {
+          "name": "budgets_scope_check",
+          "value": "\"budgets\".\"scope\" in ('overall', 'activity', 'group')"
+        },
+        "budgets_window_check": {
+          "name": "budgets_window_check",
+          "value": "\"budgets\".\"window\" in ('daily', 'weekly', 'monthly')"
+        },
+        "budgets_seconds_check": {
+          "name": "budgets_seconds_check",
+          "value": "\"budgets\".\"seconds_allowed\" >= 0"
+        },
+        "budgets_target_coherence_check": {
+          "name": "budgets_target_coherence_check",
+          "value": "(\"budgets\".\"scope\" = 'overall') = (\"budgets\".\"target_id\" is null)"
+        }
+      }
+    },
+    "clients": {
+      "name": "clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ssh_user": {
+          "name": "ssh_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "clients_hostname_unique": {
+          "name": "clients_hostname_unique",
+          "columns": [
+            "hostname"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exceptions": {
+      "name": "exceptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "exceptions_user_expires_idx": {
+          "name": "exceptions_user_expires_idx",
+          "columns": [
+            "user_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exceptions_user_id_users_id_fk": {
+          "name": "exceptions_user_id_users_id_fk",
+          "tableFrom": "exceptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "exceptions_target_kind_check": {
+          "name": "exceptions_target_kind_check",
+          "value": "\"exceptions\".\"target_kind\" in ('overall', 'activity', 'group')"
+        },
+        "exceptions_action_check": {
+          "name": "exceptions_action_check",
+          "value": "\"exceptions\".\"action\" in ('allow', 'deny', 'extend')"
+        },
+        "exceptions_target_coherence_check": {
+          "name": "exceptions_target_coherence_check",
+          "value": "(\"exceptions\".\"target_kind\" = 'overall') = (\"exceptions\".\"target_id\" is null)"
+        }
+      }
+    },
+    "grants": {
+      "name": "grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seconds_granted": {
+          "name": "seconds_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "grants_source_ref_unique": {
+          "name": "grants_source_ref_unique",
+          "columns": [
+            "source_ref"
+          ],
+          "isUnique": true
+        },
+        "grants_user_scope_target_idx": {
+          "name": "grants_user_scope_target_idx",
+          "columns": [
+            "user_id",
+            "scope",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "grants_user_expires_idx": {
+          "name": "grants_user_expires_idx",
+          "columns": [
+            "user_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "grants_user_id_users_id_fk": {
+          "name": "grants_user_id_users_id_fk",
+          "tableFrom": "grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "grants_scope_check": {
+          "name": "grants_scope_check",
+          "value": "\"grants\".\"scope\" in ('overall', 'activity', 'group')"
+        },
+        "grants_seconds_check": {
+          "name": "grants_seconds_check",
+          "value": "\"grants\".\"seconds_granted\" > 0"
+        },
+        "grants_target_coherence_check": {
+          "name": "grants_target_coherence_check",
+          "value": "(\"grants\".\"scope\" = 'overall') = (\"grants\".\"target_id\" is null)"
+        },
+        "grants_source_check": {
+          "name": "grants_source_check",
+          "value": "\"grants\".\"source\" = 'admin' or \"grants\".\"source\" like 'integration:%'"
+        }
+      }
+    },
+    "integration_tokens": {
+      "name": "integration_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_secret": {
+          "name": "hashed_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "integration_tokens_name_unique": {
+          "name": "integration_tokens_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_policies": {
+      "name": "notification_policies",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sound_profile": {
+          "name": "sound_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "grace_seconds": {
+          "name": "grace_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "cadence_overrides_json": {
+          "name": "cadence_overrides_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_policies_user_id_users_id_fk": {
+          "name": "notification_policies_user_id_users_id_fk",
+          "tableFrom": "notification_policies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "notification_policies_grace_check": {
+          "name": "notification_policies_grace_check",
+          "value": "\"notification_policies\".\"grace_seconds\" >= 0"
+        }
+      }
+    },
+    "schedules": {
+      "name": "schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_or_window": {
+          "name": "cron_or_window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "schedules_user_idx": {
+          "name": "schedules_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedules_user_id_users_id_fk": {
+          "name": "schedules_user_id_users_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "schedules_target_kind_check": {
+          "name": "schedules_target_kind_check",
+          "value": "\"schedules\".\"target_kind\" in ('overall', 'activity', 'group')"
+        },
+        "schedules_action_check": {
+          "name": "schedules_action_check",
+          "value": "\"schedules\".\"action\" in ('allow', 'deny', 'extend')"
+        },
+        "schedules_target_coherence_check": {
+          "name": "schedules_target_coherence_check",
+          "value": "(\"schedules\".\"target_kind\" = 'overall') = (\"schedules\".\"target_id\" is null)"
+        }
+      }
+    },
+    "usage_samples": {
+      "name": "usage_samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_samples_user_started_idx": {
+          "name": "usage_samples_user_started_idx",
+          "columns": [
+            "user_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "usage_samples_user_activity_started_idx": {
+          "name": "usage_samples_user_activity_started_idx",
+          "columns": [
+            "user_id",
+            "activity_id",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "usage_samples_user_id_users_id_fk": {
+          "name": "usage_samples_user_id_users_id_fk",
+          "tableFrom": "usage_samples",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_samples_client_id_clients_id_fk": {
+          "name": "usage_samples_client_id_clients_id_fk",
+          "tableFrom": "usage_samples",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_samples_activity_id_activities_id_fk": {
+          "name": "usage_samples_activity_id_activities_id_fk",
+          "tableFrom": "usage_samples",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "usage_samples_interval_check": {
+          "name": "usage_samples_interval_check",
+          "value": "\"usage_samples\".\"ended_at\" >= \"usage_samples\".\"started_at\""
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tz": {
+          "name": "tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_on_clients": {
+      "name": "users_on_clients",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linux_username": {
+          "name": "linux_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linux_uid": {
+          "name": "linux_uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_on_clients_client_idx": {
+          "name": "users_on_clients_client_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "users_on_clients_client_uid_unique": {
+          "name": "users_on_clients_client_uid_unique",
+          "columns": [
+            "client_id",
+            "linux_uid"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_on_clients_user_id_users_id_fk": {
+          "name": "users_on_clients_user_id_users_id_fk",
+          "tableFrom": "users_on_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_on_clients_client_id_clients_id_fk": {
+          "name": "users_on_clients_client_id_clients_id_fk",
+          "tableFrom": "users_on_clients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_on_clients_user_id_client_id_pk": {
+          "columns": [
+            "user_id",
+            "client_id"
+          ],
+          "name": "users_on_clients_user_id_client_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1781639162753,
       "tag": "0000_broad_slapstick",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1781647561616,
+      "tag": "0001_sparkling_talkback",
+      "breakpoints": true
     }
   ]
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "license": "SEE LICENSE IN ../LICENSE",
       "dependencies": {
+        "@fastify/cookie": "^11.0.2",
         "@fastify/static": "^8.2.0",
         "@fastify/websocket": "^11.2.0",
+        "argon2": "^0.44.0",
         "better-sqlite3": "^12.4.1",
         "croner": "^9.1.0",
         "drizzle-orm": "^0.44.5",
@@ -117,6 +119,12 @@
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -1199,6 +1207,26 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@fastify/cookie": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.0.2.tgz",
+      "integrity": "sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.0",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
@@ -1488,6 +1516,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -2481,6 +2518,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2819,6 +2872,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -4323,6 +4393,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/on-exit-leak-free": {

--- a/server/package.json
+++ b/server/package.json
@@ -23,8 +23,10 @@
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
+    "@fastify/cookie": "^11.0.2",
     "@fastify/static": "^8.2.0",
     "@fastify/websocket": "^11.2.0",
+    "argon2": "^0.44.0",
     "better-sqlite3": "^12.4.1",
     "croner": "^9.1.0",
     "drizzle-orm": "^0.44.5",

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -22,3 +22,13 @@ export {
 } from "./errors.js";
 export { metaResponseSchema, type MetaResponse } from "./meta.js";
 export type { ZodTypeProvider } from "./validation.js";
+
+// Auth DTOs (#52). Re-exported here so the frontend imports the auth contract
+// from the same `/api` surface as every other DTO; the schemas themselves live
+// in `../auth/dtos.ts` next to the routes that use them.
+export {
+  loginRequestSchema,
+  sessionResponseSchema,
+  type LoginRequest,
+  type SessionResponse,
+} from "../auth/dtos.js";

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -1,23 +1,37 @@
 /**
  * The `/api` Fastify plugin: one encapsulated scope that installs the shared
  * validation/envelope conventions and mounts the JSON routes. Mounting it
- * under the `/api` prefix keeps the conventions (and any future policy/auth/
+ * under the `/api` prefix keeps the conventions (and the auth/policy/
  * integration routes) from touching `/`, `/healthz`, `/admin`, or `/app`.
  *
  * License boundary: none touched.
  */
 import type { FastifyInstance, FastifyPluginAsync } from "fastify";
 
+import { registerAuth } from "../auth/index.js";
+import type { Settings } from "../config.js";
 import { registerMetaRoute } from "./meta.js";
 import { installApiConventions } from "./validation.js";
 
-/** The encapsulated `/api` plugin: conventions first, then routes. */
-export const apiPlugin: FastifyPluginAsync = async (scope) => {
+/** Options the `/api` plugin needs from its host app. */
+export interface ApiPluginOptions {
+  /** Parsed settings (auth keys, etc.) threaded in from {@link registerApi}. */
+  settings: Settings;
+}
+
+/**
+ * The encapsulated `/api` plugin: conventions first, then auth (cookie plugin,
+ * the `requireAdmin` guard, bootstrap, and the auth routes), then the rest of
+ * the routes. Auth is installed before other routes so its `requireAdmin`
+ * decoration is available to them within this scope.
+ */
+export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opts) => {
   installApiConventions(scope);
+  await registerAuth(scope, opts.settings);
   registerMetaRoute(scope);
 };
 
 /** Mount the JSON API under `/api` on the given app. */
-export function registerApi(app: FastifyInstance): void {
-  app.register(apiPlugin, { prefix: "/api" });
+export function registerApi(app: FastifyInstance, settings: Settings): void {
+  app.register(apiPlugin, { prefix: "/api", settings });
 }

--- a/server/src/auth/credentials.ts
+++ b/server/src/auth/credentials.ts
@@ -1,0 +1,75 @@
+/**
+ * The admin credential store and first-admin bootstrap (#52).
+ *
+ * Reads and writes the singleton {@link adminCredentials} row through the
+ * shared `app.db` handle. The bootstrap is the answer to the gap the issue
+ * flags — the docs promised single-admin login but never said how the first
+ * password is set: on first run, `PCT_ADMIN_USERNAME` + `PCT_ADMIN_PASSWORD`
+ * seed the row (hashed immediately), and that path is documented in
+ * `docs/server-deployment.md` → "Authentication".
+ *
+ * License boundary: none touched — Drizzle + better-sqlite3 are permissive.
+ */
+import type { FastifyBaseLogger } from "fastify";
+
+import type { Settings } from "../config.js";
+import type { PolicyDb } from "../policy/db.js";
+import { adminCredentials } from "../policy/schema.js";
+import { hashPassword } from "./passwords.js";
+
+/** The stored admin credential (the singleton `id = 1` row). */
+export interface AdminCredential {
+  id: number;
+  username: string;
+  passwordHash: string;
+}
+
+/** Outcome of {@link bootstrapAdmin}, returned so callers/tests need not parse logs. */
+export type BootstrapResult = "already-exists" | "seeded" | "unconfigured";
+
+/** Fetch the single admin credential row, or `undefined` if none is seeded yet. */
+export function getAdmin(db: PolicyDb): AdminCredential | undefined {
+  return db
+    .select({
+      id: adminCredentials.id,
+      username: adminCredentials.username,
+      passwordHash: adminCredentials.passwordHash,
+    })
+    .from(adminCredentials)
+    .limit(1)
+    .get();
+}
+
+/**
+ * Seed the first admin from the environment, idempotently.
+ *
+ * - If an admin row already exists, do nothing (so a restart never reseeds and
+ *   `PCT_ADMIN_PASSWORD` can be dropped from the environment after first run).
+ * - Else, if both `PCT_ADMIN_USERNAME` and `PCT_ADMIN_PASSWORD` are set, hash
+ *   the password with Argon2id and insert the singleton row.
+ * - Else, log a warning and leave login disabled until an admin is configured.
+ */
+export async function bootstrapAdmin(
+  db: PolicyDb,
+  settings: Pick<Settings, "adminUsername" | "adminPassword">,
+  logger: FastifyBaseLogger,
+): Promise<BootstrapResult> {
+  if (getAdmin(db) !== undefined) {
+    logger.debug("admin credential already present; skipping bootstrap");
+    return "already-exists";
+  }
+
+  const { adminUsername, adminPassword } = settings;
+  if (adminUsername === undefined || adminPassword === undefined) {
+    logger.warn(
+      "no admin credential and PCT_ADMIN_USERNAME/PCT_ADMIN_PASSWORD not both set; " +
+        "login is disabled until an admin is configured",
+    );
+    return "unconfigured";
+  }
+
+  const passwordHash = await hashPassword(adminPassword);
+  db.insert(adminCredentials).values({ id: 1, username: adminUsername, passwordHash }).run();
+  logger.info({ username: adminUsername }, "seeded initial admin credential");
+  return "seeded";
+}

--- a/server/src/auth/dtos.ts
+++ b/server/src/auth/dtos.ts
@@ -1,0 +1,32 @@
+/**
+ * Auth request/response DTOs (#52).
+ *
+ * zod schemas are the single source of truth for the auth contract; the
+ * inferred types are re-exported from `server/src/api/index.ts` so the
+ * SvelteKit frontend imports them from the same `/api` surface as every other
+ * DTO (`CLAUDE.md` → "Validation / DTOs").
+ */
+import { z } from "zod";
+
+/** `POST /api/auth/login` request body. */
+export const loginRequestSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1),
+});
+
+/** The inferred login request type. */
+export type LoginRequest = z.infer<typeof loginRequestSchema>;
+
+/**
+ * Response shape of `GET /api/auth/session` and `POST /api/auth/login`:
+ * whether the caller holds a valid admin session, and the admin username when
+ * they do. The admin UI reads this to decide between the login screen and the
+ * dashboard.
+ */
+export const sessionResponseSchema = z.object({
+  authenticated: z.boolean(),
+  username: z.string().optional(),
+});
+
+/** The inferred session/login response type. */
+export type SessionResponse = z.infer<typeof sessionResponseSchema>;

--- a/server/src/auth/guard.ts
+++ b/server/src/auth/guard.ts
@@ -1,0 +1,60 @@
+/**
+ * The reusable admin guard (#52).
+ *
+ * `makeRequireAdmin` builds a Fastify `preHandler` that rejects any request
+ * without a valid admin session with a `401` in the shared error envelope. It
+ * is decorated onto the `/api` scope as `app.requireAdmin` so the policy routes
+ * (#51) and any other admin-only route apply it with
+ * `{ preHandler: app.requireAdmin }`. On success it records the authenticated
+ * admin on `request.admin` for downstream handlers.
+ *
+ * License boundary: none touched.
+ */
+import type { preHandlerHookHandler } from "fastify";
+
+import { ApiError } from "../api/errors.js";
+import { readSession } from "./session.js";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    /**
+     * Admin guard `preHandler` (#52): apply with `{ preHandler: app.requireAdmin }`
+     * to gate a route behind the admin session. Decorated by `registerAuth`.
+     */
+    requireAdmin: preHandlerHookHandler;
+  }
+  interface FastifyRequest {
+    /** The authenticated admin, set by {@link makeRequireAdmin}; `null` until then. */
+    admin: { username: string } | null;
+  }
+}
+
+/**
+ * Throw a `503 auth_not_configured` if `PCT_SECRET_KEY` is unset. A session
+ * cannot be signed or verified without it, so login, logout, and the guard all
+ * fail closed with a clear, machine-readable code rather than a confusing 500.
+ */
+export function assertAuthConfigured(authConfigured: boolean): void {
+  if (!authConfigured) {
+    throw new ApiError(
+      503,
+      "auth_not_configured",
+      "Authentication is not configured: set PCT_SECRET_KEY",
+    );
+  }
+}
+
+/**
+ * Build the admin guard. `authConfigured` is whether `PCT_SECRET_KEY` is set;
+ * when it is not, the guard fails closed via {@link assertAuthConfigured}.
+ */
+export function makeRequireAdmin(authConfigured: boolean): preHandlerHookHandler {
+  return async function requireAdmin(request) {
+    assertAuthConfigured(authConfigured);
+    const session = readSession(request);
+    if (session === null) {
+      throw new ApiError(401, "unauthorized", "Authentication required");
+    }
+    request.admin = { username: session.sub };
+  };
+}

--- a/server/src/auth/index.ts
+++ b/server/src/auth/index.ts
@@ -1,0 +1,65 @@
+/**
+ * Single-admin authentication (#52): Argon2id password hashing, a signed
+ * session cookie keyed on `PCT_SECRET_KEY`, login/logout/session routes, a
+ * reusable admin guard, and first-admin bootstrap from the environment.
+ *
+ * The whole feature is encapsulated within the `/api` plugin scope by
+ * {@link registerAuth}: the cookie plugin, the `requireAdmin` decoration, the
+ * bootstrap hook, and the routes all live there, so the conventions never leak
+ * onto `/`, `/healthz`, `/admin`, or `/app`. Scope boundary is deliberate —
+ * one admin login, not a user system (`docs/server-deployment.md` →
+ * "Authentication"); the policy-model `User` is a supervised person, not an
+ * auth principal.
+ *
+ * License boundary: none touched. `argon2` (MIT) and `@fastify/cookie` (MIT)
+ * are permissively licensed and linked in-process freely; no GPL component is
+ * involved.
+ */
+import cookie from "@fastify/cookie";
+import type { FastifyInstance } from "fastify";
+
+import type { Settings } from "../config.js";
+import { bootstrapAdmin } from "./credentials.js";
+import { makeRequireAdmin } from "./guard.js";
+import { LoginRateLimiter } from "./rate-limit.js";
+import { registerAuthRoutes } from "./routes.js";
+
+/**
+ * Wire authentication onto the `/api` scope.
+ *
+ * Registers `@fastify/cookie` (signing enabled only when `PCT_SECRET_KEY` is
+ * set), decorates `app.requireAdmin` and `request.admin`, schedules the
+ * first-admin bootstrap for when the app is ready, and mounts the auth routes.
+ */
+export async function registerAuth(
+  scope: FastifyInstance,
+  settings: Pick<Settings, "secretKey" | "adminUsername" | "adminPassword">,
+): Promise<void> {
+  const secret = settings.secretKey;
+  const authConfigured = secret !== undefined;
+
+  // Signing needs the secret; without it the cookie plugin is still registered
+  // (so request.cookies parses) but auth endpoints fail closed with 503.
+  await scope.register(cookie, secret !== undefined ? { secret } : {});
+
+  scope.decorateRequest("admin", null);
+  scope.decorate("requireAdmin", makeRequireAdmin(authConfigured));
+
+  // Seed the first admin once the app (and app.db) are ready. Idempotent: a
+  // restart with an existing admin is a no-op.
+  scope.addHook("onReady", async () => {
+    await bootstrapAdmin(scope.db, settings, scope.log);
+  });
+
+  registerAuthRoutes(scope, { authConfigured, limiter: new LoginRateLimiter() });
+}
+
+export { makeRequireAdmin, assertAuthConfigured } from "./guard.js";
+export {
+  loginRequestSchema,
+  sessionResponseSchema,
+  type LoginRequest,
+  type SessionResponse,
+} from "./dtos.js";
+export { SESSION_COOKIE, SESSION_TTL_SECONDS } from "./session.js";
+export { bootstrapAdmin, getAdmin, type BootstrapResult } from "./credentials.js";

--- a/server/src/auth/passwords.ts
+++ b/server/src/auth/passwords.ts
@@ -1,0 +1,53 @@
+/**
+ * Argon2id password hashing for the single admin login (#52).
+ *
+ * Thin, typed wrappers over the `argon2` library so the rest of the auth code
+ * never touches its options directly. We use **Argon2id** — the variant the
+ * OWASP Password Storage Cheat Sheet recommends as the default — at the
+ * library's built-in memory/time/parallelism cost, which already matches the
+ * OWASP baseline (m=64MiB, t=3, p=4).
+ *
+ * License boundary: `argon2` is MIT-licensed and linked in-process freely; no
+ * GPL component is involved.
+ */
+import argon2 from "argon2";
+
+/** Argon2id options shared by every hash we mint. */
+const HASH_OPTIONS = { type: argon2.argon2id } as const;
+
+/**
+ * A pre-computed Argon2id hash of a throwaway string. {@link verifyPassword}
+ * runs against this when the supplied username has no admin row, so a login
+ * attempt for a non-existent user costs the same as one for the real admin —
+ * denying an attacker a timing oracle for username enumeration. It is a hash of
+ * a non-secret constant; its only job is to make the verify path do real work.
+ */
+const DUMMY_HASH =
+  "$argon2id$v=19$m=65536,t=3,p=4$IhDI7BiGvw/LNZ7+BcUvlQ$QhhS4JpF/r+NTZ/g1rhXDm2LA7Bxwg8X0AwMFT3zC74";
+
+/** Hash a plaintext password with Argon2id. Returns the encoded hash string. */
+export function hashPassword(plaintext: string): Promise<string> {
+  return argon2.hash(plaintext, HASH_OPTIONS);
+}
+
+/**
+ * Verify a plaintext password against an encoded Argon2id hash. Returns `false`
+ * (never throws) on a mismatch or a malformed/foreign hash string, so callers
+ * can treat any non-`true` result as "wrong password".
+ */
+export async function verifyPassword(hash: string, plaintext: string): Promise<boolean> {
+  try {
+    return await argon2.verify(hash, plaintext);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run a verify against {@link DUMMY_HASH} and discard the result. Called on the
+ * unknown-username path so its timing matches a real verify; always resolves
+ * (the dummy password never matches, and a throw is swallowed).
+ */
+export async function verifyDummy(plaintext: string): Promise<void> {
+  await verifyPassword(DUMMY_HASH, plaintext);
+}

--- a/server/src/auth/rate-limit.ts
+++ b/server/src/auth/rate-limit.ts
@@ -1,0 +1,77 @@
+/**
+ * A minimal in-memory rate limiter for failed logins (#52).
+ *
+ * Scope-appropriate for a single-admin homelab dashboard: a fixed-window count
+ * of *failed* attempts per key (client IP), held in process memory. It is not a
+ * distributed limiter and does not need to be — there is one admin and one
+ * process. A successful login clears the key; the window otherwise resets once
+ * it elapses. The clock is injectable so the behaviour is testable without
+ * real time.
+ *
+ * Deliberately not a dependency: `@fastify/rate-limit` targets per-route
+ * request-rate limiting across a cluster, which is far more than the
+ * "basic login rate-limiting" this issue calls for.
+ */
+
+/** A failed-attempt window for one key. */
+interface Window {
+  count: number;
+  /** Epoch ms when the current window started. */
+  startedAt: number;
+}
+
+/** Options for {@link LoginRateLimiter}. */
+export interface LoginRateLimiterOptions {
+  /** Failed attempts allowed within a window before the key is blocked. */
+  maxAttempts?: number;
+  /** Window length in milliseconds. */
+  windowMs?: number;
+  /** Clock seam for tests; defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/** Fixed-window failed-login limiter keyed by an arbitrary string (e.g. IP). */
+export class LoginRateLimiter {
+  private readonly maxAttempts: number;
+  private readonly windowMs: number;
+  private readonly now: () => number;
+  private readonly windows = new Map<string, Window>();
+
+  constructor(options: LoginRateLimiterOptions = {}) {
+    this.maxAttempts = options.maxAttempts ?? 5;
+    this.windowMs = options.windowMs ?? 15 * 60 * 1000;
+    this.now = options.now ?? Date.now;
+  }
+
+  /** Return the live window for `key`, dropping it first if it has elapsed. */
+  private current(key: string): Window | undefined {
+    const window = this.windows.get(key);
+    if (window === undefined) return undefined;
+    if (this.now() - window.startedAt >= this.windowMs) {
+      this.windows.delete(key);
+      return undefined;
+    }
+    return window;
+  }
+
+  /** True when `key` has reached the failure limit within the current window. */
+  isBlocked(key: string): boolean {
+    const window = this.current(key);
+    return window !== undefined && window.count >= this.maxAttempts;
+  }
+
+  /** Record a failed attempt for `key`, opening a new window if none is live. */
+  recordFailure(key: string): void {
+    const window = this.current(key);
+    if (window === undefined) {
+      this.windows.set(key, { count: 1, startedAt: this.now() });
+    } else {
+      window.count += 1;
+    }
+  }
+
+  /** Clear any recorded failures for `key` (called on a successful login). */
+  recordSuccess(key: string): void {
+    this.windows.delete(key);
+  }
+}

--- a/server/src/auth/routes.ts
+++ b/server/src/auth/routes.ts
@@ -1,0 +1,87 @@
+/**
+ * Auth routes (#52): `POST /api/auth/login`, `POST /api/auth/logout`,
+ * `GET /api/auth/session`.
+ *
+ * Registered inside the `/api` plugin scope so they inherit its zod validator
+ * compiler and shared error envelope. Login verifies the Argon2id hash and
+ * issues the signed session cookie; logout clears it; session reports the
+ * current login state for the admin UI.
+ *
+ * License boundary: none touched.
+ */
+import type { FastifyInstance } from "fastify";
+
+import { ApiError } from "../api/errors.js";
+import type { ZodTypeProvider } from "../api/validation.js";
+import { getAdmin } from "./credentials.js";
+import { loginRequestSchema, type SessionResponse } from "./dtos.js";
+import { assertAuthConfigured } from "./guard.js";
+import { verifyDummy, verifyPassword } from "./passwords.js";
+import type { LoginRateLimiter } from "./rate-limit.js";
+import { clearSession, issueSession, readSession } from "./session.js";
+
+/** Dependencies the auth routes close over. */
+export interface AuthRouteDeps {
+  /** Whether `PCT_SECRET_KEY` is set (sessions can be signed). */
+  authConfigured: boolean;
+  /** Failed-login limiter, keyed by client IP. */
+  limiter: LoginRateLimiter;
+}
+
+/** Register the auth routes on an already-`/api`-prefixed scope. */
+export function registerAuthRoutes(scope: FastifyInstance, deps: AuthRouteDeps): void {
+  const typed = scope.withTypeProvider<ZodTypeProvider>();
+
+  typed.post(
+    "/auth/login",
+    { schema: { body: loginRequestSchema } },
+    async (request, reply): Promise<SessionResponse> => {
+      assertAuthConfigured(deps.authConfigured);
+
+      const key = request.ip;
+      if (deps.limiter.isBlocked(key)) {
+        throw new ApiError(
+          429,
+          "too_many_requests",
+          "Too many failed login attempts; try again later",
+        );
+      }
+
+      const { username, password } = request.body;
+      const admin = getAdmin(scope.db);
+
+      // Unknown username: still do a verify (against a dummy hash) so the
+      // response time matches the real path and cannot be used to enumerate
+      // the admin username.
+      if (admin === undefined || admin.username !== username) {
+        await verifyDummy(password);
+        deps.limiter.recordFailure(key);
+        throw new ApiError(401, "invalid_credentials", "Invalid username or password");
+      }
+
+      if (!(await verifyPassword(admin.passwordHash, password))) {
+        deps.limiter.recordFailure(key);
+        throw new ApiError(401, "invalid_credentials", "Invalid username or password");
+      }
+
+      deps.limiter.recordSuccess(key);
+      issueSession(reply, admin.username);
+      return { authenticated: true, username: admin.username };
+    },
+  );
+
+  // Logout is idempotent and needs no secret (clearing a cookie does not sign
+  // anything), so it works even when auth is unconfigured.
+  typed.post("/auth/logout", async (_request, reply): Promise<SessionResponse> => {
+    clearSession(reply);
+    return { authenticated: false };
+  });
+
+  typed.get("/auth/session", async (request): Promise<SessionResponse> => {
+    assertAuthConfigured(deps.authConfigured);
+    const session = readSession(request);
+    return session === null
+      ? { authenticated: false }
+      : { authenticated: true, username: session.sub };
+  });
+}

--- a/server/src/auth/session.ts
+++ b/server/src/auth/session.ts
@@ -1,0 +1,99 @@
+/**
+ * The signed admin session cookie (#52).
+ *
+ * The session is stateless: a small, **non-secret** payload (`{ sub, iat }`)
+ * is base64url-encoded and carried in a cookie that `@fastify/cookie` signs
+ * with `PCT_SECRET_KEY` (HMAC, via `cookie-signature`). Signing gives
+ * integrity — a tampered or unsigned cookie is rejected — which is all a
+ * single-admin "this request is the admin" marker needs; there is nothing
+ * secret to encrypt. Expiry is enforced twice: the browser drops the cookie at
+ * `maxAge`, and {@link readSession} independently rejects a payload whose `iat`
+ * is older than {@link SESSION_TTL_SECONDS} (so a replayed cookie cannot
+ * outlive the window even if the client ignores `maxAge`).
+ *
+ * License boundary: none touched — `@fastify/cookie` is MIT and the payload is
+ * our own.
+ */
+import type { CookieSerializeOptions } from "@fastify/cookie";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+
+/** Cookie name for the admin session. */
+export const SESSION_COOKIE = "pct_session";
+
+/** How long a session is valid, in seconds (7 days). */
+export const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/** The signed session payload. `sub` is the admin username; `iat` is epoch seconds. */
+const sessionPayloadSchema = z.object({
+  sub: z.string().min(1),
+  iat: z.number().int().positive(),
+});
+
+/** The decoded, validated session. */
+export type Session = z.infer<typeof sessionPayloadSchema>;
+
+/** Cookie attributes shared by set and clear so they always match. */
+const COOKIE_OPTIONS: CookieSerializeOptions = {
+  // Not readable from JS (mitigates XSS token theft); the admin UI never needs
+  // to read it — it calls GET /api/auth/session to learn its login state.
+  httpOnly: true,
+  // Strict: the cookie is not sent on cross-site requests at all, which closes
+  // off CSRF against the cookie-authenticated mutating routes.
+  sameSite: "strict",
+  // Sent to every path so /admin (the SvelteKit app) and /api/* both see it.
+  path: "/",
+};
+
+/** base64url-encode the JSON payload (no signing — `setCookie` signs it). */
+function encode(payload: Session): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+/** Reverse {@link encode}; returns `null` on any malformed/invalid input. */
+function decode(raw: string): Session | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  const result = sessionPayloadSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+/** Issue a fresh signed session cookie for `username` on the reply. */
+export function issueSession(reply: FastifyReply, username: string): void {
+  const payload: Session = { sub: username, iat: Math.floor(Date.now() / 1000) };
+  reply.setCookie(SESSION_COOKIE, encode(payload), {
+    ...COOKIE_OPTIONS,
+    signed: true,
+    maxAge: SESSION_TTL_SECONDS,
+  });
+}
+
+/** Clear the session cookie (logout). Mirrors {@link issueSession}'s attributes. */
+export function clearSession(reply: FastifyReply): void {
+  reply.clearCookie(SESSION_COOKIE, COOKIE_OPTIONS);
+}
+
+/**
+ * Read and validate the session from a request. Returns the decoded
+ * {@link Session} when the cookie is present, correctly signed, well-formed,
+ * and within {@link SESSION_TTL_SECONDS}; otherwise `null`.
+ */
+export function readSession(request: FastifyRequest): Session | null {
+  const raw = request.cookies[SESSION_COOKIE];
+  if (raw === undefined) return null;
+
+  const unsigned = request.unsignCookie(raw);
+  if (!unsigned.valid || unsigned.value === null) return null;
+
+  const session = decode(unsigned.value);
+  if (session === null) return null;
+
+  const ageSeconds = Math.floor(Date.now() / 1000) - session.iat;
+  if (ageSeconds > SESSION_TTL_SECONDS) return null;
+
+  return session;
+}

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -98,8 +98,24 @@ const settingsSchema = z
      * stays JSON.
      */
     logPretty: z.stringbool().default(false),
-    /** Signs sessions / integration tokens (consumed in later phases). */
+    /**
+     * Signs the admin session cookie (#52) and, later, integration tokens.
+     * Optional so dev/CI can build the app without it; auth endpoints and the
+     * admin guard return `503 auth_not_configured` until it is set, since a
+     * session cannot be signed without it.
+     */
     secretKey: z.string().min(1).optional(),
+    /**
+     * First-admin bootstrap (#52). On first run, if no admin row exists and
+     * **both** of these are set, the admin credential is seeded from them: the
+     * password is Argon2id-hashed immediately and the plaintext is never
+     * persisted (see `auth/credentials.ts` and `docs/server-deployment.md` →
+     * "Authentication"). Optional, and only read at bootstrap; once an admin
+     * exists they are ignored, so they can be dropped from the environment
+     * after the first successful start.
+     */
+    adminUsername: z.string().min(1).optional(),
+    adminPassword: z.string().min(1).optional(),
     adguard: adguardSchema,
   })
   .superRefine((settings, ctx) => {
@@ -154,6 +170,8 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
     logLevel: env.PCT_LOG_LEVEL,
     logPretty: env.PCT_LOG_PRETTY,
     secretKey: env.PCT_SECRET_KEY,
+    adminUsername: env.PCT_ADMIN_USERNAME,
+    adminPassword: env.PCT_ADMIN_PASSWORD,
     adguard: {
       mode: env.PCT_ADGUARD_MODE ?? "disabled",
       url: env.PCT_ADGUARD_URL,

--- a/server/src/policy/schema.ts
+++ b/server/src/policy/schema.ts
@@ -331,6 +331,30 @@ export const integrationTokens = sqliteTable(
 );
 
 /**
+ * The single dashboard administrator's login credential (#52).
+ *
+ * This is **not** part of the policy model: a policy-model {@link users} row is
+ * a *supervised person*, never an auth principal (`docs/architecture.md` →
+ * "Policy model"). There is exactly one admin login for the whole dashboard,
+ * and that singleton invariant is encoded structurally — `CHECK (id = 1)` means
+ * the table can hold at most one row, so the schema itself rules out a second
+ * admin sneaking in. Only the Argon2id `password_hash` is stored; the plaintext
+ * (from `PCT_ADMIN_PASSWORD` on first run) is hashed immediately and never
+ * persisted. Accounts/roles/MFA are out of scope until the identity work
+ * (Phase 11 / stretch #24 → #26).
+ */
+export const adminCredentials = sqliteTable(
+  "admin_credentials",
+  {
+    id: integer("id").primaryKey(),
+    username: text("username").notNull(),
+    passwordHash: text("password_hash").notNull(),
+    createdAt: timestampNow("created_at"),
+  },
+  (table) => [check("admin_credentials_singleton_check", sql`${table.id} = 1`)],
+);
+
+/**
  * Per-user knobs for the client-side notification experience (Phase 8b).
  * 1:1 with {@link users} (the `user_id` is the primary key).
  * `cadence_overrides_json` is an optional JSON blob of warning-cadence

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -85,8 +85,10 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
 
   // Mount the JSON API at /api (#50). Encapsulated: the zod validation hook,
   // the shared error envelope, and the /api not-found envelope apply only
-  // within this prefix, leaving /, /healthz, /admin and /app untouched.
-  registerApi(app);
+  // within this prefix, leaving /, /healthz, /admin and /app untouched. Auth
+  // (#52) is wired inside this scope and needs the settings (PCT_SECRET_KEY,
+  // first-admin bootstrap) threaded through.
+  registerApi(app, settings);
 
   // Serve the prerendered SvelteKit build at /admin and /app (#40). Skipped
   // (with a warning) when the build directory is absent, so /, /healthz, and

--- a/server/tests/api/auth.test.ts
+++ b/server/tests/api/auth.test.ts
@@ -1,0 +1,230 @@
+/**
+ * End-to-end tests for the auth routes and guard (#52), driven through real
+ * Fastify instances with `app.inject()` (no sockets) — per docs/testing.md →
+ * "HTTP routes".
+ *
+ * Covers login success/failure, the session endpoint, logout, rate limiting,
+ * the unconfigured (`503`) path, and the reusable `requireAdmin` guard.
+ */
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { registerAuth } from "../../src/auth/index.js";
+import { SESSION_COOKIE } from "../../src/auth/session.js";
+import { installApiConventions } from "../../src/api/validation.js";
+import { loadSettings } from "../../src/config.js";
+import { buildTestApp, type TestApp } from "../helpers/app.js";
+import { testDb, type TestDb } from "../helpers/db.js";
+
+/** Settings with a secret and a seeded admin (`ben` / `hunter2`). */
+function configuredSettings() {
+  return loadSettings({
+    PCT_LOG_LEVEL: "silent",
+    PCT_SECRET_KEY: "auth-test-secret",
+    PCT_ADMIN_USERNAME: "ben",
+    PCT_ADMIN_PASSWORD: "hunter2",
+  });
+}
+
+/** Extract the `pct_session=<signed>` wire cookie from a login response. */
+function sessionCookie(res: { headers: Record<string, unknown> }): string {
+  const raw = res.headers["set-cookie"];
+  const headers = Array.isArray(raw) ? (raw as string[]) : [String(raw ?? "")];
+  const match = headers.find((h) => h.startsWith(`${SESSION_COOKIE}=`));
+  if (match === undefined) throw new Error("no session cookie set");
+  return match.split(";")[0] ?? "";
+}
+
+describe("auth routes (configured, admin seeded)", () => {
+  let harness: TestApp;
+
+  beforeEach(async () => {
+    harness = buildTestApp({ appOptions: { settings: configuredSettings() } });
+    await harness.app.ready(); // triggers the first-admin bootstrap
+  });
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  it("logs in with correct credentials and sets a session cookie", async () => {
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ authenticated: true, username: "ben" });
+    expect(sessionCookie(res)).toContain(`${SESSION_COOKIE}=`);
+  });
+
+  it("rejects a wrong password with a 401 envelope and no cookie", async () => {
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "nope" },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error.code).toBe("invalid_credentials");
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("rejects an unknown username with the same 401", async () => {
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "nobody", password: "hunter2" },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error.code).toBe("invalid_credentials");
+  });
+
+  it("rejects a malformed body with a 400 validation envelope", async () => {
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("reports an anonymous session as unauthenticated", async () => {
+    const res = await harness.app.inject({ method: "GET", url: "/api/auth/session" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ authenticated: false });
+  });
+
+  it("reports the logged-in session when the cookie is presented", async () => {
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    const res = await harness.app.inject({
+      method: "GET",
+      url: "/api/auth/session",
+      headers: { cookie: sessionCookie(login) },
+    });
+    expect(res.json()).toEqual({ authenticated: true, username: "ben" });
+  });
+
+  it("logs out, clearing the session cookie", async () => {
+    const res = await harness.app.inject({ method: "POST", url: "/api/auth/logout" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ authenticated: false });
+    const raw = res.headers["set-cookie"];
+    const header = Array.isArray(raw) ? raw.join("\n") : String(raw ?? "");
+    expect(header).toContain(`${SESSION_COOKIE}=`);
+  });
+
+  it("rate-limits repeated failed logins with a 429", async () => {
+    for (let i = 0; i < 5; i += 1) {
+      const fail = await harness.app.inject({
+        method: "POST",
+        url: "/api/auth/login",
+        payload: { username: "ben", password: "wrong" },
+      });
+      expect(fail.statusCode).toBe(401);
+    }
+    const blocked = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    expect(blocked.statusCode).toBe(429);
+    expect(blocked.json().error.code).toBe("too_many_requests");
+  });
+});
+
+describe("auth routes (unconfigured — no PCT_SECRET_KEY)", () => {
+  let harness: TestApp;
+
+  beforeEach(async () => {
+    // No PCT_SECRET_KEY: sessions cannot be signed, so auth fails closed.
+    const settings = loadSettings({
+      PCT_LOG_LEVEL: "silent",
+      PCT_ADMIN_USERNAME: "ben",
+      PCT_ADMIN_PASSWORD: "hunter2",
+    });
+    harness = buildTestApp({ appOptions: { settings } });
+    await harness.app.ready();
+  });
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  it("returns 503 auth_not_configured for login", async () => {
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json().error.code).toBe("auth_not_configured");
+  });
+
+  it("returns 503 for the session endpoint", async () => {
+    const res = await harness.app.inject({ method: "GET", url: "/api/auth/session" });
+    expect(res.statusCode).toBe(503);
+    expect(res.json().error.code).toBe("auth_not_configured");
+  });
+
+  it("still allows logout (no secret needed to clear a cookie)", async () => {
+    const res = await harness.app.inject({ method: "POST", url: "/api/auth/logout" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ authenticated: false });
+  });
+});
+
+/** A plugin that wires auth and a probe route behind the `requireAdmin` guard. */
+const guardedApi: FastifyPluginAsync<{ settings: ReturnType<typeof configuredSettings> }> = async (
+  scope,
+  opts,
+) => {
+  installApiConventions(scope);
+  await registerAuth(scope, opts.settings);
+  scope.get("/protected", { preHandler: scope.requireAdmin }, async (request) => ({
+    username: request.admin?.username,
+  }));
+};
+
+describe("requireAdmin guard", () => {
+  let app: FastifyInstance;
+  let db: TestDb;
+
+  beforeEach(async () => {
+    db = testDb();
+    app = Fastify({ logger: false });
+    app.decorate("db", db);
+    await app.register(guardedApi, { prefix: "/api", settings: configuredSettings() });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.$client.close();
+  });
+
+  it("rejects an anonymous request with a 401 envelope", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/protected" });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error.code).toBe("unauthorized");
+  });
+
+  it("allows a request carrying a valid admin session", async () => {
+    const login = await app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/protected",
+      headers: { cookie: sessionCookie(login) },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ username: "ben" });
+  });
+});

--- a/server/tests/api/plugin.test.ts
+++ b/server/tests/api/plugin.test.ts
@@ -16,8 +16,7 @@ import { z } from "zod";
 
 import { ApiError } from "../../src/api/errors.js";
 import { installApiConventions, type ZodTypeProvider } from "../../src/api/validation.js";
-import { buildApp } from "../../src/web/app.js";
-import { loadSettings } from "../../src/config.js";
+import { buildTestApp, type TestApp } from "../helpers/app.js";
 
 const bodySchema = z.object({ seconds: z.number().int().positive() });
 const querySchema = z.object({ n: z.coerce.number().int() });
@@ -126,14 +125,20 @@ describe("/api conventions", () => {
 });
 
 describe("GET /api/meta (via buildApp)", () => {
+  let harness: TestApp;
   let app: FastifyInstance;
 
+  // buildTestApp() builds the real buildApp() but injects an in-memory db, so
+  // the test exercises the actual /api mount without createDb() opening the
+  // default /data file (which doesn't exist in CI). Same pattern every other
+  // buildApp route test uses.
   beforeEach(() => {
-    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "silent" }) });
+    harness = buildTestApp();
+    app = harness.app;
   });
 
   afterEach(async () => {
-    await app.close();
+    await harness.close();
   });
 
   it("is mounted and returns the meta DTO", async () => {

--- a/server/tests/auth/credentials.test.ts
+++ b/server/tests/auth/credentials.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the admin credential store and first-admin bootstrap (#52).
+ */
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { bootstrapAdmin, getAdmin } from "../../src/auth/credentials.js";
+import { verifyPassword } from "../../src/auth/passwords.js";
+import { testDb, type TestDb } from "../helpers/db.js";
+
+/** A real (silent) FastifyBaseLogger so bootstrapAdmin gets a correctly-typed logger. */
+function testLogger() {
+  return Fastify({ logger: false }).log;
+}
+
+describe("admin credential bootstrap", () => {
+  let db: TestDb;
+
+  beforeEach(() => {
+    db = testDb();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    db.$client.close();
+  });
+
+  it("getAdmin returns undefined on an empty store", () => {
+    expect(getAdmin(db)).toBeUndefined();
+  });
+
+  it("seeds the admin from the environment, hashing the password", async () => {
+    const result = await bootstrapAdmin(
+      db,
+      { adminUsername: "ben", adminPassword: "hunter2" },
+      testLogger(),
+    );
+    expect(result).toBe("seeded");
+
+    const admin = getAdmin(db);
+    expect(admin?.username).toBe("ben");
+    expect(admin?.id).toBe(1);
+    // Stored as a hash, never the plaintext, and the hash verifies.
+    expect(admin?.passwordHash).not.toContain("hunter2");
+    expect(await verifyPassword(admin?.passwordHash ?? "", "hunter2")).toBe(true);
+  });
+
+  it("is idempotent: a second run with an existing admin is a no-op", async () => {
+    await bootstrapAdmin(db, { adminUsername: "ben", adminPassword: "hunter2" }, testLogger());
+    const firstHash = getAdmin(db)?.passwordHash;
+
+    const result = await bootstrapAdmin(
+      db,
+      { adminUsername: "someone-else", adminPassword: "different" },
+      testLogger(),
+    );
+    expect(result).toBe("already-exists");
+    // The original admin is untouched — not overwritten or duplicated.
+    const admin = getAdmin(db);
+    expect(admin?.username).toBe("ben");
+    expect(admin?.passwordHash).toBe(firstHash);
+  });
+
+  it("warns and seeds nothing when the bootstrap env is incomplete", async () => {
+    const logger = testLogger();
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const onlyUser = await bootstrapAdmin(db, { adminUsername: "ben" }, logger);
+    expect(onlyUser).toBe("unconfigured");
+
+    const neither = await bootstrapAdmin(db, {}, logger);
+    expect(neither).toBe("unconfigured");
+
+    expect(getAdmin(db)).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/server/tests/auth/passwords.test.ts
+++ b/server/tests/auth/passwords.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for the Argon2id password helpers (#52).
+ */
+import { describe, expect, it } from "vitest";
+
+import { hashPassword, verifyDummy, verifyPassword } from "../../src/auth/passwords.js";
+
+describe("password hashing", () => {
+  it("produces an Argon2id encoded hash that verifies the original", async () => {
+    const hash = await hashPassword("correct horse battery staple");
+    // Argon2id encoded form, not the plaintext.
+    expect(hash.startsWith("$argon2id$")).toBe(true);
+    expect(hash).not.toContain("correct horse battery staple");
+    expect(await verifyPassword(hash, "correct horse battery staple")).toBe(true);
+  });
+
+  it("rejects a wrong password", async () => {
+    const hash = await hashPassword("s3cret");
+    expect(await verifyPassword(hash, "wrong")).toBe(false);
+  });
+
+  it("returns false (never throws) on a malformed hash string", async () => {
+    expect(await verifyPassword("not-a-hash", "whatever")).toBe(false);
+  });
+
+  it("verifyDummy resolves without throwing", async () => {
+    await expect(verifyDummy("anything")).resolves.toBeUndefined();
+  });
+
+  it("salts: hashing the same password twice yields different hashes", async () => {
+    const a = await hashPassword("same");
+    const b = await hashPassword("same");
+    expect(a).not.toBe(b);
+    expect(await verifyPassword(a, "same")).toBe(true);
+    expect(await verifyPassword(b, "same")).toBe(true);
+  });
+});

--- a/server/tests/auth/rate-limit.test.ts
+++ b/server/tests/auth/rate-limit.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for the failed-login rate limiter (#52).
+ */
+import { describe, expect, it } from "vitest";
+
+import { LoginRateLimiter } from "../../src/auth/rate-limit.js";
+
+describe("LoginRateLimiter", () => {
+  it("allows attempts under the limit and blocks once it is reached", () => {
+    const limiter = new LoginRateLimiter({ maxAttempts: 3, windowMs: 1000, now: () => 0 });
+    expect(limiter.isBlocked("ip")).toBe(false);
+    limiter.recordFailure("ip");
+    limiter.recordFailure("ip");
+    expect(limiter.isBlocked("ip")).toBe(false);
+    limiter.recordFailure("ip");
+    expect(limiter.isBlocked("ip")).toBe(true);
+  });
+
+  it("tracks keys independently", () => {
+    const limiter = new LoginRateLimiter({ maxAttempts: 1, windowMs: 1000, now: () => 0 });
+    limiter.recordFailure("a");
+    expect(limiter.isBlocked("a")).toBe(true);
+    expect(limiter.isBlocked("b")).toBe(false);
+  });
+
+  it("resets after the window elapses", () => {
+    let clock = 0;
+    const limiter = new LoginRateLimiter({ maxAttempts: 1, windowMs: 1000, now: () => clock });
+    limiter.recordFailure("ip");
+    expect(limiter.isBlocked("ip")).toBe(true);
+    clock = 1000; // window elapsed (>= windowMs)
+    expect(limiter.isBlocked("ip")).toBe(false);
+    // A failure after the window opens a fresh window rather than carrying over.
+    limiter.recordFailure("ip");
+    expect(limiter.isBlocked("ip")).toBe(true);
+  });
+
+  it("a success clears the recorded failures", () => {
+    const limiter = new LoginRateLimiter({ maxAttempts: 2, windowMs: 1000, now: () => 0 });
+    limiter.recordFailure("ip");
+    limiter.recordFailure("ip");
+    expect(limiter.isBlocked("ip")).toBe(true);
+    limiter.recordSuccess("ip");
+    expect(limiter.isBlocked("ip")).toBe(false);
+  });
+
+  it("defaults to 5 attempts when no limit is given", () => {
+    const limiter = new LoginRateLimiter({ now: () => 0 });
+    for (let i = 0; i < 4; i += 1) limiter.recordFailure("ip");
+    expect(limiter.isBlocked("ip")).toBe(false);
+    limiter.recordFailure("ip");
+    expect(limiter.isBlocked("ip")).toBe(true);
+  });
+});

--- a/server/tests/auth/session.test.ts
+++ b/server/tests/auth/session.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for the signed session cookie helpers (#52).
+ *
+ * Exercises the real `@fastify/cookie` signing path through a throwaway Fastify
+ * instance with `/set`, `/read`, and `/clear` probe routes, so the tests cover
+ * issue → read round-trips, tamper rejection, and TTL expiry exactly as the
+ * runtime behaves.
+ */
+import cookie from "@fastify/cookie";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SESSION_COOKIE,
+  SESSION_TTL_SECONDS,
+  clearSession,
+  issueSession,
+  readSession,
+} from "../../src/auth/session.js";
+
+/** Build an app with the cookie plugin and probe routes over the session helpers. */
+async function buildCookieApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(cookie, { secret: "session-test-secret" });
+  app.post("/set", async (_request, reply) => {
+    issueSession(reply, "alice");
+    return { ok: true };
+  });
+  app.get("/read", async (request) => ({ session: readSession(request) }));
+  // Sets a *validly signed* cookie whose payload is not the expected JSON, so
+  // the decode step (not the signature check) is what rejects it.
+  app.post("/set-raw", async (_request, reply) => {
+    reply.setCookie(SESSION_COOKIE, "not-base64url-json!!", { signed: true, path: "/" });
+    return { ok: true };
+  });
+  app.post("/clear", async (_request, reply) => {
+    clearSession(reply);
+    return { ok: true };
+  });
+  await app.ready();
+  return app;
+}
+
+/** The wire form of the session cookie (`pct_session=<signed>`) from a Set-Cookie header. */
+function sessionCookieHeader(setCookie: string | string[] | undefined): string {
+  const headers = Array.isArray(setCookie) ? setCookie : [setCookie ?? ""];
+  const match = headers.find((h) => h.startsWith(`${SESSION_COOKIE}=`));
+  if (match === undefined) throw new Error("no session cookie in Set-Cookie");
+  return match.split(";")[0] ?? "";
+}
+
+describe("session cookie", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await buildCookieApp();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await app.close();
+  });
+
+  it("issues a signed, httpOnly, SameSite=Strict session cookie", async () => {
+    const res = await app.inject({ method: "POST", url: "/set" });
+    const raw = res.headers["set-cookie"];
+    const header = Array.isArray(raw) ? raw.join("\n") : (raw ?? "");
+    expect(header).toContain(`${SESSION_COOKIE}=`);
+    expect(header).toContain("HttpOnly");
+    expect(header).toMatch(/SameSite=Strict/i);
+    expect(header).toContain("Path=/");
+    expect(header).toContain(`Max-Age=${SESSION_TTL_SECONDS}`);
+  });
+
+  it("round-trips: a freshly issued cookie reads back as the session", async () => {
+    const setRes = await app.inject({ method: "POST", url: "/set" });
+    const cookieHeader = sessionCookieHeader(setRes.headers["set-cookie"]);
+
+    const readRes = await app.inject({
+      method: "GET",
+      url: "/read",
+      headers: { cookie: cookieHeader },
+    });
+    expect(readRes.json().session).toMatchObject({ sub: "alice" });
+  });
+
+  it("reads back null when no cookie is present", async () => {
+    const res = await app.inject({ method: "GET", url: "/read" });
+    expect(res.json().session).toBeNull();
+  });
+
+  it("rejects a tampered cookie value", async () => {
+    const setRes = await app.inject({ method: "POST", url: "/set" });
+    const header = sessionCookieHeader(setRes.headers["set-cookie"]);
+    // Flip the last character of the signed value to break the signature.
+    const tampered = header.slice(0, -1) + (header.endsWith("a") ? "b" : "a");
+
+    const readRes = await app.inject({
+      method: "GET",
+      url: "/read",
+      headers: { cookie: tampered },
+    });
+    expect(readRes.json().session).toBeNull();
+  });
+
+  it("rejects an unsigned / garbage cookie", async () => {
+    const readRes = await app.inject({
+      method: "GET",
+      url: "/read",
+      headers: { cookie: `${SESSION_COOKIE}=garbage` },
+    });
+    expect(readRes.json().session).toBeNull();
+  });
+
+  it("rejects a validly-signed cookie whose payload is not the expected JSON", async () => {
+    const setRes = await app.inject({ method: "POST", url: "/set-raw" });
+    const cookieHeader = sessionCookieHeader(setRes.headers["set-cookie"]);
+    const readRes = await app.inject({
+      method: "GET",
+      url: "/read",
+      headers: { cookie: cookieHeader },
+    });
+    expect(readRes.json().session).toBeNull();
+  });
+
+  it("rejects a cookie whose iat is older than the TTL", async () => {
+    const base = 1_700_000_000_000; // fixed epoch ms
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(base);
+    const setRes = await app.inject({ method: "POST", url: "/set" });
+    const cookieHeader = sessionCookieHeader(setRes.headers["set-cookie"]);
+
+    // Advance past the TTL: the signature is still valid, but readSession
+    // must reject it on age.
+    nowSpy.mockReturnValue(base + (SESSION_TTL_SECONDS + 10) * 1000);
+    const readRes = await app.inject({
+      method: "GET",
+      url: "/read",
+      headers: { cookie: cookieHeader },
+    });
+    expect(readRes.json().session).toBeNull();
+  });
+
+  it("clears the session cookie on logout", async () => {
+    const res = await app.inject({ method: "POST", url: "/clear" });
+    const raw = res.headers["set-cookie"];
+    const header = Array.isArray(raw) ? raw.join("\n") : (raw ?? "");
+    expect(header).toContain(`${SESSION_COOKIE}=`);
+    // Cleared cookies expire immediately (Max-Age=0 or a past Expires).
+    expect(header).toMatch(/Max-Age=0|Expires=/i);
+  });
+});

--- a/server/tests/helpers/app.ts
+++ b/server/tests/helpers/app.ts
@@ -50,7 +50,12 @@ export interface BuildTestAppOptions {
 export function buildTestApp(options: BuildTestAppOptions = {}): TestApp {
   const db = options.db ?? testDb();
   const app = buildApp({
-    settings: loadSettings({ PCT_LOG_LEVEL: "silent" }),
+    // A secret so auth (#52) is "configured" in the common path — guarded
+    // routes and the auth endpoints work without each test re-supplying one.
+    // Tests that need the unconfigured path pass their own settings via
+    // appOptions. No admin is seeded by default (no PCT_ADMIN_* here), so
+    // login tests opt in by supplying those.
+    settings: loadSettings({ PCT_LOG_LEVEL: "silent", PCT_SECRET_KEY: "test-secret-key" }),
     ...options.appOptions,
     // Inject the bundled db last so app.db is the handle this helper returns,
     // regardless of any db passed via appOptions.

--- a/server/tests/policy/migrations.test.ts
+++ b/server/tests/policy/migrations.test.ts
@@ -50,11 +50,17 @@ function userTableNames(sqlite: Database.Database): string[] {
     .all() as string[];
 }
 
-/** The policy-model tables this migration must materialise (docs/architecture.md). */
+/**
+ * Every table the committed migrations must materialise. These are the
+ * policy-model tables (docs/architecture.md) plus `admin_credentials`, the
+ * single-admin login row added in #52 (not part of the policy model — see the
+ * table comment in `schema.ts`). Sorted to match the `ORDER BY name` query.
+ */
 const EXPECTED_TABLES = [
   "activities",
   "activities_to_groups",
   "activity_groups",
+  "admin_credentials",
   "budgets",
   "clients",
   "exceptions",


### PR DESCRIPTION
## Summary

- Single-admin local login (the guard #51 policy routes and #53 admin UI sit behind): **Argon2id** hashing, a **signed session cookie** keyed on `PCT_SECRET_KEY`, `login` / `logout` / `session` endpoints under `/api/auth/*`, and a reusable `requireAdmin` guard.
- **First-admin bootstrap** — the gap the issue flagged: `PCT_ADMIN_USERNAME` / `PCT_ADMIN_PASSWORD` seed the admin row on first run (hashed immediately, idempotent). Until `PCT_SECRET_KEY` is set, auth fails closed with `503 auth_not_configured`.
- New `admin_credentials` **singleton** table (`CHECK (id = 1)`) storing only the hash; drizzle migration `0001`.

## Plan

Linked plan: `.claude/plans/issue-52-single-admin-auth.md`
Roadmap: `docs/roadmap.md` → Phase 2

## Scope (kept deliberately minimal)

Per the owner note on #52: one admin login, not a user system. The policy-model `User` is a supervised person, not an auth principal — so no multi-user framework, roles, MFA, or federation (those belong to Phase 11 / stretch #24 → #26). Just `argon2` + a signed cookie + a guard + bootstrap.

## Design notes

- **Module:** new `server/src/auth/` (per-responsibility, like `transport/*`), wired inside the encapsulated `/api` plugin scope so it inherits the zod validator + error-envelope conventions and never leaks onto `/`, `/healthz`, `/admin`, `/app`. Auth DTO types are re-exported from `api/index.ts` so the frontend's import surface stays `server/src/api`. `CLAUDE.md` module split + `docs/server-deployment.md` + `.env.example` updated to match.
- **Session:** `@fastify/cookie`-signed, `HttpOnly`, `SameSite=Strict`, 7-day TTL. Payload is a small non-secret `{ sub, iat }` — integrity (not secrecy) is all a "this is the admin" marker needs. Expiry enforced both by `Max-Age` and an `iat`-age check on read. Not `Secure` (default LAN deployment is plain HTTP); TLS is the reverse proxy's job.
- **Hardening within scope:** unknown-username login still runs a dummy Argon2 verify (no username-enumeration timing oracle); a minimal in-memory per-IP failed-login limiter returns `429`. No tamper-resistance scope creep.

## License-boundary note

No GPL code imported and no GPL binaries added to the image. `argon2` (MIT) and `@fastify/cookie` (MIT) are permissive and linked in-process freely. No transport/packaging change.

## New dependencies

- **`argon2`** — Argon2id password hashing; no existing dependency hashes passwords. Mandated by the issue and already named in `docs/server-deployment.md`'s runtime-dependency list.
- **`@fastify/cookie`** — the idiomatic Fastify cookie handler for setting/reading the signed session cookie. Chosen over `@fastify/secure-session` (no payload secrecy needed) and over a JWT library (overkill for one signed marker).

## Test plan

- [x] `passwords` — Argon2id hash verifies; wrong/malformed rejected; salted; dummy-verify resolves.
- [x] `session` — issue→read round-trip; tamper, garbage, non-JSON payload, and TTL-expiry all rejected; logout clears.
- [x] `credentials` — seeds from env (hashed); idempotent no-op when an admin exists; warns + seeds nothing when env incomplete.
- [x] `rate-limit` — under/over limit, per-key isolation, window reset, success clears.
- [x] `api/auth` (e2e via `app.inject()`) — login success sets cookie; wrong password / unknown user → `401`; missing field → `400`; anon/auth session; logout; `429` after repeated failures; `503` when unconfigured; `requireAdmin` rejects anon (`401`) and allows a valid session.
- [x] `format:check`, `lint`, `typecheck`, `npm test` green; coverage 100% lines / 96% branch (gate 80%); `db:check` reports no drift.

## Deferred / follow-up

- The admin UI login screen and calling these endpoints is **#53** (depends on this).
- Applying `requireAdmin` to the policy CRUD routes is **#51** (this PR ships the guard it will use; no policy routes exist yet to attach it to).

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQ4f8b3ga2VeBcGSMjdKRj)_