### PR TITLE
feat(transport/activitywatch): REST client + zod-validated event parsing (#87)

### DIFF
--- a/.claude/plans/issue-87-activitywatch-rest-client.md
+++ b/.claude/plans/issue-87-activitywatch-rest-client.md
@@ -1,0 +1,105 @@
+# Issue #87 — ActivityWatch REST client + zod-validated event parsing
+
+Roadmap: `docs/roadmap.md` → Phase 5 ("ActivityWatch telemetry pull").
+Module home: `server/src/transport/activitywatch/`.
+Test home: `server/tests/transport/activitywatch/`.
+
+## Goal
+
+A typed, REST-only client for `aw-server`'s buckets/events API that the
+Phase-5 telemetry job (#86 SSH port-forward, #88 normalisation) drives. It
+takes an injected base URL (the local end of the SSH forward, typically
+`http://localhost:<forwarded>`), queries buckets and events for a polling
+window, and validates every response with zod before it crosses into typed
+code. REST-only — no source-level coupling to ActivityWatch (license
+boundary, `docs/licensing-analysis.md`; AW is REST-only per
+`CLAUDE.md` → "License boundaries" rule 4).
+
+## Boundary with neighbouring issues
+
+- **In scope (#87):** connection options + per-request timeout, the
+  buckets/events/info REST calls, zod schemas for AW responses, windowed
+  querying (caller supplies `start`/`end`), an error taxonomy that separates
+  *unreachable* (feeds the offline-queue / retry) from *request failed* and
+  *malformed response*, and typed `window`/`afk` event projections.
+- **Out of scope:** normalisation into `UsageSample` rows, dedup of
+  clock-skew overlaps, dropping future-timestamped events, aggregation —
+  that is #88. The SSH port-forward itself is #86; this client only needs the
+  resulting base URL. No `croner` scheduling here (#86).
+
+## API surface
+
+```ts
+interface ActivityWatchClientOptions {
+  baseUrl: string;          // e.g. "http://localhost:5600"
+  timeoutMs?: number;       // per-request; default 10_000
+  fetch?: typeof fetch;     // injectable for DI/tests; default global fetch
+}
+
+interface EventQuery { start: Date; end: Date; limit?: number }
+
+class ActivityWatchClient {
+  getInfo(): Promise<AwServerInfo>;                 // GET /api/0/info
+  listBuckets(): Promise<AwBucket[]>;               // GET /api/0/buckets/
+  getEvents(bucketId, query): Promise<AwEvent[]>;   // GET /api/0/buckets/{id}/events
+  getWindowEvents(query): Promise<AwWindowEvent[]>; // currentwindow buckets, typed data
+  getAfkEvents(query): Promise<AwAfkEvent[]>;       // afkstatus buckets, typed data
+}
+```
+
+`getWindowEvents` / `getAfkEvents` locate buckets by AW `type`
+(`currentwindow` / `afkstatus`), then project each event's `data` through the
+watcher-specific zod schema; events whose `data` does not match are **skipped**
+(robustness — "skip malformed payloads rather than trusting them"), while a
+whole-response shape mismatch on the generic events call is **rejected** with a
+typed parse error.
+
+## Files
+
+- `src/transport/activitywatch/errors.ts` — `ActivityWatchError` base +
+  `ActivityWatchUnreachableError` (carries `cause`, `timedOut`),
+  `ActivityWatchRequestError` (carries `statusCode`), `ActivityWatchParseError`
+  (carries the `ZodError`).
+- `src/transport/activitywatch/schemas.ts` — zod schemas: server info, bucket
+  (object-map → array), event (ISO timestamp → `Date`), window/afk `data`.
+- `src/transport/activitywatch/client.ts` — the client + request helper
+  (timeout via `AbortSignal.timeout`, error mapping, zod parse-or-throw).
+- `src/transport/activitywatch/index.ts` — keep `moduleName`
+  (package-layout smoke test) + re-export the public surface.
+- `tests/transport/activitywatch/client.test.ts` — undici `MockAgent` for the
+  HTTP happy / non-2xx / malformed paths and `replyWithError` for unreachable;
+  injected fetch for the deterministic timeout path.
+- `tests/transport/activitywatch/schemas.test.ts` — direct schema coverage.
+
+## Testing approach
+
+Follow `docs/testing.md` → "Transport — REST": undici `MockAgent` +
+`setGlobalDispatcher`, `disableNetConnect`, `assertNoPendingInterceptors`.
+Cases: happy buckets/events/info; bucket discovery by type; window/afk
+projection incl. skip-malformed; empty bucket → `[]`; non-2xx →
+`ActivityWatchRequestError`; connection error → `ActivityWatchUnreachableError`;
+timeout (injected fetch honouring the abort signal) → unreachable with
+`timedOut`; non-JSON / shape-mismatch → `ActivityWatchParseError`; invalid
+window (`end` before `start`) rejected before any request. Coverage gate 80%.
+
+## New dependency
+
+`undici` (devDependency only) — the REST-mock pattern prescribed by
+`docs/testing.md`; Node bundles undici for global `fetch` but the importable
+`MockAgent`/`setGlobalDispatcher` test API needs the package present. No
+existing dependency intercepts outbound HTTP. Not shipped in the runtime image.
+
+## Observability — don't silently drop telemetry
+
+`getWindowEvents` / `getAfkEvents` and `listBuckets` **skip** individual
+malformed entries rather than failing the whole pull, but skipping silently
+would hide a real watcher/version problem. The client takes an optional
+injected `logger` (`{ warn(obj, msg): void }`, default a noop) and emits a warn
+per skipped entry. The top-level shape is still validated strictly (a buckets
+body that is not an object, or an events body that is not an array, throws
+`ActivityWatchParseError`); only per-entry shape mismatches are skipped+warned.
+
+## License-boundary note
+
+REST-only over HTTP; no ActivityWatch source linked, no GPL binary added to the
+image. New dep is dev-only.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -30,6 +30,7 @@
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.45.0",
+        "undici": "^8.5.0",
         "vitest": "^3.2.4",
         "yaml": "^2.9.0"
       },
@@ -6140,6 +6141,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/server/package.json
+++ b/server/package.json
@@ -44,6 +44,7 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.45.0",
+    "undici": "^8.5.0",
     "vitest": "^3.2.4",
     "yaml": "^2.9.0"
   },

--- a/server/src/transport/activitywatch/client.ts
+++ b/server/src/transport/activitywatch/client.ts
@@ -1,0 +1,331 @@
+/**
+ * REST client for a single client's `aw-server`.
+ *
+ * The Phase-5 telemetry job (`docs/architecture.md` → "Inbound (client →
+ * server)") opens an SSH port-forward to the client's `aw-server`
+ * (`localhost:5600`, never network-exposed — #86) and then drives this client
+ * against the local end of that forward to pull window/afk events for a
+ * polling window. This module only needs the resulting base URL; it never
+ * opens the tunnel itself.
+ *
+ * License boundary: REST-only over HTTP. No ActivityWatch source is linked in
+ * process and no GPL binary is added to the image — the integration is purely
+ * the documented HTTP API (`CLAUDE.md` → "License boundaries" rule 4;
+ * `docs/licensing-analysis.md`).
+ */
+import { z } from "zod";
+import {
+  ActivityWatchParseError,
+  ActivityWatchRequestError,
+  ActivityWatchUnreachableError,
+} from "./errors.js";
+import {
+  awAfkDataSchema,
+  awBucketSchema,
+  awBucketsResponseSchema,
+  awEventSchema,
+  awEventsResponseSchema,
+  awServerInfoSchema,
+  awWindowDataSchema,
+  BUCKET_TYPE_AFK,
+  BUCKET_TYPE_WINDOW,
+  type AwAfkEvent,
+  type AwBucket,
+  type AwEvent,
+  type AwServerInfo,
+  type AwWindowEvent,
+} from "./schemas.js";
+
+/** Minimal structured-logger seam (a subset of pino's `warn`); default noop. */
+export interface ActivityWatchLogger {
+  warn(obj: Record<string, unknown>, msg: string): void;
+}
+
+const NOOP_LOGGER: ActivityWatchLogger = { warn: () => undefined };
+
+/**
+ * The minimal `fetch` surface this client uses. Deliberately structural rather
+ * than the full global `typeof fetch`: the Node 22 global `fetch` satisfies it
+ * in production, and a test can satisfy it with undici's `fetch` bound to a
+ * `MockAgent` dispatcher — without an `as` cast on either side (`CLAUDE.md` →
+ * "no unchecked `as` casts").
+ */
+export type FetchLike = (
+  input: string | URL,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<unknown>;
+}>;
+
+/** Options for constructing an {@link ActivityWatchClient}. */
+export interface ActivityWatchClientOptions {
+  /**
+   * Base URL of the `aw-server` REST API, e.g. `http://localhost:5600` — in
+   * production the local end of the SSH port-forward (#86). A trailing slash
+   * is tolerated.
+   */
+  baseUrl: string;
+  /** Per-request timeout in milliseconds. Defaults to 10_000. */
+  timeoutMs?: number;
+  /**
+   * `fetch` implementation to use. Defaults to the global `fetch`; injectable
+   * for dependency injection and deterministic timeout tests.
+   */
+  fetch?: FetchLike;
+  /** Structured logger for skipped-entry warnings. Defaults to a noop. */
+  logger?: ActivityWatchLogger;
+}
+
+/** Time window for an events query. */
+export interface EventQuery {
+  /** Pull events at/after this instant. */
+  start: Date;
+  /** Pull events up to this instant; must not be before {@link start}. */
+  end: Date;
+  /** Optional cap on the number of events returned (`aw-server` `limit`). */
+  limit?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Typed, REST-only client for `aw-server`'s buckets/events/info endpoints.
+ *
+ * Every method validates the response with a zod schema before returning. The
+ * three failure modes are distinguished by the error taxonomy in
+ * `./errors.ts`: unreachable (feeds the offline-queue / retry), non-2xx
+ * request failure, and malformed response.
+ */
+export class ActivityWatchClient {
+  readonly #baseUrl: string;
+  readonly #timeoutMs: number;
+  readonly #fetch: FetchLike;
+  readonly #logger: ActivityWatchLogger;
+
+  constructor(options: ActivityWatchClientOptions) {
+    // Normalize away any trailing slashes so `${baseUrl}${path}` (path starts
+    // with `/api/0/...`) never produces a double slash.
+    this.#baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.#fetch = options.fetch ?? globalThis.fetch;
+    this.#logger = options.logger ?? NOOP_LOGGER;
+  }
+
+  /** The normalized base URL this client targets. */
+  get baseUrl(): string {
+    return this.#baseUrl;
+  }
+
+  /** `GET /api/0/info` — server identity and version. */
+  async getInfo(): Promise<AwServerInfo> {
+    const body = await this.#getJson("/api/0/info");
+    return this.#parse(awServerInfoSchema, body, "/api/0/info");
+  }
+
+  /**
+   * `GET /api/0/buckets/` — all buckets on the server. A bucket entry that
+   * fails validation is skipped (and logged) so one malformed bucket doesn't
+   * sink the rest; a non-object top-level body is a parse error.
+   */
+  async listBuckets(): Promise<AwBucket[]> {
+    const path = "/api/0/buckets/";
+    const body = await this.#getJson(path);
+    const record = this.#parse(awBucketsResponseSchema, body, path);
+
+    const buckets: AwBucket[] = [];
+    for (const [id, raw] of Object.entries(record)) {
+      const parsed = awBucketSchema.safeParse(raw);
+      if (parsed.success) {
+        buckets.push(parsed.data);
+      } else {
+        this.#logger.warn(
+          { bucketId: id, baseUrl: this.#baseUrl },
+          "skipping malformed aw-server bucket",
+        );
+      }
+    }
+    return buckets;
+  }
+
+  /**
+   * `GET /api/0/buckets/{id}/events` for the window — events whose `data`
+   * matches `{ start, end }`. The top-level body must be an array (else a parse
+   * error); an individual event whose envelope is malformed is skipped+logged.
+   */
+  async getEvents(bucketId: string, query: EventQuery): Promise<AwEvent[]> {
+    this.#assertWindow(query);
+    const path = this.#eventsPath(bucketId, query);
+    const body = await this.#getJson(path);
+    const rawEvents = this.#parse(awEventsResponseSchema, body, path);
+
+    const events: AwEvent[] = [];
+    for (const raw of rawEvents) {
+      const parsed = awEventSchema.safeParse(raw);
+      if (parsed.success) {
+        events.push(parsed.data);
+      } else {
+        this.#logger.warn(
+          { bucketId, baseUrl: this.#baseUrl },
+          "skipping malformed aw-server event",
+        );
+      }
+    }
+    return events;
+  }
+
+  /**
+   * Window-watcher events for the polling window, with `data` narrowed to
+   * `{ app, title }`. Locates every `currentwindow` bucket, pulls its events,
+   * and projects each; events whose `data` is not window-shaped are skipped.
+   */
+  async getWindowEvents(query: EventQuery): Promise<AwWindowEvent[]> {
+    const buckets = await this.#bucketsOfType(BUCKET_TYPE_WINDOW);
+    const out: AwWindowEvent[] = [];
+    for (const bucket of buckets) {
+      const events = await this.getEvents(bucket.id, query);
+      for (const event of events) {
+        const data = awWindowDataSchema.safeParse(event.data);
+        if (data.success) {
+          out.push({
+            bucketId: bucket.id,
+            timestamp: event.timestamp,
+            durationSeconds: event.duration,
+            app: data.data.app,
+            title: data.data.title,
+          });
+        } else {
+          this.#logger.warn(
+            { bucketId: bucket.id, baseUrl: this.#baseUrl },
+            "skipping aw-server event with non-window data",
+          );
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Afk-watcher events for the polling window, with `data` narrowed to
+   * `{ status }`. Same discovery/projection contract as
+   * {@link getWindowEvents}, over `afkstatus` buckets.
+   */
+  async getAfkEvents(query: EventQuery): Promise<AwAfkEvent[]> {
+    const buckets = await this.#bucketsOfType(BUCKET_TYPE_AFK);
+    const out: AwAfkEvent[] = [];
+    for (const bucket of buckets) {
+      const events = await this.getEvents(bucket.id, query);
+      for (const event of events) {
+        const data = awAfkDataSchema.safeParse(event.data);
+        if (data.success) {
+          out.push({
+            bucketId: bucket.id,
+            timestamp: event.timestamp,
+            durationSeconds: event.duration,
+            status: data.data.status,
+          });
+        } else {
+          this.#logger.warn(
+            { bucketId: bucket.id, baseUrl: this.#baseUrl },
+            "skipping aw-server event with non-afk data",
+          );
+        }
+      }
+    }
+    return out;
+  }
+
+  /** Buckets whose `type` matches, via {@link listBuckets}. */
+  async #bucketsOfType(type: string): Promise<AwBucket[]> {
+    const buckets = await this.listBuckets();
+    return buckets.filter((bucket) => bucket.type === type);
+  }
+
+  /** Build the `events` path with windowed query params. */
+  #eventsPath(bucketId: string, query: EventQuery): string {
+    const params = new URLSearchParams({
+      start: query.start.toISOString(),
+      end: query.end.toISOString(),
+    });
+    if (query.limit !== undefined) {
+      params.set("limit", String(query.limit));
+    }
+    return `/api/0/buckets/${encodeURIComponent(bucketId)}/events?${params.toString()}`;
+  }
+
+  /** Reject an inverted window before issuing a request. */
+  #assertWindow(query: EventQuery): void {
+    if (query.end.getTime() < query.start.getTime()) {
+      throw new RangeError(
+        `EventQuery.end (${query.end.toISOString()}) is before start (${query.start.toISOString()})`,
+      );
+    }
+  }
+
+  /**
+   * Issue a GET and return the parsed JSON body, mapping every failure to the
+   * error taxonomy: a thrown `fetch` (connection error / abort timeout) →
+   * unreachable; a non-2xx status → request error; a non-JSON body → parse
+   * error.
+   */
+  async #getJson(path: string): Promise<unknown> {
+    let response: Awaited<ReturnType<FetchLike>>;
+    try {
+      response = await this.#fetch(`${this.#baseUrl}${path}`, {
+        method: "GET",
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(this.#timeoutMs),
+      });
+    } catch (cause) {
+      throw new ActivityWatchUnreachableError(this.#baseUrl, path, cause, isTimeout(cause));
+    }
+
+    if (!response.ok) {
+      throw new ActivityWatchRequestError(
+        this.#baseUrl,
+        path,
+        response.status,
+        response.statusText,
+      );
+    }
+
+    try {
+      return (await response.json()) as unknown;
+    } catch (cause) {
+      throw new ActivityWatchParseError(
+        this.#baseUrl,
+        path,
+        cause instanceof Error ? cause.message : "response body was not valid JSON",
+      );
+    }
+  }
+
+  /** Validate a body against `schema`, throwing a parse error on mismatch. */
+  #parse<T>(schema: z.ZodType<T>, body: unknown, path: string): T {
+    const result = schema.safeParse(body);
+    if (!result.success) {
+      throw new ActivityWatchParseError(
+        this.#baseUrl,
+        path,
+        z.prettifyError(result.error),
+        result.error,
+      );
+    }
+    return result.data;
+  }
+}
+
+/**
+ * Whether a thrown `fetch` error is the per-request abort timeout.
+ * `AbortSignal.timeout` rejects with a `TimeoutError`; a manual abort yields an
+ * `AbortError`. Both are name-tagged on the thrown `DOMException`/`Error`.
+ */
+function isTimeout(cause: unknown): boolean {
+  return cause instanceof Error && (cause.name === "TimeoutError" || cause.name === "AbortError");
+}

--- a/server/src/transport/activitywatch/errors.ts
+++ b/server/src/transport/activitywatch/errors.ts
@@ -1,0 +1,87 @@
+/**
+ * Error taxonomy for the ActivityWatch REST client.
+ *
+ * The Phase-5 telemetry job needs to tell three failure modes apart so it can
+ * react correctly (`docs/architecture.md` → "Inbound (client → server)"):
+ *
+ * - {@link ActivityWatchUnreachableError} — the request never produced an HTTP
+ *   response (connection refused, DNS failure, the SSH forward is down, or the
+ *   per-request timeout fired). This is the "host unreachable" case that feeds
+ *   the offline-queue / retry path; the client should be probed again later.
+ * - {@link ActivityWatchRequestError} — `aw-server` answered with a non-2xx
+ *   status. The host is reachable; the request itself failed.
+ * - {@link ActivityWatchParseError} — `aw-server` answered 2xx but the body was
+ *   not JSON, or did not match the schema we validate against. We never trust
+ *   an unvalidated payload (`CLAUDE.md` → "Validate all external input").
+ *
+ * License boundary: none touched — plain TypeScript, no ActivityWatch code
+ * linked (REST-only integration, `docs/licensing-analysis.md`).
+ */
+import type { z } from "zod";
+
+/** Common base so callers can `instanceof ActivityWatchError` to catch all. */
+export class ActivityWatchError extends Error {
+  /** Base URL of the `aw-server` the failed request targeted. */
+  readonly baseUrl: string;
+  /** Request path (relative to {@link baseUrl}) that failed. */
+  readonly path: string;
+
+  constructor(baseUrl: string, path: string, message: string) {
+    super(message);
+    this.name = "ActivityWatchError";
+    this.baseUrl = baseUrl;
+    this.path = path;
+  }
+}
+
+/**
+ * The request never produced an HTTP response. Carries the underlying `cause`
+ * (the error `fetch` threw) and {@link timedOut}, set when the failure was the
+ * per-request abort timeout rather than a connection error — both feed the
+ * offline-queue / retry path the same way, but the distinction is useful in
+ * logs and tests.
+ */
+export class ActivityWatchUnreachableError extends ActivityWatchError {
+  /** True when the per-request timeout aborted the call. */
+  readonly timedOut: boolean;
+
+  constructor(baseUrl: string, path: string, cause: unknown, timedOut: boolean) {
+    super(
+      baseUrl,
+      path,
+      `ActivityWatch server at ${baseUrl} is unreachable${timedOut ? " (request timed out)" : ""}`,
+    );
+    // Preserve the originating error without widening this class's typed API.
+    super.cause = cause;
+    this.name = "ActivityWatchUnreachableError";
+    this.timedOut = timedOut;
+  }
+}
+
+/** `aw-server` answered with a non-2xx status. */
+export class ActivityWatchRequestError extends ActivityWatchError {
+  /** The HTTP status code returned. */
+  readonly statusCode: number;
+
+  constructor(baseUrl: string, path: string, statusCode: number, statusText: string) {
+    super(
+      baseUrl,
+      path,
+      `ActivityWatch request to ${path} failed with ${statusCode} ${statusText}`.trimEnd(),
+    );
+    this.name = "ActivityWatchRequestError";
+    this.statusCode = statusCode;
+  }
+}
+
+/** The response body was not JSON, or did not match the expected schema. */
+export class ActivityWatchParseError extends ActivityWatchError {
+  /** The zod error when a schema rejected the body; absent for non-JSON. */
+  readonly zodError: z.ZodError | undefined;
+
+  constructor(baseUrl: string, path: string, message: string, zodError?: z.ZodError) {
+    super(baseUrl, path, `Malformed ActivityWatch response from ${path}: ${message}`);
+    this.name = "ActivityWatchParseError";
+    this.zodError = zodError;
+  }
+}

--- a/server/src/transport/activitywatch/index.ts
+++ b/server/src/transport/activitywatch/index.ts
@@ -1,2 +1,32 @@
 /** ActivityWatch transport: HTTP REST client tunneled over SSH to `aw-server`. */
 export const moduleName = "transport/activitywatch";
+
+export {
+  ActivityWatchClient,
+  type ActivityWatchClientOptions,
+  type ActivityWatchLogger,
+  type EventQuery,
+  type FetchLike,
+} from "./client.js";
+export {
+  ActivityWatchError,
+  ActivityWatchParseError,
+  ActivityWatchRequestError,
+  ActivityWatchUnreachableError,
+} from "./errors.js";
+export {
+  awAfkDataSchema,
+  awBucketSchema,
+  awBucketsResponseSchema,
+  awEventSchema,
+  awEventsResponseSchema,
+  awServerInfoSchema,
+  awWindowDataSchema,
+  BUCKET_TYPE_AFK,
+  BUCKET_TYPE_WINDOW,
+  type AwAfkEvent,
+  type AwBucket,
+  type AwEvent,
+  type AwServerInfo,
+  type AwWindowEvent,
+} from "./schemas.js";

--- a/server/src/transport/activitywatch/schemas.ts
+++ b/server/src/transport/activitywatch/schemas.ts
@@ -1,0 +1,125 @@
+/**
+ * zod schemas for the `aw-server` REST responses this client consumes.
+ *
+ * Everything `aw-server` returns is untrusted external input and is validated
+ * here before it crosses into typed code (`CLAUDE.md` → "Validate all external
+ * input"). We validate only the fields the dashboard actually uses; zod strips
+ * unknown keys by default, so ActivityWatch adding or renaming fields we don't
+ * read never breaks us.
+ *
+ * Normalisation of these events into `UsageSample` rows (dedup of clock-skew
+ * overlaps, dropping future-timestamped events, aggregation) is deliberately
+ * NOT here — that is #88. This module only shapes and types the raw API.
+ */
+import { z } from "zod";
+
+/**
+ * An ISO-8601 timestamp string from `aw-server`, parsed to a `Date`. AW emits
+ * offset-qualified timestamps (`…Z` or `…+00:00`); we accept anything
+ * `Date.parse` understands and reject only genuinely unparseable values so a
+ * corrupt timestamp surfaces as a parse error rather than an `Invalid Date`.
+ */
+const awTimestamp = z
+  .string()
+  .refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: "not a parseable ISO-8601 timestamp",
+  })
+  .transform((value) => new Date(value));
+
+/** `GET /api/0/info` — server identity and version. */
+export const awServerInfoSchema = z.object({
+  hostname: z.string(),
+  version: z.string(),
+  testing: z.boolean(),
+  device_id: z.string().optional(),
+});
+
+/** Inferred `aw-server` info. */
+export type AwServerInfo = z.infer<typeof awServerInfoSchema>;
+
+/**
+ * One bucket's metadata. `type` is the watcher discriminator we filter on
+ * (`currentwindow` for the window watcher, `afkstatus` for the afk watcher);
+ * `name`/`last_updated` are nullable in practice and unused beyond display.
+ */
+export const awBucketSchema = z.object({
+  id: z.string(),
+  created: awTimestamp,
+  name: z.string().nullable().optional(),
+  type: z.string(),
+  client: z.string(),
+  hostname: z.string(),
+  last_updated: awTimestamp.nullable().optional(),
+});
+
+/** Inferred bucket metadata. */
+export type AwBucket = z.infer<typeof awBucketSchema>;
+
+/**
+ * `GET /api/0/buckets/` returns an object keyed by bucket id. The top-level
+ * shape must be an object of unknown values; each entry is validated
+ * individually by the client so one malformed bucket doesn't sink the rest.
+ */
+export const awBucketsResponseSchema = z.record(z.string(), z.unknown());
+
+/**
+ * One event from `GET /api/0/buckets/{id}/events`. `duration` is in seconds
+ * (a float). `data` is left as an opaque record here; the watcher-specific
+ * shape is applied per event by {@link awWindowDataSchema} /
+ * {@link awAfkDataSchema} so a stray non-conforming event can be skipped
+ * rather than failing the whole pull.
+ */
+export const awEventSchema = z.object({
+  id: z.number().optional(),
+  timestamp: awTimestamp,
+  duration: z.number().nonnegative(),
+  data: z.record(z.string(), z.unknown()),
+});
+
+/** Inferred generic event (untyped `data`). */
+export type AwEvent = z.infer<typeof awEventSchema>;
+
+/** `GET /api/0/buckets/{id}/events` — the response is a JSON array of events. */
+export const awEventsResponseSchema = z.array(z.unknown());
+
+/** `data` for an `aw-watcher-window` event. */
+export const awWindowDataSchema = z.object({
+  app: z.string(),
+  title: z.string(),
+});
+
+/** `data` for an `aw-watcher-afk` event. */
+export const awAfkDataSchema = z.object({
+  status: z.enum(["afk", "not-afk"]),
+});
+
+/** AW bucket `type` for the window watcher. */
+export const BUCKET_TYPE_WINDOW = "currentwindow";
+/** AW bucket `type` for the afk watcher. */
+export const BUCKET_TYPE_AFK = "afkstatus";
+
+/** A window event with `data` narrowed to `{ app, title }`. */
+export interface AwWindowEvent {
+  /** The bucket this event came from (a client may host more than one). */
+  bucketId: string;
+  /** Event start, in UTC. */
+  timestamp: Date;
+  /** Event duration in seconds. */
+  durationSeconds: number;
+  /** Foreground application identifier reported by the watcher. */
+  app: string;
+  /** Foreground window title reported by the watcher. */
+  title: string;
+}
+
+/** An afk event with `data` narrowed to `{ status }`. */
+export interface AwAfkEvent {
+  /** The bucket this event came from. */
+  bucketId: string;
+  /** Event start, in UTC. */
+  timestamp: Date;
+  /** Event duration in seconds. */
+  durationSeconds: number;
+  /** Whether the user was away-from-keyboard for this interval. */
+  status: "afk" | "not-afk";
+}

