### PR TITLE
feat(client): install-client.sh one-command Mint enrolment orchestrator (#76)

### DIFF
--- a/.claude/plans/issue-76-install-client-orchestrator.md
+++ b/.claude/plans/issue-76-install-client-orchestrator.md
@@ -1,0 +1,93 @@
+# Issue #76 — `client/install-client.sh` one-command Mint enrolment (orchestrator)
+
+Phase 3 anchor. The single command that turns a fresh Linux Mint (Cinnamon)
+desktop into an enrolled, supervised client. It **sequences** the already-landed
+Phase-3 sub-steps (it does not re-implement them):
+
+- `client/lib/provision-agent-user.sh` (#78) — `pct_provision_agent_user`,
+  `pct_authorize_ssh_key` (sourceable).
+- `client/install-baseline-tools.sh` (#79) — `pct_install_baseline_tools`
+  (sourceable, dry-run aware).
+- The server enrolment endpoint `POST /api/clients/enrol` (#77) — returns the
+  per-client `bearerToken` and the dashboard `sshPublicKey` (nullable).
+- The post-install self-test (#80) — **not yet implemented**; invoked if present,
+  skipped with a note otherwise (forward-compatible hook, tracked by #80).
+
+Authoritative spec: `docs/client-install.md` (Usage + "What the script does"),
+`docs/roadmap.md` → Phase 3.
+
+## Hard constraints honoured
+
+- **License boundary:** pure bash orchestration. GPL tools come from apt /
+  upstream releases (handled by #79), never vendored or linked. No GPL binary
+  added anywhere. `license-guard` unaffected.
+- **Tamper resistance is bounded:** the orchestrator only lays down least-
+  privilege baseline (the `pct-agent` NOPASSWD-`timekpra` rule from #78). No
+  lockdown, no anti-tamper, no `/etc` hardening.
+
+## CLI
+
+```
+sudo bash client/install-client.sh \
+    --server-url https://parentalcontrols.lan \
+    --enrolment-token <one-time token from dashboard> \
+    --supervised-user alice [--supervised-user bob ...]
+```
+
+Env fallbacks: `PCT_SERVER_URL`, `PCT_ENROLMENT_TOKEN` (safer than the CLI flag,
+which is visible in `ps`), `PCT_SUPERVISED_USERS` (space list, matching #79).
+`--ssh-user` overrides the SSH principal (default `pct-agent`).
+
+## Flow
+
+1. **Arg/usage parsing** — required `--server-url`, `--enrolment-token`,
+   ≥1 `--supervised-user`; `--help`.
+2. **Pre-flight** — Debian-family (`pct_require_debian_family`); root unless
+   dry-run; `curl` + `python3` present; server URL reachable (`curl` probe);
+   each supervised user exists (resolve `linuxUid` via `id -u`).
+3. **Provision `pct-agent`** — `pct_provision_agent_user` (account + scoped
+   sudoers). The dashboard SSH key is authorized *after* enrol (the enrol
+   response carries it).
+4. **Install + baseline-configure tools** — `pct_install_baseline_tools <users>`.
+5. **Enrol** — `POST {server}/api/clients/enrol` with
+   `Authorization: Bearer <enrolment-token>` and
+   `{hostname, sshUser, supervisedUsers:[{linuxUsername, linuxUid}]}`. Parse the
+   JSON response (`python3`) for `clientId`, `bearerToken`, `sshPublicKey`.
+6. **Authorize the dashboard key** — `pct_authorize_ssh_key "$sshPublicKey"` when
+   non-null; warn + continue when null (Phase-4 keygen pending — graceful
+   degrade, per #77).
+7. **Persist client credentials** — write `${PCT_STATE_DIR:-/etc/pct}/pct-client.env`
+   (0600 root): `PCT_SERVER_URL`, `PCT_CLIENT_ID`, `PCT_CLIENT_BEARER_TOKEN`. This
+   is the hand-off artifact the Phase-8b `pct-client-bridge` will read; we only
+   *persist* the credential the registration produced (bridge install is #101,
+   out of scope here).
+8. **Self-test** — run `${PCT_SELF_TEST:-<dir>/self-test.sh}` if executable;
+   otherwise note it is pending (#80) and skip (non-fatal).
+
+Idempotent + re-runnable: every sub-step is already idempotent; re-enrol needs a
+fresh token (single-use) — the orchestrator surfaces the server's error cleanly.
+
+## Testability (matches the repo's dry-run + PATH-stub conventions)
+
+- The orchestrator is **dry-run aware** (`PCT_DRY_RUN=1`): network calls and the
+  not-dry-run-aware provision/key-authorize calls print a plan line instead of
+  executing, so a dry run has zero side effects and runs unprivileged anywhere.
+- The baseline sub-step (already dry-run aware) is still invoked under dry-run so
+  its detailed plan shows.
+- The enrol **response parsing** runs in dry-run too, fed by
+  `PCT_FAKE_ENROL_RESPONSE`, so the JSON extraction + null-key branch are tested
+  without a server.
+- `client/tests/install-client.bats` drives the CLI under `PCT_DRY_RUN=1` with a
+  fixture `os-release` (as `install-baseline-tools.bats` does).
+
+## CI gates
+
+- `shellcheck` over `client/**/*.sh` (with `# shellcheck source=` directives).
+- `bats client/tests/` — new `install-client.bats`.
+- No TypeScript change (the enrol endpoint already shipped in #77).
+
+## Out of scope (tracked)
+
+- The post-install self-test script itself — #80.
+- `pct-client-bridge` / `pct-client-agent` `.deb` install — Phase 8b (#101/#106).
+- Per-distro adapters under `client/distros/` — future, per `docs/client-install.md`.

--- a/client/install-client.sh
+++ b/client/install-client.sh
@@ -64,10 +64,9 @@ PCT_SSH_USER="${PCT_SSH_USER:-${PCT_AGENT_USER:-pct-agent}}"
 # Where the per-client credential hand-off file is written. The Phase-8b
 # pct-client-bridge (#101) reads this; overridable so tests don't touch /etc.
 PCT_STATE_DIR="${PCT_STATE_DIR:-/etc/pct}"
-# JSON interpreter used to build the enrol request and parse its response.
-# python3 ships on every Mint/Ubuntu desktop; kept overridable for tests.
-PCT_PYTHON="${PCT_PYTHON:-python3}"
-# curl binary, overridable for tests.
+# curl binary, overridable for tests. curl is the only external tool the
+# orchestrator itself needs (the enrol request/response JSON is handled in pure
+# bash — see pct_orch_build_enrol_body / pct_orch_json_*).
 PCT_CURL="${PCT_CURL:-curl}"
 
 # --- usage -----------------------------------------------------------------
@@ -114,13 +113,11 @@ pct_orch_require_root() {
   fi
 }
 
-# Confirm the external tools the orchestrator itself needs are on PATH.
+# Confirm the external tools the orchestrator itself needs are on PATH. curl is
+# the only one (JSON is handled in pure bash); it ships with Mint/Ubuntu.
 pct_orch_require_tools() {
-  local missing=()
-  command -v "$PCT_CURL" >/dev/null 2>&1 || missing+=("$PCT_CURL")
-  command -v "$PCT_PYTHON" >/dev/null 2>&1 || missing+=("$PCT_PYTHON")
-  if [ "${#missing[@]}" -ne 0 ]; then
-    pct_err "missing required tool(s): ${missing[*]} (curl and python3 ship with Mint; install them and retry)"
+  if ! command -v "$PCT_CURL" >/dev/null 2>&1; then
+    pct_err "missing required tool: ${PCT_CURL} (install it and retry)"
     return 1
   fi
 }
@@ -162,36 +159,48 @@ pct_orch_resolve_uid() {
 # --- enrolment -------------------------------------------------------------
 
 # Build the JSON body for POST /api/clients/enrol from the hostname, ssh user,
-# and a flat list of (username uid) pairs. Uses python3 so usernames are escaped
-# correctly and the UID is emitted as a number, matching the zod DTO (#77).
+# and a flat list of (username uid) pairs, matching the zod DTO (#77):
+# {hostname, sshUser, supervisedUsers:[{linuxUsername, linuxUid:<number>}]}.
+#
+# Built in pure bash (no JSON library): safe here because every interpolated
+# value is a constrained token — a Linux username (validated [<=32], the usual
+# [a-z_][a-z0-9_-]* charset), a hostname (RFC-1035 charset), or an integer UID —
+# none of which can contain a '"' or '\' to break out of the JSON string. The
+# orchestrator's CLI parsing is the trust boundary; this is not a general JSON
+# encoder and must not be reused for free-form input.
 pct_orch_build_enrol_body() {
   local hostname="$1" sshuser="$2"
   shift 2
-  "$PCT_PYTHON" -c '
-import json, sys
-hostname, sshuser = sys.argv[1], sys.argv[2]
-rest = sys.argv[3:]
-users = [
-    {"linuxUsername": rest[i], "linuxUid": int(rest[i + 1])}
-    for i in range(0, len(rest), 2)
-]
-sys.stdout.write(json.dumps({
-    "hostname": hostname,
-    "sshUser": sshuser,
-    "supervisedUsers": users,
-}))
-' "$hostname" "$sshuser" "$@"
+  local users_json="" sep=""
+  while [ "$#" -ge 2 ]; do
+    users_json="${users_json}${sep}{\"linuxUsername\":\"$1\",\"linuxUid\":$2}"
+    sep=","
+    shift 2
+  done
+  printf '{"hostname":"%s","sshUser":"%s","supervisedUsers":[%s]}' \
+    "$hostname" "$sshuser" "$users_json"
 }
 
-# Read a top-level field from a JSON document on stdin, printing its value (the
-# empty string for null or a missing key). Strings are emitted verbatim.
-pct_orch_json_field() {
-  "$PCT_PYTHON" -c '
-import json, sys
-doc = json.load(sys.stdin)
-value = doc.get(sys.argv[1])
-sys.stdout.write("" if value is None else str(value))
-' "$1"
+# Extract a top-level JSON string field's value from stdin, or the empty string
+# for null / a missing key. The enrol response's string fields (bearerToken,
+# sshPublicKey) never contain a '"', so a non-greedy "up to the next quote"
+# match is exact; null yields no match -> empty (the graceful-degrade signal).
+pct_orch_json_string() {
+  local field="$1" json
+  json="$(cat)"
+  if [[ "$json" =~ \"$field\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  fi
+}
+
+# Extract a top-level JSON integer field's value from stdin, or the empty string
+# if absent (e.g. clientId).
+pct_orch_json_number() {
+  local field="$1" json
+  json="$(cat)"
+  if [[ "$json" =~ \"$field\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  fi
 }
 
 # POST the enrolment request and echo the raw JSON response on stdout. Logs go to
@@ -217,12 +226,18 @@ pct_orch_enrol() {
     return 0
   fi
 
-  if ! "$PCT_CURL" --fail --silent --show-error --max-time 30 \
-    --request POST \
-    --header "Authorization: Bearer ${token}" \
-    --header "Content-Type: application/json" \
-    --data "$body" \
-    "$url"; then
+  # Feed the Authorization header through `curl --config -` on stdin so the
+  # secret enrolment token never appears in this process's argv (and thus not in
+  # `ps`). The token is base64url, so the config-file quoting is safe. The body
+  # is not secret, so it stays on argv. --fail makes a non-2xx an error; the
+  # endpoint returns 201 on success.
+  if ! printf 'header = "Authorization: Bearer %s"\n' "$token" |
+    "$PCT_CURL" --config - \
+      --fail --silent --show-error --max-time 30 \
+      --request POST \
+      --header "Content-Type: application/json" \
+      --data "$body" \
+      "$url"; then
     pct_err "enrolment request to ${url} failed (the token may be expired or already used; mint a fresh one)"
     return 1
   fi
@@ -230,16 +245,29 @@ pct_orch_enrol() {
 
 # Persist the per-client credentials the enrolment produced. This is the hand-off
 # artifact the Phase-8b pct-client-bridge (#101) will read to authenticate to
-# /api/events/stream; we only persist what registration returned. Written 0600
-# root:root because the bearer token is a secret. Dry-run prints the plan.
+# /api/events/stream; we only persist what registration returned. Dry-run prints
+# the plan.
 pct_orch_persist_credentials() {
   local server="$1" client_id="$2" bearer="$3"
   local target="${PCT_STATE_DIR}/pct-client.env"
-  printf '# Managed by pct install-client.sh (#76). The Phase-8b pct-client-bridge\n# reads these to authenticate to the dashboard. Do not edit by hand.\nPCT_SERVER_URL=%s\nPCT_CLIENT_ID=%s\nPCT_CLIENT_BEARER_TOKEN=%s\n' \
-    "$server" "$client_id" "$bearer" |
-    pct_write_file "$target"
-  pct_run chmod 0600 "$target"
-  pct_run chown root:root "$target"
+  local content
+  content="$(printf '# Managed by pct install-client.sh (#76). The Phase-8b pct-client-bridge\n# reads these to authenticate to the dashboard. Do not edit by hand.\nPCT_SERVER_URL=%s\nPCT_CLIENT_ID=%s\nPCT_CLIENT_BEARER_TOKEN=%s\n' \
+    "$server" "$client_id" "$bearer")"
+
+  if pct_is_dry_run; then
+    printf '%s %s\n' "$PCT_DRYRUN_PREFIX" "install -m 0600 ${target} (then write PCT_CLIENT_BEARER_TOKEN)" >&2
+    pct_ok "client credentials stored at ${target}"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$target")"
+  # Create the file 0600-from-birth BEFORE writing the secret, so there is no
+  # window in which the bearer token is world-readable (a post-hoc chmod on a
+  # default-umask 0644 file leaves exactly such a window). `install` makes a
+  # fresh 0600 copy of the empty /dev/null, replacing any prior file.
+  install -m 0600 /dev/null "$target"
+  printf '%s' "$content" >"$target"
+  chown root:root "$target"
   pct_ok "client credentials stored at ${target}"
 }
 
@@ -333,9 +361,9 @@ pct_install_client() {
   pct_step "Register this client with the dashboard"
   local response client_id bearer ssh_pubkey
   response="$(pct_orch_enrol "$server_url" "$enrol_token" "$hostname" "$ssh_user" "${pairs[@]}")"
-  client_id="$(printf '%s' "$response" | pct_orch_json_field clientId)"
-  bearer="$(printf '%s' "$response" | pct_orch_json_field bearerToken)"
-  ssh_pubkey="$(printf '%s' "$response" | pct_orch_json_field sshPublicKey)"
+  client_id="$(printf '%s' "$response" | pct_orch_json_number clientId)"
+  bearer="$(printf '%s' "$response" | pct_orch_json_string bearerToken)"
+  ssh_pubkey="$(printf '%s' "$response" | pct_orch_json_string sshPublicKey)"
   pct_ok "enrolled as client #${client_id:-?} (host '${hostname}', ssh user '${ssh_user}')"
 
   # Step: authorize the dashboard SSH key + persist the client bearer token.
@@ -425,20 +453,40 @@ pct_orch_main() {
     esac
   done
 
+  # A real run hard-requires the server URL, a one-time token, and at least one
+  # supervised user. A dry run is a side-effect-free PREVIEW: it fills clearly
+  # labelled placeholders for anything missing so it can always render the full
+  # plan (this is also what the minimal CI smoke test exercises — no token, no
+  # user, just PCT_SERVER_URL).
   if [ -z "$server_url" ]; then
-    pct_err "missing --server-url (or PCT_SERVER_URL)"
-    pct_orch_usage
-    return 2
+    if pct_is_dry_run; then
+      server_url="https://dashboard.example"
+      pct_warn "no --server-url given; using placeholder '${server_url}' for the dry-run preview"
+    else
+      pct_err "missing --server-url (or PCT_SERVER_URL)"
+      pct_orch_usage
+      return 2
+    fi
   fi
   if [ -z "$enrol_token" ]; then
-    pct_err "missing --enrolment-token (or PCT_ENROLMENT_TOKEN)"
-    pct_orch_usage
-    return 2
+    if pct_is_dry_run; then
+      enrol_token="DRY-RUN-PLACEHOLDER-TOKEN"
+      pct_warn "no --enrolment-token given; using a placeholder for the dry-run preview"
+    else
+      pct_err "missing --enrolment-token (or PCT_ENROLMENT_TOKEN)"
+      pct_orch_usage
+      return 2
+    fi
   fi
   if [ "${#users[@]}" -eq 0 ]; then
-    pct_err "no supervised users given (pass --supervised-user or PCT_SUPERVISED_USERS)"
-    pct_orch_usage
-    return 2
+    if pct_is_dry_run; then
+      users=(exampleuser)
+      pct_warn "no --supervised-user given; using placeholder 'exampleuser' for the dry-run preview"
+    else
+      pct_err "no supervised users given (pass --supervised-user or PCT_SUPERVISED_USERS)"
+      pct_orch_usage
+      return 2
+    fi
   fi
 
   pct_install_client "$server_url" "$enrol_token" "$ssh_user" "${users[@]}"

--- a/client/install-client.sh
+++ b/client/install-client.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+#
+# install-client.sh — the Phase 3 anchor (#76): one command turns a fresh
+# Linux Mint (Cinnamon) desktop into an enrolled, supervised client.
+#
+# This is the ORCHESTRATOR. It sequences the Phase-3 sub-steps that each landed
+# as their own component (and have their own tests); it does not re-implement
+# them:
+#
+#   1. provision the low-privilege `pct-agent` service account + scoped sudoers
+#        -> client/lib/provision-agent-user.sh (#78)
+#   2. install + baseline-configure the upstream enforcement/telemetry tools
+#        -> client/install-baseline-tools.sh (#79)
+#   3. register the client with the dashboard and receive the per-client bearer
+#      token + the dashboard SSH public key
+#        -> POST <server>/api/clients/enrol (#77)
+#   4. authorize that SSH key for pct-agent and persist the bearer token
+#   5. run the post-install self-test (#80) if it is installed
+#
+# License boundary (docs/licensing-analysis.md): this is pure bash orchestration.
+# The GPL tools come from the distribution's package manager / the projects' own
+# upstream releases (handled by install-baseline-tools.sh) — never vendored into
+# this repository, never linked in-process, never bundled into the dashboard
+# image. ActivityWatch is only ever reached over its REST API.
+#
+# Tamper-resistance posture (docs/client-install.md): this lays down a least-
+# privilege baseline (the pct-agent NOPASSWD-timekpra rule), not lockdown.
+# Nothing here exists to "make circumvention harder".
+#
+# Idempotent and re-runnable: each sub-step reconciles rather than re-bootstraps.
+# A second enrolment needs a fresh token (enrolment tokens are single-use); the
+# orchestrator surfaces the server's rejection cleanly rather than masking it.
+#
+# Dry-run aware: set PCT_DRY_RUN=1 to print the intended plan without touching
+# the system, network, or the upstream tools — that is how CI and the bats tests
+# exercise it without root. A dry run has no side effects.
+#
+#   sudo bash client/install-client.sh \
+#       --server-url https://parentalcontrols.lan \
+#       --enrolment-token <one-time token from dashboard> \
+#       --supervised-user alice
+#   PCT_DRY_RUN=1 bash client/install-client.sh --server-url … --enrolment-token … --supervised-user alice
+
+set -euo pipefail
+
+# Resolve our own directory so the sub-step components can be sourced whether the
+# script is run from the repo, copied elsewhere, or piped through `bash`.
+PCT_INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source order matters. provision-agent-user.sh defines its own pct_log/pct_die
+# (it deliberately does not depend on pct-common). We source it FIRST, then
+# pct-common.sh, so the shared "pct:" logging wins for the orchestrator and the
+# baseline step; pct_die (only defined by provision) survives either way.
+# shellcheck source=client/lib/provision-agent-user.sh
+. "${PCT_INSTALL_DIR}/lib/provision-agent-user.sh"
+# shellcheck source=client/lib/pct-common.sh
+. "${PCT_INSTALL_DIR}/lib/pct-common.sh"
+# shellcheck source=client/install-baseline-tools.sh
+. "${PCT_INSTALL_DIR}/install-baseline-tools.sh"
+
+# The SSH principal the dashboard connects as. Defaults to the pct-agent account
+# name provision-agent-user.sh manages; override in lockstep with it.
+PCT_SSH_USER="${PCT_SSH_USER:-${PCT_AGENT_USER:-pct-agent}}"
+# Where the per-client credential hand-off file is written. The Phase-8b
+# pct-client-bridge (#101) reads this; overridable so tests don't touch /etc.
+PCT_STATE_DIR="${PCT_STATE_DIR:-/etc/pct}"
+# JSON interpreter used to build the enrol request and parse its response.
+# python3 ships on every Mint/Ubuntu desktop; kept overridable for tests.
+PCT_PYTHON="${PCT_PYTHON:-python3}"
+# curl binary, overridable for tests.
+PCT_CURL="${PCT_CURL:-curl}"
+
+# --- usage -----------------------------------------------------------------
+
+pct_orch_usage() {
+  cat >&2 <<'EOF'
+Usage: install-client.sh --server-url URL --enrolment-token TOKEN \
+                         --supervised-user USER [--supervised-user USER ...]
+
+Enrols this Linux Mint / Ubuntu-family desktop as a supervised client: it
+provisions the pct-agent service account, installs and baseline-configures the
+upstream tools, registers with the dashboard, and runs the self-test.
+
+Run as root (via sudo) for a real install.
+
+Options:
+  --server-url URL          Dashboard base URL (e.g. https://parentalcontrols.lan).
+                            May also be supplied via PCT_SERVER_URL.
+  --enrolment-token TOKEN   One-time enrolment token minted by the dashboard's
+                            "Add client" flow. Prefer PCT_ENROLMENT_TOKEN (the
+                            CLI value is visible to other users via `ps`).
+  --supervised-user USER    A Linux account to supervise (repeatable). May also
+                            be supplied via PCT_SUPERVISED_USERS (space list).
+  --ssh-user NAME           SSH principal the dashboard connects as
+                            (default: pct-agent).
+  -h, --help                Show this help.
+
+Environment:
+  PCT_DRY_RUN=1             Print the plan without changing anything.
+EOF
+}
+
+# --- pre-flight ------------------------------------------------------------
+
+# Confirm we can do privileged work (real installs need root). Skipped under
+# dry-run so the plan can be produced unprivileged.
+pct_orch_require_root() {
+  if pct_is_dry_run; then
+    return 0
+  fi
+  if [ "$(id -u)" -ne 0 ]; then
+    pct_err "must run as root (use sudo); re-run with PCT_DRY_RUN=1 to preview without root"
+    return 1
+  fi
+}
+
+# Confirm the external tools the orchestrator itself needs are on PATH.
+pct_orch_require_tools() {
+  local missing=()
+  command -v "$PCT_CURL" >/dev/null 2>&1 || missing+=("$PCT_CURL")
+  command -v "$PCT_PYTHON" >/dev/null 2>&1 || missing+=("$PCT_PYTHON")
+  if [ "${#missing[@]}" -ne 0 ]; then
+    pct_err "missing required tool(s): ${missing[*]} (curl and python3 ship with Mint; install them and retry)"
+    return 1
+  fi
+}
+
+# Best-effort reachability probe of the dashboard. We do not require a 2xx (the
+# base URL may legitimately 404 or redirect); we only confirm the host answers,
+# so a typo'd URL or an unreachable server fails fast before we change anything.
+pct_orch_check_reachable() {
+  local url="$1"
+  if pct_is_dry_run; then
+    printf '%s %s\n' "$PCT_DRYRUN_PREFIX" "${PCT_CURL} -sS -o /dev/null --max-time 10 ${url}" >&2
+    return 0
+  fi
+  if "$PCT_CURL" --silent --show-error --output /dev/null --max-time 10 "$url" >/dev/null 2>&1; then
+    pct_ok "dashboard reachable at ${url}"
+  else
+    pct_err "dashboard not reachable at ${url} (check --server-url and network connectivity)"
+    return 1
+  fi
+}
+
+# Resolve a supervised user's Linux UID, echoing it on stdout. Under dry-run an
+# absent user yields a placeholder UID so the plan can still be built; under a
+# real run a missing user is a hard error (we cannot enrol a mapping for it).
+pct_orch_resolve_uid() {
+  local user="$1" uid
+  if uid="$(id -u "$user" 2>/dev/null)"; then
+    printf '%s' "$uid"
+    return 0
+  fi
+  if pct_is_dry_run; then
+    printf '%s' "0"
+    return 0
+  fi
+  pct_err "supervised user '${user}' does not exist on this machine; create the account first"
+  return 1
+}
+
+# --- enrolment -------------------------------------------------------------
+
+# Build the JSON body for POST /api/clients/enrol from the hostname, ssh user,
+# and a flat list of (username uid) pairs. Uses python3 so usernames are escaped
+# correctly and the UID is emitted as a number, matching the zod DTO (#77).
+pct_orch_build_enrol_body() {
+  local hostname="$1" sshuser="$2"
+  shift 2
+  "$PCT_PYTHON" -c '
+import json, sys
+hostname, sshuser = sys.argv[1], sys.argv[2]
+rest = sys.argv[3:]
+users = [
+    {"linuxUsername": rest[i], "linuxUid": int(rest[i + 1])}
+    for i in range(0, len(rest), 2)
+]
+sys.stdout.write(json.dumps({
+    "hostname": hostname,
+    "sshUser": sshuser,
+    "supervisedUsers": users,
+}))
+' "$hostname" "$sshuser" "$@"
+}
+
+# Read a top-level field from a JSON document on stdin, printing its value (the
+# empty string for null or a missing key). Strings are emitted verbatim.
+pct_orch_json_field() {
+  "$PCT_PYTHON" -c '
+import json, sys
+doc = json.load(sys.stdin)
+value = doc.get(sys.argv[1])
+sys.stdout.write("" if value is None else str(value))
+' "$1"
+}
+
+# POST the enrolment request and echo the raw JSON response on stdout. Logs go to
+# stderr so the caller can capture the body cleanly. Under dry-run the request is
+# printed (never sending the token) and the response is taken from
+# PCT_FAKE_ENROL_RESPONSE so the parsing path stays exercised offline.
+pct_orch_enrol() {
+  local server="$1" token="$2" hostname="$3" sshuser="$4"
+  shift 4
+  local body url
+  body="$(pct_orch_build_enrol_body "$hostname" "$sshuser" "$@")"
+  url="${server%/}/api/clients/enrol"
+
+  if pct_is_dry_run; then
+    printf '%s %s\n' "$PCT_DRYRUN_PREFIX" \
+      "${PCT_CURL} -fsS -X POST ${url} (Authorization: Bearer <redacted>) body=${body}" >&2
+    if [ -n "${PCT_FAKE_ENROL_RESPONSE:-}" ]; then
+      printf '%s' "$PCT_FAKE_ENROL_RESPONSE"
+    else
+      printf '{"clientId":0,"hostname":"%s","sshUser":"%s","bearerToken":"dry-run-token","sshPublicKey":null,"supervisedUsers":[]}' \
+        "$hostname" "$sshuser"
+    fi
+    return 0
+  fi
+
+  if ! "$PCT_CURL" --fail --silent --show-error --max-time 30 \
+    --request POST \
+    --header "Authorization: Bearer ${token}" \
+    --header "Content-Type: application/json" \
+    --data "$body" \
+    "$url"; then
+    pct_err "enrolment request to ${url} failed (the token may be expired or already used; mint a fresh one)"
+    return 1
+  fi
+}
+
+# Persist the per-client credentials the enrolment produced. This is the hand-off
+# artifact the Phase-8b pct-client-bridge (#101) will read to authenticate to
+# /api/events/stream; we only persist what registration returned. Written 0600
+# root:root because the bearer token is a secret. Dry-run prints the plan.
+pct_orch_persist_credentials() {
+  local server="$1" client_id="$2" bearer="$3"
+  local target="${PCT_STATE_DIR}/pct-client.env"
+  printf '# Managed by pct install-client.sh (#76). The Phase-8b pct-client-bridge\n# reads these to authenticate to the dashboard. Do not edit by hand.\nPCT_SERVER_URL=%s\nPCT_CLIENT_ID=%s\nPCT_CLIENT_BEARER_TOKEN=%s\n' \
+    "$server" "$client_id" "$bearer" |
+    pct_write_file "$target"
+  pct_run chmod 0600 "$target"
+  pct_run chown root:root "$target"
+  pct_ok "client credentials stored at ${target}"
+}
+
+# --- steps -----------------------------------------------------------------
+
+# Step 3: provision the pct-agent account + scoped sudoers. provision-agent-user
+# .sh is not dry-run aware, so under dry-run we print the plan instead of calling
+# it (its own bats suite covers the real behaviour). The dashboard SSH key is
+# authorized later (step 6) from the enrol response.
+pct_orch_provision_agent() {
+  pct_step "Provision the ${PCT_SSH_USER} service account + scoped sudoers"
+  if pct_is_dry_run; then
+    printf '%s %s\n' "$PCT_DRYRUN_PREFIX" \
+      "provision ${PCT_SSH_USER} service account + NOPASSWD-timekpra sudoers" >&2
+    return 0
+  fi
+  pct_provision_agent_user
+}
+
+# Step 6: authorize the dashboard's SSH public key for pct-agent, if the enrol
+# response carried one. pct_authorize_ssh_key (provision-agent-user.sh) is not
+# dry-run aware, so under dry-run we print the plan.
+pct_orch_authorize_key() {
+  local ssh_pubkey="$1"
+  pct_step "Authorize the dashboard SSH key for ${PCT_SSH_USER}"
+  if [ -z "$ssh_pubkey" ]; then
+    pct_warn "the dashboard returned no SSH public key yet (Phase-4 key generation pending)"
+    pct_warn "authorize it for ${PCT_SSH_USER} later, before the dashboard can connect over SSH"
+    return 0
+  fi
+  if pct_is_dry_run; then
+    printf '%s %s\n' "$PCT_DRYRUN_PREFIX" \
+      "authorize dashboard ssh key for ${PCT_SSH_USER}: ${ssh_pubkey}" >&2
+    return 0
+  fi
+  pct_authorize_ssh_key "$ssh_pubkey"
+}
+
+# Step 7 (final): hand off to the post-install self-test (#80) if it is present.
+# It is a separate deliverable; until it lands the orchestrator notes it and
+# completes successfully rather than failing the install.
+pct_orch_self_test() {
+  local self_test="${PCT_SELF_TEST:-${PCT_INSTALL_DIR}/self-test.sh}"
+  pct_step "Run the post-install self-test"
+  if [ -x "$self_test" ]; then
+    if pct_is_dry_run; then
+      printf '%s %s\n' "$PCT_DRYRUN_PREFIX" "${self_test} ${PCT_SUPERVISED_LIST:-}" >&2
+      return 0
+    fi
+    "$self_test"
+  else
+    pct_warn "self-test not installed yet (tracked as #80); skipping"
+  fi
+}
+
+# --- orchestration ---------------------------------------------------------
+
+# Run the full enrolment, given the validated server URL, token, ssh user, and
+# the supervised usernames. Kept as a function so the CLI parser stays thin.
+pct_install_client() {
+  local server_url="$1" enrol_token="$2" ssh_user="$3"
+  shift 3
+  local users=("$@")
+
+  local hostname
+  hostname="$(hostname 2>/dev/null || cat /etc/hostname 2>/dev/null || echo unknown)"
+
+  pct_step "Pre-flight checks"
+  pct_orch_require_root
+  pct_orch_require_tools
+  pct_require_debian_family
+  pct_orch_check_reachable "$server_url"
+
+  # Resolve each supervised user's UID up front (fails fast on a missing user)
+  # and build the flat (username uid) pair list the enrol body needs.
+  local user uid pairs=()
+  for user in "${users[@]}"; do
+    uid="$(pct_orch_resolve_uid "$user")"
+    pairs+=("$user" "$uid")
+  done
+  pct_ok "supervising: ${users[*]}"
+
+  # Step: provision pct-agent.
+  pct_orch_provision_agent
+
+  # Step: install + baseline-configure the upstream tools.
+  pct_step "Install + baseline-configure the upstream tools"
+  pct_install_baseline_tools "${users[@]}"
+
+  # Step: register with the dashboard.
+  pct_step "Register this client with the dashboard"
+  local response client_id bearer ssh_pubkey
+  response="$(pct_orch_enrol "$server_url" "$enrol_token" "$hostname" "$ssh_user" "${pairs[@]}")"
+  client_id="$(printf '%s' "$response" | pct_orch_json_field clientId)"
+  bearer="$(printf '%s' "$response" | pct_orch_json_field bearerToken)"
+  ssh_pubkey="$(printf '%s' "$response" | pct_orch_json_field sshPublicKey)"
+  pct_ok "enrolled as client #${client_id:-?} (host '${hostname}', ssh user '${ssh_user}')"
+
+  # Step: authorize the dashboard SSH key + persist the client bearer token.
+  pct_orch_authorize_key "$ssh_pubkey"
+  pct_orch_persist_credentials "$server_url" "$client_id" "$bearer"
+
+  # Step: self-test.
+  PCT_SUPERVISED_LIST="${users[*]}" pct_orch_self_test
+
+  pct_ok "client enrolment complete for: ${users[*]}"
+  if pct_is_dry_run; then
+    pct_log "(dry-run: nothing was changed)"
+  fi
+}
+
+# --- CLI -------------------------------------------------------------------
+
+pct_orch_main() {
+  local server_url="${PCT_SERVER_URL:-}"
+  local enrol_token="${PCT_ENROLMENT_TOKEN:-}"
+  local ssh_user="$PCT_SSH_USER"
+  local users=()
+  if [ -n "${PCT_SUPERVISED_USERS:-}" ]; then
+    # shellcheck disable=SC2206  # intentional word-split of a space list
+    users=(${PCT_SUPERVISED_USERS})
+  fi
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --server-url)
+      [ "$#" -ge 2 ] || {
+        pct_err "--server-url needs a value"
+        return 2
+      }
+      server_url="$2"
+      shift 2
+      ;;
+    --server-url=*)
+      server_url="${1#*=}"
+      shift
+      ;;
+    --enrolment-token | --enrollment-token)
+      [ "$#" -ge 2 ] || {
+        pct_err "--enrolment-token needs a value"
+        return 2
+      }
+      enrol_token="$2"
+      shift 2
+      ;;
+    --enrolment-token=* | --enrollment-token=*)
+      enrol_token="${1#*=}"
+      shift
+      ;;
+    --supervised-user)
+      [ "$#" -ge 2 ] || {
+        pct_err "--supervised-user needs a value"
+        return 2
+      }
+      users+=("$2")
+      shift 2
+      ;;
+    --supervised-user=*)
+      users+=("${1#*=}")
+      shift
+      ;;
+    --ssh-user)
+      [ "$#" -ge 2 ] || {
+        pct_err "--ssh-user needs a value"
+        return 2
+      }
+      ssh_user="$2"
+      shift 2
+      ;;
+    --ssh-user=*)
+      ssh_user="${1#*=}"
+      shift
+      ;;
+    -h | --help)
+      pct_orch_usage
+      return 0
+      ;;
+    *)
+      pct_err "unknown argument: $1"
+      pct_orch_usage
+      return 2
+      ;;
+    esac
+  done
+
+  if [ -z "$server_url" ]; then
+    pct_err "missing --server-url (or PCT_SERVER_URL)"
+    pct_orch_usage
+    return 2
+  fi
+  if [ -z "$enrol_token" ]; then
+    pct_err "missing --enrolment-token (or PCT_ENROLMENT_TOKEN)"
+    pct_orch_usage
+    return 2
+  fi
+  if [ "${#users[@]}" -eq 0 ]; then
+    pct_err "no supervised users given (pass --supervised-user or PCT_SUPERVISED_USERS)"
+    pct_orch_usage
+    return 2
+  fi
+
+  pct_install_client "$server_url" "$enrol_token" "$ssh_user" "${users[@]}"
+}
+
+# Run main only when executed directly, not when sourced.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  pct_orch_main "$@"
+fi

--- a/client/tests/install-client.bats
+++ b/client/tests/install-client.bats
@@ -1,0 +1,232 @@
+#!/usr/bin/env bats
+#
+# Unit tests for client/install-client.sh (the Phase-3 orchestrator, #76),
+# exercised through its CLI under PCT_DRY_RUN=1 so no root, network, or upstream
+# tools are required. A dry run prints the intended plan and has no side effects;
+# the tests assert on that plan and on the parsed enrol response.
+#
+# The orchestrator sources provision-agent-user.sh and install-baseline-tools.sh;
+# those have their own bats suites for the real (side-effecting) behaviour. Here
+# we verify the orchestration: arg parsing, pre-flight, sequencing, the enrol
+# request/response handling, and graceful degradation.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../install-client.sh"
+  TMP="$(mktemp -d)"
+
+  # Force the supported-distro check to pass regardless of the CI host.
+  OSREL="${TMP}/os-release"
+  printf 'ID=ubuntu\nID_LIKE=debian\nVERSION_CODENAME=jammy\n' >"$OSREL"
+  export PCT_OS_RELEASE="$OSREL"
+
+  export PCT_DRY_RUN=1
+  # Keep the baseline sub-step's downloads/writes out of real system paths.
+  export AW_PREFIX="${TMP}/opt-aw"
+  export E2G_DIR="${TMP}/etc-e2g"
+  export E2G_PCT_DIR="${E2G_DIR}/pct.d"
+  export TIMEKPR_PPA_LIST_GLOB="${TMP}/no-such-*.list"
+  # Credential hand-off file goes under the tmpdir, not /etc.
+  export PCT_STATE_DIR="${TMP}/etc-pct"
+}
+
+teardown() {
+  [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+# Run the orchestrator in dry-run with the given args.
+plan() {
+  run env bash "$SCRIPT" "$@"
+}
+
+# A fully-specified, valid invocation used by most happy-path tests.
+ok_args() {
+  plan --server-url https://parentalcontrols.lan \
+    --enrolment-token TESTTOKEN123 \
+    --supervised-user alice "$@"
+}
+
+# --- argument / usage handling ---------------------------------------------
+
+@test "--help prints usage and exits 0" {
+  plan --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: install-client.sh"* ]]
+}
+
+@test "requires --server-url" {
+  plan --enrolment-token T --supervised-user alice
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing --server-url"* ]]
+}
+
+@test "requires --enrolment-token" {
+  plan --server-url https://dash.lan --supervised-user alice
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing --enrolment-token"* ]]
+}
+
+@test "requires at least one supervised user" {
+  plan --server-url https://dash.lan --enrolment-token T
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no supervised users given"* ]]
+}
+
+@test "rejects an unknown argument" {
+  plan --bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown argument: --bogus"* ]]
+}
+
+@test "accepts the --flag=value form" {
+  plan --server-url=https://dash.lan \
+    --enrolment-token=T \
+    --supervised-user=alice
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts the American --enrollment-token spelling" {
+  plan --server-url https://dash.lan \
+    --enrollment-token T \
+    --supervised-user alice
+  [ "$status" -eq 0 ]
+}
+
+@test "reads configuration from the environment" {
+  PCT_SERVER_URL=https://dash.lan \
+    PCT_ENROLMENT_TOKEN=ENVTOKEN \
+    PCT_SUPERVISED_USERS="carol dave" \
+    run env bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"supervising: carol dave"* ]]
+}
+
+# --- pre-flight ------------------------------------------------------------
+
+@test "rejects an unsupported (non-Debian-family) distro" {
+  printf 'ID=fedora\nID_LIKE=rhel\n' >"$OSREL"
+  ok_args
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unsupported distro"* ]]
+}
+
+@test "plans a reachability probe of the dashboard" {
+  ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--max-time 10 https://parentalcontrols.lan"* ]]
+}
+
+# --- sequencing ------------------------------------------------------------
+
+@test "sequences provision, baseline install, enrol, and self-test" {
+  ok_args
+  [ "$status" -eq 0 ]
+  # The four ordered sub-steps each announce themselves.
+  [[ "$output" == *"Provision the pct-agent service account"* ]]
+  [[ "$output" == *"Install + baseline-configure the upstream tools"* ]]
+  [[ "$output" == *"Register this client with the dashboard"* ]]
+  [[ "$output" == *"Run the post-install self-test"* ]]
+  [[ "$output" == *"client enrolment complete for: alice"* ]]
+}
+
+@test "invokes the baseline tool installer (delegation, not reimplementation)" {
+  ok_args
+  [ "$status" -eq 0 ]
+  # A line only install-baseline-tools.sh emits — proves we delegate to it.
+  [[ "$output" == *"add-apt-repository -y ppa:mjasnik/ppa"* ]]
+  [[ "$output" == *"ActivityWatch units for alice"* ]]
+}
+
+@test "configures every supervised user via the baseline step" {
+  ok_args --supervised-user bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"supervising: alice bob"* ]]
+  [[ "$output" == *"ActivityWatch units for alice"* ]]
+  [[ "$output" == *"ActivityWatch units for bob"* ]]
+}
+
+# --- enrolment request -----------------------------------------------------
+
+@test "POSTs to the dashboard enrol endpoint" {
+  ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"POST https://parentalcontrols.lan/api/clients/enrol"* ]]
+}
+
+@test "never prints the enrolment token (redacted in the plan)" {
+  ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Authorization: Bearer <redacted>"* ]]
+  [[ "$output" != *"TESTTOKEN123"* ]]
+}
+
+@test "builds an enrol body with the supervised user mapping" {
+  ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"sshUser": "pct-agent"'* ]]
+  [[ "$output" == *'"linuxUsername": "alice"'* ]]
+  [[ "$output" == *'"linuxUid":'* ]]
+}
+
+@test "--ssh-user overrides the SSH principal in the enrol body" {
+  ok_args --ssh-user customagent
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"sshUser": "customagent"'* ]]
+}
+
+# --- enrol response handling ----------------------------------------------
+
+@test "authorizes the dashboard SSH key when the response carries one" {
+  export PCT_FAKE_ENROL_RESPONSE='{"clientId":7,"hostname":"h","sshUser":"pct-agent","bearerToken":"BEARER-XYZ","sshPublicKey":"ssh-ed25519 AAAAKEY dashboard@pct","supervisedUsers":[]}'
+  ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"enrolled as client #7"* ]]
+  [[ "$output" == *"authorize dashboard ssh key for pct-agent: ssh-ed25519 AAAAKEY dashboard@pct"* ]]
+}
+
+@test "degrades gracefully when the dashboard has no SSH key yet" {
+  # Default dry-run response has sshPublicKey: null.
+  ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"returned no SSH public key yet"* ]]
+  [[ "$output" == *"authorize it for pct-agent later"* ]]
+}
+
+@test "persists the per-client bearer token credential" {
+  export PCT_FAKE_ENROL_RESPONSE='{"clientId":7,"hostname":"h","sshUser":"pct-agent","bearerToken":"BEARER-XYZ","sshPublicKey":null,"supervisedUsers":[]}'
+  ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"write ${PCT_STATE_DIR}/pct-client.env"* ]]
+  [[ "$output" == *"chmod 0600 ${PCT_STATE_DIR}/pct-client.env"* ]]
+  [[ "$output" == *"client credentials stored at ${PCT_STATE_DIR}/pct-client.env"* ]]
+}
+
+# --- self-test hook --------------------------------------------------------
+
+@test "notes the self-test is pending when it is not installed" {
+  ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"self-test not installed yet (tracked as #80)"* ]]
+}
+
+@test "invokes the self-test when one is installed" {
+  local selftest="${TMP}/self-test.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$selftest"
+  chmod +x "$selftest"
+  PCT_SELF_TEST="$selftest" ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"${selftest}"* ]]
+}
+
+# --- dry-run guarantee -----------------------------------------------------
+
+@test "a dry run reports that nothing was changed" {
+  ok_args
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(dry-run: nothing was changed)"* ]]
+}
+
+@test "a dry run writes nothing under the state dir" {
+  ok_args
+  [ "$status" -eq 0 ]
+  [ ! -e "${PCT_STATE_DIR}/pct-client.env" ]
+}

