### PR TITLE
feat(api): policy CRUD for users, clients & user-client links (#51, slice 1)

### DIFF
--- a/.claude/plans/issue-51-policy-crud.md
+++ b/.claude/plans/issue-51-policy-crud.md
@@ -1,0 +1,77 @@
+# Plan — #51 `/api/*` policy CRUD (slice 1: accounts + devices)
+
+Roadmap: `docs/roadmap.md` → Phase 2 ("`/api/*` JSON endpoints for the full
+policy model"). Umbrella issue #51 explicitly allows landing as per-entity
+follow-up PRs, each with tests.
+
+## Scope of this PR
+
+CRUD for the **account/device core** — the foundational entities every other
+policy row references by FK:
+
+- `User` (`/api/users`)
+- `Client` (`/api/clients`)
+- `UserOnClient` link (`/api/users/:userId/clients/:clientId`)
+
+Deferred to their own follow-up PRs under #51 (tracked issues, linked from the
+PR): `Activity` + `ActivityGroup` (+ the M2M), `Budget`, `Schedule`,
+`Exception`. `Grant` / `IntegrationToken` writes are explicitly Phase 10 (out
+of scope per the issue).
+
+## Why this slice
+
+`User` and `Client` are referenced by FK from `budgets`, `schedules`,
+`exceptions`, `usage_samples`, `grants`, `users_on_clients`. Landing them first
+gives the later per-entity PRs something to reference and lets the admin UI
+(#53) build the users/clients screens immediately.
+
+## Design (follows the merged #50/#52 conventions)
+
+- **DTOs** — zod schemas in `server/src/api/policy/dtos.ts`, reusing the shared
+  enums (`enums.ts`) and the error envelope (`api/errors.ts`). `tz` validated
+  with `isValidTimeZone` (ADR-0001) so a bad IANA name is a 400, not a stored
+  bad value. Response DTOs serialize epoch-second `Date` columns as ISO-8601
+  strings; types are inferred and shared with the frontend.
+- **Repository** — pure data-access functions in
+  `server/src/policy/repository.ts` taking the injected `PolicyDb` ("reads and
+  writes go through the policy service over `app.db`", `CLAUDE.md`). No HTTP
+  concerns here; unique-violation detection exposed as `isUniqueViolation()`
+  for the route layer to map to 409.
+- **Routes** — `server/src/api/policy/routes.ts`, registered inside the `/api`
+  plugin **after** `registerAuth` so every route sits behind
+  `app.requireAdmin` (anonymous → 401 envelope). Mutations map:
+  - missing row on GET/PATCH/DELETE → `404 not_found`
+  - duplicate `hostname` / duplicate `(client, linux_uid)` → `409 conflict`
+  - empty PATCH body / bad field → `400 validation_error`
+  - link PUT to a non-existent user or client → `404 not_found`
+
+## Routes
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| GET | `/api/users` | list |
+| POST | `/api/users` | create (201) |
+| GET | `/api/users/:id` | 404 if missing |
+| PATCH | `/api/users/:id` | partial; `tz: null` clears |
+| DELETE | `/api/users/:id` | 204; cascades links |
+| GET | `/api/clients` | list |
+| POST | `/api/clients` | create (201); dup hostname → 409 |
+| GET | `/api/clients/:id` | |
+| PATCH | `/api/clients/:id` | dup hostname → 409 |
+| DELETE | `/api/clients/:id` | 204; cascades links |
+| GET | `/api/users/:userId/clients` | list a user's links (404 if user missing) |
+| PUT | `/api/users/:userId/clients/:clientId` | upsert link; dup uid → 409 |
+| DELETE | `/api/users/:userId/clients/:clientId` | 204; 404 if link missing |
+
+## Tests
+
+- `tests/policy/repository.test.ts` — unit, against `testDb()`: CRUD round-trips,
+  cascade on user/client delete, unique-violation detection, link upsert.
+- `tests/api/policy.test.ts` — `app.inject()` through `buildTestApp` with a real
+  login cookie: per entity happy path + a validation-failure path + anonymous
+  401; plus 404 and 409 paths.
+
+## License boundary
+
+N/A — pure TypeScript + zod + Drizzle (`better-sqlite3`/`drizzle-orm`, already
+deps). No transport, no subprocess, no packaging change. No new dependency.

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -23,6 +23,32 @@ export {
 export { metaResponseSchema, type MetaResponse } from "./meta.js";
 export type { ZodTypeProvider } from "./validation.js";
 
+// Policy CRUD DTOs (#51): the account/device-core contract shared with the
+// frontend and integrators. Schemas live in `./policy/dtos.ts` next to the
+// routes; surfaced here so the whole `/api` contract imports from one barrel.
+export {
+  clientResponseSchema,
+  createClientSchema,
+  createUserSchema,
+  idParamsSchema,
+  linkResponseSchema,
+  tzSchema,
+  updateClientSchema,
+  updateUserSchema,
+  upsertLinkSchema,
+  userClientParamsSchema,
+  userIdParamsSchema,
+  userResponseSchema,
+  type ClientResponse,
+  type CreateClientRequest,
+  type CreateUserRequest,
+  type LinkResponse,
+  type UpdateClientRequest,
+  type UpdateUserRequest,
+  type UpsertLinkRequest,
+  type UserResponse,
+} from "./policy/index.js";
+
 // Auth DTOs (#52). Re-exported here so the frontend imports the auth contract
 // from the same `/api` surface as every other DTO; the schemas themselves live
 // in `../auth/dtos.ts` next to the routes that use them.

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -11,6 +11,7 @@ import type { FastifyInstance, FastifyPluginAsync } from "fastify";
 import { registerAuth } from "../auth/index.js";
 import type { Settings } from "../config.js";
 import { registerMetaRoute } from "./meta.js";
+import { registerPolicyRoutes } from "./policy/index.js";
 import { installApiConventions } from "./validation.js";
 
 /** Options the `/api` plugin needs from its host app. */
@@ -29,6 +30,8 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   installApiConventions(scope);
   await registerAuth(scope, opts.settings);
   registerMetaRoute(scope);
+  // Policy CRUD (#51) — registered after auth so `scope.requireAdmin` exists.
+  registerPolicyRoutes(scope);
 };
 
 /** Mount the JSON API under `/api` on the given app. */

--- a/server/src/api/policy/dtos.ts
+++ b/server/src/api/policy/dtos.ts
@@ -1,0 +1,138 @@
+/**
+ * zod DTOs for the account/device-core CRUD surface (#51): request bodies,
+ * URL params, and response shapes for `User`, `Client`, and the `UserOnClient`
+ * link. As with every `/api/*` DTO these are the single contract shared with
+ * the SvelteKit frontend and external integrators — types are inferred from the
+ * schemas, never hand-written twice (`CLAUDE.md` → "api/ — zod DTOs ...").
+ *
+ * Storage uses epoch-second `Date` columns (see `policy/schema.ts`); the
+ * response mappers below serialize them as ISO-8601 UTC strings so the wire
+ * contract is unambiguous and human-readable.
+ *
+ * License boundary: none touched — plain TypeScript + zod.
+ */
+import { z } from "zod";
+
+import { isValidTimeZone } from "../../policy/budget-window.js";
+import type { ClientRow, UserOnClientRow, UserRow } from "../../policy/repository.js";
+
+/** An IANA timezone name, validated against the host's tz database (ADR-0001). */
+export const tzSchema = z.string().refine(isValidTimeZone, { message: "Unknown IANA timezone" });
+
+/** `:id` path param, coerced from the string Fastify provides. */
+export const idParamsSchema = z.object({ id: z.coerce.number().int().positive() });
+
+/** Reject a PATCH that carries no updatable fields with a clear 400. */
+function nonEmpty(value: object): boolean {
+  return Object.keys(value).length > 0;
+}
+
+// --- Users -----------------------------------------------------------------
+
+export const createUserSchema = z.object({
+  displayName: z.string().trim().min(1).max(200),
+  tz: tzSchema.nullable().optional(),
+});
+
+export const updateUserSchema = z
+  .object({
+    displayName: z.string().trim().min(1).max(200).optional(),
+    tz: tzSchema.nullable().optional(),
+  })
+  .refine(nonEmpty, { message: "At least one field must be provided" });
+
+export const userResponseSchema = z.object({
+  id: z.number().int(),
+  displayName: z.string(),
+  tz: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+export type CreateUserRequest = z.infer<typeof createUserSchema>;
+export type UpdateUserRequest = z.infer<typeof updateUserSchema>;
+export type UserResponse = z.infer<typeof userResponseSchema>;
+
+/** Map a stored user row to its wire DTO. */
+export function toUserResponse(row: UserRow): UserResponse {
+  return {
+    id: row.id,
+    displayName: row.displayName,
+    tz: row.tz,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+// --- Clients ---------------------------------------------------------------
+
+export const createClientSchema = z.object({
+  hostname: z.string().trim().min(1).max(253),
+  sshUser: z.string().trim().min(1).max(64),
+});
+
+export const updateClientSchema = z
+  .object({
+    hostname: z.string().trim().min(1).max(253).optional(),
+    sshUser: z.string().trim().min(1).max(64).optional(),
+  })
+  .refine(nonEmpty, { message: "At least one field must be provided" });
+
+export const clientResponseSchema = z.object({
+  id: z.number().int(),
+  hostname: z.string(),
+  sshUser: z.string(),
+  enrolledAt: z.string(),
+  lastSeen: z.string().nullable(),
+});
+
+export type CreateClientRequest = z.infer<typeof createClientSchema>;
+export type UpdateClientRequest = z.infer<typeof updateClientSchema>;
+export type ClientResponse = z.infer<typeof clientResponseSchema>;
+
+/** Map a stored client row to its wire DTO. */
+export function toClientResponse(row: ClientRow): ClientResponse {
+  return {
+    id: row.id,
+    hostname: row.hostname,
+    sshUser: row.sshUser,
+    enrolledAt: row.enrolledAt.toISOString(),
+    lastSeen: row.lastSeen === null ? null : row.lastSeen.toISOString(),
+  };
+}
+
+// --- User-on-client links --------------------------------------------------
+
+/** `:userId` path param for the nested link routes. */
+export const userIdParamsSchema = z.object({ userId: z.coerce.number().int().positive() });
+
+/** `:userId`/`:clientId` path params for a single link. */
+export const userClientParamsSchema = z.object({
+  userId: z.coerce.number().int().positive(),
+  clientId: z.coerce.number().int().positive(),
+});
+
+export const upsertLinkSchema = z.object({
+  linuxUsername: z.string().trim().min(1).max(32),
+  // Linux UIDs are non-negative; 0 (root) is permitted at the type level even
+  // if policy would never map a supervised user to it.
+  linuxUid: z.number().int().min(0),
+});
+
+export const linkResponseSchema = z.object({
+  userId: z.number().int(),
+  clientId: z.number().int(),
+  linuxUsername: z.string(),
+  linuxUid: z.number().int(),
+});
+
+export type UpsertLinkRequest = z.infer<typeof upsertLinkSchema>;
+export type LinkResponse = z.infer<typeof linkResponseSchema>;
+
+/** Map a stored link row to its wire DTO. */
+export function toLinkResponse(row: UserOnClientRow): LinkResponse {
+  return {
+    userId: row.userId,
+    clientId: row.clientId,
+    linuxUsername: row.linuxUsername,
+    linuxUid: row.linuxUid,
+  };
+}

--- a/server/src/api/policy/index.ts
+++ b/server/src/api/policy/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Policy CRUD surface (#51): the route registrar plus the zod DTOs and inferred
+ * types the frontend and integrators consume. Re-exported from the top-level
+ * `api/` barrel so the contract is imported from one place.
+ */
+export { registerPolicyRoutes } from "./routes.js";
+export {
+  clientResponseSchema,
+  createClientSchema,
+  createUserSchema,
+  idParamsSchema,
+  linkResponseSchema,
+  tzSchema,
+  updateClientSchema,
+  updateUserSchema,
+  upsertLinkSchema,
+  userClientParamsSchema,
+  userIdParamsSchema,
+  userResponseSchema,
+  type ClientResponse,
+  type CreateClientRequest,
+  type CreateUserRequest,
+  type LinkResponse,
+  type UpdateClientRequest,
+  type UpdateUserRequest,
+  type UpsertLinkRequest,
+  type UserResponse,
+} from "./dtos.js";

--- a/server/src/api/policy/routes.ts
+++ b/server/src/api/policy/routes.ts
@@ -1,0 +1,218 @@
+/**
+ * Policy CRUD routes for the account/device core (#51): `User`, `Client`, and
+ * the `UserOnClient` link.
+ *
+ * Registered inside the `/api` plugin scope (after `registerAuth`) so every
+ * route inherits the zod validator compiler + shared error envelope and sits
+ * behind the `requireAdmin` guard — anonymous requests get a `401` envelope,
+ * never an unguarded read/write (`CLAUDE.md` → "no privileged in-process
+ * shortcuts"). Handlers stay thin: they validate via the DTOs, delegate to the
+ * `policy/repository` service over `app.db`, and map "missing row" → `404` and
+ * unique-constraint collisions → `409`.
+ *
+ * License boundary: none touched — plain TypeScript + zod + Drizzle.
+ */
+import type { FastifyInstance } from "fastify";
+
+import * as repo from "../../policy/repository.js";
+import { ApiError } from "../errors.js";
+import type { ZodTypeProvider } from "../validation.js";
+import {
+  createClientSchema,
+  createUserSchema,
+  idParamsSchema,
+  toClientResponse,
+  toLinkResponse,
+  toUserResponse,
+  updateClientSchema,
+  updateUserSchema,
+  upsertLinkSchema,
+  userClientParamsSchema,
+  userIdParamsSchema,
+  type ClientResponse,
+  type LinkResponse,
+  type UserResponse,
+} from "./dtos.js";
+
+/** Run a repository write, mapping a UNIQUE collision to a `409 conflict`. */
+function asConflict<T>(write: () => T, message: string): T {
+  try {
+    return write();
+  } catch (err) {
+    if (repo.isUniqueViolation(err)) {
+      throw new ApiError(409, "conflict", message);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Register the policy CRUD routes on an already-`/api`-prefixed scope. Call
+ * after {@link registerAuth} so `scope.requireAdmin` is decorated.
+ */
+export function registerPolicyRoutes(scope: FastifyInstance): void {
+  const typed = scope.withTypeProvider<ZodTypeProvider>();
+  const guard = { preHandler: scope.requireAdmin };
+
+  // --- Users ---------------------------------------------------------------
+
+  typed.get(
+    "/users",
+    guard,
+    async (): Promise<UserResponse[]> => repo.listUsers(scope.db).map(toUserResponse),
+  );
+
+  typed.post(
+    "/users",
+    { ...guard, schema: { body: createUserSchema } },
+    async (request, reply): Promise<UserResponse> => {
+      const row = repo.createUser(scope.db, request.body);
+      reply.code(201);
+      return toUserResponse(row);
+    },
+  );
+
+  typed.get(
+    "/users/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request): Promise<UserResponse> => {
+      const row = repo.getUser(scope.db, request.params.id);
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `User ${request.params.id} not found`);
+      }
+      return toUserResponse(row);
+    },
+  );
+
+  typed.patch(
+    "/users/:id",
+    { ...guard, schema: { params: idParamsSchema, body: updateUserSchema } },
+    async (request): Promise<UserResponse> => {
+      const row = repo.updateUser(scope.db, request.params.id, request.body);
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `User ${request.params.id} not found`);
+      }
+      return toUserResponse(row);
+    },
+  );
+
+  typed.delete(
+    "/users/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request, reply) => {
+      if (!repo.deleteUser(scope.db, request.params.id)) {
+        throw new ApiError(404, "not_found", `User ${request.params.id} not found`);
+      }
+      return reply.code(204).send();
+    },
+  );
+
+  // --- Clients -------------------------------------------------------------
+
+  typed.get(
+    "/clients",
+    guard,
+    async (): Promise<ClientResponse[]> => repo.listClients(scope.db).map(toClientResponse),
+  );
+
+  typed.post(
+    "/clients",
+    { ...guard, schema: { body: createClientSchema } },
+    async (request, reply): Promise<ClientResponse> => {
+      const row = asConflict(
+        () => repo.createClient(scope.db, request.body),
+        `A client with hostname "${request.body.hostname}" already exists`,
+      );
+      reply.code(201);
+      return toClientResponse(row);
+    },
+  );
+
+  typed.get(
+    "/clients/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request): Promise<ClientResponse> => {
+      const row = repo.getClient(scope.db, request.params.id);
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Client ${request.params.id} not found`);
+      }
+      return toClientResponse(row);
+    },
+  );
+
+  typed.patch(
+    "/clients/:id",
+    { ...guard, schema: { params: idParamsSchema, body: updateClientSchema } },
+    async (request): Promise<ClientResponse> => {
+      const row = asConflict(
+        () => repo.updateClient(scope.db, request.params.id, request.body),
+        "That hostname is already in use by another client",
+      );
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Client ${request.params.id} not found`);
+      }
+      return toClientResponse(row);
+    },
+  );
+
+  typed.delete(
+    "/clients/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request, reply) => {
+      if (!repo.deleteClient(scope.db, request.params.id)) {
+        throw new ApiError(404, "not_found", `Client ${request.params.id} not found`);
+      }
+      return reply.code(204).send();
+    },
+  );
+
+  // --- User-on-client links ------------------------------------------------
+
+  typed.get(
+    "/users/:userId/clients",
+    { ...guard, schema: { params: userIdParamsSchema } },
+    async (request): Promise<LinkResponse[]> => {
+      if (repo.getUser(scope.db, request.params.userId) === undefined) {
+        throw new ApiError(404, "not_found", `User ${request.params.userId} not found`);
+      }
+      return repo.listUserLinks(scope.db, request.params.userId).map(toLinkResponse);
+    },
+  );
+
+  typed.put(
+    "/users/:userId/clients/:clientId",
+    { ...guard, schema: { params: userClientParamsSchema, body: upsertLinkSchema } },
+    async (request): Promise<LinkResponse> => {
+      const { userId, clientId } = request.params;
+      // Confirm both ends exist so the caller gets a precise 404 rather than an
+      // opaque foreign-key failure.
+      if (repo.getUser(scope.db, userId) === undefined) {
+        throw new ApiError(404, "not_found", `User ${userId} not found`);
+      }
+      if (repo.getClient(scope.db, clientId) === undefined) {
+        throw new ApiError(404, "not_found", `Client ${clientId} not found`);
+      }
+      const row = asConflict(
+        () => repo.upsertLink(scope.db, userId, clientId, request.body),
+        `Linux UID ${request.body.linuxUid} is already mapped to another user on client ${clientId}`,
+      );
+      return toLinkResponse(row);
+    },
+  );
+
+  typed.delete(
+    "/users/:userId/clients/:clientId",
+    { ...guard, schema: { params: userClientParamsSchema } },
+    async (request, reply) => {
+      const { userId, clientId } = request.params;
+      if (!repo.deleteLink(scope.db, userId, clientId)) {
+        throw new ApiError(
+          404,
+          "not_found",
+          `No link between user ${userId} and client ${clientId}`,
+        );
+      }
+      return reply.code(204).send();
+    },
+  );
+}

--- a/server/src/policy/repository.ts
+++ b/server/src/policy/repository.ts
@@ -1,0 +1,194 @@
+/**
+ * Policy-store data access for the account/device core (#51).
+ *
+ * Thin, synchronous repository functions over the shared {@link PolicyDb}
+ * handle (better-sqlite3 + Drizzle). They carry no HTTP concerns — the `/api`
+ * route layer (`api/policy/routes.ts`) maps their results and the
+ * {@link isUniqueViolation} signal onto status codes and the shared error
+ * envelope. Keeping persistence here honours `CLAUDE.md` → "policy/ — Drizzle
+ * schema, policy model, DB access" and #51's "reads and writes go through the
+ * policy service over `app.db`".
+ *
+ * Scope: `User`, `Client`, and the `UserOnClient` link. The remaining policy
+ * entities (Activity/ActivityGroup, Budget, Schedule, Exception) land in their
+ * own follow-up modules under the #51 umbrella.
+ *
+ * License boundary: none touched — Drizzle (Apache-2.0) and better-sqlite3
+ * (MIT) only.
+ */
+import { and, eq } from "drizzle-orm";
+
+import type { PolicyDb } from "./db.js";
+import { clients, users, usersOnClients } from "./schema.js";
+
+/** A persisted {@link users} row. */
+export type UserRow = typeof users.$inferSelect;
+/** A persisted {@link clients} row. */
+export type ClientRow = typeof clients.$inferSelect;
+/** A persisted {@link usersOnClients} link row. */
+export type UserOnClientRow = typeof usersOnClients.$inferSelect;
+
+/** Fields accepted when creating a {@link users} row. */
+export interface UserCreate {
+  displayName: string;
+  /** IANA timezone, or `null`/absent to inherit the server default. */
+  tz?: string | null | undefined;
+}
+
+/** Mutable fields on a {@link users} row; omitted keys are left unchanged. */
+export interface UserUpdate {
+  displayName?: string | undefined;
+  tz?: string | null | undefined;
+}
+
+/** Fields accepted when creating a {@link clients} row. */
+export interface ClientCreate {
+  hostname: string;
+  sshUser: string;
+}
+
+/** Mutable fields on a {@link clients} row; omitted keys are left unchanged. */
+export interface ClientUpdate {
+  hostname?: string | undefined;
+  sshUser?: string | undefined;
+}
+
+/** The link's own attributes (the user/client pair comes from the route). */
+export interface LinkUpsert {
+  linuxUsername: string;
+  linuxUid: number;
+}
+
+// --- Users -----------------------------------------------------------------
+
+/** All users, ascending by id. */
+export function listUsers(db: PolicyDb): UserRow[] {
+  return db.select().from(users).orderBy(users.id).all();
+}
+
+/** One user by id, or `undefined` if absent. */
+export function getUser(db: PolicyDb, id: number): UserRow | undefined {
+  return db.select().from(users).where(eq(users.id, id)).get();
+}
+
+/** Insert a user and return the stored row. */
+export function createUser(db: PolicyDb, input: UserCreate): UserRow {
+  return db
+    .insert(users)
+    .values({ displayName: input.displayName, tz: input.tz ?? null })
+    .returning()
+    .get();
+}
+
+/**
+ * Apply a partial update and return the stored row, or `undefined` if no user
+ * with `id` exists. `patch` must carry at least one key (the route enforces
+ * this); a `tz` of `null` clears the override.
+ */
+export function updateUser(db: PolicyDb, id: number, patch: UserUpdate): UserRow | undefined {
+  return db.update(users).set(patch).where(eq(users.id, id)).returning().get();
+}
+
+/** Delete a user (cascading its links). Returns whether a row was removed. */
+export function deleteUser(db: PolicyDb, id: number): boolean {
+  return db.delete(users).where(eq(users.id, id)).returning({ id: users.id }).get() !== undefined;
+}
+
+// --- Clients ---------------------------------------------------------------
+
+/** All clients, ascending by id. */
+export function listClients(db: PolicyDb): ClientRow[] {
+  return db.select().from(clients).orderBy(clients.id).all();
+}
+
+/** One client by id, or `undefined` if absent. */
+export function getClient(db: PolicyDb, id: number): ClientRow | undefined {
+  return db.select().from(clients).where(eq(clients.id, id)).get();
+}
+
+/**
+ * Insert a client and return the stored row. Throws the underlying
+ * unique-constraint error on a duplicate `hostname` — see
+ * {@link isUniqueViolation}.
+ */
+export function createClient(db: PolicyDb, input: ClientCreate): ClientRow {
+  return db
+    .insert(clients)
+    .values({ hostname: input.hostname, sshUser: input.sshUser })
+    .returning()
+    .get();
+}
+
+/**
+ * Apply a partial update and return the stored row, or `undefined` if no client
+ * with `id` exists. Throws on a `hostname` collision (see
+ * {@link isUniqueViolation}).
+ */
+export function updateClient(db: PolicyDb, id: number, patch: ClientUpdate): ClientRow | undefined {
+  return db.update(clients).set(patch).where(eq(clients.id, id)).returning().get();
+}
+
+/** Delete a client (cascading its links). Returns whether a row was removed. */
+export function deleteClient(db: PolicyDb, id: number): boolean {
+  return (
+    db.delete(clients).where(eq(clients.id, id)).returning({ id: clients.id }).get() !== undefined
+  );
+}
+
+// --- User-on-client links --------------------------------------------------
+
+/** All links for a user, ascending by client id. */
+export function listUserLinks(db: PolicyDb, userId: number): UserOnClientRow[] {
+  return db
+    .select()
+    .from(usersOnClients)
+    .where(eq(usersOnClients.userId, userId))
+    .orderBy(usersOnClients.clientId)
+    .all();
+}
+
+/**
+ * Create or replace the link between `userId` and `clientId` (idempotent on the
+ * composite key). Throws on the `(client, linux_uid)` uniqueness collision —
+ * i.e. another user already mapped to that UID on the same client (see
+ * {@link isUniqueViolation}). The caller is responsible for confirming the user
+ * and client exist first (FK violations otherwise surface as opaque errors).
+ */
+export function upsertLink(
+  db: PolicyDb,
+  userId: number,
+  clientId: number,
+  input: LinkUpsert,
+): UserOnClientRow {
+  return db
+    .insert(usersOnClients)
+    .values({ userId, clientId, linuxUsername: input.linuxUsername, linuxUid: input.linuxUid })
+    .onConflictDoUpdate({
+      target: [usersOnClients.userId, usersOnClients.clientId],
+      set: { linuxUsername: input.linuxUsername, linuxUid: input.linuxUid },
+    })
+    .returning()
+    .get();
+}
+
+/** Delete a link. Returns whether a row was removed. */
+export function deleteLink(db: PolicyDb, userId: number, clientId: number): boolean {
+  return (
+    db
+      .delete(usersOnClients)
+      .where(and(eq(usersOnClients.userId, userId), eq(usersOnClients.clientId, clientId)))
+      .returning({ userId: usersOnClients.userId })
+      .get() !== undefined
+  );
+}
+
+/**
+ * Whether an error thrown by better-sqlite3 is a UNIQUE/PRIMARY-KEY constraint
+ * violation, which the route layer maps to `409 conflict`. Reads `.code`
+ * structurally (via `Reflect.get`) so no `as` cast or `any` is needed.
+ */
+export function isUniqueViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = Reflect.get(err, "code");
+  return code === "SQLITE_CONSTRAINT_UNIQUE" || code === "SQLITE_CONSTRAINT_PRIMARYKEY";
+}