--- a/server/tests/transport/activitywatch/client.test.ts
+++ b/server/tests/transport/activitywatch/client.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Unit tests for the ActivityWatch REST client.
+ *
+ * Follows `docs/testing.md` → "Transport — REST": undici's `MockAgent`
+ * intercepts HTTP so no live `aw-server` is needed for the happy / non-2xx /
+ * malformed paths, and `replyWithError` simulates a connection failure. The
+ * client is driven with undici's `fetch` bound to the mock agent via its
+ * `dispatcher` option (Node's global `fetch` does not honour the npm undici
+ * package's global dispatcher, so per-request injection is both correct and
+ * leak-free across tests). The deterministic timeout path uses an injected
+ * `fetch` that honours the abort signal, avoiding a flaky delayed reply.
+ */
+import { MockAgent, fetch as undiciFetch } from "undici";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ActivityWatchClient,
+  ActivityWatchParseError,
+  ActivityWatchRequestError,
+  ActivityWatchUnreachableError,
+  type ActivityWatchClientOptions,
+  type ActivityWatchLogger,
+  type FetchLike,
+} from "../../../src/transport/activitywatch/index.js";
+
+const BASE_URL = "http://localhost:5600";
+const START = new Date("2024-01-01T00:00:00.000Z");
+const END = new Date("2024-01-01T01:00:00.000Z");
+
+/** A JSON reply with the content-type `Response.json()` expects. */
+const JSON_HEADERS = { headers: { "content-type": "application/json" } } as const;
+
+let agent: MockAgent;
+
+beforeEach(() => {
+  agent = new MockAgent();
+  agent.disableNetConnect();
+});
+
+afterEach(async () => {
+  await agent.close();
+});
+
+/** undici `fetch` bound to the per-test mock agent — satisfies `FetchLike`. */
+function mockFetch(): FetchLike {
+  return (input, init) => undiciFetch(input, { ...init, dispatcher: agent });
+}
+
+/** A client whose fetch is routed through the mock agent. */
+function makeClient(extra: Partial<Omit<ActivityWatchClientOptions, "baseUrl">> = {}) {
+  return new ActivityWatchClient({ baseUrl: BASE_URL, fetch: mockFetch(), ...extra });
+}
+
+function spyLogger(): ActivityWatchLogger & { warn: ReturnType<typeof vi.fn> } {
+  return { warn: vi.fn() };
+}
+
+describe("ActivityWatchClient construction", () => {
+  it("strips a trailing slash from the base URL", () => {
+    const client = new ActivityWatchClient({ baseUrl: "http://localhost:5600///" });
+    expect(client.baseUrl).toBe("http://localhost:5600");
+  });
+});
+
+describe("getInfo", () => {
+  it("returns parsed server info on the happy path", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/api/0/info", method: "GET" })
+      .reply(
+        200,
+        { hostname: "kid-laptop", version: "aw-server 0.13", testing: false, device_id: "abc" },
+        JSON_HEADERS,
+      );
+
+    await expect(makeClient().getInfo()).resolves.toEqual({
+      hostname: "kid-laptop",
+      version: "aw-server 0.13",
+      testing: false,
+      device_id: "abc",
+    });
+    agent.assertNoPendingInterceptors();
+  });
+
+  it("rejects a malformed info body with a parse error carrying the zod issue", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/api/0/info", method: "GET" })
+      .reply(200, { hostname: "kid-laptop" }, JSON_HEADERS); // missing version/testing
+
+    const error = await makeClient()
+      .getInfo()
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ActivityWatchParseError);
+    expect((error as ActivityWatchParseError).zodError).toBeDefined();
+  });
+});
+
+describe("listBuckets", () => {
+  it("returns the parsed buckets and coerces timestamps to Date", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/api/0/buckets/", method: "GET" })
+      .reply(
+        200,
+        {
+          "aw-watcher-window_host": {
+            id: "aw-watcher-window_host",
+            created: "2024-01-01T00:00:00.000Z",
+            name: null,
+            type: "currentwindow",
+            client: "aw-watcher-window",
+            hostname: "host",
+            last_updated: "2024-01-02T00:00:00.000Z",
+          },
+        },
+        JSON_HEADERS,
+      );
+
+    const buckets = await makeClient().listBuckets();
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]?.type).toBe("currentwindow");
+    expect(buckets[0]?.created).toBeInstanceOf(Date);
+  });
+
+  it("skips a malformed bucket entry, keeps the rest, and warns", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/api/0/buckets/", method: "GET" })
+      .reply(
+        200,
+        {
+          good: {
+            id: "good",
+            created: "2024-01-01T00:00:00.000Z",
+            type: "afkstatus",
+            client: "aw-watcher-afk",
+            hostname: "host",
+          },
+          bad: { id: 123 }, // id must be a string; whole entry is malformed
+        },
+        JSON_HEADERS,
+      );
+
+    const logger = spyLogger();
+    const buckets = await makeClient({ logger }).listBuckets();
+    expect(buckets.map((b) => b.id)).toEqual(["good"]);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a non-object buckets body with a parse error", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/api/0/buckets/", method: "GET" })
+      .reply(200, JSON.stringify(42), JSON_HEADERS);
+
+    await expect(makeClient().listBuckets()).rejects.toBeInstanceOf(ActivityWatchParseError);
+  });
+});
+
+describe("getEvents", () => {
+  it("serializes the window as start/end/limit query params", async () => {
+    let capturedPath = "";
+    agent
+      .get(BASE_URL)
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          capturedPath = p;
+          return p.startsWith("/api/0/buckets/");
+        },
+      })
+      .reply(200, [], JSON_HEADERS);
+
+    await makeClient().getEvents("aw-watcher-window_host", { start: START, end: END, limit: 100 });
+
+    expect(capturedPath).toContain("/api/0/buckets/aw-watcher-window_host/events?");
+    expect(capturedPath).toContain("start=2024-01-01T00%3A00%3A00.000Z");
+    expect(capturedPath).toContain("end=2024-01-01T01%3A00%3A00.000Z");
+    expect(capturedPath).toContain("limit=100");
+  });
+
+  it("omits the limit param when not supplied and returns an empty list for an empty bucket", async () => {
+    let capturedPath = "";
+    agent
+      .get(BASE_URL)
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          capturedPath = p;
+          return p.startsWith("/api/0/buckets/");
+        },
+      })
+      .reply(200, [], JSON_HEADERS);
+
+    await expect(makeClient().getEvents("b", { start: START, end: END })).resolves.toEqual([]);
+    expect(capturedPath).not.toContain("limit=");
+  });
+
+  it("skips a malformed event, keeps the valid ones, and warns", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/0/buckets/") })
+      .reply(
+        200,
+        [
+          { id: 1, timestamp: "2024-01-01T00:10:00.000Z", duration: 60, data: { app: "firefox" } },
+          { id: 2, timestamp: "not-a-date", duration: 60, data: {} }, // bad timestamp
+          { id: 3, timestamp: "2024-01-01T00:20:00.000Z", duration: -5, data: {} }, // negative duration
+        ],
+        JSON_HEADERS,
+      );
+
+    const logger = spyLogger();
+    const events = await makeClient({ logger }).getEvents("b", { start: START, end: END });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.timestamp).toBeInstanceOf(Date);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a non-array events body with a parse error", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/0/buckets/") })
+      .reply(200, { not: "an array" }, JSON_HEADERS);
+
+    await expect(makeClient().getEvents("b", { start: START, end: END })).rejects.toBeInstanceOf(
+      ActivityWatchParseError,
+    );
+  });
+
+  it("rejects an inverted window before issuing any request", async () => {
+    // No interceptor registered: if a request were made, disableNetConnect
+    // would surface a different error. A RangeError proves we never sent one.
+    await expect(makeClient().getEvents("b", { start: END, end: START })).rejects.toBeInstanceOf(
+      RangeError,
+    );
+  });
+});
+
+describe("getWindowEvents / getAfkEvents", () => {
+  function bucketsBody(): Record<string, unknown> {
+    return {
+      "aw-watcher-window_host": {
+        id: "aw-watcher-window_host",
+        created: "2024-01-01T00:00:00.000Z",
+        type: "currentwindow",
+        client: "aw-watcher-window",
+        hostname: "host",
+      },
+      "aw-watcher-afk_host": {
+        id: "aw-watcher-afk_host",
+        created: "2024-01-01T00:00:00.000Z",
+        type: "afkstatus",
+        client: "aw-watcher-afk",
+        hostname: "host",
+      },
+    };
+  }
+
+  it("projects window events and skips events whose data is not window-shaped", async () => {
+    const pool = agent.get(BASE_URL);
+    pool
+      .intercept({ path: "/api/0/buckets/", method: "GET" })
+      .reply(200, bucketsBody(), JSON_HEADERS);
+    pool
+      .intercept({
+        method: "GET",
+        path: (p) => p.startsWith("/api/0/buckets/aw-watcher-window_host/events"),
+      })
+      .reply(
+        200,
+        [
+          {
+            id: 1,
+            timestamp: "2024-01-01T00:10:00.000Z",
+            duration: 60,
+            data: { app: "firefox", title: "ActivityWatch" },
+          },
+          { id: 2, timestamp: "2024-01-01T00:11:00.000Z", duration: 30, data: { status: "afk" } },
+        ],
+        JSON_HEADERS,
+      );
+
+    const logger = spyLogger();
+    const events = await makeClient({ logger }).getWindowEvents({ start: START, end: END });
+    expect(events).toEqual([
+      {
+        bucketId: "aw-watcher-window_host",
+        timestamp: new Date("2024-01-01T00:10:00.000Z"),
+        durationSeconds: 60,
+        app: "firefox",
+        title: "ActivityWatch",
+      },
+    ]);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("projects afk events from the afkstatus bucket", async () => {
+    const pool = agent.get(BASE_URL);
+    pool
+      .intercept({ path: "/api/0/buckets/", method: "GET" })
+      .reply(200, bucketsBody(), JSON_HEADERS);
+    pool
+      .intercept({
+        method: "GET",
+        path: (p) => p.startsWith("/api/0/buckets/aw-watcher-afk_host/events"),
+      })
+      .reply(
+        200,
+        [{ id: 1, timestamp: "2024-01-01T00:10:00.000Z", duration: 600, data: { status: "afk" } }],
+        JSON_HEADERS,
+      );
+
+    const events = await makeClient().getAfkEvents({ start: START, end: END });
+    expect(events).toEqual([
+      {
+        bucketId: "aw-watcher-afk_host",
+        timestamp: new Date("2024-01-01T00:10:00.000Z"),
+        durationSeconds: 600,
+        status: "afk",
+      },
+    ]);
+  });
+
+  it("skips afk-bucket events whose data is not afk-shaped and warns", async () => {
+    const pool = agent.get(BASE_URL);
+    pool
+      .intercept({ path: "/api/0/buckets/", method: "GET" })
+      .reply(200, bucketsBody(), JSON_HEADERS);
+    pool
+      .intercept({
+        method: "GET",
+        path: (p) => p.startsWith("/api/0/buckets/aw-watcher-afk_host/events"),
+      })
+      .reply(
+        200,
+        [
+          { id: 1, timestamp: "2024-01-01T00:10:00.000Z", duration: 600, data: { status: "afk" } },
+          {
+            id: 2,
+            timestamp: "2024-01-01T00:20:00.000Z",
+            duration: 30,
+            data: { app: "firefox", title: "x" }, // window data in an afk bucket
+          },
+        ],
+        JSON_HEADERS,
+      );
+
+    const logger = spyLogger();
+    const events = await makeClient({ logger }).getAfkEvents({ start: START, end: END });
+    expect(events.map((e) => e.status)).toEqual(["afk"]);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty list when no bucket of the requested type exists", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/api/0/buckets/", method: "GET" })
+      .reply(
+        200,
+        {
+          "aw-watcher-afk_host": {
+            id: "aw-watcher-afk_host",
+            created: "2024-01-01T00:00:00.000Z",
+            type: "afkstatus",
+            client: "aw-watcher-afk",
+            hostname: "host",
+          },
+        },
+        JSON_HEADERS,
+      );
+
+    await expect(makeClient().getWindowEvents({ start: START, end: END })).resolves.toEqual([]);
+  });
+});
+
+describe("error taxonomy", () => {
+  it("maps a non-2xx status to a request error that preserves the status code", async () => {
+    agent.get(BASE_URL).intercept({ path: "/api/0/info", method: "GET" }).reply(503, "unavailable");
+
+    const error = await makeClient()
+      .getInfo()
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ActivityWatchRequestError);
+    expect((error as ActivityWatchRequestError).statusCode).toBe(503);
+  });
+
+  it("maps a connection failure to an unreachable error (not timed out)", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/api/0/info", method: "GET" })
+      .replyWithError(new Error("connect ECONNREFUSED 127.0.0.1:5600"));
+
+    const error = await makeClient()
+      .getInfo()
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ActivityWatchUnreachableError);
+    expect((error as ActivityWatchUnreachableError).timedOut).toBe(false);
+    expect((error as ActivityWatchUnreachableError).cause).toBeInstanceOf(Error);
+  });
+
+  it("maps a per-request timeout to an unreachable error flagged timedOut", async () => {
+    // Injected fetch that never resolves until the abort signal fires, so the
+    // 5ms timeout deterministically rejects with the signal's TimeoutError.
+    const hangingFetch: FetchLike = (_input, init) =>
+      new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal) {
+          signal.addEventListener("abort", () => {
+            reject(signal.reason);
+          });
+        }
+      });
+
+    const client = new ActivityWatchClient({
+      baseUrl: BASE_URL,
+      timeoutMs: 5,
+      fetch: hangingFetch,
+    });
+    const error = await client.getInfo().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ActivityWatchUnreachableError);
+    expect((error as ActivityWatchUnreachableError).timedOut).toBe(true);
+  });
+
+  it("maps a non-JSON body to a parse error with no zod issue", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/api/0/info", method: "GET" })
+      .reply(200, "<<not json>>", JSON_HEADERS);
+
+    const error = await makeClient()
+      .getInfo()
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ActivityWatchParseError);
+    expect((error as ActivityWatchParseError).zodError).toBeUndefined();
+  });
+
+  it("uses the noop logger by default when an entry is skipped", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/api/0/buckets/", method: "GET" })
+      .reply(200, { bad: { id: 7 } }, JSON_HEADERS);
+
+    // No logger injected: exercises the default noop path without throwing.
+    await expect(makeClient().listBuckets()).resolves.toEqual([]);
+  });
+});