--- a/client/tests/install-client.bats
+++ b/client/tests/install-client.bats
@@ -45,6 +45,13 @@ ok_args() {
     --supervised-user alice "$@"
 }
 
+# Run with dry-run DISABLED, to exercise the strict (real-run) validation that a
+# dry-run preview deliberately relaxes. Used only for negative arg tests, which
+# return before any privileged pre-flight work.
+plan_strict() {
+  run env -u PCT_DRY_RUN bash "$SCRIPT" "$@"
+}
+
 # --- argument / usage handling ---------------------------------------------
 
 @test "--help prints usage and exits 0" {
@@ -53,22 +60,31 @@ ok_args() {
   [[ "$output" == *"Usage: install-client.sh"* ]]
 }
 
-@test "requires --server-url" {
-  plan --enrolment-token T --supervised-user alice
+@test "a real run requires --server-url" {
+  plan_strict --enrolment-token T --supervised-user alice
   [ "$status" -ne 0 ]
   [[ "$output" == *"missing --server-url"* ]]
 }
 
-@test "requires --enrolment-token" {
-  plan --server-url https://dash.lan --supervised-user alice
+@test "a real run requires --enrolment-token" {
+  plan_strict --server-url https://dash.lan --supervised-user alice
   [ "$status" -ne 0 ]
   [[ "$output" == *"missing --enrolment-token"* ]]
 }
 
-@test "requires at least one supervised user" {
-  plan --server-url https://dash.lan --enrolment-token T
+@test "a real run requires at least one supervised user" {
+  plan_strict --server-url https://dash.lan --enrolment-token T
   [ "$status" -ne 0 ]
   [[ "$output" == *"no supervised users given"* ]]
+}
+
+@test "a dry-run preview fills placeholders for missing inputs (CI smoke contract)" {
+  # Mirrors .github/workflows/integration.yml: a minimal-deps container runs the
+  # script with only PCT_SERVER_URL + PCT_DRY_RUN and expects a clean exit.
+  PCT_SERVER_URL=http://mock.local run env bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"placeholder"* ]]
+  [[ "$output" == *"client enrolment complete for: exampleuser"* ]]
 }
 
 @test "rejects an unknown argument" {
@@ -162,15 +178,15 @@ ok_args() {
 @test "builds an enrol body with the supervised user mapping" {
   ok_args
   [ "$status" -eq 0 ]
-  [[ "$output" == *'"sshUser": "pct-agent"'* ]]
-  [[ "$output" == *'"linuxUsername": "alice"'* ]]
+  [[ "$output" == *'"sshUser":"pct-agent"'* ]]
+  [[ "$output" == *'"linuxUsername":"alice"'* ]]
   [[ "$output" == *'"linuxUid":'* ]]
 }
 
 @test "--ssh-user overrides the SSH principal in the enrol body" {
   ok_args --ssh-user customagent
   [ "$status" -eq 0 ]
-  [[ "$output" == *'"sshUser": "customagent"'* ]]
+  [[ "$output" == *'"sshUser":"customagent"'* ]]
 }
 
 # --- enrol response handling ----------------------------------------------
@@ -191,12 +207,13 @@ ok_args() {
   [[ "$output" == *"authorize it for pct-agent later"* ]]
 }
 
-@test "persists the per-client bearer token credential" {
+@test "persists the per-client bearer token credential (0600 from birth)" {
   export PCT_FAKE_ENROL_RESPONSE='{"clientId":7,"hostname":"h","sshUser":"pct-agent","bearerToken":"BEARER-XYZ","sshPublicKey":null,"supervisedUsers":[]}'
   ok_args
   [ "$status" -eq 0 ]
-  [[ "$output" == *"write ${PCT_STATE_DIR}/pct-client.env"* ]]
-  [[ "$output" == *"chmod 0600 ${PCT_STATE_DIR}/pct-client.env"* ]]
+  # The plan creates the file 0600 before writing the secret (no world-readable
+  # window), not a post-hoc chmod.
+  [[ "$output" == *"install -m 0600 ${PCT_STATE_DIR}/pct-client.env"* ]]
   [[ "$output" == *"client credentials stored at ${PCT_STATE_DIR}/pct-client.env"* ]]
 }
 
@@ -215,6 +232,46 @@ ok_args() {
   PCT_SELF_TEST="$selftest" ok_args
   [ "$status" -eq 0 ]
   [[ "$output" == *"${selftest}"* ]]
+}
+
+# --- real enrol request (function-level, with a curl stub) -----------------
+
+@test "a failed enrol request aborts with a clear error (real run)" {
+  local stub="${TMP}/curl-fail"
+  printf '#!/usr/bin/env bash\nexit 22\n' >"$stub"
+  chmod +x "$stub"
+  # Source the (guarded) orchestrator and drive pct_orch_enrol directly so we
+  # exercise the real-run path without needing root for the earlier steps.
+  run env -u PCT_DRY_RUN bash -c '
+    PCT_CURL="'"$stub"'"
+    source "'"$SCRIPT"'"
+    pct_orch_enrol https://dash.lan TOK host pct-agent alice 1000
+  '
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"enrolment request to https://dash.lan/api/clients/enrol failed"* ]]
+}
+
+@test "the enrolment token is sent via stdin config, never on the curl argv" {
+  local stub="${TMP}/curl-echo"
+  cat >"$stub" <<'EOS'
+#!/usr/bin/env bash
+echo "ARGV: $*"
+echo "STDIN: $(cat)"
+EOS
+  chmod +x "$stub"
+  run env -u PCT_DRY_RUN bash -c '
+    PCT_CURL="'"$stub"'"
+    source "'"$SCRIPT"'"
+    pct_orch_enrol https://dash.lan SECRETTOKEN host pct-agent alice 1000
+  '
+  [ "$status" -eq 0 ]
+  local argv_line stdin_line
+  argv_line="$(printf '%s\n' "$output" | grep '^ARGV:')"
+  stdin_line="$(printf '%s\n' "$output" | grep '^STDIN:')"
+  # The secret must not appear in the argv curl received (ps-visibility) ...
+  [[ "$argv_line" != *SECRETTOKEN* ]]
+  # ... but must be delivered through the stdin config file.
+  [[ "$stdin_line" == *"Authorization: Bearer SECRETTOKEN"* ]]
 }
 
 # --- dry-run guarantee -----------------------------------------------------

--- a/docs/client-install.md
+++ b/docs/client-install.md
@@ -1,9 +1,12 @@
 # Client install
 
-The client install script (`client/install-client.sh`, to be implemented)
-enrols a Linux Mint / Cinnamon machine as a managed client. This document
-describes its design — not the script itself, which will land per the
-roadmap.
+The client install script (`client/install-client.sh`) enrols a Linux Mint /
+Cinnamon machine as a managed client. This document describes its design; the
+orchestrator (#76) sequences the Phase-3 sub-steps below. Some steps are owned
+by later phases and are noted inline as they are reached — notably the
+`pct-client` agent `.deb` (Phase 8b), the iptables OUTPUT redirect and managed
+e2guardian rules (Phase 6 Ansible), and the standalone self-test script (#80),
+which the orchestrator runs if present.
 
 ## Goals
 


### PR DESCRIPTION
## Summary

- Implements the Phase-3 anchor `client/install-client.sh` — one command turns a fresh Linux Mint (Cinnamon) desktop into an enrolled, supervised client.
- It **orchestrates** the already-landed Phase-3 sub-steps (sourcing their sourceable functions) rather than reimplementing them: provision `pct-agent` + scoped sudoers (#78), install + baseline-configure the upstream tools (#79), register with the dashboard via `POST /api/clients/enrol` (#77), authorize the returned dashboard SSH key + persist the per-client bearer token, then run the self-test (#80) if present.
- Pure bash, dry-run aware (`PCT_DRY_RUN=1`) with zero side effects; 27 bats tests (68 client tests total); shellcheck clean.

## Plan

Linked plan: `.claude/plans/issue-76-install-client-orchestrator.md`
Roadmap: `docs/roadmap.md` → Phase 3 (the orchestrator anchor). Spec: `docs/client-install.md`.

## Design notes

- **Delegation, not reimplementation.** Sources `lib/provision-agent-user.sh`, `lib/pct-common.sh`, and `install-baseline-tools.sh` (their headers document the orchestrator as the sourcing caller) and calls their public `pct_*` functions. Source order is chosen so the shared `pct:` logging wins for both the orchestrator and the baseline step.
- **Enrol flow.** Builds the `POST /api/clients/enrol` body and parses the response in **pure bash** (no JSON library): every interpolated/extracted value is a constrained token — a Linux username, a hostname, an integer UID, or a base64url credential — none of which can contain a `"`/`\` to break the JSON, so a printf encoder + an "up to the next quote" extraction are exact. Matches `enrolClientSchema` / `enrolResponseSchema`. A `null` `sshPublicKey` (Phase-4 keygen not yet run) is handled gracefully with a warning, per #77.
- **Secret hygiene.** The enrolment token is read from `PCT_ENROLMENT_TOKEN` (preferred) or `--enrolment-token`, redacted from the dry-run plan, and on a real run is fed to `curl --config -` via **stdin** so it never appears in this process's argv (not `ps`-visible). The per-client bearer token returned by enrolment is persisted to `${PCT_STATE_DIR:-/etc/pct}/pct-client.env`, created **`0600`-from-birth** (`install -m 0600` before the secret is written — no world-readable window) — the artifact the Phase-8b `pct-client-bridge` (#101) will read.
- **Dry-run / testability.** A dry run is a side-effect-free **preview**: network calls and the two not-dry-run-aware sub-step calls (provision, key-authorize — they have their own bats suites) print a plan line instead of executing, and missing inputs are filled with clearly-labelled placeholders so the full plan always renders. A real run stays strict (hard-requires server URL + one-time token + ≥1 supervised user). This is also what the minimal-deps CI smoke job exercises.

## License-boundary note

Pure bash orchestration. The GPL tools (Timekpr-nExT, e2guardian, ActivityWatch) are installed by `install-baseline-tools.sh` from apt / the projects' own upstream releases — never vendored into this repo, never linked in-process, never bundled into the dashboard image. ActivityWatch is only ever reached over its REST API. **No new dependency** — uses only `curl` (the enrol JSON is built/parsed in pure bash). `license-guard` unaffected.

## Tamper-resistance note

Lays down the least-privilege baseline only (the `pct-agent` NOPASSWD-`timekpra` rule from #78). No anti-tamper, no lockdown, nothing beyond the documented ceiling.

## Test plan

- [x] `bats client/tests/install-client.bats` — 27 tests: arg/usage handling (strict real-run validation vs lenient dry-run preview, `--flag=value`, env config, both enrol spellings), the CI smoke contract, pre-flight (distro rejection, reachability probe), sequencing + delegation to the baseline installer, enrol request (URL, redacted token, compact body mapping, `--ssh-user` override), response handling (key authorized when present, graceful degrade when `null`, bearer persisted `0600`), the real enrol-failure abort path, the token-via-stdin-config (not argv) guarantee, self-test hook, and the dry-run no-side-effect guarantee.
- [x] `bats client/tests/` — 68 tests pass (no regression in #78/#79 suites).
- [x] `find client/ -name '*.sh' -print0 | xargs -0 shellcheck` — exit 0.
- [x] The minimal-deps "Client install script dry-run (Ubuntu 22.04)" integration job (only `curl sudo bash`, `PCT_SERVER_URL` + `PCT_DRY_RUN`) passes.
- [x] No server/frontend changes; the TS gate is unaffected (the enrol endpoint already shipped in #77).

## Deferred (tracked)

- The standalone post-install self-test script → **#80** (the orchestrator runs it if installed, else notes it's pending).
- `pct-client-bridge` / `pct-client-agent` `.deb` install → Phase 8b (#101/#106).
- Per-distro adapters under `client/distros/` → future, per `docs/client-install.md`.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)