--- a/server/tests/api/policy-dtos.test.ts
+++ b/server/tests/api/policy-dtos.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the policy-DTO response mappers (#51): the epoch-second `Date`
+ * columns must serialize to ISO-8601 UTC strings, including the nullable
+ * `Client.lastSeen` once a health probe has populated it (not reachable through
+ * the CRUD routes yet, so covered directly here).
+ */
+import { describe, expect, it } from "vitest";
+
+import { toClientResponse, toUserResponse } from "../../src/api/policy/dtos.js";
+import type { ClientRow, UserRow } from "../../src/policy/repository.js";
+
+describe("policy DTO mappers", () => {
+  it("maps a user row, preserving a null tz", () => {
+    const row: UserRow = {
+      id: 1,
+      displayName: "Alice",
+      tz: null,
+      createdAt: new Date("2026-06-17T00:00:00.000Z"),
+    };
+    expect(toUserResponse(row)).toEqual({
+      id: 1,
+      displayName: "Alice",
+      tz: null,
+      createdAt: "2026-06-17T00:00:00.000Z",
+    });
+  });
+
+  it("serializes a client's lastSeen when present", () => {
+    const row: ClientRow = {
+      id: 2,
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      enrolledAt: new Date("2026-06-17T00:00:00.000Z"),
+      lastSeen: new Date("2026-06-17T08:30:00.000Z"),
+    };
+    expect(toClientResponse(row)).toEqual({
+      id: 2,
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      enrolledAt: "2026-06-17T00:00:00.000Z",
+      lastSeen: "2026-06-17T08:30:00.000Z",
+    });
+  });
+
+  it("maps a client's lastSeen of null to null", () => {
+    const row: ClientRow = {
+      id: 3,
+      hostname: "mint-02",
+      sshUser: "pct-agent",
+      enrolledAt: new Date("2026-06-17T00:00:00.000Z"),
+      lastSeen: null,
+    };
+    expect(toClientResponse(row).lastSeen).toBeNull();
+  });
+});

--- a/server/tests/api/policy.test.ts
+++ b/server/tests/api/policy.test.ts
@@ -1,0 +1,362 @@
+/**
+ * HTTP tests for the account/device-core CRUD routes (#51), driven through the
+ * real app via `app.inject()` with a genuine admin session cookie — per
+ * docs/testing.md → "HTTP routes". Covers happy paths, validation failures,
+ * the anonymous-401 guard, 404s, and 409 conflicts for each entity.
+ */
+import type { InjectOptions } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SESSION_COOKIE } from "../../src/auth/session.js";
+import { loadSettings } from "../../src/config.js";
+import { buildTestApp, type TestApp } from "../helpers/app.js";
+
+/** Settings with a secret and a seeded admin (`ben` / `hunter2`). */
+function configuredSettings() {
+  return loadSettings({
+    PCT_LOG_LEVEL: "silent",
+    PCT_SECRET_KEY: "policy-test-secret",
+    PCT_ADMIN_USERNAME: "ben",
+    PCT_ADMIN_PASSWORD: "hunter2",
+  });
+}
+
+/** Pull the `pct_session=<signed>` wire cookie out of a login response. */
+function sessionCookie(res: { headers: Record<string, unknown> }): string {
+  const raw = res.headers["set-cookie"];
+  const headers = Array.isArray(raw) ? (raw as string[]) : [String(raw ?? "")];
+  const match = headers.find((h) => h.startsWith(`${SESSION_COOKIE}=`));
+  if (match === undefined) throw new Error("no session cookie set");
+  return match.split(";")[0] ?? "";
+}
+
+describe("policy CRUD routes", () => {
+  let harness: TestApp;
+  let cookie: string;
+
+  beforeEach(async () => {
+    harness = buildTestApp({ appOptions: { settings: configuredSettings() } });
+    await harness.app.ready(); // triggers first-admin bootstrap
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    cookie = sessionCookie(login);
+  });
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  /** Inject with the admin session cookie attached. */
+  function auth(opts: InjectOptions) {
+    return harness.app.inject({ ...opts, headers: { ...opts.headers, cookie } });
+  }
+
+  // --- auth guard ----------------------------------------------------------
+
+  it("rejects anonymous access to every collection with a 401 envelope", async () => {
+    for (const url of ["/api/users", "/api/clients"]) {
+      const res = await harness.app.inject({ method: "GET", url });
+      expect(res.statusCode).toBe(401);
+      expect(res.json().error.code).toBe("unauthorized");
+    }
+  });
+
+  it("rejects an anonymous write with a 401", async () => {
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/users",
+      payload: { displayName: "Mallory" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  // --- users ---------------------------------------------------------------
+
+  it("creates a user (201) and reads it back", async () => {
+    const created = await auth({
+      method: "POST",
+      url: "/api/users",
+      payload: { displayName: "Alice", tz: "Europe/London" },
+    });
+    expect(created.statusCode).toBe(201);
+    const body = created.json();
+    expect(body).toMatchObject({ displayName: "Alice", tz: "Europe/London" });
+    expect(typeof body.id).toBe("number");
+    expect(typeof body.createdAt).toBe("string");
+
+    const list = await auth({ method: "GET", url: "/api/users" });
+    expect(list.json()).toEqual([body]);
+
+    const one = await auth({ method: "GET", url: `/api/users/${body.id}` });
+    expect(one.json()).toEqual(body);
+  });
+
+  it("rejects an invalid timezone with a 400 validation envelope", async () => {
+    const res = await auth({
+      method: "POST",
+      url: "/api/users",
+      payload: { displayName: "Alice", tz: "Mars/Phobos" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("rejects an empty user body with a 400", async () => {
+    const res = await auth({ method: "POST", url: "/api/users", payload: {} });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("patches a user, clearing tz with an explicit null", async () => {
+    const created = (
+      await auth({
+        method: "POST",
+        url: "/api/users",
+        payload: { displayName: "Alice", tz: "Europe/London" },
+      })
+    ).json();
+
+    const patched = await auth({
+      method: "PATCH",
+      url: `/api/users/${created.id}`,
+      payload: { tz: null },
+    });
+    expect(patched.statusCode).toBe(200);
+    expect(patched.json()).toMatchObject({ displayName: "Alice", tz: null });
+  });
+
+  it("rejects a no-op (empty) PATCH with a 400", async () => {
+    const created = (
+      await auth({ method: "POST", url: "/api/users", payload: { displayName: "Alice" } })
+    ).json();
+    const res = await auth({ method: "PATCH", url: `/api/users/${created.id}`, payload: {} });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("deletes a user (204) and 404s afterwards", async () => {
+    const created = (
+      await auth({ method: "POST", url: "/api/users", payload: { displayName: "Alice" } })
+    ).json();
+    const del = await auth({ method: "DELETE", url: `/api/users/${created.id}` });
+    expect(del.statusCode).toBe(204);
+    expect(del.body).toBe("");
+
+    const missing = await auth({ method: "GET", url: `/api/users/${created.id}` });
+    expect(missing.statusCode).toBe(404);
+    expect(missing.json().error.code).toBe("not_found");
+  });
+
+  it("404s on patch/delete of a missing user", async () => {
+    const patch = await auth({
+      method: "PATCH",
+      url: "/api/users/999",
+      payload: { displayName: "x" },
+    });
+    expect(patch.statusCode).toBe(404);
+    const del = await auth({ method: "DELETE", url: "/api/users/999" });
+    expect(del.statusCode).toBe(404);
+  });
+
+  it("rejects a non-numeric id with a 400", async () => {
+    const res = await auth({ method: "GET", url: "/api/users/abc" });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  // --- clients -------------------------------------------------------------
+
+  it("creates a client (201), updates it, and lists it", async () => {
+    const created = await auth({
+      method: "POST",
+      url: "/api/clients",
+      payload: { hostname: "mint-01", sshUser: "pct-agent" },
+    });
+    expect(created.statusCode).toBe(201);
+    const body = created.json();
+    expect(body).toMatchObject({ hostname: "mint-01", sshUser: "pct-agent", lastSeen: null });
+
+    const patched = await auth({
+      method: "PATCH",
+      url: `/api/clients/${body.id}`,
+      payload: { hostname: "mint-renamed" },
+    });
+    expect(patched.json().hostname).toBe("mint-renamed");
+
+    const one = await auth({ method: "GET", url: `/api/clients/${body.id}` });
+    expect(one.json()).toMatchObject({ id: body.id, hostname: "mint-renamed" });
+
+    const list = await auth({ method: "GET", url: "/api/clients" });
+    expect(list.json()).toHaveLength(1);
+  });
+
+  it("409s on a duplicate hostname", async () => {
+    await auth({
+      method: "POST",
+      url: "/api/clients",
+      payload: { hostname: "dup", sshUser: "pct-agent" },
+    });
+    const conflict = await auth({
+      method: "POST",
+      url: "/api/clients",
+      payload: { hostname: "dup", sshUser: "pct-agent" },
+    });
+    expect(conflict.statusCode).toBe(409);
+    expect(conflict.json().error.code).toBe("conflict");
+  });
+
+  it("409s when a client PATCH collides with another hostname", async () => {
+    await auth({
+      method: "POST",
+      url: "/api/clients",
+      payload: { hostname: "taken", sshUser: "pct-agent" },
+    });
+    const second = (
+      await auth({
+        method: "POST",
+        url: "/api/clients",
+        payload: { hostname: "free", sshUser: "pct-agent" },
+      })
+    ).json();
+    const res = await auth({
+      method: "PATCH",
+      url: `/api/clients/${second.id}`,
+      payload: { hostname: "taken" },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("rejects an empty hostname with a 400 and 404s a missing client", async () => {
+    const bad = await auth({
+      method: "POST",
+      url: "/api/clients",
+      payload: { hostname: "", sshUser: "pct-agent" },
+    });
+    expect(bad.statusCode).toBe(400);
+
+    const missing = await auth({ method: "GET", url: "/api/clients/999" });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it("404s on patch/delete of a missing client", async () => {
+    const patch = await auth({
+      method: "PATCH",
+      url: "/api/clients/999",
+      payload: { sshUser: "pct-agent" },
+    });
+    expect(patch.statusCode).toBe(404);
+    expect(patch.json().error.code).toBe("not_found");
+
+    const del = await auth({ method: "DELETE", url: "/api/clients/999" });
+    expect(del.statusCode).toBe(404);
+  });
+
+  it("deletes a client (204)", async () => {
+    const created = (
+      await auth({
+        method: "POST",
+        url: "/api/clients",
+        payload: { hostname: "to-remove", sshUser: "pct-agent" },
+      })
+    ).json();
+    const del = await auth({ method: "DELETE", url: `/api/clients/${created.id}` });
+    expect(del.statusCode).toBe(204);
+    expect(del.body).toBe("");
+  });
+
+  // --- links ---------------------------------------------------------------
+
+  async function makeUserAndClient(): Promise<{ userId: number; clientId: number }> {
+    const userId = (
+      await auth({ method: "POST", url: "/api/users", payload: { displayName: "Alice" } })
+    ).json().id;
+    const clientId = (
+      await auth({
+        method: "POST",
+        url: "/api/clients",
+        payload: { hostname: "mint-01", sshUser: "pct-agent" },
+      })
+    ).json().id;
+    return { userId, clientId };
+  }
+
+  it("upserts a link and lists it under the user", async () => {
+    const { userId, clientId } = await makeUserAndClient();
+    const put = await auth({
+      method: "PUT",
+      url: `/api/users/${userId}/clients/${clientId}`,
+      payload: { linuxUsername: "alice", linuxUid: 1001 },
+    });
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toEqual({ userId, clientId, linuxUsername: "alice", linuxUid: 1001 });
+
+    const list = await auth({ method: "GET", url: `/api/users/${userId}/clients` });
+    expect(list.json()).toHaveLength(1);
+
+    // Idempotent replace.
+    const again = await auth({
+      method: "PUT",
+      url: `/api/users/${userId}/clients/${clientId}`,
+      payload: { linuxUsername: "alice2", linuxUid: 1002 },
+    });
+    expect(again.json().linuxUid).toBe(1002);
+    expect(
+      (await auth({ method: "GET", url: `/api/users/${userId}/clients` })).json(),
+    ).toHaveLength(1);
+  });
+
+  it("404s a link PUT when the user or client is missing", async () => {
+    const { userId, clientId } = await makeUserAndClient();
+    const noUser = await auth({
+      method: "PUT",
+      url: `/api/users/999/clients/${clientId}`,
+      payload: { linuxUsername: "x", linuxUid: 1001 },
+    });
+    expect(noUser.statusCode).toBe(404);
+    const noClient = await auth({
+      method: "PUT",
+      url: `/api/users/${userId}/clients/999`,
+      payload: { linuxUsername: "x", linuxUid: 1001 },
+    });
+    expect(noClient.statusCode).toBe(404);
+  });
+
+  it("404s listing links for a missing user", async () => {
+    const res = await auth({ method: "GET", url: "/api/users/999/clients" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("409s when a UID is already mapped to another user on the same client", async () => {
+    const { userId, clientId } = await makeUserAndClient();
+    const otherUser = (
+      await auth({ method: "POST", url: "/api/users", payload: { displayName: "Bob" } })
+    ).json().id;
+    await auth({
+      method: "PUT",
+      url: `/api/users/${userId}/clients/${clientId}`,
+      payload: { linuxUsername: "alice", linuxUid: 1001 },
+    });
+    const conflict = await auth({
+      method: "PUT",
+      url: `/api/users/${otherUser}/clients/${clientId}`,
+      payload: { linuxUsername: "bob", linuxUid: 1001 },
+    });
+    expect(conflict.statusCode).toBe(409);
+  });
+
+  it("deletes a link (204) and 404s afterwards", async () => {
+    const { userId, clientId } = await makeUserAndClient();
+    await auth({
+      method: "PUT",
+      url: `/api/users/${userId}/clients/${clientId}`,
+      payload: { linuxUsername: "alice", linuxUid: 1001 },
+    });
+    const del = await auth({ method: "DELETE", url: `/api/users/${userId}/clients/${clientId}` });
+    expect(del.statusCode).toBe(204);
+    const again = await auth({ method: "DELETE", url: `/api/users/${userId}/clients/${clientId}` });
+    expect(again.statusCode).toBe(404);
+  });
+});

--- a/server/tests/helpers/db.ts
+++ b/server/tests/helpers/db.ts
@@ -47,6 +47,11 @@ export function testDb(): TestDb {
   // default here since hermetic unit tests opt into FK checks when they need
   // them. Once CRUD routes land (#51), consider enabling foreign_keys here so
   // route tests over app.db catch referential bugs the way runtime does.
+  // Enable foreign_keys (SQLite leaves it OFF per connection) so hermetic
+  // route/repository tests over app.db enforce referential integrity — and
+  // exercise ON DELETE CASCADE — exactly the way the runtime createDb() does.
+  // Landed with the CRUD routes (#51), as this helper's prior note anticipated.
+  sqlite.pragma("foreign_keys = ON");
   const db: PolicyDb = drizzle(sqlite, { schema });
   migrate(db, { migrationsFolder });
   return db;

--- a/server/tests/policy/repository.test.ts
+++ b/server/tests/policy/repository.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the account/device-core repository (#51) against a hermetic
+ * in-memory policy DB (`testDb`, foreign_keys ON). Covers CRUD round-trips,
+ * ON DELETE CASCADE, link upsert, and the unique-violation signal the route
+ * layer maps to 409.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import * as repo from "../../src/policy/repository.js";
+import { testDb, type TestDb } from "../helpers/db.js";
+
+describe("policy repository — users", () => {
+  let db: TestDb;
+  beforeEach(() => {
+    db = testDb();
+  });
+  afterEach(() => {
+    db.$client.close();
+  });
+
+  it("creates, reads, lists, updates, and deletes a user", () => {
+    const created = repo.createUser(db, { displayName: "Alice", tz: "Europe/London" });
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.displayName).toBe("Alice");
+    expect(created.tz).toBe("Europe/London");
+    expect(created.createdAt).toBeInstanceOf(Date);
+
+    expect(repo.getUser(db, created.id)).toEqual(created);
+    expect(repo.listUsers(db)).toEqual([created]);
+
+    const updated = repo.updateUser(db, created.id, { displayName: "Alice B." });
+    expect(updated?.displayName).toBe("Alice B.");
+    expect(updated?.tz).toBe("Europe/London");
+
+    // tz: null clears the override; displayName stays.
+    const cleared = repo.updateUser(db, created.id, { tz: null });
+    expect(cleared?.tz).toBeNull();
+    expect(cleared?.displayName).toBe("Alice B.");
+
+    expect(repo.deleteUser(db, created.id)).toBe(true);
+    expect(repo.getUser(db, created.id)).toBeUndefined();
+  });
+
+  it("defaults tz to null when omitted", () => {
+    const created = repo.createUser(db, { displayName: "Bob" });
+    expect(created.tz).toBeNull();
+  });
+
+  it("returns undefined / false for a missing user", () => {
+    expect(repo.getUser(db, 999)).toBeUndefined();
+    expect(repo.updateUser(db, 999, { displayName: "x" })).toBeUndefined();
+    expect(repo.deleteUser(db, 999)).toBe(false);
+  });
+});
+
+describe("policy repository — clients", () => {
+  let db: TestDb;
+  beforeEach(() => {
+    db = testDb();
+  });
+  afterEach(() => {
+    db.$client.close();
+  });
+
+  it("creates, reads, updates, and deletes a client", () => {
+    const created = repo.createClient(db, { hostname: "mint-01", sshUser: "pct-agent" });
+    expect(created.hostname).toBe("mint-01");
+    expect(created.lastSeen).toBeNull();
+    expect(created.enrolledAt).toBeInstanceOf(Date);
+
+    expect(repo.getClient(db, created.id)).toEqual(created);
+    expect(repo.listClients(db)).toEqual([created]);
+
+    const updated = repo.updateClient(db, created.id, { hostname: "mint-renamed" });
+    expect(updated?.hostname).toBe("mint-renamed");
+
+    expect(repo.deleteClient(db, created.id)).toBe(true);
+    expect(repo.getClient(db, created.id)).toBeUndefined();
+  });
+
+  it("throws a unique violation on a duplicate hostname", () => {
+    repo.createClient(db, { hostname: "dup", sshUser: "pct-agent" });
+    let caught: unknown;
+    try {
+      repo.createClient(db, { hostname: "dup", sshUser: "pct-agent" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(repo.isUniqueViolation(caught)).toBe(true);
+  });
+
+  it("returns undefined / false for a missing client", () => {
+    expect(repo.getClient(db, 999)).toBeUndefined();
+    expect(repo.updateClient(db, 999, { sshUser: "x" })).toBeUndefined();
+    expect(repo.deleteClient(db, 999)).toBe(false);
+  });
+});
+
+describe("policy repository — user/client links", () => {
+  let db: TestDb;
+  let userId: number;
+  let clientId: number;
+  beforeEach(() => {
+    db = testDb();
+    userId = repo.createUser(db, { displayName: "Alice" }).id;
+    clientId = repo.createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+  });
+  afterEach(() => {
+    db.$client.close();
+  });
+
+  it("upserts a link idempotently and lists it", () => {
+    const link = repo.upsertLink(db, userId, clientId, { linuxUsername: "alice", linuxUid: 1001 });
+    expect(link).toEqual({ userId, clientId, linuxUsername: "alice", linuxUid: 1001 });
+    expect(repo.listUserLinks(db, userId)).toEqual([link]);
+
+    // Re-upsert replaces the link's attributes rather than inserting a second.
+    const replaced = repo.upsertLink(db, userId, clientId, {
+      linuxUsername: "alice2",
+      linuxUid: 1002,
+    });
+    expect(replaced.linuxUid).toBe(1002);
+    expect(repo.listUserLinks(db, userId)).toEqual([replaced]);
+  });
+
+  it("rejects a duplicate (client, uid) for a different user with a unique violation", () => {
+    const otherUser = repo.createUser(db, { displayName: "Bob" }).id;
+    repo.upsertLink(db, userId, clientId, { linuxUsername: "alice", linuxUid: 1001 });
+    let caught: unknown;
+    try {
+      repo.upsertLink(db, otherUser, clientId, { linuxUsername: "bob", linuxUid: 1001 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(repo.isUniqueViolation(caught)).toBe(true);
+  });
+
+  it("cascades link removal when the user is deleted", () => {
+    repo.upsertLink(db, userId, clientId, { linuxUsername: "alice", linuxUid: 1001 });
+    expect(repo.deleteUser(db, userId)).toBe(true);
+    expect(repo.listUserLinks(db, userId)).toEqual([]);
+  });
+
+  it("cascades link removal when the client is deleted", () => {
+    repo.upsertLink(db, userId, clientId, { linuxUsername: "alice", linuxUid: 1001 });
+    expect(repo.deleteClient(db, clientId)).toBe(true);
+    expect(repo.listUserLinks(db, userId)).toEqual([]);
+  });
+
+  it("deleteLink reports whether a row was removed", () => {
+    repo.upsertLink(db, userId, clientId, { linuxUsername: "alice", linuxUid: 1001 });
+    expect(repo.deleteLink(db, userId, clientId)).toBe(true);
+    expect(repo.deleteLink(db, userId, clientId)).toBe(false);
+  });
+});
+
+describe("isUniqueViolation", () => {
+  it("is false for non-constraint values", () => {
+    expect(repo.isUniqueViolation(null)).toBe(false);
+    expect(repo.isUniqueViolation(undefined)).toBe(false);
+    expect(repo.isUniqueViolation("SQLITE_CONSTRAINT_UNIQUE")).toBe(false);
+    expect(repo.isUniqueViolation(new Error("boom"))).toBe(false);
+    expect(repo.isUniqueViolation({ code: "SQLITE_BUSY" })).toBe(false);
+  });
+
+  it("is true for UNIQUE and PRIMARYKEY constraint codes", () => {
+    expect(repo.isUniqueViolation({ code: "SQLITE_CONSTRAINT_UNIQUE" })).toBe(true);
+    expect(repo.isUniqueViolation({ code: "SQLITE_CONSTRAINT_PRIMARYKEY" })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the #51 umbrella — `/api/*` CRUD for the **account/device
core**, the entities every other policy row references by FK:

- **`policy/repository.ts`** — thin synchronous data-access over the shared
  `app.db` handle: list/get/create/update/delete for `User` and `Client`,
  plus list/upsert/delete for the `UserOnClient` link. Exposes
  `isUniqueViolation()` so the route layer maps UNIQUE/PK collisions to 409.
- **`api/policy/`** — zod DTOs (the single contract shared with the frontend
  and integrators) + routes, registered inside the `/api` plugin **after**
  `registerAuth` so every route sits behind `requireAdmin` (anonymous → 401
  envelope). Missing row → 404; duplicate `hostname` / duplicate
  `(client, linux_uid)` → 409; invalid IANA `tz` and empty/no-op bodies →
  400. Response mappers serialize epoch-second `Date` columns as ISO-8601.
- **`tests/helpers/db.ts`** — enables `foreign_keys = ON` in the in-memory
  `testDb()` (matching runtime `createDb`), exactly as that helper's own
  prior note anticipated "once CRUD routes land (#51)", so route/repository
  tests exercise `ON DELETE CASCADE` and referential integrity.

No schema change → no new drizzle migration.

## Plan

Linked plan: `.claude/plans/issue-51-policy-crud.md`
Roadmap: `docs/roadmap.md` → Phase 2 ("`/api/*` JSON endpoints for the full
policy model").

## Scope / deferred (tracked)

`#51` is an umbrella ("fine to land … with per-entity follow-up PRs"), so
this PR **does not close it**. The remaining entities —
`Activity`/`ActivityGroup` (+ M2M), `Budget`, `Schedule`, `Exception` — are
tracked in **#148** and will reuse the conventions established here.
`Grant`/`IntegrationToken` writes stay Phase 10.

## License-boundary note

N/A — pure TypeScript + zod + Drizzle (`better-sqlite3`/`drizzle-orm`,
already deps). No transport, no subprocess, no packaging change. **No new
dependency.**

## Test plan

- [x] `format:check`, `lint`, `typecheck` clean
- [x] `npm test` — 262 passing; new code 100% (repository) / 98.7% (routes);
      overall coverage 99.85% (gate 80%)
- [x] repository unit tests: CRUD round-trips, `tz` default/clear, cascade on
      user/client delete, duplicate-hostname & duplicate-UID unique
      violations, link upsert idempotency, `isUniqueViolation` truth table
- [x] `app.inject()` HTTP tests per entity: happy path, validation failure
      (bad tz, empty body, non-numeric id), anonymous 401, 404 (get/patch/
      delete/list-missing-user), 409 (dup hostname, patch collision, dup UID),
      204 deletes, DTO mappers (ISO serialization incl. `lastSeen`)

Part of #51 · deferred entities → #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbLYQWURfxtsPFRVZpCGVY)_