### PR TITLE
test(api): make the via-buildApp meta test hermetic (fixes red main) (#127)

### DIFF
--- a/server/tests/api/plugin.test.ts
+++ b/server/tests/api/plugin.test.ts
@@ -129,7 +129,13 @@ describe("GET /api/meta (via buildApp)", () => {
   let app: FastifyInstance;
 
   beforeEach(() => {
-    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "silent" }) });
+    // In-memory DB so buildApp's own createDb (we deliberately don't inject a
+    // handle here — the point is to exercise the real buildApp wiring) doesn't
+    // try to open the default /data/policy.sqlite, which doesn't exist on a CI
+    // runner or a dev box without the mounted data volume.
+    app = buildApp({
+      settings: loadSettings({ PCT_LOG_LEVEL: "silent", DATABASE_URL: ":memory:" }),
+    });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary

- Fixes the **Unit tests** CI job that has been red on `main` since the #50 merge (#68).
- The `GET /api/meta (via buildApp)` block opened the default `/data/policy.sqlite` (no db injected → `buildApp` runs `createDb`), which fails on any box without the mounted data volume. Now it loads `DATABASE_URL=:memory:`.

## Why this isn't a test weakening

The block intentionally exercises the **real** `buildApp` wiring (rather than the `buildTestApp` helper) to prove `/api/meta` is mounted. Injecting a handle would change that intent; pointing `buildApp`'s own `createDb` at an in-memory database keeps the intent and makes it hermetic.

## License-boundary note

N/A — test-only change; no transport, packaging, or dependency changes.

## Test plan

- [x] `npm test` passes with **no** `/data` directory present (190 tests, 100% lines / 95% branch).
- [x] `format:check`, `lint`, `typecheck` green.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyTvMhj5pjLsxmXp7ek242)_