### PR TITLE
feat(transport/ansible): ansible-playbook subprocess runner + dynamic inventory (#89)

### DIFF
--- a/.claude/plans/issue-89-ansible-runner.md
+++ b/.claude/plans/issue-89-ansible-runner.md
@@ -1,0 +1,82 @@
+# Issue #89 — `transport/ansible/` runner (subprocess + dynamic inventory)
+
+Roadmap: `docs/roadmap.md` → Phase 6 ("Ansible runner inside the dashboard
+(subprocess)"). Foundation the per-playbook issues (#90/#91/#92) depend on.
+
+## Goal
+
+A `transport/ansible/` module that invokes `ansible-playbook` **as a
+subprocess** from the isolated Python venv bootstrapped into the data volume
+at first run, with a dynamic inventory generated from the dashboard's `Client`
+records. Never embed or vendor Ansible — the subprocess boundary *is* the
+license boundary (`docs/licensing-analysis.md`, `CLAUDE.md` → "License
+boundaries", rule 3).
+
+## License-boundary check
+
+- Only ever `execFile("<venv>/bin/ansible-playbook", argv)` — no in-process
+  Ansible, no bindings, no vendored source.
+- No new runtime dependency, no GPL binary added to the image (the venv lives
+  in `/data`, bootstrapped by #39 — out of scope here). `license-guard` stays
+  green.
+
+## Scope (this PR)
+
+1. **Pure inventory generation** (`inventory.ts`): `buildInventory(hosts)` →
+   an Ansible **INI** inventory string (`[supervised]` group, one line per
+   host `<hostname> ansible_user=<sshUser>`). INI chosen over YAML so we add
+   **no `yaml` runtime dependency** and the output is trivial to reason about.
+   Hostnames and SSH usernames are validated against a strict charset and
+   rejected otherwise, so a hostile/garbled `Client` row can never inject
+   extra inventory tokens or newlines (`AnsibleInventoryError`).
+2. **The runner** (`index.ts`): `createAnsibleRunner({ ansibleDir, logger })`
+   exposing `runPlaybook({ playbook, hosts, extraVars?, limit? })`:
+   - resolves `<ansibleDir>/venv/bin/ansible-playbook` and
+     `<ansibleDir>/playbooks/<playbook>` (playbook name validated — no path
+     traversal);
+   - writes the generated inventory to a per-run temp file (`mkdtemp`), passes
+     `-i <file>`, and removes it in a `finally` (no clobber of a user-managed
+     `/data/ansible/inventory.yml`, safe under concurrent runs);
+   - `execFile`s the binary (callback style, raised `maxBuffer`), captures
+     stdout/stderr/exit code, logs a structured run record via the
+     `componentLogger(app, "transport/ansible")` convention (#11);
+   - maps the outcome to a typed **error taxonomy** (`errors.ts`).
+3. **Config** (`config.ts`): add `ansibleDir` (`PCT_ANSIBLE_DIR`, default
+   `/data/ansible`) so the eventual caller/job and tests resolve the same
+   path; mirror in `.env.example` + the deployment-doc env note.
+
+## Error taxonomy (`errors.ts`)
+
+`ansible-playbook`'s exit codes are bit-flagged by Ansible's TaskQueueManager:
+`2` = failed hosts, `4` = unreachable hosts (OR-able). Map:
+
+- spawn `ENOENT` → `AnsibleUnavailableError` (venv/binary missing — feeds the
+  "Ansible not bootstrapped yet" path, #39).
+- exit `(code & 4)` set → `AnsibleUnreachableError` (host(s) unreachable —
+  this is what the Phase-4 offline-queue, #84, will key on).
+- any other non-zero → `AnsiblePlaybookFailedError` (carries `exitCode`,
+  `stderr`).
+- exit `0` → resolves `AnsibleRunResult { exitCode, stdout, stderr, playbook }`.
+
+Bad inventory input → `AnsibleInventoryError`. All extend `AnsibleError`.
+
+## Tests (`tests/transport/ansible/`)
+
+- `inventory.test.ts` — group/line format, per-host `ansible_user`, empty-host
+  list, hostname/username validation rejects injection attempts.
+- `runner.test.ts` — `vi.mock("node:child_process")` per `docs/testing.md`:
+  asserts the binary path + `-i <tmp>` + playbook path + `--extra-vars` /
+  `--limit` argv; the temp inventory file content; happy-path result; `ENOENT`
+  → `AnsibleUnavailableError`; `code & 4` → `AnsibleUnreachableError`; other
+  non-zero → `AnsiblePlaybookFailedError`; temp file cleaned up; playbook-name
+  traversal rejected.
+- A `config.test.ts` case for the `PCT_ANSIBLE_DIR` default/override.
+
+## Out of scope (own issues)
+
+- The venv bootstrap itself + `playbooks/` sync (#39, Phase 6 first-run setup).
+- DB-backed audit persistence of each run (#85) — this PR logs a structured
+  run record and leaves the seam; the audit *table* lands with #85.
+- Loading real `Client` rows from the DB (#51 CRUD) — the runner takes injected
+  hosts; a `clients` row already satisfies the `AnsibleHost` shape.
+- The concrete playbooks (#90/#91/#92) and incremental output streaming.

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,12 @@
 # random value in any real deployment.
 # PCT_SECRET_KEY=
 
+# Root of the data-volume Ansible directory (Phase 6). The runner resolves
+# ansible-playbook at <dir>/venv/bin/ and playbooks under <dir>/playbooks/;
+# the venv is bootstrapped here on first run. Defaults to the documented
+# /data/ansible layout — see docs/server-deployment.md → "Volume layout".
+# PCT_ANSIBLE_DIR=/data/ansible
+
 # --- AdGuard Home (optional DNS filtering) ----------------------------------
 # Mode: disabled (default) | external | managed
 # See docs/server-deployment.md → "AdGuard Home deployment modes".

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -89,7 +89,12 @@ idempotently:
    (issues #49, #39).
 2. **Ansible bootstrap** — if `/data/ansible/venv` is missing, create it
    and `pip install ansible-core` (downloaded from PyPI at runtime, not
-   from the image). Sync `playbooks/` from the image.
+   from the image). Sync `playbooks/` from the image. The directory root is
+   `PCT_ANSIBLE_DIR` (default `/data/ansible`); the Phase-6 runner
+   (`transport/ansible`) execs `ansible-playbook` from
+   `<PCT_ANSIBLE_DIR>/venv/bin/` against playbooks in
+   `<PCT_ANSIBLE_DIR>/playbooks/` — always as a subprocess, never linked
+   in-process (`docs/licensing-analysis.md`).
 3. **AdGuard Home bootstrap** — driven by `PCT_ADGUARD_MODE` (see
    "AdGuard Home deployment modes" below). In `managed` mode, the
    first-time fetch downloads the latest stable release from

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -100,6 +100,14 @@ const settingsSchema = z
     logPretty: z.stringbool().default(false),
     /** Signs sessions / integration tokens (consumed in later phases). */
     secretKey: z.string().min(1).optional(),
+    /**
+     * Root of the data-volume Ansible directory (`PCT_ANSIBLE_DIR`). The
+     * Phase-6 runner resolves `ansible-playbook` at `<dir>/venv/bin/` and
+     * playbooks under `<dir>/playbooks/`; the venv itself is bootstrapped into
+     * this directory on first run (#39). Defaults to the documented
+     * `/data/ansible` layout (`docs/server-deployment.md` → "Volume layout").
+     */
+    ansibleDir: z.string().min(1).default("/data/ansible"),
     adguard: adguardSchema,
   })
   .superRefine((settings, ctx) => {
@@ -154,6 +162,7 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
     logLevel: env.PCT_LOG_LEVEL,
     logPretty: env.PCT_LOG_PRETTY,
     secretKey: env.PCT_SECRET_KEY,
+    ansibleDir: env.PCT_ANSIBLE_DIR,
     adguard: {
       mode: env.PCT_ADGUARD_MODE ?? "disabled",
       url: env.PCT_ADGUARD_URL,

--- a/server/src/transport/ansible/errors.ts
+++ b/server/src/transport/ansible/errors.ts
@@ -55,29 +55,37 @@ export class AnsibleUnavailableError extends AnsibleError {
  */
 export class AnsibleUnreachableError extends AnsibleError {
   readonly exitCode: number;
+  readonly stdout: string;
   readonly stderr: string;
 
-  constructor(exitCode: number, stderr: string) {
+  constructor(exitCode: number, stdout: string, stderr: string) {
     super(`ansible-playbook reported unreachable host(s) (exit code ${exitCode})`);
     this.name = "AnsibleUnreachableError";
     this.exitCode = exitCode;
+    this.stdout = stdout;
     this.stderr = stderr;
   }
 }
 
 /**
- * The playbook ran but exited non-zero for a reason other than an unreachable
- * host (a failed task, a parse error, a bad invocation). Not automatically
- * retryable — the admin needs to see what failed.
+ * The playbook ran but did not succeed for a reason other than an unreachable
+ * host: a failed task or parse error (a numeric, non-zero `exitCode`), or a
+ * non-exit termination such as a kill-by-signal or the captured output
+ * exceeding `maxBuffer` (then `exitCode` is `null` and the message carries the
+ * raw reason). Not automatically retryable — the admin needs to see what
+ * failed, so both `stdout` (where Ansible writes the PLAY RECAP and most task
+ * output) and `stderr` are retained.
  */
 export class AnsiblePlaybookFailedError extends AnsibleError {
-  readonly exitCode: number;
+  readonly exitCode: number | null;
+  readonly stdout: string;
   readonly stderr: string;
 
-  constructor(exitCode: number, stderr: string) {
-    super(`ansible-playbook failed (exit code ${exitCode})`);
+  constructor(exitCode: number | null, stdout: string, stderr: string, detail?: string) {
+    super(`ansible-playbook failed (${detail ?? `exit code ${exitCode ?? "unknown"}`})`);
     this.name = "AnsiblePlaybookFailedError";
     this.exitCode = exitCode;
+    this.stdout = stdout;
     this.stderr = stderr;
   }
 }

--- a/server/src/transport/ansible/errors.ts
+++ b/server/src/transport/ansible/errors.ts
@@ -1,0 +1,95 @@
+/**
+ * Error taxonomy for the Ansible transport.
+ *
+ * `runPlaybook` surfaces every failure as one of these typed errors so callers
+ * can branch without parsing prose. The split mirrors how `ansible-playbook`
+ * itself reports trouble, and feeds later phases:
+ *
+ * - {@link AnsibleUnavailableError} — the venv / `ansible-playbook` binary is
+ *   absent (the first-run bootstrap of #39 has not happened yet). Distinct
+ *   from a playbook that ran and failed.
+ * - {@link AnsibleUnreachableError} — one or more target hosts were
+ *   unreachable. This is the retryable category the Phase-4 offline-queue
+ *   (#84) keys on, the same way the SSH transport distinguishes "host
+ *   unreachable" from "command failed".
+ * - {@link AnsiblePlaybookFailedError} — the binary ran and exited non-zero
+ *   for any other reason (a task failed, a syntax/parse error, bad CLI).
+ * - {@link AnsibleInventoryError} — a `Client` record could not be rendered
+ *   into a safe inventory line (rejected before any subprocess is spawned).
+ *
+ * License boundary: plain TypeScript error classes; nothing links Ansible
+ * in-process. See `docs/licensing-analysis.md`.
+ */
+
+/** Base class for every error the Ansible transport raises. */
+export class AnsibleError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AnsibleError";
+  }
+}
+
+/**
+ * The `ansible-playbook` binary could not be spawned — typically because the
+ * first-run venv (`<ansibleDir>/venv`, bootstrapped by #39) does not exist
+ * yet. Carries the path we tried to execute.
+ */
+export class AnsibleUnavailableError extends AnsibleError {
+  readonly binaryPath: string;
+
+  constructor(binaryPath: string, cause?: unknown) {
+    super(
+      `ansible-playbook is not available at ${binaryPath} — has the first-run ` +
+        `Ansible venv been bootstrapped? (see docs/server-deployment.md → First-run setup)`,
+    );
+    this.name = "AnsibleUnavailableError";
+    this.binaryPath = binaryPath;
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+/**
+ * One or more target hosts were unreachable (Ansible exit code with the `4`
+ * bit set). Retryable: the run should be queued and replayed when the client
+ * is next reachable (#84).
+ */
+export class AnsibleUnreachableError extends AnsibleError {
+  readonly exitCode: number;
+  readonly stderr: string;
+
+  constructor(exitCode: number, stderr: string) {
+    super(`ansible-playbook reported unreachable host(s) (exit code ${exitCode})`);
+    this.name = "AnsibleUnreachableError";
+    this.exitCode = exitCode;
+    this.stderr = stderr;
+  }
+}
+
+/**
+ * The playbook ran but exited non-zero for a reason other than an unreachable
+ * host (a failed task, a parse error, a bad invocation). Not automatically
+ * retryable — the admin needs to see what failed.
+ */
+export class AnsiblePlaybookFailedError extends AnsibleError {
+  readonly exitCode: number;
+  readonly stderr: string;
+
+  constructor(exitCode: number, stderr: string) {
+    super(`ansible-playbook failed (exit code ${exitCode})`);
+    this.name = "AnsiblePlaybookFailedError";
+    this.exitCode = exitCode;
+    this.stderr = stderr;
+  }
+}
+
+/**
+ * A `Client` record (or a playbook name) could not be turned into a safe
+ * argument — e.g. a hostname containing characters that would inject extra
+ * tokens into the inventory file. Raised before any subprocess is spawned.
+ */
+export class AnsibleInventoryError extends AnsibleError {
+  constructor(message: string) {
+    super(message);
+    this.name = "AnsibleInventoryError";
+  }
+}

--- a/server/src/transport/ansible/index.ts
+++ b/server/src/transport/ansible/index.ts
@@ -134,24 +134,36 @@ function runProcess(
 }
 
 /**
- * Map an `execFile` failure onto the transport's error taxonomy. `ENOENT`
- * means the binary itself is missing (venv not bootstrapped); a numeric exit
- * code is interpreted via Ansible's bit set; anything else is a generic
- * failure.
+ * Map an `execFile` failure onto the transport's error taxonomy.
+ *
+ * `error.code` is either a spawn/exec-level string code (`ENOENT` if the
+ * binary is missing, `EACCES` if it is not executable,
+ * `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` if the output overflowed), a numeric
+ * process exit code, or `null` when the process was killed by a signal. We
+ * never fabricate an exit code: a non-numeric failure carries
+ * `exitCode === null` and surfaces the raw reason in the message.
  */
 function classifyFailure(
   binaryPath: string,
   error: ExecFileException,
+  stdout: string,
   stderr: string,
 ): AnsibleError {
-  if (error.code === "ENOENT") {
+  const code = error.code;
+  // Spawn-level failures: the binary could not be executed at all.
+  if (code === "ENOENT" || code === "EACCES") {
     return new AnsibleUnavailableError(binaryPath, error);
   }
-  const exitCode = typeof error.code === "number" ? error.code : 1;
-  if ((exitCode & UNREACHABLE_BIT) !== 0) {
-    return new AnsibleUnreachableError(exitCode, stderr);
+  if (typeof code === "number") {
+    if ((code & UNREACHABLE_BIT) !== 0) {
+      return new AnsibleUnreachableError(code, stdout, stderr);
+    }
+    return new AnsiblePlaybookFailedError(code, stdout, stderr);
   }
-  return new AnsiblePlaybookFailedError(exitCode, stderr);
+  // No numeric exit code: a kill-by-signal (`code` null, `signal` set) or a
+  // non-spawn exec error such as the captured output exceeding `maxBuffer`.
+  const reason = typeof code === "string" ? code : (error.signal ?? "unknown error");
+  return new AnsiblePlaybookFailedError(null, stdout, stderr, `terminated: ${reason}`);
 }
 
 /**
@@ -178,6 +190,11 @@ export function createAnsibleRunner(options: AnsibleRunnerOptions): AnsibleRunne
         await writeFile(inventoryPath, inventory, "utf8");
 
         const args = ["-i", inventoryPath, playbookPath];
+        // `limit` is an Ansible host-pattern from the (trusted, server-side)
+        // caller and is passed through unvalidated — unlike hostnames/users,
+        // which come from `Client` rows and are charset-checked in
+        // `buildInventory`. It is still a single argv token (no shell), so it
+        // cannot inject anything beyond a `--limit` value.
         if (limit !== undefined) args.push("--limit", limit);
         if (extraVars !== undefined) args.push("--extra-vars", JSON.stringify(extraVars));
 
@@ -190,7 +207,7 @@ export function createAnsibleRunner(options: AnsibleRunnerOptions): AnsibleRunne
           return { playbook, exitCode: 0, stdout, stderr };
         }
 
-        const failure = classifyFailure(binaryPath, error, stderr);
+        const failure = classifyFailure(binaryPath, error, stdout, stderr);
         logger.warn(
           { playbook, error: failure.name, message: failure.message },
           "ansible-playbook run failed",

--- a/server/src/transport/ansible/index.ts
+++ b/server/src/transport/ansible/index.ts
@@ -2,7 +2,203 @@
  * Ansible transport: runs `ansible-playbook` as a subprocess
  * (node:child_process), from the venv bootstrapped into the data volume.
  *
- * License boundary: never link Ansible code in-process.
- * See docs/licensing-analysis.md.
+ * This is the structural license boundary for Ansible: we only ever **exec**
+ * the `ansible-playbook` binary out of the isolated `/data` venv and parse its
+ * exit code/output. Ansible (GPL-3.0) is never linked, imported, embedded, or
+ * vendored — a Node process cannot import it, and that separation is the
+ * point. See `CLAUDE.md` → "License boundaries" (rule 3) and
+ * `docs/licensing-analysis.md`.
+ *
+ * The runner is the foundation the per-playbook issues (#90/#91/#92) build on.
+ * It is deliberately thin: generate a dynamic inventory from the dashboard's
+ * `Client` records, invoke one playbook against it, and surface the result
+ * through a typed error taxonomy ({@link ./errors.ts}). Loading the real
+ * `Client` rows (Phase-2 CRUD, #51), bootstrapping the venv (#39), persisting
+ * an audit row per run (#85), and the playbooks themselves are separate
+ * issues; this module takes injected hosts and logs a structured run record.
  */
+import { execFile, type ExecFileException } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { FastifyBaseLogger } from "fastify";
+
+import {
+  AnsibleError,
+  AnsiblePlaybookFailedError,
+  AnsibleUnavailableError,
+  AnsibleUnreachableError,
+} from "./errors.js";
+import { buildInventory, type AnsibleHost } from "./inventory.js";
+
 export const moduleName = "transport/ansible";
+
+export * from "./errors.js";
+export { buildInventory, INVENTORY_GROUP, type AnsibleHost } from "./inventory.js";
+
+/**
+ * Ansible's `TaskQueueManager` encodes the run outcome as an OR-able bit set
+ * in the process exit code: `2` = one or more hosts failed, `4` = one or more
+ * hosts were unreachable. We single out the unreachable bit so the caller can
+ * treat that case as retryable (offline-queue, #84).
+ */
+const UNREACHABLE_BIT = 4;
+
+/** Generous cap so a verbose playbook run is not truncated mid-capture. */
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
+
+/**
+ * A bare playbook file name — no directory separators, no `..` — so a caller
+ * can never escape the `<ansibleDir>/playbooks/` directory.
+ */
+const PLAYBOOK_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+/** Construction-time configuration for {@link createAnsibleRunner}. */
+export interface AnsibleRunnerOptions {
+  /**
+   * Root of the data-volume Ansible directory (`PCT_ANSIBLE_DIR`, default
+   * `/data/ansible`). The binary is resolved at `<ansibleDir>/venv/bin/
+   * ansible-playbook` and playbooks at `<ansibleDir>/playbooks/`.
+   */
+  ansibleDir: string;
+  /** Component child logger (`componentLogger(app, "transport/ansible")`). */
+  logger: FastifyBaseLogger;
+  /** Override the captured-output buffer cap (bytes). */
+  maxBuffer?: number;
+}
+
+/** Arguments for a single {@link AnsibleRunner.runPlaybook} invocation. */
+export interface RunPlaybookOptions {
+  /** Playbook file name within `<ansibleDir>/playbooks/`. */
+  playbook: string;
+  /** Target clients; rendered into a per-run dynamic inventory. */
+  hosts: readonly AnsibleHost[];
+  /** Optional `--extra-vars`, passed to Ansible as a single JSON object. */
+  extraVars?: Record<string, string | number | boolean>;
+  /** Optional `--limit` host pattern to narrow the run within the inventory. */
+  limit?: string;
+}
+
+/** The outcome of a successful run (exit code 0). */
+export interface AnsibleRunResult {
+  /** The playbook that was run. */
+  playbook: string;
+  /** Always `0` here — non-zero exits throw (see {@link ./errors.ts}). */
+  exitCode: number;
+  /** Captured standard output. */
+  stdout: string;
+  /** Captured standard error. */
+  stderr: string;
+}
+
+/** The Ansible runner facade. */
+export interface AnsibleRunner {
+  /**
+   * Run one playbook against the given hosts.
+   *
+   * @throws {AnsibleError} if the playbook name is unsafe.
+   * @throws {AnsibleInventoryError} if a host cannot be rendered safely.
+   * @throws {AnsibleUnavailableError} if the venv/binary is missing.
+   * @throws {AnsibleUnreachableError} if any host was unreachable.
+   * @throws {AnsiblePlaybookFailedError} on any other non-zero exit.
+   */
+  runPlaybook(options: RunPlaybookOptions): Promise<AnsibleRunResult>;
+}
+
+/** Resolve the `ansible-playbook` binary path inside the first-run venv. */
+function binaryPathFor(ansibleDir: string): string {
+  return join(ansibleDir, "venv", "bin", "ansible-playbook");
+}
+
+function assertSafePlaybookName(playbook: string): void {
+  if (!PLAYBOOK_NAME_PATTERN.test(playbook) || playbook === "." || playbook === "..") {
+    throw new AnsibleError(
+      `refusing to run playbook ${JSON.stringify(playbook)}: the name must be a bare ` +
+        `file under the playbooks directory (letters, digits, '.', '_', '-')`,
+    );
+  }
+}
+
+/** Wrap callback-style `execFile` so the outcome is awaitable in one place. */
+function runProcess(
+  binaryPath: string,
+  args: string[],
+  maxBuffer: number,
+): Promise<{ error: ExecFileException | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile(binaryPath, args, { encoding: "utf8", maxBuffer }, (error, stdout, stderr) => {
+      resolve({ error, stdout: String(stdout), stderr: String(stderr) });
+    });
+  });
+}
+
+/**
+ * Map an `execFile` failure onto the transport's error taxonomy. `ENOENT`
+ * means the binary itself is missing (venv not bootstrapped); a numeric exit
+ * code is interpreted via Ansible's bit set; anything else is a generic
+ * failure.
+ */
+function classifyFailure(
+  binaryPath: string,
+  error: ExecFileException,
+  stderr: string,
+): AnsibleError {
+  if (error.code === "ENOENT") {
+    return new AnsibleUnavailableError(binaryPath, error);
+  }
+  const exitCode = typeof error.code === "number" ? error.code : 1;
+  if ((exitCode & UNREACHABLE_BIT) !== 0) {
+    return new AnsibleUnreachableError(exitCode, stderr);
+  }
+  return new AnsiblePlaybookFailedError(exitCode, stderr);
+}
+
+/**
+ * Create an {@link AnsibleRunner} bound to a data-volume Ansible directory and
+ * a component logger.
+ */
+export function createAnsibleRunner(options: AnsibleRunnerOptions): AnsibleRunner {
+  const { ansibleDir, logger } = options;
+  const maxBuffer = options.maxBuffer ?? DEFAULT_MAX_BUFFER;
+  const binaryPath = binaryPathFor(ansibleDir);
+
+  return {
+    async runPlaybook({ playbook, hosts, extraVars, limit }) {
+      assertSafePlaybookName(playbook);
+
+      // Build (and validate) the inventory before touching the filesystem, so
+      // a bad host record fails fast without leaving a temp directory behind.
+      const inventory = buildInventory(hosts);
+      const playbookPath = join(ansibleDir, "playbooks", playbook);
+
+      const workDir = await mkdtemp(join(tmpdir(), "pct-ansible-"));
+      const inventoryPath = join(workDir, "inventory.ini");
+      try {
+        await writeFile(inventoryPath, inventory, "utf8");
+
+        const args = ["-i", inventoryPath, playbookPath];
+        if (limit !== undefined) args.push("--limit", limit);
+        if (extraVars !== undefined) args.push("--extra-vars", JSON.stringify(extraVars));
+
+        logger.info({ playbook, hostCount: hosts.length, limit }, "running ansible-playbook");
+
+        const { error, stdout, stderr } = await runProcess(binaryPath, args, maxBuffer);
+
+        if (error === null) {
+          logger.info({ playbook, exitCode: 0 }, "ansible-playbook run completed");
+          return { playbook, exitCode: 0, stdout, stderr };
+        }
+
+        const failure = classifyFailure(binaryPath, error, stderr);
+        logger.warn(
+          { playbook, error: failure.name, message: failure.message },
+          "ansible-playbook run failed",
+        );
+        throw failure;
+      } finally {
+        await rm(workDir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/server/src/transport/ansible/inventory.ts
+++ b/server/src/transport/ansible/inventory.ts
@@ -1,0 +1,76 @@
+/**
+ * Dynamic Ansible inventory generation from the dashboard's `Client` records.
+ *
+ * A run targets the set of enrolled clients; this module turns those records
+ * into an Ansible **INI** inventory string. INI (rather than YAML) is a
+ * deliberate choice: it is trivial to generate with no templating, easy to
+ * eyeball, and — most importantly — lets us avoid adding a YAML serialiser to
+ * the dashboard's *runtime* dependency tree just to emit a handful of lines.
+ *
+ * Inventory lines are assembled from values that originate in the policy store
+ * (`clients.hostname`, `clients.ssh_user`). Even though those are not
+ * end-user input, we still validate every token against a strict charset
+ * before writing it: a hostname carrying a space, a newline, or `=` could
+ * otherwise inject extra inventory tokens or host entries. A bad value is
+ * rejected with {@link AnsibleInventoryError} rather than silently producing a
+ * malformed file.
+ *
+ * License boundary: pure string assembly; nothing links Ansible in-process.
+ */
+import { AnsibleInventoryError } from "./errors.js";
+
+/**
+ * The slice of a `clients` row the inventory needs. A full Drizzle `clients`
+ * select row is assignable to this shape, so callers can pass DB rows
+ * directly once the Phase-2 CRUD (#51) loads them.
+ */
+export interface AnsibleHost {
+  /** DNS hostname (or IP) Ansible connects to. */
+  hostname: string;
+  /** The `pct-agent` service account the dashboard authenticates as. */
+  sshUser: string;
+}
+
+/** The inventory group every supervised client is placed in. */
+export const INVENTORY_GROUP = "supervised";
+
+/**
+ * Hostnames/IPs: letters, digits, dot and hyphen (DNS labels) — no
+ * whitespace, `=`, `:`, or `[` that would change the meaning of an INI line.
+ */
+const HOSTNAME_PATTERN = /^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?$/;
+
+/** POSIX-ish login name: starts with a letter/underscore, then word chars. */
+const SSH_USER_PATTERN = /^[a-z_][a-z0-9_-]*$/;
+
+function requireSafe(value: string, pattern: RegExp, what: string): string {
+  if (!pattern.test(value)) {
+    throw new AnsibleInventoryError(
+      `refusing to build an Ansible inventory: ${what} ${JSON.stringify(value)} ` +
+        `contains characters that are not allowed in an inventory entry`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Build an Ansible INI inventory string for the given hosts.
+ *
+ * The result always ends with a trailing newline. An empty host list still
+ * produces a valid (empty) group header, so `ansible-playbook` runs cleanly
+ * against zero hosts rather than erroring on a missing inventory.
+ *
+ * @throws {AnsibleInventoryError} if any hostname or SSH user contains a
+ *   character that is unsafe in an inventory line.
+ */
+export function buildInventory(hosts: readonly AnsibleHost[]): string {
+  const lines: string[] = [`[${INVENTORY_GROUP}]`];
+
+  for (const host of hosts) {
+    const hostname = requireSafe(host.hostname, HOSTNAME_PATTERN, "hostname");
+    const sshUser = requireSafe(host.sshUser, SSH_USER_PATTERN, "ssh user");
+    lines.push(`${hostname} ansible_user=${sshUser}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -15,7 +15,12 @@ describe("loadSettings", () => {
     expect(settings.defaultTz).toBe("UTC");
     expect(settings.logLevel).toBe("info");
     expect(settings.secretKey).toBeUndefined();
+    expect(settings.ansibleDir).toBe("/data/ansible");
     expect(settings.adguard).toEqual({ mode: "disabled" });
+  });
+
+  it("honours an explicit PCT_ANSIBLE_DIR", () => {
+    expect(loadSettings({ PCT_ANSIBLE_DIR: "/srv/ansible" }).ansibleDir).toBe("/srv/ansible");
   });
 
   it("round-trips explicit base values", () => {

--- a/server/tests/transport/ansible/inventory.test.ts
+++ b/server/tests/transport/ansible/inventory.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the pure Ansible inventory generator.
+ *
+ * No subprocess, no filesystem — just the string the runner hands to
+ * `ansible-playbook -i`. The injection-rejection cases matter most: a hostile
+ * or corrupt `Client` row must never be able to inject extra inventory tokens.
+ */
+import { describe, expect, it } from "vitest";
+
+import { AnsibleInventoryError } from "../../../src/transport/ansible/errors.js";
+import {
+  buildInventory,
+  INVENTORY_GROUP,
+  type AnsibleHost,
+} from "../../../src/transport/ansible/inventory.js";
+
+describe("buildInventory", () => {
+  it("renders one INI line per host under the supervised group", () => {
+    const hosts: AnsibleHost[] = [
+      { hostname: "mint-01.lan", sshUser: "pct-agent" },
+      { hostname: "192.168.1.50", sshUser: "pct-agent" },
+    ];
+
+    expect(buildInventory(hosts)).toBe(
+      `[${INVENTORY_GROUP}]\n` +
+        "mint-01.lan ansible_user=pct-agent\n" +
+        "192.168.1.50 ansible_user=pct-agent\n",
+    );
+  });
+
+  it("carries each host's own ssh user", () => {
+    const inventory = buildInventory([{ hostname: "box", sshUser: "pct_agent" }]);
+    expect(inventory).toContain("box ansible_user=pct_agent");
+  });
+
+  it("produces a valid empty group for zero hosts (a clean no-op run)", () => {
+    expect(buildInventory([])).toBe(`[${INVENTORY_GROUP}]\n`);
+  });
+
+  it("always ends with a trailing newline", () => {
+    expect(buildInventory([{ hostname: "a", sshUser: "pct-agent" }]).endsWith("\n")).toBe(true);
+  });
+
+  it.each([
+    ["a space", "evil host"],
+    ["a newline + injected entry", "host\n[all]\nrogue"],
+    ["an equals sign", "host=ansible_user=root"],
+    ["a leading hyphen", "-host"],
+    ["an empty hostname", ""],
+  ])("rejects a hostname with %s", (_label, hostname) => {
+    expect(() => buildInventory([{ hostname, sshUser: "pct-agent" }])).toThrow(
+      AnsibleInventoryError,
+    );
+  });
+
+  it.each([
+    ["a space", "pct agent"],
+    ["a shell metacharacter", "pct;agent"],
+    ["an uppercase start", "Agent"],
+  ])("rejects an ssh user with %s", (_label, sshUser) => {
+    expect(() => buildInventory([{ hostname: "box", sshUser }])).toThrow(AnsibleInventoryError);
+  });
+});

--- a/server/tests/transport/ansible/runner.test.ts
+++ b/server/tests/transport/ansible/runner.test.ts
@@ -118,9 +118,24 @@ describe("createAnsibleRunner.runPlaybook — error taxonomy", () => {
     );
   });
 
+  it("maps a spawn EACCES (binary not executable) to AnsibleUnavailableError", async () => {
+    mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(Object.assign(new Error("spawn EACCES"), { code: "EACCES" }), "", "");
+    });
+
+    const runner = makeRunner();
+    await expect(runner.runPlaybook({ playbook: "site.yml", hosts: [] })).rejects.toBeInstanceOf(
+      AnsibleUnavailableError,
+    );
+  });
+
   it("maps an exit code with the unreachable bit (4) to AnsibleUnreachableError", async () => {
     mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
-      cb(Object.assign(new Error("unreachable"), { code: 4 }), "", "host unreachable");
+      cb(
+        Object.assign(new Error("unreachable"), { code: 4 }),
+        "RECAP unreachable=1",
+        "ssh: timeout",
+      );
     });
 
     const runner = makeRunner();
@@ -131,7 +146,8 @@ describe("createAnsibleRunner.runPlaybook — error taxonomy", () => {
     expect(error).toBeInstanceOf(AnsibleUnreachableError);
     if (error instanceof AnsibleUnreachableError) {
       expect(error.exitCode).toBe(4);
-      expect(error.stderr).toBe("host unreachable");
+      expect(error.stdout).toContain("RECAP unreachable=1");
+      expect(error.stderr).toBe("ssh: timeout");
     }
   });
 
@@ -146,9 +162,9 @@ describe("createAnsibleRunner.runPlaybook — error taxonomy", () => {
     );
   });
 
-  it("maps a plain non-zero exit (2) to AnsiblePlaybookFailedError", async () => {
+  it("maps a plain non-zero exit (2) to AnsiblePlaybookFailedError, keeping stdout+stderr", async () => {
     mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
-      cb(Object.assign(new Error("failed"), { code: 2 }), "", "a task failed");
+      cb(Object.assign(new Error("failed"), { code: 2 }), "PLAY RECAP failed=1", "a task failed");
     });
 
     const runner = makeRunner();
@@ -159,12 +175,19 @@ describe("createAnsibleRunner.runPlaybook — error taxonomy", () => {
     expect(error).toBeInstanceOf(AnsiblePlaybookFailedError);
     if (error instanceof AnsiblePlaybookFailedError) {
       expect(error.exitCode).toBe(2);
+      // The PLAY RECAP and task output live in stdout, not stderr.
+      expect(error.stdout).toContain("PLAY RECAP failed=1");
+      expect(error.stderr).toBe("a task failed");
     }
   });
 
-  it("treats a kill-by-signal (no numeric code) as a generic playbook failure", async () => {
+  it("treats a kill-by-signal (code null) as a failure with no numeric exit code", async () => {
     mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
-      cb(Object.assign(new Error("killed"), { killed: true, signal: "SIGTERM" }), "", "");
+      cb(
+        Object.assign(new Error("killed"), { code: null, killed: true, signal: "SIGTERM" }),
+        "",
+        "",
+      );
     });
 
     const runner = makeRunner();
@@ -174,7 +197,48 @@ describe("createAnsibleRunner.runPlaybook — error taxonomy", () => {
 
     expect(error).toBeInstanceOf(AnsiblePlaybookFailedError);
     if (error instanceof AnsiblePlaybookFailedError) {
-      expect(error.exitCode).toBe(1);
+      expect(error.exitCode).toBeNull();
+      expect(error.message).toContain("SIGTERM");
+    }
+  });
+
+  it("treats a maxBuffer overflow (string code, no exit code) as a failure, not exit 1", async () => {
+    mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(
+        Object.assign(new Error("stdout maxBuffer exceeded"), {
+          code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
+        }),
+        "",
+        "",
+      );
+    });
+
+    const runner = makeRunner();
+    const error = await runner
+      .runPlaybook({ playbook: "site.yml", hosts: [] })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(AnsiblePlaybookFailedError);
+    if (error instanceof AnsiblePlaybookFailedError) {
+      expect(error.exitCode).toBeNull();
+      expect(error.message).toContain("ERR_CHILD_PROCESS_STDIO_MAXBUFFER");
+    }
+  });
+
+  it("falls back to 'unknown error' when there is neither an exit code nor a signal", async () => {
+    mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(Object.assign(new Error("mystery"), { code: null }), "", "");
+    });
+
+    const runner = makeRunner();
+    const error = await runner
+      .runPlaybook({ playbook: "site.yml", hosts: [] })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(AnsiblePlaybookFailedError);
+    if (error instanceof AnsiblePlaybookFailedError) {
+      expect(error.exitCode).toBeNull();
+      expect(error.message).toContain("unknown error");
     }
   });
 });

--- a/server/tests/transport/ansible/runner.test.ts
+++ b/server/tests/transport/ansible/runner.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Unit tests for the Ansible runner.
+ *
+ * `node:child_process` is mocked at the module level (per `docs/testing.md` →
+ * "Transport — subprocess") so no real `ansible-playbook` is ever spawned —
+ * the subprocess boundary is the license boundary and the unit suite must not
+ * cross it. The mock both records the invocation (asserting the exact argv we
+ * hand Ansible) and reads back the per-run inventory file the runner wrote.
+ */
+import { existsSync, readFileSync } from "node:fs";
+
+import Fastify from "fastify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockSubprocess } from "../../helpers/subprocess.js";
+
+// `mock`-prefixed so the hoisted `vi.mock` factory may reference it.
+const mockCp = mockSubprocess();
+vi.mock("node:child_process", () => mockCp.module);
+
+// Deferred import so the mock is registered before the module resolves.
+const {
+  createAnsibleRunner,
+  AnsibleError,
+  AnsibleInventoryError,
+  AnsiblePlaybookFailedError,
+  AnsibleUnavailableError,
+  AnsibleUnreachableError,
+} = await import("../../../src/transport/ansible/index.js");
+
+const ANSIBLE_DIR = "/data/ansible";
+const BINARY = "/data/ansible/venv/bin/ansible-playbook";
+const PLAYBOOK_PATH = "/data/ansible/playbooks/site.yml";
+
+// A no-op FastifyBaseLogger (logger:false), so the runner's structured logging
+// runs without producing output or needing a hand-built logger stub.
+const logger = Fastify({ logger: false }).log;
+
+function makeRunner() {
+  return createAnsibleRunner({ ansibleDir: ANSIBLE_DIR, logger });
+}
+
+/** The inventory path inside the recorded argv (`-i <path>`). */
+function inventoryArg(): string {
+  const [call] = mockCp.execFileCalls();
+  if (call === undefined) throw new Error("execFile was not called");
+  const idx = call.args.indexOf("-i");
+  const path = call.args[idx + 1];
+  if (path === undefined) throw new Error("no -i argument recorded");
+  return path;
+}
+
+beforeEach(() => {
+  mockCp.reset();
+  // Default: a clean, successful run that echoes back the inventory it saw.
+  mockCp.execFile.mockImplementation((_cmd, args, _opts, cb) => {
+    const invPath = args[args.indexOf("-i") + 1];
+    cb(null, `read inventory:\n${readFileSync(invPath, "utf8")}`, "");
+  });
+});
+
+describe("createAnsibleRunner.runPlaybook — happy path", () => {
+  it("invokes the venv binary with -i, the playbook path, and a generated inventory", async () => {
+    const runner = makeRunner();
+
+    const result = await runner.runPlaybook({
+      playbook: "site.yml",
+      hosts: [{ hostname: "mint-01.lan", sshUser: "pct-agent" }],
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const [call] = mockCp.execFileCalls();
+    expect(call?.command).toBe(BINARY);
+    expect(call?.args.slice(0, 3)).toEqual(["-i", inventoryArg(), PLAYBOOK_PATH]);
+    // The inventory the runner wrote (echoed back by the mock) has the host.
+    expect(result.stdout).toContain("mint-01.lan ansible_user=pct-agent");
+  });
+
+  it("appends --limit and --extra-vars (as JSON) when provided", async () => {
+    const runner = makeRunner();
+
+    await runner.runPlaybook({
+      playbook: "site.yml",
+      hosts: [{ hostname: "box", sshUser: "pct-agent" }],
+      limit: "box",
+      extraVars: { filter_group: "kids", enabled: true },
+    });
+
+    const [call] = mockCp.execFileCalls();
+    expect(call?.args).toContain("--limit");
+    expect(call?.args).toContain("box");
+    const evIndex = call?.args.indexOf("--extra-vars") ?? -1;
+    expect(evIndex).toBeGreaterThan(-1);
+    expect(JSON.parse(call?.args[evIndex + 1] ?? "{}")).toEqual({
+      filter_group: "kids",
+      enabled: true,
+    });
+  });
+
+  it("removes the per-run temp inventory afterwards", async () => {
+    const runner = makeRunner();
+    await runner.runPlaybook({ playbook: "site.yml", hosts: [] });
+
+    expect(existsSync(inventoryArg())).toBe(false);
+  });
+});
+
+describe("createAnsibleRunner.runPlaybook — error taxonomy", () => {
+  it("maps a spawn ENOENT to AnsibleUnavailableError (venv not bootstrapped)", async () => {
+    mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(Object.assign(new Error("spawn ansible-playbook ENOENT"), { code: "ENOENT" }), "", "");
+    });
+
+    const runner = makeRunner();
+    await expect(runner.runPlaybook({ playbook: "site.yml", hosts: [] })).rejects.toBeInstanceOf(
+      AnsibleUnavailableError,
+    );
+  });
+
+  it("maps an exit code with the unreachable bit (4) to AnsibleUnreachableError", async () => {
+    mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(Object.assign(new Error("unreachable"), { code: 4 }), "", "host unreachable");
+    });
+
+    const runner = makeRunner();
+    const error = await runner
+      .runPlaybook({ playbook: "site.yml", hosts: [] })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(AnsibleUnreachableError);
+    if (error instanceof AnsibleUnreachableError) {
+      expect(error.exitCode).toBe(4);
+      expect(error.stderr).toBe("host unreachable");
+    }
+  });
+
+  it("treats a combined failed+unreachable code (6) as unreachable", async () => {
+    mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(Object.assign(new Error("mixed"), { code: 6 }), "", "");
+    });
+
+    const runner = makeRunner();
+    await expect(runner.runPlaybook({ playbook: "site.yml", hosts: [] })).rejects.toBeInstanceOf(
+      AnsibleUnreachableError,
+    );
+  });
+
+  it("maps a plain non-zero exit (2) to AnsiblePlaybookFailedError", async () => {
+    mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(Object.assign(new Error("failed"), { code: 2 }), "", "a task failed");
+    });
+
+    const runner = makeRunner();
+    const error = await runner
+      .runPlaybook({ playbook: "site.yml", hosts: [] })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(AnsiblePlaybookFailedError);
+    if (error instanceof AnsiblePlaybookFailedError) {
+      expect(error.exitCode).toBe(2);
+    }
+  });
+
+  it("treats a kill-by-signal (no numeric code) as a generic playbook failure", async () => {
+    mockCp.execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(Object.assign(new Error("killed"), { killed: true, signal: "SIGTERM" }), "", "");
+    });
+
+    const runner = makeRunner();
+    const error = await runner
+      .runPlaybook({ playbook: "site.yml", hosts: [] })
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(AnsiblePlaybookFailedError);
+    if (error instanceof AnsiblePlaybookFailedError) {
+      expect(error.exitCode).toBe(1);
+    }
+  });
+});
+
+describe("createAnsibleRunner.runPlaybook — input validation", () => {
+  it("rejects a playbook name that escapes the playbooks directory", async () => {
+    const runner = makeRunner();
+
+    await expect(
+      runner.runPlaybook({ playbook: "../../etc/passwd", hosts: [] }),
+    ).rejects.toBeInstanceOf(AnsibleError);
+    // Nothing was spawned: the guard fires before any subprocess.
+    expect(mockCp.execFileCalls()).toEqual([]);
+  });
+
+  it("rejects an unsafe host before spawning anything", async () => {
+    const runner = makeRunner();
+
+    await expect(
+      runner.runPlaybook({
+        playbook: "site.yml",
+        hosts: [{ hostname: "a b", sshUser: "pct-agent" }],
+      }),
+    ).rejects.toBeInstanceOf(AnsibleInventoryError);
+    expect(mockCp.execFileCalls()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- The `transport/ansible/` runner that invokes **`ansible-playbook` as a subprocess** from the isolated first-run venv, with a dynamic inventory generated from the dashboard's `Client` records — the foundation the per-playbook issues (#90/#91/#92) build on.
- `createAnsibleRunner({ ansibleDir, logger }).runPlaybook({ playbook, hosts, extraVars?, limit? })`: resolves `<ansibleDir>/venv/bin/ansible-playbook` and `playbooks/<name>` (name validated against path traversal), writes a per-run temp inventory (`-i`), execs, captures output, logs a structured run record, and cleans up.
- A typed **error taxonomy** mirroring how Ansible reports trouble: `AnsibleUnavailableError` (spawn `ENOENT` — venv not bootstrapped yet), `AnsibleUnreachableError` (exit-code unreachable bit `4`, the retryable case the offline-queue #84 will key on), `AnsiblePlaybookFailedError` (any other non-zero), `AnsibleInventoryError` (a `Client` row that can't be rendered safely).

## Plan

Linked plan: `.claude/plans/issue-89-ansible-runner.md`
Roadmap: `docs/roadmap.md` → Phase 6 ("Ansible runner inside the dashboard (subprocess)")

## License-boundary note

**Confirmed clean.** This is the structural license boundary for Ansible: the runner only ever `execFile`s the `ansible-playbook` binary out of the `/data` venv and parses its exit code/output. Ansible (GPL-3.0) is never linked, imported, embedded, or vendored. No GPL binary is added to the Docker image (the venv lives in `/data`, bootstrapped on first run by #39 — out of scope here), so `license-guard` stays green. **No new dependencies** — the inventory is emitted as Ansible **INI** (plain string assembly) specifically to avoid adding a YAML serialiser to the runtime tree.

## Security note

Inventory lines and the playbook name are assembled from policy-store values; even though those aren't end-user input, every token is validated against a strict charset before it reaches the inventory file or the argv, so a hostile/garbled hostname can't inject extra inventory entries and a crafted playbook name can't escape the playbooks directory. Arguments are always passed as a vector (no shell string), consistent with `CLAUDE.md` → "License boundaries".

## Test plan

- [x] `format:check` / `lint` / `typecheck` clean
- [x] `npm test` — 186 passing; new `transport/ansible` module at **100%** line/branch/fn coverage (gate 80%)
- [x] `inventory.test.ts`: INI format, per-host `ansible_user`, empty-host no-op, hostname/ssh-user injection rejection
- [x] `runner.test.ts` (`vi.mock("node:child_process")` per `docs/testing.md`): correct binary + `-i <tmp>` + playbook path + `--limit`/`--extra-vars` argv; temp-inventory content; happy path; `ENOENT`→unavailable; exit `4`/`6`→unreachable; exit `2` & signal-kill→failed; temp file cleaned up; playbook-traversal & unsafe-host rejected before any spawn
- [x] `config.test.ts`: `PCT_ANSIBLE_DIR` default + override

> Note: the pre-existing `tests/api/plugin.test.ts` cases assume the default `/data` directory exists (the default `DATABASE_URL`); they fail on a clean checkout where it doesn't and are unrelated to this change (also flagged on #123).

## Deferred to their own issues

- DB-backed audit persistence of each run — **#85** (this PR logs a structured run record and leaves the seam).
- The first-run venv bootstrap + `playbooks/` sync — **#39**.
- Loading real `Client` rows from the DB — **#51** (a `clients` row already satisfies the injected `AnsibleHost` shape).
- The concrete playbooks (e2guardian/iptables, AW units, AppArmor) — **#90/#91/#92**.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015NY2t7HSJRyKJJNfTzXEt1)_