### PR TITLE
feat(transport): typed timekpra CLI wrapper over SSH (#83)

### DIFF
--- a/.claude/plans/issue-83-timekpra-invocations.md
+++ b/.claude/plans/issue-83-timekpra-invocations.md
@@ -1,0 +1,103 @@
+# Plan — #83 `timekpra` invocations (limits, allowed hours, PlayTime)
+
+Roadmap: `docs/roadmap.md` → Phase 4 ("`timekpra` invocations for: set
+daily/weekly/monthly limits, set allowed hours, set PlayTime configuration").
+Module: `server/src/transport/timekpr/`.
+
+## Goal
+
+A typed wrapper over the Timekpr-nExT **`timekpra` admin CLI**, invoked as a
+subprocess over the merged Phase-4 SSH facade (`transport/ssh`, #82). Translates
+transport-level inputs into `timekpra` argv vectors, runs them via
+`execChecked` / `execAndParse`, and confirms application by zod-parsing
+`timekpra --userinfo` stdout. This is the structural **license boundary**: the
+dashboard only ever *execs* `timekpra` (GPL) as a subprocess — never links it
+in-process (`CLAUDE.md` → "License boundaries" rules 1–2; `docs/licensing-analysis.md`).
+
+## Why this is independent of the in-flight Phase-2 schema work
+
+#146 is reshaping the `schedules`/`exceptions` tables (recurrence/date-scoping
+columns). This module sits *below* the policy model: it takes transport-level
+input structs (limit-seconds, an allowed-hours spec, a PlayTime spec), not the
+DB rows. The policy→transport translation of recurring schedule windows (#140)
+and the effective-policy resolver (#143) are explicitly **out of scope** and
+will feed this layer once #146 lands — so #83 is not coded against the schema
+being changed.
+
+## `timekpra` CLI grammar (verified against upstream docs)
+
+ISO-8601 conventions: weekdays `1`(Mon)–`7`(Sun); hours `0`–`23`; times in
+seconds. Lists are `;`-separated.
+
+- `--setalloweddays USER 'd;d;…'` — allowed ISO weekdays.
+- `--setallowedhours USER (DAY|ALL) 'H;H[mm-mm];!H;…'` — DAY is a single ISO
+  weekday `1..7` or the literal `ALL`. Each hour `0..23`, optional minute
+  interval `[start-end]` (0..60), optional `!` prefix = *unaccounted* (free).
+- `--settimelimits USER 's;s;…'` — per-allowed-day daily limit seconds.
+- `--settimelimitweek USER s` / `--settimelimitmonth USER s` — rolling limits.
+- PlayTime (app-group time):
+  - `--setplaytimeenabled USER (true|false)`
+  - `--setplaytimelimitoverride USER (true|false)`
+  - `--setplaytimeunaccountedintervalsenabled USER (true|false)`
+  - `--setplaytimealloweddays USER 'd;d;…'`
+  - `--setplaytimelimits USER 's;s;…'`
+  - `--setplaytimeactivities USER 'mask[desc];mask;…'`
+- `--userinfo USER` — prints config as `KEY: VALUE` lines (read/confirm).
+
+Invocation: the client provisions `pct-agent ALL=(root) NOPASSWD:
+/usr/bin/timekpra` (#78), so the dashboard runs `sudo timekpra …`. The binary
+vector is configurable (default `["sudo", "timekpra"]`).
+
+## Files (`server/src/transport/timekpr/`)
+
+- `commands.ts` — **pure** argv builders + value formatters/validators
+  (`formatSecondsList`, `formatDays`, `formatAllowedHours`, `formatActivities`,
+  `formatBool`). Each builder returns `readonly string[]`. Throws
+  `TimekprArgumentError` on invalid input (negative seconds, weekday ∉ 1..7,
+  hour ∉ 0..23, minute ∉ 0..60, empty mask, …). No I/O.
+- `userinfo.ts` — zod schema/transform parsing `--userinfo` stdout into a
+  `TimekprUserInfo` (robust generic `KEY: VALUE` line parse → typed wrapper
+  with getters; tolerant of the exact key set, which #140 pins when it wires
+  the resolver). Rejects empty / non-`KEY: VALUE` output (→ `SshParseError`).
+- `errors.ts` — `TimekprArgumentError` (synchronous, builder-side; distinct
+  from the SSH exec taxonomy that surfaces reachability/command/parse failures).
+- `client.ts` — `TimekprClient` over `SshTransport` + `SshTarget` + `username`:
+  semantic methods (`setTimeLimits`, `setTimeLimitWeek`, `setTimeLimitMonth`,
+  `setAllowedDays`, `setAllowedHours`, the PlayTime setters, `getUserInfo`).
+  Setters use `execChecked` (non-zero exit → `SshCommandError`); `getUserInfo`
+  uses `execAndParse`.
+- `index.ts` — `moduleName = "transport/timekpr"` + public re-exports.
+
+## Types (transport-level inputs)
+
+- `IsoWeekday` (validated 1..7), `ALL_DAYS` sentinel for allowed-hours.
+- `AllowedHour { hour; startMinute?; endMinute?; unaccounted? }`.
+- `PlayTimeActivity { mask; description? }`.
+- `TimeAdjustOperation`-free (setTimeLeft deferred — see below).
+
+## Out of scope (deferred, tracked)
+
+- `--settimeleft` (grant time adjustment) → belongs to the grant recompute
+  pipeline (#117) / grant-unlock (#108). Note in PR.
+- The policy→`timekpra` translation (which Budget/Schedule maps to which
+  command) → resolver #143 + recurring-windows #140, both gated on #146.
+- A live integration test against a `timekpra`-bearing container → follow-up
+  (mirrors the SSH facade's deferred `ssh.int.test.ts`).
+
+## Tests (`server/tests/transport/timekpr/`)
+
+- `commands.test.ts` — every builder: happy argv, list formatting, the
+  allowed-hours minute-bracket + `!` syntax, `ALL` day, and each validation
+  failure → `TimekprArgumentError`.
+- `userinfo.test.ts` — `KEY: VALUE` parse, whitespace tolerance, typed getters,
+  empty/garbage stdout rejected.
+- `client.test.ts` — drives a fake `SshTransport` (typed stub recording argv);
+  asserts each method builds the right argv and routes through
+  `execChecked`/`execAndParse`; `getUserInfo` parse path; binary override; a
+  `SshCommandError` from a setter propagates unchanged.
+
+## License-boundary note
+
+Pure exec-over-SSH of the `timekpra` CLI; `ssh2` (MIT) already a dependency. No
+GPL code linked in-process, no GPL binary added to the image. `license-guard`
+unaffected.

--- a/server/src/transport/timekpr/client.ts
+++ b/server/src/transport/timekpr/client.ts
@@ -1,0 +1,196 @@
+/**
+ * `TimekprClient` — the typed Timekpr-nExT control surface for one supervised
+ * user on one enrolled client.
+ *
+ * It binds an SSH {@link SshTarget} and a `linux_username` to the pure argv
+ * builders in {@link ./commands.ts}, runs each command over the Phase-4 SSH
+ * facade ({@link ../ssh/facade.ts}) as a **subprocess**, and confirms reads by
+ * zod-parsing stdout. Setters use the facade's `execChecked` (a non-zero
+ * `timekpra` exit becomes an `SshCommandError`); {@link getUserInfo} uses
+ * `execAndParse`. The facade's error taxonomy — `SshUnreachableError` (the
+ * offline-queue's retry signal, #84), `SshCommandError`, `SshParseError`,
+ * `SshExecTimeoutError` — propagates unchanged, so callers branch on it exactly
+ * as they do for any other transport command.
+ *
+ * License boundary: the dashboard only ever *execs* `timekpra` (GPL) over SSH;
+ * it never links Timekpr-nExT in-process and never parses its on-disk state with
+ * its own code (`CLAUDE.md` → "License boundaries" rules 1–2;
+ * `docs/licensing-analysis.md`). This module adds no new boundary crossing.
+ */
+import type { ZodType } from "zod";
+
+import type { ExecOptions, ExecResult, SshTarget } from "../ssh/facade.js";
+import {
+  buildSetAllowedDays,
+  buildSetAllowedHours,
+  buildSetPlayTimeActivities,
+  buildSetPlayTimeAllowedDays,
+  buildSetPlayTimeEnabled,
+  buildSetPlayTimeLimitOverride,
+  buildSetPlayTimeLimits,
+  buildSetPlayTimeUnaccountedIntervalsEnabled,
+  buildSetTimeLimits,
+  buildSetTimeLimitMonth,
+  buildSetTimeLimitWeek,
+  buildUserInfo,
+  type AllowedHour,
+  type AllowedHoursDay,
+  type IsoWeekday,
+  type PlayTimeActivity,
+} from "./commands.js";
+import { TimekprArgumentError } from "./errors.js";
+import { timekprUserInfoSchema, type TimekprUserInfo } from "./userinfo.js";
+
+/**
+ * The slice of {@link SshTransport} the client needs: a checked exec for the
+ * setters and a parse-on-success exec for reads. Declared structurally (rather
+ * than depending on the whole class) so a real `SshTransport` satisfies it and
+ * a test can pass a lightweight fake without an `as` cast.
+ */
+export interface TimekprTransport {
+  execChecked(
+    target: SshTarget,
+    argv: readonly string[],
+    options?: ExecOptions,
+  ): Promise<ExecResult>;
+  execAndParse<T>(
+    target: SshTarget,
+    argv: readonly string[],
+    schema: ZodType<T>,
+    options?: ExecOptions,
+  ): Promise<T>;
+}
+
+/** The argv prefix that runs the `timekpra` admin CLI as root on the client.
+ *
+ * `pct-agent` is provisioned with `NOPASSWD: /usr/bin/timekpra` (#78), so the
+ * dashboard runs `sudo timekpra …`. Overridable for clients that expose the
+ * binary differently. */
+export const DEFAULT_TIMEKPRA_BINARY: readonly string[] = ["sudo", "timekpra"];
+
+/** Construction options for {@link TimekprClient}. */
+export interface TimekprClientOptions {
+  /** Argv prefix invoking `timekpra` on the client. Default {@link DEFAULT_TIMEKPRA_BINARY}. */
+  readonly binary?: readonly string[];
+  /** Per-exec overrides (e.g. `timeoutMs`) forwarded to the transport. */
+  readonly execOptions?: ExecOptions;
+}
+
+export class TimekprClient {
+  readonly #transport: TimekprTransport;
+  readonly #target: SshTarget;
+  readonly #username: string;
+  readonly #binary: readonly string[];
+  readonly #execOptions: ExecOptions | undefined;
+
+  /**
+   * @param transport the SSH transport (or a structural stand-in) to run on.
+   * @param target the enrolled client to reach.
+   * @param username the supervised Linux account `timekpra` acts on.
+   * @param options binary override and per-exec options.
+   */
+  constructor(
+    transport: TimekprTransport,
+    target: SshTarget,
+    username: string,
+    options: TimekprClientOptions = {},
+  ) {
+    const binary = options.binary ?? DEFAULT_TIMEKPRA_BINARY;
+    if (binary.length === 0) {
+      throw new TimekprArgumentError("timekpra: binary prefix must name the timekpra program");
+    }
+    // `buildUserInfo` (and every other builder) validates the username, but do
+    // it once up front so an invalid name fails at construction rather than on
+    // the first call.
+    buildUserInfo(username);
+    this.#transport = transport;
+    this.#target = target;
+    this.#username = username;
+    this.#binary = binary;
+    this.#execOptions = options.execOptions;
+  }
+
+  /** The supervised Linux account this client controls. */
+  get username(): string {
+    return this.#username;
+  }
+
+  /** Set the weekdays the user may log in (`--setalloweddays`). */
+  setAllowedDays(days: readonly IsoWeekday[]): Promise<ExecResult> {
+    return this.#exec(() => buildSetAllowedDays(this.#username, days));
+  }
+
+  /** Set the allowed hours for one weekday (or every day) (`--setallowedhours`). */
+  setAllowedHours(day: AllowedHoursDay, hours: readonly AllowedHour[]): Promise<ExecResult> {
+    return this.#exec(() => buildSetAllowedHours(this.#username, day, hours));
+  }
+
+  /** Set the per-weekday daily session-time limits in seconds (`--settimelimits`). */
+  setTimeLimits(perDaySeconds: readonly number[]): Promise<ExecResult> {
+    return this.#exec(() => buildSetTimeLimits(this.#username, perDaySeconds));
+  }
+
+  /** Set the rolling weekly session-time limit in seconds (`--settimelimitweek`). */
+  setTimeLimitWeek(seconds: number): Promise<ExecResult> {
+    return this.#exec(() => buildSetTimeLimitWeek(this.#username, seconds));
+  }
+
+  /** Set the rolling monthly session-time limit in seconds (`--settimelimitmonth`). */
+  setTimeLimitMonth(seconds: number): Promise<ExecResult> {
+    return this.#exec(() => buildSetTimeLimitMonth(this.#username, seconds));
+  }
+
+  /** Enable or disable PlayTime (app-group time) for the user (`--setplaytimeenabled`). */
+  setPlayTimeEnabled(enabled: boolean): Promise<ExecResult> {
+    return this.#exec(() => buildSetPlayTimeEnabled(this.#username, enabled));
+  }
+
+  /** Set whether PlayTime limits override the overall limit (`--setplaytimelimitoverride`). */
+  setPlayTimeLimitOverride(enabled: boolean): Promise<ExecResult> {
+    return this.#exec(() => buildSetPlayTimeLimitOverride(this.#username, enabled));
+  }
+
+  /** Set whether PlayTime counts during free hours (`--setplaytimeunaccountedintervalsenabled`). */
+  setPlayTimeUnaccountedIntervalsEnabled(enabled: boolean): Promise<ExecResult> {
+    return this.#exec(() => buildSetPlayTimeUnaccountedIntervalsEnabled(this.#username, enabled));
+  }
+
+  /** Set the weekdays PlayTime is allowed (`--setplaytimealloweddays`). */
+  setPlayTimeAllowedDays(days: readonly IsoWeekday[]): Promise<ExecResult> {
+    return this.#exec(() => buildSetPlayTimeAllowedDays(this.#username, days));
+  }
+
+  /** Set the per-weekday PlayTime limits in seconds (`--setplaytimelimits`). */
+  setPlayTimeLimits(perDaySeconds: readonly number[]): Promise<ExecResult> {
+    return this.#exec(() => buildSetPlayTimeLimits(this.#username, perDaySeconds));
+  }
+
+  /** Set the PlayTime activity matchers (`--setplaytimeactivities`). */
+  setPlayTimeActivities(activities: readonly PlayTimeActivity[]): Promise<ExecResult> {
+    return this.#exec(() => buildSetPlayTimeActivities(this.#username, activities));
+  }
+
+  /** Read the user's current Timekpr configuration (`--userinfo`), zod-parsed. */
+  async getUserInfo(): Promise<TimekprUserInfo> {
+    return this.#transport.execAndParse(
+      this.#target,
+      [...this.#binary, ...buildUserInfo(this.#username)],
+      timekprUserInfoSchema,
+      this.#execOptions,
+    );
+  }
+
+  /**
+   * Run a command as a checked exec. The argv `build`er is invoked **inside**
+   * this async method so a {@link TimekprArgumentError} from an out-of-grammar
+   * value surfaces as a rejected promise, exactly like the transport's own
+   * failures — the method never throws synchronously.
+   */
+  async #exec(build: () => readonly string[]): Promise<ExecResult> {
+    return this.#transport.execChecked(
+      this.#target,
+      [...this.#binary, ...build()],
+      this.#execOptions,
+    );
+  }
+}

--- a/server/src/transport/timekpr/commands.ts
+++ b/server/src/transport/timekpr/commands.ts
@@ -43,8 +43,14 @@ export type IsoWeekday = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 /** Sentinel for "every day" in {@link buildSetAllowedHours}'s day position. */
 export const ALL_DAYS = "ALL";
 
-/** The day an allowed-hours rule applies to: one ISO weekday, or every day. */
-export type AllowedHoursDay = IsoWeekday | typeof ALL_DAYS;
+/**
+ * Which day(s) an allowed-hours rule applies to:
+ * - a single ISO weekday (`3`),
+ * - a non-empty list of ISO weekdays (`[1, 2, 3, 4, 5]`), which `timekpra`
+ *   accepts as a `;`-joined set in the day position, or
+ * - the {@link ALL_DAYS} sentinel for every day.
+ */
+export type AllowedHoursDay = IsoWeekday | readonly IsoWeekday[] | typeof ALL_DAYS;
 
 /**
  * One entry in a `timekpra` allowed-hours list.
@@ -134,15 +140,20 @@ function formatDays(days: readonly IsoWeekday[], label: string): string {
   return days.join(LIST_SEPARATOR);
 }
 
-/** Render the day position of an allowed-hours command: an ISO weekday or `ALL`. */
+/** Render the day position of an allowed-hours command: a weekday, list, or `ALL`. */
 function formatAllowedHoursDay(day: AllowedHoursDay): string {
   if (day === ALL_DAYS) return ALL_DAYS;
-  if (!Number.isInteger(day) || day < 1 || day > 7) {
-    throw new TimekprArgumentError(
-      `timekpra: allowed-hours day must be an ISO weekday 1..7 or "ALL", got ${day}`,
-    );
+  // `typeof === "number"` narrows the single-weekday case cleanly out of the
+  // union (unlike `Array.isArray`, which does not narrow a `readonly` array).
+  if (typeof day === "number") {
+    if (!Number.isInteger(day) || day < 1 || day > 7) {
+      throw new TimekprArgumentError(
+        `timekpra: allowed-hours day must be an ISO weekday 1..7, a weekday list, or "ALL", got ${day}`,
+      );
+    }
+    return String(day);
   }
-  return String(day);
+  return formatDays(day, "allowed-hours days");
 }
 
 /** Render one {@link AllowedHour} as `[!]H[(start)-(end)]`. */
@@ -198,7 +209,9 @@ function formatActivities(activities: readonly PlayTimeActivity[]): string {
           `timekpra: PlayTime activity mask ${JSON.stringify(mask)} must be non-empty and contain no ';', '[' or ']'`,
         );
       }
-      if (description === undefined) return mask;
+      // Treat an absent or empty description identically: emit the bare mask
+      // rather than an empty `mask[]` bracket.
+      if (description === undefined || description === "") return mask;
       if (/[;[\]]/.test(description)) {
         throw new TimekprArgumentError(
           `timekpra: PlayTime activity description ${JSON.stringify(description)} must contain no ';', '[' or ']'`,

--- a/server/src/transport/timekpr/commands.ts
+++ b/server/src/transport/timekpr/commands.ts
@@ -1,0 +1,322 @@
+/**
+ * Pure argv builders for the Timekpr-nExT **`timekpra` admin CLI**.
+ *
+ * Each `build*` function returns an argv **vector** (`readonly string[]`) — the
+ * exact shape the SSH facade shell-quotes into one command string
+ * ({@link ../ssh/facade.ts}), never a pre-joined string — so a value can never
+ * be reinterpreted by the remote shell. The functions are pure and total: they
+ * either return a valid vector or throw {@link TimekprArgumentError}
+ * synchronously; they perform no I/O. {@link TimekprClient} composes them with
+ * the transport.
+ *
+ * CLI grammar (verified against the upstream `timekpra` docs), using ISO-8601
+ * conventions throughout — weekdays `1` (Mon) … `7` (Sun), hours `0`–`23`,
+ * durations in **seconds**, list items separated by `;`:
+ *
+ * - `--setalloweddays USER 'd;d;…'`
+ * - `--setallowedhours USER (DAY|ALL) 'H;H[mm-mm];!H;…'`
+ * - `--settimelimits USER 's;s;…'`  (per allowed weekday)
+ * - `--settimelimitweek USER s` / `--settimelimitmonth USER s`
+ * - `--setplaytimeenabled USER (true|false)`
+ * - `--setplaytimelimitoverride USER (true|false)`
+ * - `--setplaytimeunaccountedintervalsenabled USER (true|false)`
+ * - `--setplaytimealloweddays USER 'd;d;…'`
+ * - `--setplaytimelimits USER 's;s;…'`
+ * - `--setplaytimeactivities USER 'mask[desc];mask;…'`
+ * - `--userinfo USER`
+ *
+ * The policy→`timekpra` mapping (which Budget/Schedule becomes which command)
+ * is **not** here — it belongs to the resolver (#143) and the recurring-window
+ * push (#140), which feed these builders transport-level inputs once the Phase-2
+ * schema reservation (#146) lands. Keeping that mapping out keeps this layer
+ * decoupled from the policy schema currently being reshaped.
+ *
+ * License boundary: none touched — plain TypeScript building an argv vector for
+ * a subprocess. No GPL code is linked in-process (`CLAUDE.md` → "License
+ * boundaries"; `docs/licensing-analysis.md`).
+ */
+import { TimekprArgumentError } from "./errors.js";
+
+/** An ISO-8601 weekday number: `1` = Monday … `7` = Sunday. */
+export type IsoWeekday = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+/** Sentinel for "every day" in {@link buildSetAllowedHours}'s day position. */
+export const ALL_DAYS = "ALL";
+
+/** The day an allowed-hours rule applies to: one ISO weekday, or every day. */
+export type AllowedHoursDay = IsoWeekday | typeof ALL_DAYS;
+
+/**
+ * One entry in a `timekpra` allowed-hours list.
+ *
+ * Renders as `[!]H[(start)-(end)]`:
+ * - `hour` — the clock hour, `0`–`23`.
+ * - `startMinute`/`endMinute` — optional minute window *within* the hour,
+ *   `0 ≤ start < end ≤ 60`. Both must be given together or neither (the
+ *   bracket needs both bounds); omit both for the whole hour.
+ * - `unaccounted` — when true, prefixes `!`: the hour is *allowed but free*
+ *   (does not count against the time limit).
+ */
+export interface AllowedHour {
+  readonly hour: number;
+  readonly startMinute?: number;
+  readonly endMinute?: number;
+  readonly unaccounted?: boolean;
+}
+
+/**
+ * One PlayTime activity matcher.
+ *
+ * Renders as `mask` or `mask[description]`:
+ * - `mask` — the process-name mask Timekpr matches (e.g. `"minetest"`).
+ * - `description` — optional human label shown in the client.
+ *
+ * Neither field may contain the grammar's separators (`;`) or brackets
+ * (`[` / `]`); a value that does throws {@link TimekprArgumentError} rather
+ * than producing an ambiguous list.
+ */
+export interface PlayTimeActivity {
+  readonly mask: string;
+  readonly description?: string;
+}
+
+const LIST_SEPARATOR = ";";
+
+/**
+ * A Linux account name is safe for a `timekpra` positional argument. Usernames
+ * cannot contain whitespace, `;`, `[`, `]`, or control characters; rejecting
+ * those here turns a malformed caller value into a clear error rather than a
+ * silently wrong invocation. (The SSH facade additionally shell-quotes every
+ * argument, so this is about argument *correctness*, not shell safety.)
+ */
+export function assertUsername(username: string): void {
+  if (username.length === 0) {
+    throw new TimekprArgumentError("timekpra: username must not be empty");
+  }
+  // eslint-disable-next-line no-control-regex -- intentionally rejecting controls
+  if (/[\s;[\]\x00-\x1f]/.test(username)) {
+    throw new TimekprArgumentError(
+      `timekpra: invalid username ${JSON.stringify(username)} (whitespace, ';', '[', ']', or control characters are not allowed)`,
+    );
+  }
+}
+
+/** Assert `value` is a non-negative safe integer (a duration in seconds). */
+function assertSeconds(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TimekprArgumentError(
+      `timekpra: ${label} must be a non-negative integer number of seconds, got ${value}`,
+    );
+  }
+}
+
+/** Format a non-empty list of per-day second values as `'s;s;…'`. */
+function formatSecondsList(perDaySeconds: readonly number[], label: string): string {
+  if (perDaySeconds.length === 0) {
+    throw new TimekprArgumentError(`timekpra: ${label} must list at least one day`);
+  }
+  for (const seconds of perDaySeconds) assertSeconds(seconds, label);
+  return perDaySeconds.join(LIST_SEPARATOR);
+}
+
+/** Format a non-empty list of ISO weekdays as `'d;d;…'`. */
+function formatDays(days: readonly IsoWeekday[], label: string): string {
+  if (days.length === 0) {
+    throw new TimekprArgumentError(`timekpra: ${label} must list at least one weekday`);
+  }
+  for (const day of days) {
+    if (!Number.isInteger(day) || day < 1 || day > 7) {
+      throw new TimekprArgumentError(
+        `timekpra: ${label} weekday must be an ISO weekday 1..7 (Mon..Sun), got ${day}`,
+      );
+    }
+  }
+  return days.join(LIST_SEPARATOR);
+}
+
+/** Render the day position of an allowed-hours command: an ISO weekday or `ALL`. */
+function formatAllowedHoursDay(day: AllowedHoursDay): string {
+  if (day === ALL_DAYS) return ALL_DAYS;
+  if (!Number.isInteger(day) || day < 1 || day > 7) {
+    throw new TimekprArgumentError(
+      `timekpra: allowed-hours day must be an ISO weekday 1..7 or "ALL", got ${day}`,
+    );
+  }
+  return String(day);
+}
+
+/** Render one {@link AllowedHour} as `[!]H[(start)-(end)]`. */
+function formatAllowedHour(entry: AllowedHour): string {
+  const { hour, startMinute, endMinute, unaccounted } = entry;
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+    throw new TimekprArgumentError(`timekpra: allowed hour must be 0..23, got ${hour}`);
+  }
+  const hasStart = startMinute !== undefined;
+  const hasEnd = endMinute !== undefined;
+  if (hasStart !== hasEnd) {
+    throw new TimekprArgumentError(
+      `timekpra: allowed hour ${hour} minute window needs both startMinute and endMinute, or neither`,
+    );
+  }
+  let bracket = "";
+  if (hasStart && hasEnd) {
+    const start = startMinute;
+    const end = endMinute;
+    if (
+      !Number.isInteger(start) ||
+      !Number.isInteger(end) ||
+      start < 0 ||
+      end > 60 ||
+      start >= end
+    ) {
+      throw new TimekprArgumentError(
+        `timekpra: allowed hour ${hour} minute window must satisfy 0 <= start < end <= 60, got [${start}-${end}]`,
+      );
+    }
+    bracket = `[${pad2(start)}-${pad2(end)}]`;
+  }
+  return `${unaccounted === true ? "!" : ""}${hour}${bracket}`;
+}
+
+/** Format a non-empty allowed-hours list as `'H;H[mm-mm];!H;…'`. */
+function formatAllowedHours(hours: readonly AllowedHour[]): string {
+  if (hours.length === 0) {
+    throw new TimekprArgumentError("timekpra: allowed hours must list at least one hour");
+  }
+  return hours.map(formatAllowedHour).join(LIST_SEPARATOR);
+}
+
+/** Format a non-empty PlayTime activity list as `'mask[desc];mask;…'`. */
+function formatActivities(activities: readonly PlayTimeActivity[]): string {
+  if (activities.length === 0) {
+    throw new TimekprArgumentError("timekpra: PlayTime activities must list at least one entry");
+  }
+  return activities
+    .map(({ mask, description }) => {
+      if (mask.length === 0 || /[;[\]]/.test(mask)) {
+        throw new TimekprArgumentError(
+          `timekpra: PlayTime activity mask ${JSON.stringify(mask)} must be non-empty and contain no ';', '[' or ']'`,
+        );
+      }
+      if (description === undefined) return mask;
+      if (/[;[\]]/.test(description)) {
+        throw new TimekprArgumentError(
+          `timekpra: PlayTime activity description ${JSON.stringify(description)} must contain no ';', '[' or ']'`,
+        );
+      }
+      return `${mask}[${description}]`;
+    })
+    .join(LIST_SEPARATOR);
+}
+
+/** Render a boolean toggle as the `timekpra` literals `true` / `false`. */
+function formatBool(value: boolean): string {
+  return value ? "true" : "false";
+}
+
+/** Zero-pad a minute value to two digits (`5` → `"05"`). */
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+// --- argv builders ---------------------------------------------------------
+
+/** `--setalloweddays USER 'd;d;…'` — the weekdays the user may log in. */
+export function buildSetAllowedDays(username: string, days: readonly IsoWeekday[]): string[] {
+  assertUsername(username);
+  return ["--setalloweddays", username, formatDays(days, "allowed days")];
+}
+
+/** `--setallowedhours USER (DAY|ALL) 'H;…'` — the hours allowed on a day. */
+export function buildSetAllowedHours(
+  username: string,
+  day: AllowedHoursDay,
+  hours: readonly AllowedHour[],
+): string[] {
+  assertUsername(username);
+  return ["--setallowedhours", username, formatAllowedHoursDay(day), formatAllowedHours(hours)];
+}
+
+/** `--settimelimits USER 's;s;…'` — daily limit seconds, per allowed weekday. */
+export function buildSetTimeLimits(username: string, perDaySeconds: readonly number[]): string[] {
+  assertUsername(username);
+  return ["--settimelimits", username, formatSecondsList(perDaySeconds, "daily time limits")];
+}
+
+/** `--settimelimitweek USER s` — rolling weekly limit in seconds. */
+export function buildSetTimeLimitWeek(username: string, seconds: number): string[] {
+  assertUsername(username);
+  assertSeconds(seconds, "weekly time limit");
+  return ["--settimelimitweek", username, String(seconds)];
+}
+
+/** `--settimelimitmonth USER s` — rolling monthly limit in seconds. */
+export function buildSetTimeLimitMonth(username: string, seconds: number): string[] {
+  assertUsername(username);
+  assertSeconds(seconds, "monthly time limit");
+  return ["--settimelimitmonth", username, String(seconds)];
+}
+
+/** `--setplaytimeenabled USER (true|false)` — master PlayTime switch. */
+export function buildSetPlayTimeEnabled(username: string, enabled: boolean): string[] {
+  assertUsername(username);
+  return ["--setplaytimeenabled", username, formatBool(enabled)];
+}
+
+/**
+ * `--setplaytimelimitoverride USER (true|false)` — when true, PlayTime limits
+ * apply *instead of* (override) the overall session limit rather than within it.
+ */
+export function buildSetPlayTimeLimitOverride(username: string, enabled: boolean): string[] {
+  assertUsername(username);
+  return ["--setplaytimelimitoverride", username, formatBool(enabled)];
+}
+
+/**
+ * `--setplaytimeunaccountedintervalsenabled USER (true|false)` — when true,
+ * PlayTime is counted even during otherwise-unaccounted (free) hours.
+ */
+export function buildSetPlayTimeUnaccountedIntervalsEnabled(
+  username: string,
+  enabled: boolean,
+): string[] {
+  assertUsername(username);
+  return ["--setplaytimeunaccountedintervalsenabled", username, formatBool(enabled)];
+}
+
+/** `--setplaytimealloweddays USER 'd;d;…'` — weekdays PlayTime is allowed. */
+export function buildSetPlayTimeAllowedDays(
+  username: string,
+  days: readonly IsoWeekday[],
+): string[] {
+  assertUsername(username);
+  return ["--setplaytimealloweddays", username, formatDays(days, "PlayTime allowed days")];
+}
+
+/** `--setplaytimelimits USER 's;s;…'` — PlayTime limit seconds, per weekday. */
+export function buildSetPlayTimeLimits(
+  username: string,
+  perDaySeconds: readonly number[],
+): string[] {
+  assertUsername(username);
+  return [
+    "--setplaytimelimits",
+    username,
+    formatSecondsList(perDaySeconds, "PlayTime daily limits"),
+  ];
+}
+
+/** `--setplaytimeactivities USER 'mask[desc];…'` — the matched app set. */
+export function buildSetPlayTimeActivities(
+  username: string,
+  activities: readonly PlayTimeActivity[],
+): string[] {
+  assertUsername(username);
+  return ["--setplaytimeactivities", username, formatActivities(activities)];
+}
+
+/** `--userinfo USER` — print the user's current Timekpr configuration. */
+export function buildUserInfo(username: string): string[] {
+  assertUsername(username);
+  return ["--userinfo", username];
+}

--- a/server/src/transport/timekpr/errors.ts
+++ b/server/src/transport/timekpr/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Builder-side error for the `timekpra` command layer.
+ *
+ * This is distinct from the SSH facade's runtime taxonomy
+ * (`SshUnreachableError` / `SshCommandError` / `SshParseError` /
+ * `SshExecTimeoutError`, see `../ssh/errors.ts`): those describe what happened
+ * when a command *ran* over SSH, and the `timekpra` client lets them propagate
+ * unchanged. {@link TimekprArgumentError}, by contrast, is raised
+ * **synchronously, before any SSH call**, when a caller hands a builder a value
+ * the `timekpra` CLI grammar cannot represent (a negative duration, an
+ * out-of-range weekday/hour/minute, an empty PlayTime mask, …). Catching it
+ * early keeps a malformed invocation from ever reaching a client.
+ *
+ * License boundary: none touched — plain TypeScript; no GPL code is linked.
+ */
+
+/** A value handed to a `timekpra` command builder is outside the CLI grammar. */
+export class TimekprArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimekprArgumentError";
+  }
+}

--- a/server/src/transport/timekpr/index.ts
+++ b/server/src/transport/timekpr/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Timekpr-nExT transport: builds and runs the `timekpra` admin CLI over the SSH
+ * facade as a subprocess. Translates transport-level session-limit / allowed-
+ * hours / PlayTime inputs into `timekpra` invocations and confirms them by
+ * parsing stdout.
+ *
+ * License boundary: never link Timekpr-nExT (GPL) code in-process — we only run
+ * its CLI over SSH and parse stdout. See `docs/licensing-analysis.md`,
+ * `./client.ts`, and `../ssh/`.
+ */
+export const moduleName = "transport/timekpr";
+
+export { TimekprArgumentError } from "./errors.js";
+export {
+  ALL_DAYS,
+  buildSetAllowedDays,
+  buildSetAllowedHours,
+  buildSetPlayTimeActivities,
+  buildSetPlayTimeAllowedDays,
+  buildSetPlayTimeEnabled,
+  buildSetPlayTimeLimitOverride,
+  buildSetPlayTimeUnaccountedIntervalsEnabled,
+  buildSetPlayTimeLimits,
+  buildSetTimeLimits,
+  buildSetTimeLimitMonth,
+  buildSetTimeLimitWeek,
+  buildUserInfo,
+  assertUsername,
+  type AllowedHour,
+  type AllowedHoursDay,
+  type IsoWeekday,
+  type PlayTimeActivity,
+} from "./commands.js";
+export {
+  DEFAULT_TIMEKPRA_BINARY,
+  TimekprClient,
+  type TimekprClientOptions,
+  type TimekprTransport,
+} from "./client.js";
+export { TimekprUserInfo, timekprUserInfoSchema } from "./userinfo.js";

--- a/server/src/transport/timekpr/userinfo.ts
+++ b/server/src/transport/timekpr/userinfo.ts
@@ -1,0 +1,100 @@
+/**
+ * Parser for `timekpra --userinfo USER` stdout.
+ *
+ * `timekpra` prints a user's configuration as a block of `KEY: VALUE` lines
+ * (e.g. `TIME_LIMIT_PER_WEEK: 86400`). This module validates that shape with a
+ * zod schema (so the facade's {@link ../ssh/facade.ts execAndParse} rejects
+ * unparseable output as an `SshParseError` *before* it crosses into typed code,
+ * per `CLAUDE.md` → "Validate all external input … subprocess stdout") and
+ * exposes the parsed key/value pairs as a typed {@link TimekprUserInfo}.
+ *
+ * The parse is deliberately **key-agnostic**: it captures whatever `KEY: VALUE`
+ * lines `timekpra` emits rather than asserting a fixed set of field names. The
+ * exact key vocabulary is confirmed against the live CLI by the policy→Timekpr
+ * mapping work (#140) when it reads specific fields back; until then this layer
+ * guarantees only the line *grammar*, which is stable across the fields we set.
+ *
+ * License boundary: none touched — pure string parsing of subprocess stdout.
+ */
+import { z } from "zod";
+
+/** A `KEY: VALUE` line: an uppercase/underscore/digit key, then the value. */
+const KEY_VALUE_LINE = /^([A-Z0-9_]+):[ \t]?(.*)$/;
+
+/**
+ * The parsed result of `--userinfo`: the `KEY: VALUE` pairs `timekpra` printed.
+ *
+ * Immutable and key-agnostic — callers read fields by their `timekpra` key via
+ * {@link get}. A later caller that depends on a specific field validates its
+ * own value (e.g. parse a `;`-list of seconds); this type only guarantees the
+ * key/value structure.
+ */
+export class TimekprUserInfo {
+  readonly #fields: ReadonlyMap<string, string>;
+
+  constructor(fields: ReadonlyMap<string, string>) {
+    this.#fields = fields;
+  }
+
+  /** The raw string value for `key`, or `undefined` if `timekpra` omitted it. */
+  get(key: string): string | undefined {
+    return this.#fields.get(key);
+  }
+
+  /** Whether `timekpra` emitted a line for `key`. */
+  has(key: string): boolean {
+    return this.#fields.has(key);
+  }
+
+  /** Every key `timekpra` emitted, in the order encountered. */
+  keys(): string[] {
+    return [...this.#fields.keys()];
+  }
+
+  /** A plain snapshot of the parsed pairs (e.g. for logging or diffing). */
+  toRecord(): Record<string, string> {
+    return Object.fromEntries(this.#fields);
+  }
+}
+
+/**
+ * zod schema parsing raw `--userinfo` stdout into a {@link TimekprUserInfo}.
+ *
+ * Blank lines are ignored. At least one well-formed `KEY: VALUE` line must be
+ * present, and a non-blank line that is *not* a `KEY: VALUE` pair fails the
+ * parse — either signals output that isn't the userinfo block we expected
+ * (so the caller gets an `SshParseError` rather than a half-empty struct).
+ * A repeated key keeps the last value, matching how `timekpra` would emit it.
+ */
+export const timekprUserInfoSchema: z.ZodType<TimekprUserInfo, string> = z
+  .string()
+  .transform((raw, ctx) => {
+    const fields = new Map<string, string>();
+    let sawAny = false;
+    for (const rawLine of raw.split("\n")) {
+      const line = rawLine.replace(/\r$/, "");
+      if (line.trim().length === 0) continue;
+      const match = KEY_VALUE_LINE.exec(line);
+      if (match === null) {
+        ctx.addIssue({
+          code: "custom",
+          message: `timekpra --userinfo: expected "KEY: VALUE", got ${JSON.stringify(line)}`,
+        });
+        return z.NEVER;
+      }
+      sawAny = true;
+      // Both capture groups are present whenever `exec` matched (group 2 is
+      // `(.*)`, which always matches, possibly empty); the `?? ""` only
+      // satisfies `noUncheckedIndexedAccess` and is never the value in practice.
+      const [, key, value] = match;
+      fields.set(key ?? "", value ?? "");
+    }
+    if (!sawAny) {
+      ctx.addIssue({
+        code: "custom",
+        message: "timekpra --userinfo: no KEY: VALUE lines in output",
+      });
+      return z.NEVER;
+    }
+    return new TimekprUserInfo(fields);
+  });

--- a/server/src/transport/timekpr/userinfo.ts
+++ b/server/src/transport/timekpr/userinfo.ts
@@ -18,8 +18,9 @@
  */
 import { z } from "zod";
 
-/** A `KEY: VALUE` line: an uppercase/underscore/digit key, then the value. */
-const KEY_VALUE_LINE = /^([A-Z0-9_]+):[ \t]?(.*)$/;
+/** A `KEY: VALUE` line: an uppercase/underscore/digit key, then the value
+ * (any run of spaces/tabs after the colon is the separator, not part of the value). */
+const KEY_VALUE_LINE = /^([A-Z0-9_]+):[ \t]*(.*)$/;
 
 /**
  * The parsed result of `--userinfo`: the `KEY: VALUE` pairs `timekpra` printed.

--- a/server/tests/transport/timekpr/client.test.ts
+++ b/server/tests/transport/timekpr/client.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for {@link TimekprClient}.
+ *
+ * The SSH transport is a lightweight in-memory fake implementing the
+ * {@link TimekprTransport} structural interface — it records the argv it is
+ * handed and returns canned results, so these tests assert *what the client
+ * would run* (binary prefix + builder output + target + options) and that reads
+ * flow through the real `--userinfo` schema, without opening any socket.
+ */
+import type { ZodType } from "zod";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { ExecOptions, ExecResult, SshTarget } from "../../../src/transport/ssh/facade.js";
+import { SshCommandError } from "../../../src/transport/ssh/errors.js";
+import {
+  DEFAULT_TIMEKPRA_BINARY,
+  TimekprClient,
+  type TimekprTransport,
+} from "../../../src/transport/timekpr/client.js";
+import { TimekprArgumentError } from "../../../src/transport/timekpr/errors.js";
+
+const TARGET: SshTarget = { host: "client.local", username: "pct-agent", privateKey: "KEY" };
+
+interface RecordedCall {
+  target: SshTarget;
+  argv: readonly string[];
+  options: ExecOptions | undefined;
+}
+
+const OK_RESULT: ExecResult = { stdout: "ok", stderr: "", code: 0, signal: null };
+
+/** A fake transport recording every call; `execAndParse` runs the real schema. */
+class FakeTransport implements TimekprTransport {
+  readonly checked: RecordedCall[] = [];
+  readonly parsed: RecordedCall[] = [];
+  userInfoStdout = "USER_NAME: alice\nTIME_LIMIT_PER_WEEK: 86400";
+  checkedError: Error | undefined;
+
+  // `async` so a thrown error becomes a rejected promise, exactly as the real
+  // `SshTransport` (whose methods are async) surfaces failures.
+  async execChecked(
+    target: SshTarget,
+    argv: readonly string[],
+    options?: ExecOptions,
+  ): Promise<ExecResult> {
+    this.checked.push({ target, argv, options });
+    if (this.checkedError !== undefined) throw this.checkedError;
+    return OK_RESULT;
+  }
+
+  async execAndParse<T>(
+    target: SshTarget,
+    argv: readonly string[],
+    schema: ZodType<T>,
+    options?: ExecOptions,
+  ): Promise<T> {
+    this.parsed.push({ target, argv, options });
+    return schema.parse(this.userInfoStdout);
+  }
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+});
+
+function clientFor(): TimekprClient {
+  return new TimekprClient(transport, TARGET, "alice");
+}
+
+describe("TimekprClient construction", () => {
+  it("exposes the username", () => {
+    expect(clientFor().username).toBe("alice");
+  });
+
+  it("rejects an invalid username at construction", () => {
+    expect(() => new TimekprClient(transport, TARGET, "bad;name")).toThrow(TimekprArgumentError);
+  });
+
+  it("rejects an empty binary prefix", () => {
+    expect(() => new TimekprClient(transport, TARGET, "alice", { binary: [] })).toThrow(
+      TimekprArgumentError,
+    );
+  });
+});
+
+describe("TimekprClient setters", () => {
+  it("prefixes the default binary and routes through execChecked", async () => {
+    const client = clientFor();
+    await client.setTimeLimitWeek(86400);
+    expect(transport.checked).toHaveLength(1);
+    expect(transport.checked[0]?.argv).toEqual([
+      ...DEFAULT_TIMEKPRA_BINARY,
+      "--settimelimitweek",
+      "alice",
+      "86400",
+    ]);
+    expect(transport.checked[0]?.target).toBe(TARGET);
+  });
+
+  it("builds each command with the right argv", async () => {
+    const client = clientFor();
+    await client.setAllowedDays([1, 2, 3, 4, 5]);
+    await client.setAllowedHours("ALL", [{ hour: 9 }, { hour: 17, startMinute: 0, endMinute: 30 }]);
+    await client.setTimeLimits([3600, 7200]);
+    await client.setTimeLimitMonth(360000);
+    await client.setPlayTimeEnabled(true);
+    await client.setPlayTimeLimitOverride(false);
+    await client.setPlayTimeUnaccountedIntervalsEnabled(true);
+    await client.setPlayTimeAllowedDays([6, 7]);
+    await client.setPlayTimeLimits([0, 3600]);
+    await client.setPlayTimeActivities([{ mask: "minetest", description: "Minetest" }]);
+
+    const argvs = transport.checked.map((c) => c.argv.slice(DEFAULT_TIMEKPRA_BINARY.length));
+    expect(argvs).toEqual([
+      ["--setalloweddays", "alice", "1;2;3;4;5"],
+      ["--setallowedhours", "alice", "ALL", "9;17[00-30]"],
+      ["--settimelimits", "alice", "3600;7200"],
+      ["--settimelimitmonth", "alice", "360000"],
+      ["--setplaytimeenabled", "alice", "true"],
+      ["--setplaytimelimitoverride", "alice", "false"],
+      ["--setplaytimeunaccountedintervalsenabled", "alice", "true"],
+      ["--setplaytimealloweddays", "alice", "6;7"],
+      ["--setplaytimelimits", "alice", "0;3600"],
+      ["--setplaytimeactivities", "alice", "minetest[Minetest]"],
+    ]);
+  });
+
+  it("honours a binary override and forwarded exec options", async () => {
+    const client = new TimekprClient(transport, TARGET, "alice", {
+      binary: ["/usr/bin/timekpra"],
+      execOptions: { timeoutMs: 5000 },
+    });
+    await client.setTimeLimitWeek(10);
+    expect(transport.checked[0]?.argv).toEqual([
+      "/usr/bin/timekpra",
+      "--settimelimitweek",
+      "alice",
+      "10",
+    ]);
+    expect(transport.checked[0]?.options).toEqual({ timeoutMs: 5000 });
+  });
+
+  it("validates inputs before touching the transport", async () => {
+    const client = clientFor();
+    await expect(client.setTimeLimitWeek(-1)).rejects.toThrow(TimekprArgumentError);
+    expect(transport.checked).toHaveLength(0);
+  });
+
+  it("propagates an SshCommandError from a failed setter unchanged", async () => {
+    transport.checkedError = new SshCommandError(
+      { host: "client.local", port: 22, username: "pct-agent" },
+      ["sudo", "timekpra"],
+      { code: 1, signal: null, stdout: "", stderr: "boom" },
+    );
+    await expect(clientFor().setTimeLimitWeek(1)).rejects.toBeInstanceOf(SshCommandError);
+  });
+});
+
+describe("TimekprClient.getUserInfo", () => {
+  it("runs --userinfo through execAndParse and returns the parsed struct", async () => {
+    const info = await clientFor().getUserInfo();
+    expect(transport.parsed).toHaveLength(1);
+    expect(transport.parsed[0]?.argv).toEqual([...DEFAULT_TIMEKPRA_BINARY, "--userinfo", "alice"]);
+    expect(info.get("TIME_LIMIT_PER_WEEK")).toBe("86400");
+  });
+
+  it("lets a parse failure surface (the schema rejects non-userinfo output)", async () => {
+    transport.userInfoStdout = "not userinfo output";
+    await expect(clientFor().getUserInfo()).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/server/tests/transport/timekpr/commands.test.ts
+++ b/server/tests/transport/timekpr/commands.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for the pure `timekpra` argv builders.
+ *
+ * Each builder must produce the exact argv vector the SSH facade will quote and
+ * run, and must reject — synchronously, as a {@link TimekprArgumentError} — any
+ * value the `timekpra` CLI grammar cannot represent. No I/O is involved.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  ALL_DAYS,
+  assertUsername,
+  buildSetAllowedDays,
+  buildSetAllowedHours,
+  buildSetPlayTimeActivities,
+  buildSetPlayTimeAllowedDays,
+  buildSetPlayTimeEnabled,
+  buildSetPlayTimeLimitOverride,
+  buildSetPlayTimeUnaccountedIntervalsEnabled,
+  buildSetPlayTimeLimits,
+  buildSetTimeLimits,
+  buildSetTimeLimitMonth,
+  buildSetTimeLimitWeek,
+  buildUserInfo,
+  type IsoWeekday,
+} from "../../../src/transport/timekpr/commands.js";
+import { TimekprArgumentError } from "../../../src/transport/timekpr/errors.js";
+
+const USER = "alice";
+
+describe("assertUsername", () => {
+  it("accepts a plain Linux account name", () => {
+    expect(() => assertUsername("alice_2")).not.toThrow();
+  });
+
+  it.each([
+    ["empty", ""],
+    ["space", "ali ce"],
+    ["semicolon", "ali;ce"],
+    ["bracket", "ali[ce]"],
+    ["tab", "ali\tce"],
+    ["newline", "ali\nce"],
+  ])("rejects %s usernames", (_label, name) => {
+    expect(() => assertUsername(name)).toThrow(TimekprArgumentError);
+  });
+});
+
+describe("buildSetAllowedDays", () => {
+  it("joins ISO weekdays with ';'", () => {
+    expect(buildSetAllowedDays(USER, [1, 2, 3, 4, 5])).toEqual([
+      "--setalloweddays",
+      "alice",
+      "1;2;3;4;5",
+    ]);
+  });
+
+  it("rejects an empty day list", () => {
+    expect(() => buildSetAllowedDays(USER, [])).toThrow(TimekprArgumentError);
+  });
+
+  it("rejects a weekday outside 1..7", () => {
+    // 0 and 8 are out of the ISO range; cast through unknown to bypass the
+    // compile-time union and exercise the runtime guard.
+    const bad = [0] as unknown as IsoWeekday[];
+    expect(() => buildSetAllowedDays(USER, bad)).toThrow(/ISO weekday 1\.\.7/);
+  });
+});
+
+describe("buildSetAllowedHours", () => {
+  it("renders a single weekday with plain hours", () => {
+    expect(buildSetAllowedHours(USER, 3, [{ hour: 7 }, { hour: 8 }, { hour: 22 }])).toEqual([
+      "--setallowedhours",
+      "alice",
+      "3",
+      "7;8;22",
+    ]);
+  });
+
+  it("renders ALL with a minute window and an unaccounted hour", () => {
+    expect(
+      buildSetAllowedHours(USER, ALL_DAYS, [
+        { hour: 9 },
+        { hour: 12, startMinute: 0, endMinute: 30 },
+        { hour: 15, unaccounted: true },
+        { hour: 20, startMinute: 0, endMinute: 45, unaccounted: true },
+      ]),
+    ).toEqual(["--setallowedhours", "alice", "ALL", "9;12[00-30];!15;!20[00-45]"]);
+  });
+
+  it("zero-pads minute bounds to two digits", () => {
+    const [, , , hours] = buildSetAllowedHours(USER, 1, [
+      { hour: 6, startMinute: 5, endMinute: 9 },
+    ]);
+    expect(hours).toBe("6[05-09]");
+  });
+
+  it("rejects an empty hour list", () => {
+    expect(() => buildSetAllowedHours(USER, 1, [])).toThrow(TimekprArgumentError);
+  });
+
+  it("rejects an hour outside 0..23", () => {
+    expect(() => buildSetAllowedHours(USER, 1, [{ hour: 24 }])).toThrow(/0\.\.23/);
+  });
+
+  it("rejects a day outside 1..7 and not ALL", () => {
+    const bad = 9 as unknown as IsoWeekday;
+    expect(() => buildSetAllowedHours(USER, bad, [{ hour: 1 }])).toThrow(
+      /ISO weekday 1\.\.7 or "ALL"/,
+    );
+  });
+
+  it("rejects a minute window missing one bound", () => {
+    expect(() => buildSetAllowedHours(USER, 1, [{ hour: 8, startMinute: 0 }])).toThrow(
+      /both startMinute and endMinute/,
+    );
+  });
+
+  it.each([
+    ["start >= end", { hour: 8, startMinute: 30, endMinute: 30 }],
+    ["end > 60", { hour: 8, startMinute: 0, endMinute: 61 }],
+    ["negative start", { hour: 8, startMinute: -1, endMinute: 10 }],
+  ])("rejects an invalid minute window (%s)", (_label, entry) => {
+    expect(() => buildSetAllowedHours(USER, 1, [entry])).toThrow(/0 <= start < end <= 60/);
+  });
+});
+
+describe("session-limit builders", () => {
+  it("builds per-weekday daily limits", () => {
+    expect(buildSetTimeLimits(USER, [3600, 3600, 7200])).toEqual([
+      "--settimelimits",
+      "alice",
+      "3600;3600;7200",
+    ]);
+  });
+
+  it("builds the weekly limit", () => {
+    expect(buildSetTimeLimitWeek(USER, 86400)).toEqual(["--settimelimitweek", "alice", "86400"]);
+  });
+
+  it("builds the monthly limit", () => {
+    expect(buildSetTimeLimitMonth(USER, 360000)).toEqual([
+      "--settimelimitmonth",
+      "alice",
+      "360000",
+    ]);
+  });
+
+  it("allows a zero-second limit", () => {
+    expect(buildSetTimeLimitWeek(USER, 0)).toEqual(["--settimelimitweek", "alice", "0"]);
+  });
+
+  it("rejects an empty daily-limit list", () => {
+    expect(() => buildSetTimeLimits(USER, [])).toThrow(/at least one day/);
+  });
+
+  it.each([
+    ["negative", -1],
+    ["fractional", 1.5],
+    ["NaN", Number.NaN],
+  ])("rejects a %s second value", (_label, seconds) => {
+    expect(() => buildSetTimeLimitWeek(USER, seconds)).toThrow(/non-negative integer/);
+    expect(() => buildSetTimeLimits(USER, [seconds])).toThrow(/non-negative integer/);
+  });
+});
+
+describe("PlayTime builders", () => {
+  it("builds the boolean toggles", () => {
+    expect(buildSetPlayTimeEnabled(USER, true)).toEqual(["--setplaytimeenabled", "alice", "true"]);
+    expect(buildSetPlayTimeLimitOverride(USER, false)).toEqual([
+      "--setplaytimelimitoverride",
+      "alice",
+      "false",
+    ]);
+    expect(buildSetPlayTimeUnaccountedIntervalsEnabled(USER, true)).toEqual([
+      "--setplaytimeunaccountedintervalsenabled",
+      "alice",
+      "true",
+    ]);
+  });
+
+  it("builds PlayTime allowed days and limits", () => {
+    expect(buildSetPlayTimeAllowedDays(USER, [6, 7])).toEqual([
+      "--setplaytimealloweddays",
+      "alice",
+      "6;7",
+    ]);
+    expect(buildSetPlayTimeLimits(USER, [0, 0, 3600])).toEqual([
+      "--setplaytimelimits",
+      "alice",
+      "0;0;3600",
+    ]);
+  });
+
+  it("builds activities with and without descriptions", () => {
+    expect(
+      buildSetPlayTimeActivities(USER, [
+        { mask: "minetest", description: "Minetest" },
+        { mask: "dota2" },
+      ]),
+    ).toEqual(["--setplaytimeactivities", "alice", "minetest[Minetest];dota2"]);
+  });
+
+  it("rejects an empty activity list", () => {
+    expect(() => buildSetPlayTimeActivities(USER, [])).toThrow(/at least one entry/);
+  });
+
+  it.each([
+    ["empty mask", { mask: "" }],
+    ["mask with ';'", { mask: "a;b" }],
+    ["mask with bracket", { mask: "a[b]" }],
+  ])("rejects a bad activity mask (%s)", (_label, activity) => {
+    expect(() => buildSetPlayTimeActivities(USER, [activity])).toThrow(TimekprArgumentError);
+  });
+
+  it("rejects a description containing a separator", () => {
+    expect(() => buildSetPlayTimeActivities(USER, [{ mask: "ok", description: "a;b" }])).toThrow(
+      /description/,
+    );
+  });
+});
+
+describe("buildUserInfo", () => {
+  it("builds the userinfo query", () => {
+    expect(buildUserInfo(USER)).toEqual(["--userinfo", "alice"]);
+  });
+
+  it("validates the username", () => {
+    expect(() => buildUserInfo("bad;name")).toThrow(TimekprArgumentError);
+  });
+});

--- a/server/tests/transport/timekpr/commands.test.ts
+++ b/server/tests/transport/timekpr/commands.test.ts
@@ -87,6 +87,19 @@ describe("buildSetAllowedHours", () => {
     ).toEqual(["--setallowedhours", "alice", "ALL", "9;12[00-30];!15;!20[00-45]"]);
   });
 
+  it("renders a weekday list in the day position", () => {
+    expect(buildSetAllowedHours(USER, [1, 2, 3, 4, 5], [{ hour: 9 }])).toEqual([
+      "--setallowedhours",
+      "alice",
+      "1;2;3;4;5",
+      "9",
+    ]);
+  });
+
+  it("rejects an empty weekday list in the day position", () => {
+    expect(() => buildSetAllowedHours(USER, [], [{ hour: 9 }])).toThrow(/at least one weekday/);
+  });
+
   it("zero-pads minute bounds to two digits", () => {
     const [, , , hours] = buildSetAllowedHours(USER, 1, [
       { hour: 6, startMinute: 5, endMinute: 9 },
@@ -105,7 +118,7 @@ describe("buildSetAllowedHours", () => {
   it("rejects a day outside 1..7 and not ALL", () => {
     const bad = 9 as unknown as IsoWeekday;
     expect(() => buildSetAllowedHours(USER, bad, [{ hour: 1 }])).toThrow(
-      /ISO weekday 1\.\.7 or "ALL"/,
+      /ISO weekday 1\.\.7, a weekday list, or "ALL"/,
     );
   });
 
@@ -198,6 +211,14 @@ describe("PlayTime builders", () => {
         { mask: "dota2" },
       ]),
     ).toEqual(["--setplaytimeactivities", "alice", "minetest[Minetest];dota2"]);
+  });
+
+  it("emits a bare mask for an empty description (no empty bracket)", () => {
+    expect(buildSetPlayTimeActivities(USER, [{ mask: "dota2", description: "" }])).toEqual([
+      "--setplaytimeactivities",
+      "alice",
+      "dota2",
+    ]);
   });
 
   it("rejects an empty activity list", () => {

--- a/server/tests/transport/timekpr/index.test.ts
+++ b/server/tests/transport/timekpr/index.test.ts
@@ -1,0 +1,40 @@
+/**
+ * The `transport/timekpr` barrel re-exports the module's public surface and
+ * tags the module name. This guards that the intended API stays exported (a
+ * rename or accidental drop fails here).
+ */
+import { describe, expect, it } from "vitest";
+
+import * as timekpr from "../../../src/transport/timekpr/index.js";
+
+describe("transport/timekpr index", () => {
+  it("tags the module name", () => {
+    expect(timekpr.moduleName).toBe("transport/timekpr");
+  });
+
+  it("re-exports the client, builders, error, and userinfo surface", () => {
+    expect(timekpr.TimekprClient).toBeTypeOf("function");
+    expect(timekpr.TimekprArgumentError).toBeTypeOf("function");
+    expect(timekpr.TimekprUserInfo).toBeTypeOf("function");
+    expect(timekpr.timekprUserInfoSchema).toBeDefined();
+    expect(timekpr.ALL_DAYS).toBe("ALL");
+    expect(timekpr.DEFAULT_TIMEKPRA_BINARY).toEqual(["sudo", "timekpra"]);
+    for (const builder of [
+      timekpr.buildSetAllowedDays,
+      timekpr.buildSetAllowedHours,
+      timekpr.buildSetTimeLimits,
+      timekpr.buildSetTimeLimitWeek,
+      timekpr.buildSetTimeLimitMonth,
+      timekpr.buildSetPlayTimeEnabled,
+      timekpr.buildSetPlayTimeLimitOverride,
+      timekpr.buildSetPlayTimeUnaccountedIntervalsEnabled,
+      timekpr.buildSetPlayTimeAllowedDays,
+      timekpr.buildSetPlayTimeLimits,
+      timekpr.buildSetPlayTimeActivities,
+      timekpr.buildUserInfo,
+      timekpr.assertUsername,
+    ]) {
+      expect(builder).toBeTypeOf("function");
+    }
+  });
+});

--- a/server/tests/transport/timekpr/userinfo.test.ts
+++ b/server/tests/transport/timekpr/userinfo.test.ts
@@ -45,6 +45,12 @@ describe("timekprUserInfoSchema", () => {
     expect(info.keys()).toEqual(["A", "B"]);
   });
 
+  it("treats a run of spaces/tabs after the colon as the separator", () => {
+    const info = timekprUserInfoSchema.parse("K:   value\nT:\tvalue2");
+    expect(info.get("K")).toBe("value");
+    expect(info.get("T")).toBe("value2");
+  });
+
   it("keeps the last value when a key repeats", () => {
     const info = timekprUserInfoSchema.parse("K: first\nK: second");
     expect(info.get("K")).toBe("second");

--- a/server/tests/transport/timekpr/userinfo.test.ts
+++ b/server/tests/transport/timekpr/userinfo.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for the `timekpra --userinfo` stdout parser.
+ *
+ * The schema must accept the `KEY: VALUE` block `timekpra` prints, expose the
+ * pairs through {@link TimekprUserInfo}, and fail (so the facade raises an
+ * `SshParseError`) on output that is not that block.
+ */
+import { describe, expect, it } from "vitest";
+
+import { timekprUserInfoSchema } from "../../../src/transport/timekpr/userinfo.js";
+
+const SAMPLE = [
+  "USER_NAME: alice",
+  "ALLOWED_WEEKDAYS: 1;2;3;4;5",
+  "TIME_LIMIT_PER_WEEK: 86400",
+  "PLAYTIME_ENABLED: True",
+].join("\n");
+
+describe("timekprUserInfoSchema", () => {
+  it("parses KEY: VALUE lines into a typed lookup", () => {
+    const info = timekprUserInfoSchema.parse(SAMPLE);
+    expect(info.get("USER_NAME")).toBe("alice");
+    expect(info.get("ALLOWED_WEEKDAYS")).toBe("1;2;3;4;5");
+    expect(info.get("TIME_LIMIT_PER_WEEK")).toBe("86400");
+    expect(info.has("PLAYTIME_ENABLED")).toBe(true);
+    expect(info.has("NOT_PRESENT")).toBe(false);
+    expect(info.get("NOT_PRESENT")).toBeUndefined();
+  });
+
+  it("preserves key order and snapshots to a record", () => {
+    const info = timekprUserInfoSchema.parse(SAMPLE);
+    expect(info.keys()).toEqual([
+      "USER_NAME",
+      "ALLOWED_WEEKDAYS",
+      "TIME_LIMIT_PER_WEEK",
+      "PLAYTIME_ENABLED",
+    ]);
+    expect(info.toRecord()).toMatchObject({ USER_NAME: "alice", TIME_LIMIT_PER_WEEK: "86400" });
+  });
+
+  it("ignores blank lines and trailing CR, and tolerates empty values", () => {
+    const info = timekprUserInfoSchema.parse("A: 1\r\n\r\nB:\n");
+    expect(info.get("A")).toBe("1");
+    expect(info.get("B")).toBe("");
+    expect(info.keys()).toEqual(["A", "B"]);
+  });
+
+  it("keeps the last value when a key repeats", () => {
+    const info = timekprUserInfoSchema.parse("K: first\nK: second");
+    expect(info.get("K")).toBe("second");
+  });
+
+  it("rejects output with no KEY: VALUE lines", () => {
+    expect(timekprUserInfoSchema.safeParse("").success).toBe(false);
+    expect(timekprUserInfoSchema.safeParse("   \n  ").success).toBe(false);
+  });
+
+  it("rejects output containing a non KEY: VALUE line", () => {
+    const result = timekprUserInfoSchema.safeParse("USER_NAME: alice\nunexpected garbage");
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- New `server/src/transport/timekpr/` — a typed wrapper over the Timekpr-nExT **`timekpra` admin CLI**, driven as a **subprocess** through the merged Phase-4 SSH facade (#82). Translates transport-level session-limit / allowed-hours / PlayTime inputs into `timekpra` argv vectors, runs them, and confirms reads by zod-parsing stdout.
- Pure argv builders with full input validation; a `TimekprClient` that binds an SSH target + supervised username to them; a `--userinfo` stdout parser.

## Why this issue this run

Selection trace (posted on #83): Phase 1 #39 is a cross-phase tracker, not end-to-end implementable now. Phase 2 is frozen for this run — #146 (the foundational `schedules`/`exceptions` column reservation) was claimed <6h ago by a concurrent session, and #51/#148/#124 all build on or concurrently mutate those tables. Phase 3 #76 waits on the unmerged enrolment PR #153. #83 is unclaimed, unblocked (SSH facade #82 merged), and sits at the transport/command layer *below* the schedule schema being reshaped — so it's independent.

## Plan

Linked plan: `.claude/plans/issue-83-timekpra-invocations.md`
Roadmap: `docs/roadmap.md` → Phase 4 ("`timekpra` invocations for: set daily/weekly/monthly limits, set allowed hours, set PlayTime configuration").

## Design notes

- **CLI grammar** verified against upstream `timekpra` docs (ISO-8601 weekdays `1`–`7`, hours `0`–`23`, seconds, `;`-separated lists, `--setallowedhours USER (DAY|ALL) 'H;H[mm-mm];!H'` with the minute-bracket and `!`-unaccounted syntax).
- **Module split** mirrors `transport/ssh/`: `commands.ts` (pure builders + validators, like `shell-quote.ts`), `userinfo.ts` (parser), `client.ts` (I/O over the facade), `errors.ts`, `index.ts`.
- **Builders are pure & total** — return an argv vector or throw `TimekprArgumentError`; the `TimekprClient` invokes them *inside* its async methods so a validation error surfaces as a **rejected promise**, uniformly with the facade's `SshUnreachableError`/`SshCommandError`/`SshParseError` taxonomy (never a sync throw on a Promise-returning method).
- **Invocation** defaults to `sudo timekpra` — the client provisions `pct-agent ALL=(root) NOPASSWD: /usr/bin/timekpra` (#78). The binary prefix is overridable.
- **Transport-level inputs, not policy rows.** The builders take limit-seconds / an allowed-hours spec / a PlayTime spec — *not* `Budget`/`Schedule` DB rows. The policy→`timekpra` mapping is the resolver's (#143) and the recurring-window push's (#140) job; both depend on the #146 schema reservation and feed this layer once they land. This keeps #83 decoupled from the schedule schema currently being reshaped under #146.

## License-boundary note

The dashboard only ever **execs `timekpra` (GPL) over SSH and parses its stdout** — no in-process linkage to Timekpr-nExT, no parsing of its on-disk state with its own code, and no GPL binary added to the image (`CLAUDE.md` → "License boundaries" rules 1–2; `docs/licensing-analysis.md`). No new dependency. `license-guard` unaffected.

## Test plan

- [x] `format:check`, `lint`, `typecheck` clean.
- [x] `npm test` — **431 unit tests pass**; coverage **99.91%** stmts / 97.2% branch (gate 80%); new `transport/timekpr/*` files at 100%.
- [x] `commands.test.ts` — every builder's happy argv + list/minute/`!`/`ALL` formatting, and each validation failure → `TimekprArgumentError`.
- [x] `userinfo.test.ts` — `KEY: VALUE` parse, CR/blank tolerance, repeated-key, empty/garbage rejected.
- [x] `client.test.ts` — argv assembly (binary prefix + builder output), `execChecked`/`execAndParse` routing, binary/exec-option overrides, sync-validation-as-rejection, `SshCommandError` propagation, `getUserInfo` parse path.

## Deferred (tracked)

- `--settimeleft` (grant time adjustment) → belongs to the grant recompute pipeline (#117) / grant-unlock (#108).
- The policy→`timekpra` translation → resolver #143 + recurring-windows #140 (gated on #146).
- A live integration test against a `timekpra`-bearing container → follow-up (mirrors the SSH facade's deferred `ssh.int.test.ts`).

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013qUt3sdMGMXC7mbej9Azqx)_