### PR TITLE
feat(api): client enrolment-token endpoint + registration (#77)

### DIFF
--- a/.claude/plans/issue-77-enrolment-token-endpoint.md
+++ b/.claude/plans/issue-77-enrolment-token-endpoint.md
@@ -1,0 +1,100 @@
+# Issue #77 — Enrolment-token endpoint + client registration
+
+Phase 3 (server side). Adds the dashboard half of client enrolment: an
+admin-minted, single-use, short-TTL enrolment token, and the endpoint the
+install script (#76) calls to register a `Client` + its `UserOnClient`
+mappings and receive what it needs (server SSH public key, per-client bearer
+token).
+
+Authoritative spec: `docs/architecture.md` → "Policy model"/transport table,
+`docs/client-install.md` → step 7–8. Builds on #50 (DTO/envelope), #49 (`app.db`),
+#52 (`requireAdmin`), #48/#51 (`clients`, `users_on_clients`).
+
+## Endpoints
+
+1. **`POST /api/clients/enrolment-tokens`** — **admin-guarded** (`requireAdmin`).
+   Mints a single-use token bound to the supervised-user mapping the admin is
+   provisioning.
+   - Body: `{ supervisedUsers: [{ userId, linuxUsername }], ttlSeconds?, hostname? }`.
+   - Validates every `userId` exists → `404` if any missing.
+   - Mints a 256-bit token (`crypto.randomBytes(32).base64url`), stores only its
+     SHA-256 hash + the mapping payload (JSON) + `expiresAt`; returns the
+     plaintext **once** (`201`).
+
+2. **`POST /api/clients/enrol`** — **token-authenticated** (NOT admin; the client
+   has no session). `Authorization: Bearer <enrolment-token>`.
+   - Body: `{ hostname, sshUser, supervisedUsers: [{ linuxUsername, linuxUid }] }`.
+   - Validates the bearer token: hash lookup → missing/expired/consumed all →
+     `401` with distinct codes. The linuxUsername set must equal the minted
+     mapping's set → `400 enrolment_user_mismatch` otherwise. Re-checks each
+     minted `userId` still exists → `409` if deleted since mint.
+   - In **one transaction**: create the `Client`, insert the `UserOnClient`
+     rows (joining minted `userId` ↔ request `linuxUid` on `linuxUsername`),
+     mint+store a per-client bearer-token hash, mark the enrolment token
+     consumed. Duplicate hostname → `409` (already enrolled).
+   - Returns `201 { clientId, hostname, sshUser, bearerToken (once),
+     sshPublicKey: string | null, supervisedUsers }`. `sshPublicKey` is read
+     from `PCT_SSH_PUBLIC_KEY_PATH` if present, else `null` (Phase-4 keygen
+     may not have run yet — degrade gracefully).
+
+Spelling: use **`/enrol`** (British), matching `docs/client-install.md` step 8
+(authoritative), not the issue body's `/enroll`. Noted in the PR.
+
+## Schema + migration
+
+- New `enrolment_tokens` table: `id`, `token_hash` (unique), `hostname`
+  (nullable), `supervised_users` (JSON), `expires_at`, `created_at`,
+  `consumed_at` (nullable), `consumed_client_id` (nullable FK → clients,
+  `set null`).
+- `clients`: add nullable `bearer_token_hash` (only enrolled clients have one;
+  CRUD-created clients (#51) legitimately don't).
+- Generate via `npm run db:generate` (timestamp-prefixed, #133) — never
+  hand-name. Extend `migrations.test.ts`/`schema.test.ts` as needed.
+
+## Module layout (mirrors `api/policy/` + `policy/repository.ts`)
+
+- `server/src/auth/secret-token.ts` — leaf crypto util: `generateToken()`,
+  `hashToken()` (SHA-256), `timingSafeEqualHex()`. For high-entropy bearer
+  secrets (enrolment + future integration tokens), distinct from Argon2id
+  password hashing. Imports only `node:crypto`.
+- `server/src/policy/enrolment.ts` — data access over `app.db`: insert/find/
+  consume tokens, the enrol transaction (client + links + bearer).
+- `server/src/api/clients/{dtos,service,ssh-identity,routes,index}.ts` — zod
+  DTOs + response mappers, the mint/enrol orchestration, the SSH-public-key
+  reader, thin HTTP handlers, and the registrar. Wired in `api/plugin.ts`
+  after `registerPolicyRoutes`.
+- `server/src/config.ts` — add `sshPublicKeyPath`
+  (`PCT_SSH_PUBLIC_KEY_PATH`, default `/data/secrets/ssh/id_ed25519.pub`).
+
+## Security / license notes
+
+- Enrol is unauthenticated-by-session **by design** — guarded by a 256-bit,
+  hashed-at-rest, single-use, short-TTL token. Brute force is infeasible;
+  leak risk is bounded by TTL + single-use. Per-IP rate-limiting on enrol is a
+  possible follow-up (entropy makes it non-critical) — note, don't build.
+- No GPL linkage; no transport calls (SSH keygen itself is Phase 4 — we only
+  *read* a public key file if present). `license-guard` unaffected.
+
+## Tests (Vitest, ≥80% gate)
+
+- `auth/secret-token.test.ts` — uniqueness, hash determinism/difference, compare.
+- `policy/enrolment.test.ts` — token lifecycle + enrol transaction atomicity
+  (duplicate uid rolls back; no half-created client / un-consumed token).
+- `api/clients/ssh-identity` — key present → string; absent → null.
+- `api/clients-enrolment.test.ts` — full `app.inject()` matrix: mint anon→401,
+  mint bad userId→404, mint happy→201; enrol missing/invalid/expired/consumed
+  bearer→401, mismatch→400, happy→201 (+links, +bearer, +sshPublicKey null/set),
+  reuse→401, duplicate hostname→409.
+- Extend `migrations.test.ts` / `schema.test.ts` for the new table/column.
+
+## Docs
+
+- `.env.example` + `docs/server-deployment.md`: `PCT_SSH_PUBLIC_KEY_PATH`.
+- `docs/architecture.md`: add `bearer_token_hash` to the Client sketch and the
+  `enrolment_tokens` ledger; document the enrol contract.
+
+## Deferred (tracked)
+
+- Wiring into the orchestrator `install-client.sh` → #76.
+- SSH keypair generation on the server → Phase 4 (#39 entrypoint step).
+- Per-IP rate-limit on enrol → follow-up note.

--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,13 @@
 # /data/ansible layout — see docs/server-deployment.md → "Volume layout".
 # PCT_ANSIBLE_DIR=/data/ansible
 
+# Path to the dashboard's SSH PUBLIC key, returned in the client-enrolment
+# response (POST /api/clients/enrol) so the client can authorize the dashboard
+# in pct-agent's authorized_keys. The key pair is generated server-side as a
+# Phase-4 first-run step; until then the file is absent and the response carries
+# sshPublicKey: null. Defaults to the documented /data/secrets/ssh layout.
+# PCT_SSH_PUBLIC_KEY_PATH=/data/secrets/ssh/id_ed25519.pub
+
 # --- AdGuard Home (optional DNS filtering) ----------------------------------
 # Mode: disabled (default) | external | managed
 # See docs/server-deployment.md → "AdGuard Home deployment modes".

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,8 +109,20 @@ User          (id, display_name, tz?)
               --  NULL means "inherit the server default" (PCT_DEFAULT_TZ).
               --  The user's effective TZ defines daily/weekly/monthly
               --  budget rollover. See docs/adr/0001-budget-timezone.md.
-Client        (id, hostname, ssh_user, enrolled_at, last_seen)
+Client        (id, hostname, ssh_user, bearer_token_hash?, enrolled_at,
+                last_seen)
+              --  bearer_token_hash is the SHA-256 of the per-client bearer
+              --  token issued at enrolment (the /api/events/stream credential);
+              --  NULL for a client created via admin CRUD, set at enrol time.
 UserOnClient  (user_id, client_id, linux_username, linux_uid)
+
+EnrolmentToken (id, token_hash, hostname?, supervised_users[],
+                expires_at, created_at, consumed_at?, consumed_client_id?)
+              --  single-use, expiring client-enrolment credential (#77).
+              --  Admin mints one bound to the policy-user ↔ Linux-account
+              --  mapping; POST /api/clients/enrol redeems it (creating the
+              --  Client + UserOnClient rows) and marks it consumed. Only the
+              --  SHA-256 token_hash is stored, never the plaintext.
 
 Activity      (id, kind=app|app_group|domain|domain_group, matcher)
 ActivityGroup (id, name)  --  many-to-many with Activity

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -107,7 +107,7 @@ idempotently:
 4. **SSH key bootstrap** — if `/data/secrets/ssh/id_ed25519` is absent,
    generate one. The public key is shown in the dashboard's "Add client"
    flow for the admin to install on each new client (or, more commonly,
-   for the client install script to fetch via a one-time enrollment URL).
+   for the client install script to fetch via a one-time enrolment token).
    Its path is configurable via `PCT_SSH_PUBLIC_KEY_PATH` (default
    `/data/secrets/ssh/id_ed25519.pub`); the client-enrolment response
    (`POST /api/clients/enrol`, #77) returns that public key so the client can

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -108,6 +108,12 @@ idempotently:
    generate one. The public key is shown in the dashboard's "Add client"
    flow for the admin to install on each new client (or, more commonly,
    for the client install script to fetch via a one-time enrollment URL).
+   Its path is configurable via `PCT_SSH_PUBLIC_KEY_PATH` (default
+   `/data/secrets/ssh/id_ed25519.pub`); the client-enrolment response
+   (`POST /api/clients/enrol`, #77) returns that public key so the client can
+   authorize the dashboard. Until this Phase-4 keygen step lands the file is
+   absent and the enrol response carries `sshPublicKey: null` — enrolment still
+   succeeds, the client just isn't handed a key to authorize yet.
 5. Start the Node server on `0.0.0.0:8000` (default).
 
 If any of the optional downloads fail (no network, etc.), the dashboard

--- a/server/drizzle/20260618144556_woozy_imperial_guard.sql
+++ b/server/drizzle/20260618144556_woozy_imperial_guard.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `enrolment_tokens` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`token_hash` text NOT NULL,
+	`hostname` text,
+	`supervised_users` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`consumed_at` integer,
+	`consumed_client_id` integer,
+	FOREIGN KEY (`consumed_client_id`) REFERENCES `clients`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `enrolment_tokens_token_hash_unique` ON `enrolment_tokens` (`token_hash`);--> statement-breakpoint
+ALTER TABLE `clients` ADD `bearer_token_hash` text;

--- a/server/drizzle/20260618150355_daffy_mantis.sql
+++ b/server/drizzle/20260618150355_daffy_mantis.sql
@@ -11,4 +11,5 @@ CREATE TABLE `enrolment_tokens` (
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX `enrolment_tokens_token_hash_unique` ON `enrolment_tokens` (`token_hash`);--> statement-breakpoint
-ALTER TABLE `clients` ADD `bearer_token_hash` text;
+ALTER TABLE `clients` ADD `bearer_token_hash` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `clients_bearer_token_hash_unique` ON `clients` (`bearer_token_hash`);

--- a/server/drizzle/meta/20260618144556_snapshot.json
+++ b/server/drizzle/meta/20260618144556_snapshot.json
@@ -1,0 +1,1153 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6ede6b6f-0e66-4b75-bd64-c0d79c12c95d",
+  "prevId": "10ef7f27-452f-4519-9057-6860647066f7",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matcher": {
+          "name": "matcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "activities_kind_check": {
+          "name": "activities_kind_check",
+          "value": "\"activities\".\"kind\" in ('app', 'app_group', 'domain', 'domain_group')"
+        }
+      }
+    },
+    "activities_to_groups": {
+      "name": "activities_to_groups",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activities_to_groups_activity_id_activities_id_fk": {
+          "name": "activities_to_groups_activity_id_activities_id_fk",
+          "tableFrom": "activities_to_groups",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activities_to_groups_group_id_activity_groups_id_fk": {
+          "name": "activities_to_groups_group_id_activity_groups_id_fk",
+          "tableFrom": "activities_to_groups",
+          "tableTo": "activity_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activities_to_groups_activity_id_group_id_pk": {
+          "columns": [
+            "activity_id",
+            "group_id"
+          ],
+          "name": "activities_to_groups_activity_id_group_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_groups": {
+      "name": "activity_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "activity_groups_name_unique": {
+          "name": "activity_groups_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "admin_credentials": {
+      "name": "admin_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "admin_credentials_singleton_check": {
+          "name": "admin_credentials_singleton_check",
+          "value": "\"admin_credentials\".\"id\" = 1"
+        }
+      }
+    },
+    "budgets": {
+      "name": "budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seconds_allowed": {
+          "name": "seconds_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "budgets_user_scope_window_idx": {
+          "name": "budgets_user_scope_window_idx",
+          "columns": [
+            "user_id",
+            "scope",
+            "window"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "budgets_scope_check": {
+          "name": "budgets_scope_check",
+          "value": "\"budgets\".\"scope\" in ('overall', 'activity', 'group')"
+        },
+        "budgets_window_check": {
+          "name": "budgets_window_check",
+          "value": "\"budgets\".\"window\" in ('daily', 'weekly', 'monthly')"
+        },
+        "budgets_seconds_check": {
+          "name": "budgets_seconds_check",
+          "value": "\"budgets\".\"seconds_allowed\" >= 0"
+        },
+        "budgets_target_coherence_check": {
+          "name": "budgets_target_coherence_check",
+          "value": "(\"budgets\".\"scope\" = 'overall') = (\"budgets\".\"target_id\" is null)"
+        }
+      }
+    },
+    "clients": {
+      "name": "clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ssh_user": {
+          "name": "ssh_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_hash": {
+          "name": "bearer_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "clients_hostname_unique": {
+          "name": "clients_hostname_unique",
+          "columns": [
+            "hostname"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "enrolment_tokens": {
+      "name": "enrolment_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supervised_users": {
+          "name": "supervised_users",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_client_id": {
+          "name": "consumed_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "enrolment_tokens_token_hash_unique": {
+          "name": "enrolment_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "enrolment_tokens_consumed_client_id_clients_id_fk": {
+          "name": "enrolment_tokens_consumed_client_id_clients_id_fk",
+          "tableFrom": "enrolment_tokens",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "consumed_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exceptions": {
+      "name": "exceptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "exceptions_user_expires_idx": {
+          "name": "exceptions_user_expires_idx",
+          "columns": [
+            "user_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exceptions_user_id_users_id_fk": {
+          "name": "exceptions_user_id_users_id_fk",
+          "tableFrom": "exceptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "exceptions_target_kind_check": {
+          "name": "exceptions_target_kind_check",
+          "value": "\"exceptions\".\"target_kind\" in ('overall', 'activity', 'group')"
+        },
+        "exceptions_action_check": {
+          "name": "exceptions_action_check",
+          "value": "\"exceptions\".\"action\" in ('allow', 'deny', 'extend')"
+        },
+        "exceptions_target_coherence_check": {
+          "name": "exceptions_target_coherence_check",
+          "value": "(\"exceptions\".\"target_kind\" = 'overall') = (\"exceptions\".\"target_id\" is null)"
+        }
+      }
+    },
+    "grants": {
+      "name": "grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seconds_granted": {
+          "name": "seconds_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "grants_source_ref_unique": {
+          "name": "grants_source_ref_unique",
+          "columns": [
+            "source_ref"
+          ],
+          "isUnique": true
+        },
+        "grants_user_scope_target_idx": {
+          "name": "grants_user_scope_target_idx",
+          "columns": [
+            "user_id",
+            "scope",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "grants_user_expires_idx": {
+          "name": "grants_user_expires_idx",
+          "columns": [
+            "user_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "grants_user_id_users_id_fk": {
+          "name": "grants_user_id_users_id_fk",
+          "tableFrom": "grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "grants_scope_check": {
+          "name": "grants_scope_check",
+          "value": "\"grants\".\"scope\" in ('overall', 'activity', 'group')"
+        },
+        "grants_seconds_check": {
+          "name": "grants_seconds_check",
+          "value": "\"grants\".\"seconds_granted\" > 0"
+        },
+        "grants_target_coherence_check": {
+          "name": "grants_target_coherence_check",
+          "value": "(\"grants\".\"scope\" = 'overall') = (\"grants\".\"target_id\" is null)"
+        },
+        "grants_source_check": {
+          "name": "grants_source_check",
+          "value": "\"grants\".\"source\" = 'admin' or \"grants\".\"source\" like 'integration:%'"
+        }
+      }
+    },
+    "integration_tokens": {
+      "name": "integration_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_secret": {
+          "name": "hashed_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "integration_tokens_name_unique": {
+          "name": "integration_tokens_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_policies": {
+      "name": "notification_policies",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sound_profile": {
+          "name": "sound_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "grace_seconds": {
+          "name": "grace_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "cadence_overrides_json": {
+          "name": "cadence_overrides_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_policies_user_id_users_id_fk": {
+          "name": "notification_policies_user_id_users_id_fk",
+          "tableFrom": "notification_policies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "notification_policies_grace_check": {
+          "name": "notification_policies_grace_check",
+          "value": "\"notification_policies\".\"grace_seconds\" >= 0"
+        }
+      }
+    },
+    "schedules": {
+      "name": "schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_or_window": {
+          "name": "cron_or_window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "schedules_user_ordinal_idx": {
+          "name": "schedules_user_ordinal_idx",
+          "columns": [
+            "user_id",
+            "ordinal"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedules_user_id_users_id_fk": {
+          "name": "schedules_user_id_users_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "schedules_target_kind_check": {
+          "name": "schedules_target_kind_check",
+          "value": "\"schedules\".\"target_kind\" in ('overall', 'activity', 'group')"
+        },
+        "schedules_action_check": {
+          "name": "schedules_action_check",
+          "value": "\"schedules\".\"action\" in ('allow', 'deny', 'extend')"
+        },
+        "schedules_target_coherence_check": {
+          "name": "schedules_target_coherence_check",
+          "value": "(\"schedules\".\"target_kind\" = 'overall') = (\"schedules\".\"target_id\" is null)"
+        }
+      }
+    },
+    "usage_samples": {
+      "name": "usage_samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_samples_user_started_idx": {
+          "name": "usage_samples_user_started_idx",
+          "columns": [
+            "user_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "usage_samples_user_activity_started_idx": {
+          "name": "usage_samples_user_activity_started_idx",
+          "columns": [
+            "user_id",
+            "activity_id",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "usage_samples_user_id_users_id_fk": {
+          "name": "usage_samples_user_id_users_id_fk",
+          "tableFrom": "usage_samples",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_samples_client_id_clients_id_fk": {
+          "name": "usage_samples_client_id_clients_id_fk",
+          "tableFrom": "usage_samples",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_samples_activity_id_activities_id_fk": {
+          "name": "usage_samples_activity_id_activities_id_fk",
+          "tableFrom": "usage_samples",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "usage_samples_interval_check": {
+          "name": "usage_samples_interval_check",
+          "value": "\"usage_samples\".\"ended_at\" >= \"usage_samples\".\"started_at\""
+        }
+      }
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tz": {
+          "name": "tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_on_clients": {
+      "name": "users_on_clients",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linux_username": {
+          "name": "linux_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linux_uid": {
+          "name": "linux_uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_on_clients_client_idx": {
+          "name": "users_on_clients_client_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "users_on_clients_client_uid_unique": {
+          "name": "users_on_clients_client_uid_unique",
+          "columns": [
+            "client_id",
+            "linux_uid"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_on_clients_user_id_users_id_fk": {
+          "name": "users_on_clients_user_id_users_id_fk",
+          "tableFrom": "users_on_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_on_clients_client_id_clients_id_fk": {
+          "name": "users_on_clients_client_id_clients_id_fk",
+          "tableFrom": "users_on_clients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_on_clients_user_id_client_id_pk": {
+          "columns": [
+            "user_id",
+            "client_id"
+          ],
+          "name": "users_on_clients_user_id_client_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/drizzle/meta/20260618150355_snapshot.json
+++ b/server/drizzle/meta/20260618150355_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "6ede6b6f-0e66-4b75-bd64-c0d79c12c95d",
+  "id": "99bc27bd-178a-4cff-8349-f8e6d2faa75d",
   "prevId": "10ef7f27-452f-4519-9057-6860647066f7",
   "tables": {
     "activities": {
@@ -320,6 +320,13 @@
           "name": "clients_hostname_unique",
           "columns": [
             "hostname"
+          ],
+          "isUnique": true
+        },
+        "clients_bearer_token_hash_unique": {
+          "name": "clients_bearer_token_hash_unique",
+          "columns": [
+            "bearer_token_hash"
           ],
           "isUnique": true
         }

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781668720900,
       "tag": "0002_hard_green_goblin",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1781793956169,
+      "tag": "20260618144556_woozy_imperial_guard",
+      "breakpoints": true
     }
   ]
 }

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -26,8 +26,8 @@
     {
       "idx": 3,
       "version": "6",
-      "when": 1781793956169,
-      "tag": "20260618144556_woozy_imperial_guard",
+      "when": 1781795035747,
+      "tag": "20260618150355_daffy_mantis",
       "breakpoints": true
     }
   ]

--- a/server/src/api/clients/dtos.ts
+++ b/server/src/api/clients/dtos.ts
@@ -1,0 +1,94 @@
+/**
+ * zod DTOs for the client-enrolment surface (#77): the admin "mint a token"
+ * request/response and the install script's "enrol" request/response. As with
+ * every `/api/*` DTO these are the single contract shared with the SvelteKit
+ * frontend and the install script — types are inferred, never hand-written
+ * twice (`CLAUDE.md` → "api/ — zod DTOs ...").
+ *
+ * License boundary: none touched — plain TypeScript + zod.
+ */
+import { z } from "zod";
+
+/** Largest enrolment-token lifetime an admin may request: 24h. */
+export const MAX_ENROLMENT_TTL_SECONDS = 24 * 60 * 60;
+/** Default enrolment-token lifetime when the admin doesn't specify one: 1h. */
+export const DEFAULT_ENROLMENT_TTL_SECONDS = 60 * 60;
+
+/** A Linux login name (mirrors the link DTO in `../policy/dtos.ts`). */
+const linuxUsernameSchema = z.string().trim().min(1).max(32);
+/** A Linux UID; 0 (root) is representable even if policy would never use it. */
+const linuxUidSchema = z.number().int().min(0);
+/** A hostname (RFC-1035 max length); also mirrors the client DTO. */
+const hostnameSchema = z.string().trim().min(1).max(253);
+/** An SSH login name for the `pct-agent` principal. */
+const sshUserSchema = z.string().trim().min(1).max(64);
+/** A positive integer primary key. */
+const positiveIdSchema = z.number().int().positive();
+
+/** Reject a list whose `linuxUsername`s are not all distinct. */
+function distinctUsernames(list: { linuxUsername: string }[]): boolean {
+  return new Set(list.map((entry) => entry.linuxUsername)).size === list.length;
+}
+
+const distinctUsernamesMessage = { message: "linuxUsername values must be distinct" };
+
+// --- Mint (admin-guarded) --------------------------------------------------
+
+export const mintEnrolmentTokenSchema = z.object({
+  /** The policy-user ↔ Linux-account mapping this client will carry. */
+  supervisedUsers: z
+    .array(z.object({ userId: positiveIdSchema, linuxUsername: linuxUsernameSchema }))
+    .min(1)
+    .refine(distinctUsernames, distinctUsernamesMessage),
+  /** Token lifetime; defaults to {@link DEFAULT_ENROLMENT_TTL_SECONDS}. */
+  ttlSeconds: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_ENROLMENT_TTL_SECONDS)
+    .default(DEFAULT_ENROLMENT_TTL_SECONDS),
+  /** Optional expected hostname, recorded for the admin's reference. */
+  hostname: hostnameSchema.optional(),
+});
+
+export const enrolmentTokenResponseSchema = z.object({
+  id: z.number().int(),
+  /** The plaintext token — returned **once**; only its hash is stored. */
+  token: z.string(),
+  expiresAt: z.string(),
+});
+
+export type MintEnrolmentTokenRequest = z.infer<typeof mintEnrolmentTokenSchema>;
+export type EnrolmentTokenResponse = z.infer<typeof enrolmentTokenResponseSchema>;
+
+// --- Enrol (token-authenticated) -------------------------------------------
+
+export const enrolClientSchema = z.object({
+  hostname: hostnameSchema,
+  sshUser: sshUserSchema,
+  /** Each supervised user's resolved Linux account on this box. */
+  supervisedUsers: z
+    .array(z.object({ linuxUsername: linuxUsernameSchema, linuxUid: linuxUidSchema }))
+    .min(1)
+    .refine(distinctUsernames, distinctUsernamesMessage),
+});
+
+export const enrolResponseSchema = z.object({
+  clientId: z.number().int(),
+  hostname: z.string(),
+  sshUser: z.string(),
+  /** The per-client bearer token — returned **once**; only its hash is stored. */
+  bearerToken: z.string(),
+  /** The dashboard's SSH public key to authorize, or `null` if not yet generated. */
+  sshPublicKey: z.string().nullable(),
+  supervisedUsers: z.array(
+    z.object({
+      userId: z.number().int(),
+      linuxUsername: z.string(),
+      linuxUid: z.number().int(),
+    }),
+  ),
+});
+
+export type EnrolClientRequest = z.infer<typeof enrolClientSchema>;
+export type EnrolResponse = z.infer<typeof enrolResponseSchema>;

--- a/server/src/api/clients/index.ts
+++ b/server/src/api/clients/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Client-enrolment surface (#77): the route registrar plus the zod DTOs and
+ * inferred types the frontend and install script consume. Re-exported from the
+ * top-level `api/` barrel so the whole `/api` contract imports from one place.
+ */
+export { registerClientEnrolmentRoutes, parseBearer } from "./routes.js";
+export {
+  enrolClientSchema,
+  enrolResponseSchema,
+  mintEnrolmentTokenSchema,
+  enrolmentTokenResponseSchema,
+  DEFAULT_ENROLMENT_TTL_SECONDS,
+  MAX_ENROLMENT_TTL_SECONDS,
+  type EnrolClientRequest,
+  type EnrolResponse,
+  type MintEnrolmentTokenRequest,
+  type EnrolmentTokenResponse,
+} from "./dtos.js";

--- a/server/src/api/clients/routes.ts
+++ b/server/src/api/clients/routes.ts
@@ -55,6 +55,10 @@ export function registerClientEnrolmentRoutes(scope: FastifyInstance, settings: 
     { preHandler: scope.requireAdmin, schema: { body: mintEnrolmentTokenSchema } },
     async (request, reply): Promise<EnrolmentTokenResponse> => {
       const result = mintEnrolmentToken(scope.db, request.body);
+      request.log.info(
+        { event: "enrolment_token_minted", tokenId: result.id },
+        "enrolment token minted",
+      );
       reply.code(201);
       return { id: result.id, token: result.token, expiresAt: result.expiresAt.toISOString() };
     },
@@ -62,6 +66,13 @@ export function registerClientEnrolmentRoutes(scope: FastifyInstance, settings: 
 
   // Intentionally NOT behind requireAdmin — authenticated by the bearer
   // enrolment token, which the service validates.
+  //
+  // No per-IP rate limit is applied here (unlike the login route's
+  // LoginRateLimiter): the token is a 256-bit random secret, so online guessing
+  // is infeasible, and protecting the unauthenticated surface from volumetric
+  // abuse belongs at the reverse proxy (Phase 11, docs/server-deployment.md →
+  // "Reverse proxy"). Rejections are logged so abuse is observable. Revisit if
+  // an application-layer limiter is wanted — tracked as a follow-up.
   typed.post(
     "/clients/enrol",
     { schema: { body: enrolClientSchema } },

--- a/server/src/api/clients/routes.ts
+++ b/server/src/api/clients/routes.ts
@@ -1,0 +1,85 @@
+/**
+ * Client-enrolment routes (#77): the admin "mint a token" endpoint and the
+ * install script's "enrol" endpoint.
+ *
+ * Registered inside the `/api` plugin scope (after `registerAuth`) so both
+ * inherit the zod validator + shared error envelope. The split in *who* may
+ * call them is deliberate:
+ *  - `POST /clients/enrolment-tokens` is admin-only (`requireAdmin`) — minting
+ *    a credential is an admin action.
+ *  - `POST /clients/enrol` is **not** session-guarded: the install script has
+ *    no admin session. It authenticates with the one-time enrolment token in
+ *    the `Authorization: Bearer …` header, validated inside the service. This
+ *    is the single intentional unauthenticated-by-session write, and it is
+ *    gated by a 256-bit, hashed-at-rest, single-use, expiring token.
+ *
+ * Handlers stay thin: validate via the DTOs, delegate to `./service.ts`, and
+ * serialise dates as ISO strings.
+ *
+ * License boundary: none touched — plain TypeScript + zod + Fastify.
+ */
+import type { FastifyInstance } from "fastify";
+
+import type { Settings } from "../../config.js";
+import { ApiError } from "../errors.js";
+import type { ZodTypeProvider } from "../validation.js";
+import {
+  enrolClientSchema,
+  mintEnrolmentTokenSchema,
+  type EnrolResponse,
+  type EnrolmentTokenResponse,
+} from "./dtos.js";
+import { enrolClient, mintEnrolmentToken } from "./service.js";
+
+/**
+ * Extract the token from an `Authorization: Bearer <token>` header, or `null`
+ * if the header is missing or not a non-empty bearer credential.
+ */
+export function parseBearer(header: string | undefined): string | null {
+  if (header === undefined) return null;
+  const match = /^Bearer (.+)$/.exec(header.trim());
+  const token = match?.[1]?.trim();
+  return token !== undefined && token.length > 0 ? token : null;
+}
+
+/**
+ * Register the enrolment routes on an already-`/api`-prefixed scope. Call after
+ * {@link registerAuth} so `scope.requireAdmin` is decorated; `settings` carries
+ * the SSH-public-key path the enrol response returns.
+ */
+export function registerClientEnrolmentRoutes(scope: FastifyInstance, settings: Settings): void {
+  const typed = scope.withTypeProvider<ZodTypeProvider>();
+
+  typed.post(
+    "/clients/enrolment-tokens",
+    { preHandler: scope.requireAdmin, schema: { body: mintEnrolmentTokenSchema } },
+    async (request, reply): Promise<EnrolmentTokenResponse> => {
+      const result = mintEnrolmentToken(scope.db, request.body);
+      reply.code(201);
+      return { id: result.id, token: result.token, expiresAt: result.expiresAt.toISOString() };
+    },
+  );
+
+  // Intentionally NOT behind requireAdmin — authenticated by the bearer
+  // enrolment token, which the service validates.
+  typed.post(
+    "/clients/enrol",
+    { schema: { body: enrolClientSchema } },
+    async (request, reply): Promise<EnrolResponse> => {
+      const token = parseBearer(request.headers.authorization);
+      if (token === null) {
+        throw new ApiError(
+          401,
+          "unauthorized",
+          "Missing or malformed Authorization: Bearer <enrolment-token> header",
+        );
+      }
+      const result = enrolClient(scope.db, token, request.body, {
+        sshPublicKeyPath: settings.sshPublicKeyPath,
+        log: request.log,
+      });
+      reply.code(201);
+      return result;
+    },
+  );
+}

--- a/server/src/api/clients/service.ts
+++ b/server/src/api/clients/service.ts
@@ -1,0 +1,179 @@
+/**
+ * Enrolment orchestration (#77): the logic the `clients` routes delegate to,
+ * sitting between the HTTP layer and the policy store. It validates inputs
+ * against existing policy state, hashes the bearer secrets, and maps failures
+ * onto {@link ApiError}s in the shared envelope. Persistence lives in
+ * `policy/enrolment.ts`; token hashing in `auth/secret-token.ts`.
+ *
+ * License boundary: none touched — plain TypeScript + zod + Drizzle.
+ */
+import type { FastifyBaseLogger } from "fastify";
+
+import { generateToken, hashToken } from "../../auth/secret-token.js";
+import type { PolicyDb } from "../../policy/db.js";
+import * as enrolmentRepo from "../../policy/enrolment.js";
+import * as repo from "../../policy/repository.js";
+import { ApiError } from "../errors.js";
+import type { EnrolClientRequest, MintEnrolmentTokenRequest } from "./dtos.js";
+import { loadServerSshPublicKey } from "./ssh-identity.js";
+
+/** What {@link mintEnrolmentToken} hands back to the route (token shown once). */
+export interface MintResult {
+  id: number;
+  token: string;
+  expiresAt: Date;
+}
+
+/** What {@link enrolClient} hands back to the route (bearer token shown once). */
+export interface EnrolResult {
+  clientId: number;
+  hostname: string;
+  sshUser: string;
+  bearerToken: string;
+  sshPublicKey: string | null;
+  supervisedUsers: { userId: number; linuxUsername: string; linuxUid: number }[];
+}
+
+/**
+ * Mint a single-use enrolment token bound to `input.supervisedUsers`. Every
+ * referenced policy `userId` must already exist (404 otherwise) so the admin
+ * can't bind a token to a phantom user. Returns the plaintext token once; only
+ * its hash is persisted.
+ */
+export function mintEnrolmentToken(db: PolicyDb, input: MintEnrolmentTokenRequest): MintResult {
+  for (const entry of input.supervisedUsers) {
+    if (repo.getUser(db, entry.userId) === undefined) {
+      throw new ApiError(404, "not_found", `User ${entry.userId} not found`);
+    }
+  }
+
+  const token = generateToken();
+  const expiresAt = new Date(Date.now() + input.ttlSeconds * 1000);
+  const row = enrolmentRepo.createEnrolmentToken(db, {
+    tokenHash: hashToken(token),
+    hostname: input.hostname ?? null,
+    supervisedUsers: input.supervisedUsers,
+    expiresAt,
+  });
+
+  return { id: row.id, token, expiresAt: row.expiresAt };
+}
+
+/** Options threaded into {@link enrolClient} from the route. */
+export interface EnrolOptions {
+  /** Path to the server's SSH public key (`settings.sshPublicKeyPath`). */
+  sshPublicKeyPath: string;
+  /** Request logger, used to warn if the SSH key is present but unreadable. */
+  log: FastifyBaseLogger;
+}
+
+/**
+ * Redeem an enrolment token and register the client. The bearer enrolment token
+ * (from the `Authorization` header) is validated by hash lookup; a missing,
+ * expired, or already-consumed token is a `401`. The request's supervised-user
+ * set must exactly match the set the token was minted for (`400` otherwise),
+ * and every bound user must still exist (`409` if one was deleted since mint).
+ * On success the client + links are created and the token consumed in one
+ * transaction, a per-client bearer token is issued (returned once), and the
+ * server SSH public key is included when available.
+ */
+export function enrolClient(
+  db: PolicyDb,
+  bearerEnrolmentToken: string,
+  input: EnrolClientRequest,
+  options: EnrolOptions,
+): EnrolResult {
+  const tokenRow = enrolmentRepo.findEnrolmentTokenByHash(db, hashToken(bearerEnrolmentToken));
+  if (tokenRow === undefined) {
+    throw new ApiError(401, "enrolment_token_invalid", "Unknown or invalid enrolment token");
+  }
+  if (tokenRow.consumedAt !== null) {
+    throw new ApiError(401, "enrolment_token_used", "This enrolment token has already been used");
+  }
+  if (tokenRow.expiresAt.getTime() <= Date.now()) {
+    throw new ApiError(401, "enrolment_token_expired", "This enrolment token has expired");
+  }
+
+  // Join the minted mapping (userId ↔ linuxUsername) with the request's
+  // (linuxUsername ↔ linuxUid) on linuxUsername; the sets must match exactly so
+  // the client can neither drop a bound user nor smuggle in an extra one.
+  const requestByName = new Map(input.supervisedUsers.map((entry) => [entry.linuxUsername, entry]));
+  const minted = tokenRow.supervisedUsers;
+  const mismatch =
+    minted.length !== input.supervisedUsers.length ||
+    minted.some((entry) => !requestByName.has(entry.linuxUsername));
+  if (mismatch) {
+    throw new ApiError(
+      400,
+      "enrolment_user_mismatch",
+      "Supervised users do not match the ones this enrolment token was minted for",
+    );
+  }
+
+  const links: enrolmentRepo.EnrolLink[] = minted.map((entry) => {
+    const requested = requestByName.get(entry.linuxUsername);
+    if (requested === undefined) {
+      // Unreachable given the exact-match check above, but keeps the map access
+      // total without a non-null assertion.
+      throw new ApiError(400, "enrolment_user_mismatch", "Supervised user set mismatch");
+    }
+    if (repo.getUser(db, entry.userId) === undefined) {
+      throw new ApiError(409, "user_no_longer_exists", `User ${entry.userId} no longer exists`);
+    }
+    return {
+      userId: entry.userId,
+      linuxUsername: entry.linuxUsername,
+      linuxUid: requested.linuxUid,
+    };
+  });
+
+  const bearerToken = generateToken();
+  let result: enrolmentRepo.EnrolResult;
+  try {
+    result = enrolmentRepo.consumeTokenAndEnrol(db, tokenRow.id, {
+      hostname: input.hostname,
+      sshUser: input.sshUser,
+      bearerTokenHash: hashToken(bearerToken),
+      links,
+    });
+  } catch (err) {
+    if (repo.isUniqueViolation(err)) {
+      throw new ApiError(
+        409,
+        "conflict",
+        `Client "${input.hostname}" is already enrolled, or a Linux UID is duplicated for it`,
+      );
+    }
+    throw err;
+  }
+
+  return {
+    clientId: result.client.id,
+    hostname: result.client.hostname,
+    sshUser: result.client.sshUser,
+    bearerToken,
+    sshPublicKey: readSshPublicKey(options),
+    supervisedUsers: result.links.map((link) => ({
+      userId: link.userId,
+      linuxUsername: link.linuxUsername,
+      linuxUid: link.linuxUid,
+    })),
+  };
+}
+
+/**
+ * Read the server SSH public key, degrading to `null` on any failure so a key
+ * problem never breaks an otherwise-valid enrolment. A genuinely unexpected
+ * read error (not "file absent") is logged at warn level for the operator.
+ */
+function readSshPublicKey(options: EnrolOptions): string | null {
+  try {
+    return loadServerSshPublicKey(options.sshPublicKeyPath);
+  } catch (err) {
+    options.log.warn(
+      { err, path: options.sshPublicKeyPath },
+      "could not read server SSH public key for enrolment; returning null",
+    );
+    return null;
+  }
+}

--- a/server/src/api/clients/service.ts
+++ b/server/src/api/clients/service.ts
@@ -25,7 +25,7 @@ export interface MintResult {
 }
 
 /** What {@link enrolClient} hands back to the route (bearer token shown once). */
-export interface EnrolResult {
+export interface EnrolServiceResult {
   clientId: number;
   hostname: string;
   sshUser: string;
@@ -82,15 +82,29 @@ export function enrolClient(
   bearerEnrolmentToken: string,
   input: EnrolClientRequest,
   options: EnrolOptions,
-): EnrolResult {
+): EnrolServiceResult {
   const tokenRow = enrolmentRepo.findEnrolmentTokenByHash(db, hashToken(bearerEnrolmentToken));
   if (tokenRow === undefined) {
+    options.log.warn(
+      { event: "enrol_rejected", reason: "invalid_token" },
+      "client enrolment rejected",
+    );
     throw new ApiError(401, "enrolment_token_invalid", "Unknown or invalid enrolment token");
   }
   if (tokenRow.consumedAt !== null) {
+    options.log.warn(
+      { event: "enrol_rejected", reason: "used_token", tokenId: tokenRow.id },
+      "client enrolment rejected",
+    );
     throw new ApiError(401, "enrolment_token_used", "This enrolment token has already been used");
   }
+  // `expires_at` is stored at second granularity, so a token can read as expired
+  // up to ~1s early; harmless for the minute-to-hours TTLs in use.
   if (tokenRow.expiresAt.getTime() <= Date.now()) {
+    options.log.warn(
+      { event: "enrol_rejected", reason: "expired_token", tokenId: tokenRow.id },
+      "client enrolment rejected",
+    );
     throw new ApiError(401, "enrolment_token_expired", "This enrolment token has expired");
   }
 
@@ -137,6 +151,15 @@ export function enrolClient(
       links,
     });
   } catch (err) {
+    if (err instanceof enrolmentRepo.EnrolmentTokenConsumedError) {
+      // Lost a race for the same token (not reachable on today's synchronous
+      // path; the data-layer guard makes it safe regardless).
+      options.log.warn(
+        { event: "enrol_rejected", reason: "used_token", tokenId: tokenRow.id },
+        "client enrolment rejected",
+      );
+      throw new ApiError(401, "enrolment_token_used", "This enrolment token has already been used");
+    }
     if (repo.isUniqueViolation(err)) {
       throw new ApiError(
         409,
@@ -147,6 +170,10 @@ export function enrolClient(
     throw err;
   }
 
+  options.log.info(
+    { event: "client_enrolled", clientId: result.client.id, hostname: result.client.hostname },
+    "client enrolled",
+  );
   return {
     clientId: result.client.id,
     hostname: result.client.hostname,

--- a/server/src/api/clients/ssh-identity.ts
+++ b/server/src/api/clients/ssh-identity.ts
@@ -1,0 +1,35 @@
+/**
+ * Read the dashboard's own SSH public key to hand back at enrolment (#77).
+ *
+ * The enrol response includes the server's SSH public key so the client can
+ * authorize it in `~pct-agent/.ssh/authorized_keys` (client step #78). The key
+ * pair itself is generated server-side as a Phase-4 first-run step (#39); until
+ * that lands the file legitimately does not exist, so a missing (or empty) file
+ * resolves to `null` rather than failing enrolment — the client is simply told
+ * "no key yet". A genuinely unexpected read error (e.g. a permissions
+ * misconfiguration) is surfaced to the caller rather than masked.
+ *
+ * License boundary: none touched — `node:fs` only; no SSH library, no transport.
+ */
+import { readFileSync } from "node:fs";
+
+/** Whether an error is a "file does not exist" (`ENOENT`) error. */
+function isNotFound(err: unknown): boolean {
+  return typeof err === "object" && err !== null && Reflect.get(err, "code") === "ENOENT";
+}
+
+/**
+ * Return the trimmed contents of the server SSH public key at `path`, or `null`
+ * when the file is absent or empty. Rethrows any other error.
+ */
+export function loadServerSshPublicKey(path: string): string | null {
+  let contents: string;
+  try {
+    contents = readFileSync(path, "utf8");
+  } catch (err) {
+    if (isNotFound(err)) return null;
+    throw err;
+  }
+  const trimmed = contents.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -49,6 +49,19 @@ export {
   type UserResponse,
 } from "./policy/index.js";
 
+// Client-enrolment DTOs (#77): the admin token-mint + install-script enrol
+// contract. Schemas live in `./clients/dtos.ts` next to the routes.
+export {
+  enrolClientSchema,
+  enrolResponseSchema,
+  mintEnrolmentTokenSchema,
+  enrolmentTokenResponseSchema,
+  type EnrolClientRequest,
+  type EnrolResponse,
+  type MintEnrolmentTokenRequest,
+  type EnrolmentTokenResponse,
+} from "./clients/index.js";
+
 // Auth DTOs (#52). Re-exported here so the frontend imports the auth contract
 // from the same `/api` surface as every other DTO; the schemas themselves live
 // in `../auth/dtos.ts` next to the routes that use them.

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -10,6 +10,7 @@ import type { FastifyInstance, FastifyPluginAsync } from "fastify";
 
 import { registerAuth } from "../auth/index.js";
 import type { Settings } from "../config.js";
+import { registerClientEnrolmentRoutes } from "./clients/index.js";
 import { registerMetaRoute } from "./meta.js";
 import { registerPolicyRoutes } from "./policy/index.js";
 import { installApiConventions } from "./validation.js";
@@ -32,6 +33,9 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   registerMetaRoute(scope);
   // Policy CRUD (#51) — registered after auth so `scope.requireAdmin` exists.
   registerPolicyRoutes(scope);
+  // Client enrolment (#77): admin-minted token + the install script's enrol
+  // exchange. `settings` carries the SSH-public-key path the enrol response returns.
+  registerClientEnrolmentRoutes(scope, opts.settings);
 };
 
 /** Mount the JSON API under `/api` on the given app. */

--- a/server/src/auth/secret-token.ts
+++ b/server/src/auth/secret-token.ts
@@ -1,0 +1,49 @@
+/**
+ * High-entropy bearer-secret helpers (issue #77).
+ *
+ * Enrolment tokens and per-client bearer tokens are **random 256-bit secrets**,
+ * not user-chosen passwords. The right primitive for those is a fast
+ * cryptographic hash (SHA-256) of the raw token, stored at rest so a database
+ * leak never exposes a usable credential — deliberately distinct from
+ * {@link ../auth/passwords.ts}'s Argon2id, which exists to slow down brute
+ * force against *low*-entropy passwords. A 256-bit random token has no brute
+ * force to slow down, so a salted slow hash would buy nothing and only add
+ * per-request cost.
+ *
+ * Reusable for any opaque bearer secret the dashboard issues (the future
+ * `integration_tokens` secret can share it).
+ *
+ * License boundary: none touched — `node:crypto` only.
+ */
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+
+/** Bytes of entropy in a minted token (256 bits). */
+const TOKEN_BYTES = 32;
+
+/**
+ * Mint a new opaque token: URL-safe base64 of {@link TOKEN_BYTES} random bytes.
+ * The plaintext is shown to the caller exactly once; only its {@link hashToken}
+ * digest is persisted.
+ */
+export function generateToken(): string {
+  return randomBytes(TOKEN_BYTES).toString("base64url");
+}
+
+/** SHA-256 of a token, hex-encoded — the form stored and looked up by. */
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+/**
+ * Constant-time comparison of two hex digests. Lookups are by hash (so the DB
+ * index does the matching), but this is exported for any path that compares a
+ * presented hash against a stored one without leaking timing.
+ */
+export function timingSafeEqualHex(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "hex");
+  const bb = Buffer.from(b, "hex");
+  // timingSafeEqual throws on length mismatch; guard so a wrong-length input is
+  // a plain `false` rather than an exception.
+  if (ab.length !== bb.length || ab.length === 0) return false;
+  return timingSafeEqual(ab, bb);
+}

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -124,6 +124,16 @@ const settingsSchema = z
      * `/data/ansible` layout (`docs/server-deployment.md` → "Volume layout").
      */
     ansibleDir: z.string().min(1).default("/data/ansible"),
+    /**
+     * Path to the dashboard's SSH **public** key (`PCT_SSH_PUBLIC_KEY_PATH`).
+     * The client-enrolment response (#77) returns this so the client can
+     * authorize the dashboard in `pct-agent`'s `authorized_keys`. The key pair
+     * is generated server-side as a Phase-4 first-run step (#39); until then
+     * the file is legitimately absent and the enrol response carries
+     * `sshPublicKey: null`. Defaults to the documented `/data/secrets/ssh`
+     * layout (`docs/server-deployment.md` → "Volume layout").
+     */
+    sshPublicKeyPath: z.string().min(1).default("/data/secrets/ssh/id_ed25519.pub"),
     adguard: adguardSchema,
   })
   .superRefine((settings, ctx) => {
@@ -181,6 +191,7 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
     adminUsername: env.PCT_ADMIN_USERNAME,
     adminPassword: env.PCT_ADMIN_PASSWORD,
     ansibleDir: env.PCT_ANSIBLE_DIR,
+    sshPublicKeyPath: env.PCT_SSH_PUBLIC_KEY_PATH,
     adguard: {
       mode: env.PCT_ADGUARD_MODE ?? "disabled",
       url: env.PCT_ADGUARD_URL,

--- a/server/src/policy/enrolment.ts
+++ b/server/src/policy/enrolment.ts
@@ -1,0 +1,125 @@
+/**
+ * Policy-store data access for client enrolment (#77).
+ *
+ * Companion to {@link ./repository.ts}: thin, synchronous functions over the
+ * shared {@link PolicyDb} for the `enrolment_tokens` table and the one
+ * transactional write that turns a redeemed token into an enrolled client.
+ * HTTP concerns (status codes, the error envelope, token hashing) stay in the
+ * `api/clients` route/service layer — this module only touches the database.
+ *
+ * License boundary: none touched — Drizzle (Apache-2.0) + better-sqlite3 (MIT).
+ */
+import { eq } from "drizzle-orm";
+
+import type { PolicyDb } from "./db.js";
+import { clients, enrolmentTokens, usersOnClients } from "./schema.js";
+import type { ClientRow, UserOnClientRow } from "./repository.js";
+
+/** A persisted {@link enrolmentTokens} row. */
+export type EnrolmentTokenRow = typeof enrolmentTokens.$inferSelect;
+
+/** The policy-user ↔ Linux-account mapping the admin binds at mint time. */
+export interface SupervisedUserMapping {
+  userId: number;
+  linuxUsername: string;
+}
+
+/** Fields accepted when minting an {@link enrolmentTokens} row. */
+export interface EnrolmentTokenCreate {
+  /** SHA-256 of the plaintext token (never the plaintext itself). */
+  tokenHash: string;
+  hostname?: string | null;
+  supervisedUsers: SupervisedUserMapping[];
+  expiresAt: Date;
+}
+
+/** One supervised-user link to create at enrol time (uid supplied by the client). */
+export interface EnrolLink {
+  userId: number;
+  linuxUsername: string;
+  linuxUid: number;
+}
+
+/** Inputs to the {@link consumeTokenAndEnrol} transaction. */
+export interface EnrolWrite {
+  hostname: string;
+  sshUser: string;
+  /** SHA-256 of the per-client bearer token issued at enrolment. */
+  bearerTokenHash: string;
+  links: EnrolLink[];
+}
+
+/** The rows created by a successful enrolment. */
+export interface EnrolResult {
+  client: ClientRow;
+  links: UserOnClientRow[];
+}
+
+/** Insert an enrolment token and return the stored row. */
+export function createEnrolmentToken(db: PolicyDb, input: EnrolmentTokenCreate): EnrolmentTokenRow {
+  return db
+    .insert(enrolmentTokens)
+    .values({
+      tokenHash: input.tokenHash,
+      hostname: input.hostname ?? null,
+      supervisedUsers: input.supervisedUsers,
+      expiresAt: input.expiresAt,
+    })
+    .returning()
+    .get();
+}
+
+/** Look up an enrolment token by its SHA-256 hash, or `undefined` if none. */
+export function findEnrolmentTokenByHash(
+  db: PolicyDb,
+  tokenHash: string,
+): EnrolmentTokenRow | undefined {
+  return db.select().from(enrolmentTokens).where(eq(enrolmentTokens.tokenHash, tokenHash)).get();
+}
+
+/**
+ * Redeem a token in a single transaction: create the {@link clients} row (with
+ * its bearer-token hash), insert the {@link usersOnClients} links, and mark the
+ * token consumed (recording which client it created). Any failure — a duplicate
+ * hostname, a duplicate `(client, linux_uid)`, or a vanished user FK — rolls the
+ * whole thing back, so a failed enrolment never half-creates a client or burns
+ * the token. The caller is responsible for having validated the token's
+ * state (unexpired/unconsumed) and that each `userId` still exists first.
+ */
+export function consumeTokenAndEnrol(
+  db: PolicyDb,
+  tokenId: number,
+  input: EnrolWrite,
+): EnrolResult {
+  return db.transaction((tx) => {
+    const client = tx
+      .insert(clients)
+      .values({
+        hostname: input.hostname,
+        sshUser: input.sshUser,
+        bearerTokenHash: input.bearerTokenHash,
+      })
+      .returning()
+      .get();
+
+    const links = input.links.map((link) =>
+      tx
+        .insert(usersOnClients)
+        .values({
+          userId: link.userId,
+          clientId: client.id,
+          linuxUsername: link.linuxUsername,
+          linuxUid: link.linuxUid,
+        })
+        .returning()
+        .get(),
+    );
+
+    tx.update(enrolmentTokens)
+      .set({ consumedAt: new Date(), consumedClientId: client.id })
+      .where(eq(enrolmentTokens.id, tokenId))
+      .run();
+
+    return { client, links };
+  });
+}

--- a/server/src/policy/enrolment.ts
+++ b/server/src/policy/enrolment.ts
@@ -9,7 +9,7 @@
  *
  * License boundary: none touched — Drizzle (Apache-2.0) + better-sqlite3 (MIT).
  */
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
 import type { PolicyDb } from "./db.js";
 import { clients, enrolmentTokens, usersOnClients } from "./schema.js";
@@ -85,7 +85,21 @@ export function findEnrolmentTokenByHash(
  * whole thing back, so a failed enrolment never half-creates a client or burns
  * the token. The caller is responsible for having validated the token's
  * state (unexpired/unconsumed) and that each `userId` still exists first.
+ *
+ * The consume UPDATE is guarded with `consumed_at IS NULL` and its row count is
+ * asserted: although the synchronous request path already serialises the
+ * check-then-consume (the service does no `await` between them), this rolls the
+ * whole transaction back rather than double-enrolling if the token's state
+ * changed under us — defence in depth against a future async refactor.
+ * {@link EnrolmentTokenConsumedError} signals that case.
  */
+export class EnrolmentTokenConsumedError extends Error {
+  constructor() {
+    super("enrolment token was already consumed");
+    this.name = "EnrolmentTokenConsumedError";
+  }
+}
+
 export function consumeTokenAndEnrol(
   db: PolicyDb,
   tokenId: number,
@@ -115,10 +129,16 @@ export function consumeTokenAndEnrol(
         .get(),
     );
 
-    tx.update(enrolmentTokens)
+    const consumed = tx
+      .update(enrolmentTokens)
       .set({ consumedAt: new Date(), consumedClientId: client.id })
-      .where(eq(enrolmentTokens.id, tokenId))
+      .where(and(eq(enrolmentTokens.id, tokenId), isNull(enrolmentTokens.consumedAt)))
       .run();
+    if (consumed.changes !== 1) {
+      // Token was consumed between the caller's check and here — abort so the
+      // client + links insert above roll back with this transaction.
+      throw new EnrolmentTokenConsumedError();
+    }
 
     return { client, links };
   });

--- a/server/src/policy/schema.ts
+++ b/server/src/policy/schema.ts
@@ -100,7 +100,14 @@ export const clients = sqliteTable(
     enrolledAt: timestampNow("enrolled_at"),
     lastSeen: integer("last_seen", { mode: "timestamp" }),
   },
-  (table) => [uniqueIndex("clients_hostname_unique").on(table.hostname)],
+  (table) => [
+    uniqueIndex("clients_hostname_unique").on(table.hostname),
+    // The per-client bearer token is the credential the Phase-8b event stream
+    // authenticates against (a lookup by hash), so make that lookup single-row
+    // by construction. SQLite treats multiple NULLs as distinct, so the
+    // admin-CRUD clients that carry no bearer token are unaffected.
+    uniqueIndex("clients_bearer_token_hash_unique").on(table.bearerTokenHash),
+  ],
 );
 
 /**

--- a/server/src/policy/schema.ts
+++ b/server/src/policy/schema.ts
@@ -80,17 +80,63 @@ export const users = sqliteTable("users", {
   createdAt: timestampNow("created_at"),
 });
 
-/** An enrolled Linux desktop the dashboard orchestrates over SSH. */
+/**
+ * An enrolled Linux desktop the dashboard orchestrates over SSH.
+ *
+ * `bearer_token_hash` is the SHA-256 of the per-client bearer token issued at
+ * enrolment (#77), which the Phase-8b event stream (`/api/events/stream`)
+ * authenticates against. Only the hash is stored — never the plaintext. It is
+ * nullable because a client created through the admin CRUD (`POST /api/clients`,
+ * #51) has not been through the enrolment exchange and so holds no bearer
+ * token; only `POST /api/clients/enrol` sets it.
+ */
 export const clients = sqliteTable(
   "clients",
   {
     id: integer("id").primaryKey({ autoIncrement: true }),
     hostname: text("hostname").notNull(),
     sshUser: text("ssh_user").notNull(),
+    bearerTokenHash: text("bearer_token_hash"),
     enrolledAt: timestampNow("enrolled_at"),
     lastSeen: integer("last_seen", { mode: "timestamp" }),
   },
   (table) => [uniqueIndex("clients_hostname_unique").on(table.hostname)],
+);
+
+/**
+ * A single-use, expiring client-enrolment credential (#77).
+ *
+ * The admin mints one ("Add client" flow) bound to the supervised-user mapping
+ * being provisioned; the install script (#76) presents it once to
+ * `POST /api/clients/enrol`, which creates the {@link clients} row and the
+ * {@link usersOnClients} links and then **consumes** the token. Like
+ * {@link integrationTokens}, only the SHA-256 `token_hash` is stored — never
+ * the plaintext.
+ *
+ * `supervised_users` is a JSON array of `{ userId, linuxUsername }` the admin
+ * bound at mint time (the policy user ↔ Linux account mapping); the client
+ * supplies each user's `linuxUid` at enrol time. Single-use is enforced by
+ * `consumed_at` (set when redeemed, with `consumed_client_id` pointing at the
+ * client it created); expiry by `expires_at`. The token is never edited
+ * in-place beyond being marked consumed.
+ */
+export const enrolmentTokens = sqliteTable(
+  "enrolment_tokens",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    tokenHash: text("token_hash").notNull(),
+    hostname: text("hostname"),
+    supervisedUsers: text("supervised_users", { mode: "json" })
+      .$type<{ userId: number; linuxUsername: string }[]>()
+      .notNull(),
+    expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+    createdAt: timestampNow("created_at"),
+    consumedAt: integer("consumed_at", { mode: "timestamp" }),
+    consumedClientId: integer("consumed_client_id").references(() => clients.id, {
+      onDelete: "set null",
+    }),
+  },
+  (table) => [uniqueIndex("enrolment_tokens_token_hash_unique").on(table.tokenHash)],
 );
 
 /**

--- a/server/tests/api/clients-enrolment.test.ts
+++ b/server/tests/api/clients-enrolment.test.ts
@@ -299,6 +299,108 @@ describe("client enrolment routes", () => {
     expect(res.json().error.code).toBe("user_no_longer_exists");
   });
 
+  it("400s a mint whose ttlSeconds exceeds the maximum", async () => {
+    const userId = await createUser("Alice");
+    const res = await admin({
+      method: "POST",
+      url: "/api/clients/enrolment-tokens",
+      payload: {
+        supervisedUsers: [{ userId, linuxUsername: "alice" }],
+        ttlSeconds: 24 * 60 * 60 + 1,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("applies the default 1h TTL when ttlSeconds is omitted", async () => {
+    const userId = await createUser("Alice");
+    const before = Date.now();
+    const res = await admin({
+      method: "POST",
+      url: "/api/clients/enrolment-tokens",
+      payload: { supervisedUsers: [{ userId, linuxUsername: "alice" }] },
+    });
+    const expiresAt = new Date(res.json().expiresAt as string).getTime();
+    // ~1h out (allow a generous window for execution + second-granularity).
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 3600_000 - 5_000);
+    expect(expiresAt).toBeLessThanOrEqual(Date.now() + 3600_000 + 5_000);
+  });
+
+  it("400s an enrol with an empty supervisedUsers list", async () => {
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+    const res = await enrol(token, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [],
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  describe("multi-user mappings (the bijection check)", () => {
+    /** Mint a token bound to two users; returns [token, aliceId, bobId]. */
+    async function mintTwo(): Promise<[string, number, number]> {
+      const aliceId = await createUser("Alice");
+      const bobId = await createUser("Bob");
+      const res = await admin({
+        method: "POST",
+        url: "/api/clients/enrolment-tokens",
+        payload: {
+          supervisedUsers: [
+            { userId: aliceId, linuxUsername: "alice" },
+            { userId: bobId, linuxUsername: "bob" },
+          ],
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      return [res.json().token as string, aliceId, bobId];
+    }
+
+    it("enrols both users (201) mapping each minted userId to its uid", async () => {
+      const [token, aliceId, bobId] = await mintTwo();
+      const res = await enrol(token, {
+        hostname: "mint-01",
+        sshUser: "pct-agent",
+        supervisedUsers: [
+          { linuxUsername: "alice", linuxUid: 1000 },
+          { linuxUsername: "bob", linuxUid: 1001 },
+        ],
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json().supervisedUsers).toEqual([
+        { userId: aliceId, linuxUsername: "alice", linuxUid: 1000 },
+        { userId: bobId, linuxUsername: "bob", linuxUid: 1001 },
+      ]);
+    });
+
+    it("400s when a bound user is dropped from the enrol request", async () => {
+      const [token] = await mintTwo();
+      const res = await enrol(token, {
+        hostname: "mint-01",
+        sshUser: "pct-agent",
+        supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error.code).toBe("enrolment_user_mismatch");
+    });
+
+    it("400s when the enrol request smuggles in an unbound user", async () => {
+      const [token] = await mintTwo();
+      const res = await enrol(token, {
+        hostname: "mint-01",
+        sshUser: "pct-agent",
+        supervisedUsers: [
+          { linuxUsername: "alice", linuxUid: 1000 },
+          { linuxUsername: "carol", linuxUid: 1002 },
+        ],
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error.code).toBe("enrolment_user_mismatch");
+    });
+  });
+
   it("401s an enrol with an expired token", async () => {
     // Mint a token then fast-forward past its TTL by writing expiry into the past.
     const userId = await createUser("Alice");

--- a/server/tests/api/clients-enrolment.test.ts
+++ b/server/tests/api/clients-enrolment.test.ts
@@ -1,0 +1,319 @@
+/**
+ * HTTP tests for the client-enrolment routes (#77), driven through the real app
+ * via `app.inject()`. Covers the admin-guarded token mint, the token-
+ * authenticated enrol exchange, and the failure matrix (anonymous mint, bad
+ * userId, missing/invalid/expired/used bearer, user-set mismatch, duplicate
+ * hostname) — per docs/testing.md → "HTTP routes".
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { InjectOptions } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { parseBearer } from "../../src/api/clients/routes.js";
+import { hashToken } from "../../src/auth/secret-token.js";
+import { SESSION_COOKIE } from "../../src/auth/session.js";
+import { loadSettings, type Settings } from "../../src/config.js";
+import { enrolmentTokens } from "../../src/policy/schema.js";
+import { buildTestApp, type TestApp } from "../helpers/app.js";
+
+function settingsWith(env: Record<string, string> = {}): Settings {
+  return loadSettings({
+    PCT_LOG_LEVEL: "silent",
+    PCT_SECRET_KEY: "enrol-test-secret",
+    PCT_ADMIN_USERNAME: "ben",
+    PCT_ADMIN_PASSWORD: "hunter2",
+    ...env,
+  });
+}
+
+function sessionCookie(res: { headers: Record<string, unknown> }): string {
+  const raw = res.headers["set-cookie"];
+  const headers = Array.isArray(raw) ? (raw as string[]) : [String(raw ?? "")];
+  const match = headers.find((h) => h.startsWith(`${SESSION_COOKIE}=`));
+  if (match === undefined) throw new Error("no session cookie set");
+  return match.split(";")[0] ?? "";
+}
+
+describe("parseBearer", () => {
+  it("extracts a bearer token, and rejects missing/malformed/empty headers", () => {
+    expect(parseBearer("Bearer abc123")).toBe("abc123");
+    expect(parseBearer(undefined)).toBeNull();
+    expect(parseBearer("Basic abc123")).toBeNull();
+    expect(parseBearer("Bearer ")).toBeNull();
+    expect(parseBearer("Bearer    ")).toBeNull();
+  });
+});
+
+describe("client enrolment routes", () => {
+  let harness: TestApp;
+  let cookie: string;
+  let tmpDir: string;
+
+  async function start(settings: Settings): Promise<void> {
+    harness = buildTestApp({ appOptions: { settings } });
+    await harness.app.ready();
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    cookie = sessionCookie(login);
+  }
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pct-enrol-"));
+    await start(settingsWith());
+  });
+
+  afterEach(async () => {
+    await harness.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Inject with the admin session cookie attached. */
+  function admin(opts: InjectOptions) {
+    return harness.app.inject({ ...opts, headers: { ...opts.headers, cookie } });
+  }
+
+  /** Create a policy user and return its id. */
+  async function createUser(displayName: string): Promise<number> {
+    const res = await admin({ method: "POST", url: "/api/users", payload: { displayName } });
+    return res.json().id as number;
+  }
+
+  /** Mint a token for one user mapped to `linuxUsername`; returns the plaintext token. */
+  async function mintFor(userId: number, linuxUsername = "alice"): Promise<string> {
+    const res = await admin({
+      method: "POST",
+      url: "/api/clients/enrolment-tokens",
+      payload: { supervisedUsers: [{ userId, linuxUsername }] },
+    });
+    expect(res.statusCode).toBe(201);
+    return res.json().token as string;
+  }
+
+  function enrol(token: string | null, payload: Record<string, unknown>) {
+    const opts: InjectOptions = { method: "POST", url: "/api/clients/enrol", payload };
+    if (token !== null) opts.headers = { authorization: `Bearer ${token}` };
+    return harness.app.inject(opts);
+  }
+
+  // --- mint (admin-guarded) ------------------------------------------------
+
+  it("rejects an anonymous mint with 401", async () => {
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/clients/enrolment-tokens",
+      payload: { supervisedUsers: [{ userId: 1, linuxUsername: "alice" }] },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error.code).toBe("unauthorized");
+  });
+
+  it("404s a mint that references a non-existent user", async () => {
+    const res = await admin({
+      method: "POST",
+      url: "/api/clients/enrolment-tokens",
+      payload: { supervisedUsers: [{ userId: 9999, linuxUsername: "ghost" }] },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+  });
+
+  it("400s a mint with duplicate linux usernames", async () => {
+    const userId = await createUser("Alice");
+    const res = await admin({
+      method: "POST",
+      url: "/api/clients/enrolment-tokens",
+      payload: {
+        supervisedUsers: [
+          { userId, linuxUsername: "alice" },
+          { userId, linuxUsername: "alice" },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("mints a token (201) storing only its hash", async () => {
+    const userId = await createUser("Alice");
+    const res = await admin({
+      method: "POST",
+      url: "/api/clients/enrolment-tokens",
+      payload: { supervisedUsers: [{ userId, linuxUsername: "alice" }] },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(typeof body.token).toBe("string");
+    expect(typeof body.id).toBe("number");
+    expect(typeof body.expiresAt).toBe("string");
+
+    // Persisted as a hash, never the plaintext.
+    const stored = harness.db.select().from(enrolmentTokens).all();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.tokenHash).toBe(hashToken(body.token));
+    expect(stored[0]?.tokenHash).not.toBe(body.token);
+  });
+
+  // --- enrol (token-authenticated) -----------------------------------------
+
+  it("401s an enrol with no bearer header", async () => {
+    const res = await enrol(null, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error.code).toBe("unauthorized");
+  });
+
+  it("401s an enrol with an unknown token", async () => {
+    const res = await enrol("not-a-real-token", {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error.code).toBe("enrolment_token_invalid");
+  });
+
+  it("enrols a client (201): creates the client + link, returns a bearer token", async () => {
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+
+    const res = await enrol(token, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(typeof body.clientId).toBe("number");
+    expect(typeof body.bearerToken).toBe("string");
+    expect(body.sshPublicKey).toBeNull(); // no key file configured here
+    expect(body.supervisedUsers).toEqual([{ userId, linuxUsername: "alice", linuxUid: 1000 }]);
+
+    // The client now shows up in the admin inventory with its link.
+    const links = await admin({ method: "GET", url: `/api/users/${userId}/clients` });
+    expect(links.json()).toEqual([
+      { userId, clientId: body.clientId, linuxUsername: "alice", linuxUid: 1000 },
+    ]);
+  });
+
+  it("401s reuse of a consumed token (single-use)", async () => {
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+    const payload = {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+    };
+    expect((await enrol(token, payload)).statusCode).toBe(201);
+
+    const second = await enrol(token, { ...payload, hostname: "mint-02" });
+    expect(second.statusCode).toBe(401);
+    expect(second.json().error.code).toBe("enrolment_token_used");
+  });
+
+  it("400s an enrol whose supervised-user set doesn't match the token", async () => {
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+
+    const res = await enrol(token, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "bob", linuxUid: 1000 }],
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("enrolment_user_mismatch");
+  });
+
+  it("409s an enrol whose hostname is already enrolled", async () => {
+    const userId = await createUser("Alice");
+    const t1 = await mintFor(userId, "alice");
+    const payload = {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+    };
+    expect((await enrol(t1, payload)).statusCode).toBe(201);
+
+    // Fresh token, same hostname → 409 conflict.
+    const t2 = await mintFor(userId, "alice");
+    const res = await enrol(t2, { ...payload, supervisedUsers: payload.supervisedUsers });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.code).toBe("conflict");
+  });
+
+  it("returns the server SSH public key when one is configured", async () => {
+    await harness.close();
+    const keyPath = join(tmpDir, "id_ed25519.pub");
+    writeFileSync(keyPath, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 dashboard@pct\n");
+    await start(settingsWith({ PCT_SSH_PUBLIC_KEY_PATH: keyPath }));
+
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+    const res = await enrol(token, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().sshPublicKey).toBe("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 dashboard@pct");
+  });
+
+  it("still enrols (sshPublicKey null) when the configured key path is unreadable", async () => {
+    // Point the key path at a directory: readFileSync throws EISDIR (not the
+    // expected ENOENT), which the service logs and degrades to null rather than
+    // failing the enrolment.
+    await harness.close();
+    await start(settingsWith({ PCT_SSH_PUBLIC_KEY_PATH: tmpDir }));
+
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+    const res = await enrol(token, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().sshPublicKey).toBeNull();
+  });
+
+  it("409s an enrol when a bound user was deleted after the token was minted", async () => {
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+    // Admin deletes the policy user between mint and enrol.
+    expect((await admin({ method: "DELETE", url: `/api/users/${userId}` })).statusCode).toBe(204);
+
+    const res = await enrol(token, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.code).toBe("user_no_longer_exists");
+  });
+
+  it("401s an enrol with an expired token", async () => {
+    // Mint a token then fast-forward past its TTL by writing expiry into the past.
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+    harness.db
+      .update(enrolmentTokens)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .run();
+
+    const res = await enrol(token, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ linuxUsername: "alice", linuxUid: 1000 }],
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error.code).toBe("enrolment_token_expired");
+  });
+});

--- a/server/tests/api/clients/ssh-identity.test.ts
+++ b/server/tests/api/clients/ssh-identity.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the server SSH-public-key reader used by the enrol response (#77).
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadServerSshPublicKey } from "../../../src/api/clients/ssh-identity.js";
+
+describe("loadServerSshPublicKey", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pct-ssh-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns the trimmed key when the file is present", () => {
+    const path = join(dir, "id_ed25519.pub");
+    writeFileSync(path, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 dashboard@pct\n");
+    expect(loadServerSshPublicKey(path)).toBe("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 dashboard@pct");
+  });
+
+  it("returns null when the file is absent (key not yet generated — Phase 4)", () => {
+    expect(loadServerSshPublicKey(join(dir, "does-not-exist.pub"))).toBeNull();
+  });
+
+  it("returns null when the file is present but empty/whitespace", () => {
+    const path = join(dir, "empty.pub");
+    writeFileSync(path, "   \n");
+    expect(loadServerSshPublicKey(path)).toBeNull();
+  });
+
+  it("rethrows an unexpected read error that isn't 'file absent'", () => {
+    // Reading a directory throws EISDIR — a real misconfiguration, not the
+    // expected "key not generated yet" ENOENT, so it must surface.
+    expect(() => loadServerSshPublicKey(dir)).toThrow();
+  });
+});

--- a/server/tests/api/policy-dtos.test.ts
+++ b/server/tests/api/policy-dtos.test.ts
@@ -30,6 +30,7 @@ describe("policy DTO mappers", () => {
       id: 2,
       hostname: "mint-01",
       sshUser: "pct-agent",
+      bearerTokenHash: null,
       enrolledAt: new Date("2026-06-17T00:00:00.000Z"),
       lastSeen: new Date("2026-06-17T08:30:00.000Z"),
     };
@@ -47,6 +48,7 @@ describe("policy DTO mappers", () => {
       id: 3,
       hostname: "mint-02",
       sshUser: "pct-agent",
+      bearerTokenHash: null,
       enrolledAt: new Date("2026-06-17T00:00:00.000Z"),
       lastSeen: null,
     };

--- a/server/tests/auth/secret-token.test.ts
+++ b/server/tests/auth/secret-token.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for the high-entropy bearer-secret helpers (#77).
+ */
+import { describe, expect, it } from "vitest";
+
+import { generateToken, hashToken, timingSafeEqualHex } from "../../src/auth/secret-token.js";
+
+describe("generateToken", () => {
+  it("mints distinct, URL-safe, high-entropy tokens", () => {
+    const a = generateToken();
+    const b = generateToken();
+    expect(a).not.toBe(b);
+    // base64url of 32 bytes → 43 chars, no '+', '/' or '=' padding.
+    expect(a).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+});
+
+describe("hashToken", () => {
+  it("is deterministic for the same input", () => {
+    const token = generateToken();
+    expect(hashToken(token)).toBe(hashToken(token));
+  });
+
+  it("differs for different inputs and never echoes the plaintext", () => {
+    const token = generateToken();
+    const hash = hashToken(token);
+    expect(hash).not.toBe(token);
+    expect(hashToken(generateToken())).not.toBe(hash);
+    // SHA-256 hex digest.
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("timingSafeEqualHex", () => {
+  it("returns true for equal digests and false otherwise", () => {
+    const hash = hashToken("a-token");
+    expect(timingSafeEqualHex(hash, hash)).toBe(true);
+    expect(timingSafeEqualHex(hash, hashToken("other"))).toBe(false);
+  });
+
+  it("returns false (not throw) for mismatched lengths or empty input", () => {
+    expect(timingSafeEqualHex("ab", "abcd")).toBe(false);
+    expect(timingSafeEqualHex("", "")).toBe(false);
+  });
+});

--- a/server/tests/policy/enrolment.test.ts
+++ b/server/tests/policy/enrolment.test.ts
@@ -66,6 +66,35 @@ describe("enrolment repository", () => {
     expect(reloaded?.consumedClientId).toBe(result.client.id);
   });
 
+  it("refuses to consume an already-consumed token and rolls back (single-use guard)", () => {
+    const userId = seedUser();
+    const token = enrolmentRepo.createEnrolmentToken(db, {
+      tokenHash: "hash-guard",
+      supervisedUsers: [{ userId, linuxUsername: "alice" }],
+      expiresAt: new Date("2026-12-31T00:00:00Z"),
+    });
+    const links = [{ userId, linuxUsername: "alice", linuxUid: 1000 }];
+    enrolmentRepo.consumeTokenAndEnrol(db, token.id, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      bearerTokenHash: "bearer-hash-1",
+      links,
+    });
+
+    // A second redeem of the same token must throw (the consume guard) and
+    // create no second client. A fresh bearer hash is used so the rollback is
+    // driven by the consumed-token guard, not the bearer-hash unique index.
+    expect(() =>
+      enrolmentRepo.consumeTokenAndEnrol(db, token.id, {
+        hostname: "mint-02",
+        sshUser: "pct-agent",
+        bearerTokenHash: "bearer-hash-2",
+        links,
+      }),
+    ).toThrow(enrolmentRepo.EnrolmentTokenConsumedError);
+    expect(db.select().from(clients).all()).toHaveLength(1);
+  });
+
   it("rolls back the whole enrolment if a link violates a constraint", () => {
     const userId = seedUser();
     const token = enrolmentRepo.createEnrolmentToken(db, {

--- a/server/tests/policy/enrolment.test.ts
+++ b/server/tests/policy/enrolment.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the enrolment data access (#77) against a hermetic in-memory
+ * policy DB. Covers token insert/lookup, the consume+enrol transaction, and its
+ * atomicity (a duplicate Linux UID rolls the whole thing back — no half-created
+ * client, no consumed token).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import * as enrolmentRepo from "../../src/policy/enrolment.js";
+import * as repo from "../../src/policy/repository.js";
+import { clients } from "../../src/policy/schema.js";
+import { testDb, type TestDb } from "../helpers/db.js";
+
+describe("enrolment repository", () => {
+  let db: TestDb;
+  beforeEach(() => {
+    db = testDb();
+  });
+  afterEach(() => {
+    db.$client.close();
+  });
+
+  function seedUser(name = "Alice"): number {
+    return repo.createUser(db, { displayName: name }).id;
+  }
+
+  it("creates and looks up an enrolment token by hash", () => {
+    const userId = seedUser();
+    const created = enrolmentRepo.createEnrolmentToken(db, {
+      tokenHash: "deadbeef",
+      hostname: "mint-01",
+      supervisedUsers: [{ userId, linuxUsername: "alice" }],
+      expiresAt: new Date("2026-12-31T00:00:00Z"),
+    });
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.consumedAt).toBeNull();
+    expect(created.supervisedUsers).toEqual([{ userId, linuxUsername: "alice" }]);
+
+    const found = enrolmentRepo.findEnrolmentTokenByHash(db, "deadbeef");
+    expect(found?.id).toBe(created.id);
+    expect(enrolmentRepo.findEnrolmentTokenByHash(db, "nope")).toBeUndefined();
+  });
+
+  it("consumes a token and enrols the client + links atomically", () => {
+    const userId = seedUser();
+    const token = enrolmentRepo.createEnrolmentToken(db, {
+      tokenHash: "hash-1",
+      supervisedUsers: [{ userId, linuxUsername: "alice" }],
+      expiresAt: new Date("2026-12-31T00:00:00Z"),
+    });
+
+    const result = enrolmentRepo.consumeTokenAndEnrol(db, token.id, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      bearerTokenHash: "bearer-hash",
+      links: [{ userId, linuxUsername: "alice", linuxUid: 1000 }],
+    });
+
+    expect(result.client.hostname).toBe("mint-01");
+    expect(result.client.bearerTokenHash).toBe("bearer-hash");
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0]).toMatchObject({ userId, linuxUid: 1000 });
+
+    const reloaded = enrolmentRepo.findEnrolmentTokenByHash(db, "hash-1");
+    expect(reloaded?.consumedAt).toBeInstanceOf(Date);
+    expect(reloaded?.consumedClientId).toBe(result.client.id);
+  });
+
+  it("rolls back the whole enrolment if a link violates a constraint", () => {
+    const userId = seedUser();
+    const token = enrolmentRepo.createEnrolmentToken(db, {
+      tokenHash: "hash-2",
+      supervisedUsers: [{ userId, linuxUsername: "alice" }],
+      expiresAt: new Date("2026-12-31T00:00:00Z"),
+    });
+
+    // Two links sharing one UID trips the (client, linux_uid) unique index
+    // mid-transaction; the client insert + token-consume must roll back with it.
+    expect(() =>
+      enrolmentRepo.consumeTokenAndEnrol(db, token.id, {
+        hostname: "mint-01",
+        sshUser: "pct-agent",
+        bearerTokenHash: "bearer-hash",
+        links: [
+          { userId, linuxUsername: "alice", linuxUid: 1000 },
+          { userId, linuxUsername: "alice2", linuxUid: 1000 },
+        ],
+      }),
+    ).toThrow();
+
+    expect(db.select().from(clients).all()).toHaveLength(0);
+    const reloaded = enrolmentRepo.findEnrolmentTokenByHash(db, "hash-2");
+    expect(reloaded?.consumedAt).toBeNull();
+    expect(reloaded?.consumedClientId).toBeNull();
+  });
+});

--- a/server/tests/policy/migrations.test.ts
+++ b/server/tests/policy/migrations.test.ts
@@ -63,6 +63,7 @@ const EXPECTED_TABLES = [
   "admin_credentials",
   "budgets",
   "clients",
+  "enrolment_tokens",
   "exceptions",
   "grants",
   "integration_tokens",

--- a/server/tests/policy/schema.test.ts
+++ b/server/tests/policy/schema.test.ts
@@ -18,6 +18,7 @@ import {
   activityGroups,
   budgets,
   clients,
+  enrolmentTokens,
   exceptions,
   grants,
   integrationTokens,
@@ -44,6 +45,7 @@ const allTables: Record<string, SQLiteTable> = {
   grants,
   integrationTokens,
   notificationPolicies,
+  enrolmentTokens,
 };
 
 let db: TestDb;
@@ -346,6 +348,58 @@ describe("integration_tokens", () => {
 
     expect(row?.scopes).toStrictEqual(["grants:write", "policy:read"]);
     expect(row?.revokedAt).toBeNull();
+  });
+});
+
+describe("enrolment_tokens", () => {
+  it("stores only a hashed token, never the plaintext", () => {
+    const columns = db.$client
+      .prepare("SELECT name FROM pragma_table_info('enrolment_tokens')")
+      .pluck()
+      .all() as string[];
+
+    expect(columns).toContain("token_hash");
+    expect(columns).not.toContain("token");
+    expect(columns).not.toContain("secret");
+    expect(columns).not.toContain("plaintext");
+  });
+
+  it("round-trips the supervised-users JSON and defaults consumed_at to null", () => {
+    const userId = insertUser();
+    db.insert(enrolmentTokens)
+      .values({
+        tokenHash: "abc123",
+        supervisedUsers: [{ userId, linuxUsername: "alice" }],
+        expiresAt: new Date("2026-12-31T00:00:00Z"),
+      })
+      .run();
+    const row = db.select().from(enrolmentTokens).get();
+
+    expect(row?.supervisedUsers).toStrictEqual([{ userId, linuxUsername: "alice" }]);
+    expect(row?.consumedAt).toBeNull();
+    expect(row?.consumedClientId).toBeNull();
+  });
+
+  it("nulls consumed_client_id when the consuming client is deleted (ON DELETE set null)", () => {
+    const clientId = db
+      .insert(clients)
+      .values({ hostname: "mint-x", sshUser: "pct-agent" })
+      .returning({ id: clients.id })
+      .get()?.id;
+    if (clientId === undefined) throw new Error("client insert returned no row");
+    db.insert(enrolmentTokens)
+      .values({
+        tokenHash: "tok",
+        supervisedUsers: [],
+        expiresAt: new Date("2026-12-31T00:00:00Z"),
+        consumedAt: new Date("2026-06-18T00:00:00Z"),
+        consumedClientId: clientId,
+      })
+      .run();
+
+    db.delete(clients).where(eq(clients.id, clientId)).run();
+
+    expect(db.select().from(enrolmentTokens).get()?.consumedClientId).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Adds the dashboard half of client enrolment (Phase 3):

- **`POST /api/clients/enrolment-tokens`** — **admin-guarded**. Mints a single-use, short-TTL token bound to the policy-user ↔ Linux-account mapping the admin is provisioning. Stores only the SHA-256 hash; returns the plaintext **once**.
- **`POST /api/clients/enrol`** — **token-authenticated, not session-guarded** (the install script #76 has no admin session). Validates the `Authorization: Bearer <enrolment-token>` by hash lookup, then in **one transaction** creates the `Client` + `UserOnClient` links, issues a per-client bearer token (the future `/api/events/stream` credential), and consumes the token. Returns the bearer token (once) and the server SSH public key when available.

## Plan

Linked plan: `.claude/plans/issue-77-enrolment-token-endpoint.md`
Roadmap: `docs/roadmap.md` → Phase 3 ("Enrolment-token endpoint on the dashboard"); contract in `docs/client-install.md` → step 7–8.

## Design notes

- **Schema:** new `enrolment_tokens` table + nullable `clients.bearer_token_hash` (timestamp-prefixed migration via `db:generate`, #133; drift check green). Only hashes are stored — never plaintext (mirrors `integration_tokens`).
- **Secrets:** enrolment + per-client bearer tokens are 256-bit random values, hashed with **SHA-256** (`auth/secret-token.ts`) — the right primitive for high-entropy secrets, deliberately distinct from Argon2id (which exists to slow brute force against low-entropy passwords).
- **SSH public key:** new `PCT_SSH_PUBLIC_KEY_PATH` setting. The key pair itself is generated server-side as a **Phase-4** first-run step (#39); until then the file is absent and the enrol response degrades to `sshPublicKey: null` rather than failing.
- **Endpoint spelling:** `/enrol` (British), matching the authoritative `docs/client-install.md` step 8, not the issue body's `/enroll`.
- **Module layout** mirrors `api/policy/` + `policy/repository.ts`: `api/clients/{dtos,service,ssh-identity,routes,index}`, data access in `policy/enrolment.ts`, crypto leaf in `auth/secret-token.ts`.

## Security note

`POST /api/clients/enrol` is the one intentional **unauthenticated-by-session** write. It is gated by a 256-bit, hashed-at-rest, single-use, expiring token; the supervised-user set must exactly match what the token was minted for, and each bound user is re-checked to still exist. Per-IP rate-limiting on enrol is a possible follow-up (token entropy makes brute force infeasible) — noted, not built.

## License-boundary note

No GPL code imported and no GPL binary added. No transport calls — SSH keygen is Phase 4; this PR only *reads* a public-key file if present. `license-guard` unaffected.

## Test plan

- [x] `format:check`, `lint`, `typecheck`, `db:check` (drift) all clean
- [x] `npm test` — **389 passing**; coverage 99.74% stmts / 96.85% branch (gate 80%). New `api/clients/*`, `auth/secret-token.ts`, `policy/enrolment.ts` covered.
- [x] `secret-token` (mint/hash/compare), `ssh-identity` (present/absent/empty/unreadable), `policy/enrolment` (token lifecycle + **transaction rollback** on a duplicate UID), `schema`/`migrations` (new table + column, ON DELETE set null)
- [x] HTTP matrix via `app.inject()`: mint anon→401, bad userId→404, dup username→400, happy→201 (hash-only); enrol missing/invalid/expired/used bearer→401, user mismatch→400, deleted-user→409, duplicate hostname→409, happy→201 (+links, +bearer, +sshPublicKey null/set/unreadable)

## Deferred (tracked)

- Wiring into the orchestrator `install-client.sh` → #76 (this unblocks it).
- Server-side SSH keypair generation → Phase 4 (#39 entrypoint step).
- Per-IP rate-limit on enrol → follow-up note above.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4LjzUBhkoQJiJUJ9YfbBZ)_