--- a/server/tests/transport/activitywatch/client.test.ts
+++ b/server/tests/transport/activitywatch/client.test.ts
@@ -385,6 +385,19 @@ describe("error taxonomy", () => {
     expect((error as ActivityWatchRequestError).statusCode).toBe(503);
   });
 
+  it("maps a 404 (e.g. unknown bucket) to a request error preserving the status", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/0/buckets/") })
+      .reply(404, "no such bucket");
+
+    const error = await makeClient()
+      .getEvents("missing", { start: START, end: END })
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ActivityWatchRequestError);
+    expect((error as ActivityWatchRequestError).statusCode).toBe(404);
+  });
+
   it("maps a connection failure to an unreachable error (not timed out)", async () => {
     agent
       .get(BASE_URL)

--- a/server/tests/transport/activitywatch/schemas.test.ts
+++ b/server/tests/transport/activitywatch/schemas.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Direct coverage for the ActivityWatch response schemas — the validation
+ * boundary that every `aw-server` payload crosses before it becomes typed
+ * data (`CLAUDE.md` → "Validate all external input").
+ */
+import { describe, expect, it } from "vitest";
+import {
+  awAfkDataSchema,
+  awBucketSchema,
+  awEventSchema,
+  awServerInfoSchema,
+  awWindowDataSchema,
+} from "../../../src/transport/activitywatch/index.js";
+
+describe("awServerInfoSchema", () => {
+  it("accepts info with an optional device_id omitted", () => {
+    const parsed = awServerInfoSchema.parse({
+      hostname: "host",
+      version: "aw-server 0.13",
+      testing: true,
+    });
+    expect(parsed.device_id).toBeUndefined();
+  });
+
+  it("rejects info missing required fields", () => {
+    expect(awServerInfoSchema.safeParse({ hostname: "host" }).success).toBe(false);
+  });
+});
+
+describe("awBucketSchema", () => {
+  it("parses a bucket, allowing null name/last_updated and coercing created to a Date", () => {
+    const parsed = awBucketSchema.parse({
+      id: "b",
+      created: "2024-01-01T00:00:00.000Z",
+      name: null,
+      type: "currentwindow",
+      client: "aw-watcher-window",
+      hostname: "host",
+      last_updated: null,
+    });
+    expect(parsed.created).toBeInstanceOf(Date);
+    expect(parsed.created.toISOString()).toBe("2024-01-01T00:00:00.000Z");
+    expect(parsed.name).toBeNull();
+  });
+
+  it("rejects an unparseable created timestamp", () => {
+    const result = awBucketSchema.safeParse({
+      id: "b",
+      created: "yesterday",
+      type: "currentwindow",
+      client: "c",
+      hostname: "h",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("awEventSchema", () => {
+  it("coerces the timestamp to a Date and keeps duration", () => {
+    const parsed = awEventSchema.parse({
+      id: 1,
+      timestamp: "2024-01-01T00:00:00.000Z",
+      duration: 42.5,
+      data: { app: "firefox", title: "x" },
+    });
+    expect(parsed.timestamp).toBeInstanceOf(Date);
+    expect(parsed.duration).toBe(42.5);
+  });
+
+  it("rejects a negative duration", () => {
+    const result = awEventSchema.safeParse({
+      timestamp: "2024-01-01T00:00:00.000Z",
+      duration: -1,
+      data: {},
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("watcher data schemas", () => {
+  it("accepts window data and rejects a missing title", () => {
+    expect(awWindowDataSchema.safeParse({ app: "firefox", title: "x" }).success).toBe(true);
+    expect(awWindowDataSchema.safeParse({ app: "firefox" }).success).toBe(false);
+  });
+
+  it("accepts the afk status enum and rejects anything else", () => {
+    expect(awAfkDataSchema.safeParse({ status: "not-afk" }).success).toBe(true);
+    expect(awAfkDataSchema.safeParse({ status: "sleeping" }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `transport/activitywatch/` REST client the Phase-5 telemetry job drives to pull window/afk activity from a client's `aw-server`: `getInfo`, `listBuckets`, `getEvents` (windowed `start`/`end`/`limit`), and `getWindowEvents`/`getAfkEvents` that locate buckets by AW `type` and project each event's `data` through the watcher schema.
- Every response is zod-validated before it crosses into typed code; the top-level shape is strict, while individual malformed buckets/events are **skipped** and surfaced via an injected logger rather than silently dropped.
- Error taxonomy separates **unreachable** (connection error / per-request timeout — feeds the offline-queue / retry) from non-2xx **request** failures and **malformed-response** failures.

## Plan

Linked plan: `.claude/plans/issue-87-activitywatch-rest-client.md`
Roadmap: `docs/roadmap.md` → Phase 5 (ActivityWatch telemetry pull)

## Scope / boundaries

The client takes an injected base URL — the local end of the SSH port-forward (#86) — so it is a complete, fully-testable module on its own and composes with the forward later. **Out of scope (own issues):** the SSH port-forward that reaches `aw-server` (#86) and normalisation into `UsageSample` rows / dedup / clock-skew handling (#88). No `croner` scheduling here.

## License-boundary note

REST-only over HTTP per `CLAUDE.md` → "License boundaries" rule 4 and `docs/architecture.md` → "Process boundaries": no ActivityWatch source is linked in-process and no GPL binary is added to the Docker image. The one new dependency is **dev-only**, so the runtime image is unchanged and `license-guard` stays green.

## New dependency

- **`undici`** (devDependency only) — the REST-mock harness prescribed by `docs/testing.md` → "Transport — REST" (`MockAgent`). Node bundles undici for the global `fetch`, but the importable `MockAgent` test API needs the package present; no existing dependency intercepts outbound HTTP. Production uses Node's bundled global `fetch`, so nothing is added to the runtime/image. (Note: Node's global `fetch` does not honour the npm package's `setGlobalDispatcher`, so the client exposes a small structural `FetchLike` injection point and the tests pass undici's `fetch` bound to the mock agent's `dispatcher` — deterministic and leak-free across tests, no `as` casts.)

## Test plan

- [x] `format:check`, `lint`, `typecheck` clean
- [x] `npm test` — 191 passing; new module 100% lines (98% branch), overall coverage 99.5% (gate 80%)
- [x] happy paths for info / buckets / events; bucket discovery by `type`; window/afk projection incl. skip-malformed + logger warn
- [x] empty bucket → `[]`; no matching bucket → `[]`
- [x] error taxonomy: non-2xx → `ActivityWatchRequestError` (status preserved); connection error → `ActivityWatchUnreachableError` (`timedOut=false`); timeout → unreachable (`timedOut=true`); non-JSON / shape mismatch → `ActivityWatchParseError`; inverted window rejected before any request

> Note for CI/local: the pre-existing `tests/api/plugin.test.ts` cases assume the default `/data` directory exists (the default `DATABASE_URL`); they fail on a clean checkout where it doesn't and are unrelated to this change.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtD3nspgxyqv3CiV5kFp65)_