### PR TITLE
feat(client): post-install self-test (#80)

### DIFF
--- a/.claude/plans/issue-80-post-install-self-test.md
+++ b/.claude/plans/issue-80-post-install-self-test.md
@@ -1,0 +1,83 @@
+# Plan — #80 Client post-install self-test
+
+Roadmap: `docs/roadmap.md` → Phase 3 ("Self-test that runs at the end of the
+script"). Spec: `docs/client-install.md` → step 9.
+
+## Goal
+
+A standalone, read-only client-side self-test that reports a clear pass/fail
+per component and exits non-zero if any check fails, so the installer
+(`install-client.sh`, #76 / PR #158) surfaces a broken enrolment.
+
+## Interface (matches the #158 orchestrator)
+
+The orchestrator (`pct_orch_self_test`) runs, as a subprocess:
+
+```
+self_test="${PCT_SELF_TEST:-${PCT_INSTALL_DIR}/self-test.sh}"
+PCT_SUPERVISED_LIST="${users[*]}" "$self_test"
+```
+
+So the deliverable is **`client/self-test.sh`** (executable), reading the
+space-separated supervised users from `PCT_SUPERVISED_LIST` (also accepting
+repeatable `--supervised-user` for standalone use, and `PCT_SUPERVISED_USERS`
+for parity with `install-baseline-tools.sh`).
+
+## House style (mirror existing client scripts)
+
+- Source `lib/pct-common.sh` for `pct_log/ok/warn/err`, `pct_is_dry_run`,
+  distro detection.
+- Single script with `pct_selftest_*` functions + a CLI `main`, guarded by
+  `if [ "${BASH_SOURCE[0]}" = "${0}" ]` so it is both runnable and sourceable
+  (bats sources individual check functions).
+- Every external binary / path is an overridable env var so bats can stub it
+  without root, network, or the real tools (the established pattern:
+  `PCT_VISUDO`, `PCT_TIMEKPRA_PATH`, `AW_HOST`/`AW_PORT`, …).
+- Dry-run aware: `PCT_DRY_RUN=1` prints the intended probes as a
+  side-effect-free preview and exits 0 (a self-test has nothing to check on a
+  machine it must not touch).
+
+## Checks (from #80 + docs step 9)
+
+Each check is a function that calls `pct_selftest_pass`/`pct_selftest_fail`;
+a global failure counter drives the exit code.
+
+1. **pct-agent account** exists (`PCT_GETENT passwd $PCT_AGENT_USER`).
+2. **Dashboard SSH key authorized** — `~pct-agent/.ssh/authorized_keys`
+   present, non-empty, mode `0600`, `.ssh` mode `0700`. (A full loopback
+   SSH-as-dashboard needs the dashboard's *private* key, which the client does
+   not hold; the server-side round-trip is the #81 Clients-health job. We
+   verify the client-side prerequisites and that sshd is up.)
+3. **sshd active** (`PCT_SYSTEMCTL is-active $PCT_SSHD_SERVICE`).
+4. **Scoped sudoers** — the `$PCT_SUDOERS_DIR/pct-agent` drop-in exists, is
+   mode `0440`, grants exactly `NOPASSWD: $PCT_TIMEKPRA_PATH`, and grants
+   nothing broader (no `NOPASSWD: ALL`, no bare `ALL=(ALL...) ALL`).
+5. **Timekpr daemon** active (`is-active $PCT_TIMEKPR_SERVICE`).
+6. **timekpra status** — `$PCT_TIMEKPRA --userinfo <user>` returns 0 for each
+   supervised user (the verified admin-CLI grammar; the transport uses
+   `--userinfo`).
+7. **aw-server** — `$PCT_CURL` GETs `http://$AW_HOST:$AW_PORT/api/0/buckets/`
+   with a 2xx and a JSON-object body (buckets).
+8. **e2guardian** active (`is-active $PCT_E2GUARDIAN_SERVICE`).
+9. **Enrolment record** — `$PCT_STATE_DIR/pct-client.env` exists, mode `0600`,
+   carries non-empty `PCT_CLIENT_ID` and `PCT_CLIENT_BEARER_TOKEN` (what the
+   #158 orchestrator persists).
+
+Output: a non-punitive checklist (`[ok]` / `[error] … : reason`) plus a
+summary line; exit `1` if any check failed, `0` otherwise.
+
+## License / tamper notes
+
+Pure bash read-only probes. No GPL linkage (timekpra/aw-server reached only as
+a subprocess / over their loopback REST API). Nothing here hardens beyond the
+documented ceiling — it only *verifies* the least-privilege baseline #78/#79
+laid down.
+
+## Tests — `client/tests/self-test.bats`
+
+Drive the CLI under stubs in a tmpdir (fake `systemctl`/`curl`/`timekpra`/
+`getent` whose behaviour is env-controlled) plus fixture files for the
+sudoers / authorized_keys / enrolment checks. Cover: all-pass → exit 0; each
+check failing independently → exit 1 with its reason; dry-run preview → exit 0
+no side effects; supervised users from `PCT_SUPERVISED_LIST`; `--help`.
+`shellcheck` clean; no regression in the existing client suites.

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,4 @@
+# Follow `# shellcheck source=...` directives so the client scripts that
+# source client/lib/pct-common.sh lint cleanly even when shellcheck is invoked
+# on a single changed file (the pre-commit hook does this) without -x.
+external-sources=true

--- a/client/self-test.sh
+++ b/client/self-test.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+#
+# self-test.sh — post-install self-test for a supervised Linux client
+# (linux-parental-controls-toolkit, Phase 3, issue #80).
+#
+# Runs at the end of client/install-client.sh (#76) and reports a clear
+# pass/fail per component, exiting non-zero if anything is wrong so the
+# installer surfaces a broken enrolment. Per docs/client-install.md -> step 9
+# and docs/roadmap.md -> Phase 3.
+#
+# The checks are READ-ONLY probes of state the earlier install steps laid
+# down (the pct-agent account + scoped sudoers #78, the baseline tools #79,
+# the dashboard enrolment #76/#77):
+#
+#   1. the pct-agent service account exists
+#   2. the dashboard SSH key is authorized for pct-agent (and sshd is up)
+#   3. the pct-agent sudoers drop-in is scoped to exactly `timekpra`
+#   4. the Timekpr-nExT daemon is up and `timekpra` answers for each user
+#   5. aw-server is reachable on loopback and returns buckets
+#   6. e2guardian is active
+#   7. the dashboard enrolment record is present
+#
+# This is the client-side complement to the admin "Clients" health page (#81),
+# which shows the same component states from the server's perspective.
+#
+# License boundary (docs/licensing-analysis.md): pure bash. The GPL tools are
+# only ever poked as a subprocess (`timekpra`) or over their loopback REST API
+# (aw-server) — never linked, never vendored. Tamper-resistance posture
+# (docs/client-install.md): this only *verifies* the least-privilege baseline;
+# it adds no hardening beyond the documented ceiling.
+#
+# The script is dry-run aware: PCT_DRY_RUN=1 prints the intended probes as a
+# side-effect-free preview and exits 0 (there is nothing to check on a machine
+# the script must not touch). That, and the per-binary env overrides below, are
+# how CI and the bats tests exercise it without root, network, or the tools
+# installed.
+#
+# Sourceable: install-client.sh (#76) runs it as a subprocess
+# (`PCT_SELF_TEST`/`<install-dir>/self-test.sh`), passing the supervised users
+# via PCT_SUPERVISED_LIST. It is also directly runnable for standalone use and
+# sourced by the bats suite to exercise individual checks.
+#
+#   sudo bash client/self-test.sh --supervised-user alice
+#   PCT_SUPERVISED_LIST="alice bob" bash client/self-test.sh
+#   PCT_DRY_RUN=1 bash client/self-test.sh --supervised-user alice
+
+set -uo pipefail
+
+# Resolve our own directory so the shared helpers source whether the script is
+# run directly or sourced from the orchestrator.
+PCT_SELFTEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=client/lib/pct-common.sh
+. "${PCT_SELFTEST_DIR}/lib/pct-common.sh"
+
+# --- overridable knobs (defaults match a real Mint client) -----------------
+#
+# Every external binary / path is overridable so the tests can stub it without
+# root, network, or the upstream tools present (the pattern established by
+# provision-agent-user.sh / install-baseline-tools.sh).
+
+PCT_AGENT_USER="${PCT_AGENT_USER:-pct-agent}"
+PCT_GETENT="${PCT_GETENT:-getent}"
+PCT_SYSTEMCTL="${PCT_SYSTEMCTL:-systemctl}"
+PCT_CURL="${PCT_CURL:-curl}"
+PCT_TIMEKPRA="${PCT_TIMEKPRA:-timekpra}"
+
+# Absolute path the scoped sudoers rule names (must match provision-agent-user.sh).
+PCT_TIMEKPRA_PATH="${PCT_TIMEKPRA_PATH:-/usr/bin/timekpra}"
+PCT_SUDOERS_DIR="${PCT_SUDOERS_DIR:-/etc/sudoers.d}"
+
+# systemd unit names (overridable so a distro variation / test can swap them).
+PCT_SSHD_SERVICE="${PCT_SSHD_SERVICE:-ssh.service}"
+PCT_TIMEKPR_SERVICE="${PCT_TIMEKPR_SERVICE:-timekpr.service}"
+PCT_E2GUARDIAN_SERVICE="${PCT_E2GUARDIAN_SERVICE:-e2guardian.service}"
+
+# aw-server loopback bind (kept in step with install-baseline-tools.sh).
+AW_HOST="${AW_HOST:-127.0.0.1}"
+AW_PORT="${AW_PORT:-5600}"
+
+# Where install-client.sh (#76) persists the per-client enrolment record.
+PCT_STATE_DIR="${PCT_STATE_DIR:-/etc/pct}"
+
+# sudoers ignores drop-in files whose names contain '.'/'~', so this is a plain
+# token — must match PCT_SUDOERS_FILE_BASENAME in provision-agent-user.sh.
+readonly PCT_SELFTEST_SUDOERS_BASENAME="pct-agent"
+
+# --- result accounting -----------------------------------------------------
+
+PCT_SELFTEST_PASSED=0
+PCT_SELFTEST_FAILED=0
+
+# Record a passing check (also used to render the dry-run preview line).
+pct_selftest_pass() {
+  PCT_SELFTEST_PASSED=$((PCT_SELFTEST_PASSED + 1))
+  pct_ok "$1"
+}
+
+# Record a failing check with a human-readable reason.
+pct_selftest_fail() {
+  PCT_SELFTEST_FAILED=$((PCT_SELFTEST_FAILED + 1))
+  pct_err "$1: $2"
+}
+
+# Under dry-run, announce a probe as a side-effect-free preview and count it as
+# a (notional) pass. Returns 0 when it handled the check (caller should return),
+# 1 when a real probe should run.
+pct_selftest_preview() {
+  if pct_is_dry_run; then
+    pct_selftest_pass "would check: $1"
+    return 0
+  fi
+  return 1
+}
+
+# --- individual checks -----------------------------------------------------
+
+# 1. The low-privilege pct-agent service account exists (#78).
+pct_selftest_agent_user() {
+  local desc="pct-agent service account exists"
+  pct_selftest_preview "$desc" && return 0
+  if "$PCT_GETENT" passwd "$PCT_AGENT_USER" >/dev/null 2>&1; then
+    pct_selftest_pass "$desc"
+  else
+    pct_selftest_fail "$desc" "no '${PCT_AGENT_USER}' account (run the agent-provisioning step)"
+  fi
+}
+
+# pct-agent's home directory per the passwd database (first match only).
+pct_selftest_agent_home() {
+  "$PCT_GETENT" passwd "$PCT_AGENT_USER" 2>/dev/null | head -n1 | cut -d: -f6
+}
+
+# 2. The dashboard SSH key is authorized for pct-agent, with correct perms.
+#
+# Note: a full "loopback SSH as the dashboard would" needs the dashboard's
+# PRIVATE key, which the client never holds — so the authenticated round-trip
+# is verified server-side by the #81 Clients-health job. Here we confirm the
+# client-side prerequisites: authorized_keys is present, non-empty, and locked
+# down, and sshd is running so the dashboard could connect.
+pct_selftest_ssh_key() {
+  local desc="dashboard SSH key authorized for pct-agent"
+  pct_selftest_preview "$desc" && return 0
+
+  local home ssh_dir auth
+  home="$(pct_selftest_agent_home)"
+  if [ -z "$home" ]; then
+    pct_selftest_fail "$desc" "cannot resolve home for '${PCT_AGENT_USER}'"
+    return 0
+  fi
+  ssh_dir="${home}/.ssh"
+  auth="${ssh_dir}/authorized_keys"
+
+  if [ ! -s "$auth" ]; then
+    pct_selftest_fail "$desc" "no non-empty ${auth} (enrolment did not authorize the key)"
+    return 0
+  fi
+  if [ "$(pct_selftest_mode "$ssh_dir")" != "700" ]; then
+    pct_selftest_fail "$desc" "${ssh_dir} should be mode 0700"
+    return 0
+  fi
+  if [ "$(pct_selftest_mode "$auth")" != "600" ]; then
+    pct_selftest_fail "$desc" "${auth} should be mode 0600"
+    return 0
+  fi
+  pct_selftest_pass "$desc"
+}
+
+# 3. sshd is active (so the dashboard's SSH transport can reach this client).
+pct_selftest_sshd() {
+  pct_selftest_service "sshd is active" "$PCT_SSHD_SERVICE"
+}
+
+# 4. The pct-agent sudoers drop-in is scoped to EXACTLY `timekpra` (#78).
+pct_selftest_sudoers() {
+  local desc="pct-agent sudoers scoped to timekpra only"
+  pct_selftest_preview "$desc" && return 0
+
+  local target="${PCT_SUDOERS_DIR}/${PCT_SELFTEST_SUDOERS_BASENAME}"
+  if [ ! -f "$target" ]; then
+    pct_selftest_fail "$desc" "missing sudoers drop-in ${target}"
+    return 0
+  fi
+  if [ "$(pct_selftest_mode "$target")" != "440" ]; then
+    pct_selftest_fail "$desc" "${target} should be mode 0440"
+    return 0
+  fi
+
+  # The one rule we require, and nothing broader. Compare ignoring comments and
+  # blank lines so the drop-in's header doesn't trip the "nothing broader" test.
+  local expected rules
+  expected="${PCT_AGENT_USER} ALL=(root) NOPASSWD: ${PCT_TIMEKPRA_PATH}"
+  rules="$(grep -vE '^[[:space:]]*(#|$)' "$target")"
+
+  if ! printf '%s\n' "$rules" | grep -qxF "$expected"; then
+    pct_selftest_fail "$desc" "expected exactly '${expected}'"
+    return 0
+  fi
+  # Any rule line that is not the expected one is "broader than intended".
+  if printf '%s\n' "$rules" | grep -vxF "$expected" | grep -q .; then
+    pct_selftest_fail "$desc" "drop-in grants more than the single timekpra rule"
+    return 0
+  fi
+  pct_selftest_pass "$desc"
+}
+
+# 5. The Timekpr-nExT daemon is active.
+pct_selftest_timekpr_daemon() {
+  pct_selftest_service "Timekpr-nExT daemon is active" "$PCT_TIMEKPR_SERVICE"
+}
+
+# 6. `timekpra --userinfo USER` answers for each supervised user (the verified
+#    admin-CLI grammar the dashboard drives over SSH).
+pct_selftest_timekpra_users() {
+  local user
+  for user in "$@"; do
+    local desc="timekpra reports status for '${user}'"
+    if pct_selftest_preview "$desc"; then
+      continue
+    fi
+    if "$PCT_TIMEKPRA" --userinfo "$user" >/dev/null 2>&1; then
+      pct_selftest_pass "$desc"
+    else
+      pct_selftest_fail "$desc" "timekpra --userinfo '${user}' failed (daemon down or user not managed)"
+    fi
+  done
+}
+
+# 7. aw-server is reachable on loopback and returns buckets.
+pct_selftest_aw_server() {
+  local desc="aw-server reachable on ${AW_HOST}:${AW_PORT}"
+  pct_selftest_preview "$desc" && return 0
+
+  local url="http://${AW_HOST}:${AW_PORT}/api/0/buckets/"
+  local body
+  if ! body="$("$PCT_CURL" --fail --silent --show-error --max-time 5 "$url" 2>/dev/null)"; then
+    pct_selftest_fail "$desc" "no 2xx from ${url} (is the aw-server user unit running?)"
+    return 0
+  fi
+  # The buckets endpoint returns a JSON object (`{}` when empty is still valid).
+  case "$(printf '%s' "$body" | tr -d '[:space:]')" in
+  '{'*)
+    pct_selftest_pass "$desc"
+    ;;
+  *)
+    pct_selftest_fail "$desc" "unexpected (non-JSON) response from ${url}"
+    ;;
+  esac
+}
+
+# 8. e2guardian is active.
+pct_selftest_e2guardian() {
+  pct_selftest_service "e2guardian is active" "$PCT_E2GUARDIAN_SERVICE"
+}
+
+# 9. The dashboard enrolment record is present and locked down (#76/#77).
+pct_selftest_enrolment() {
+  local desc="client enrolled with the dashboard"
+  pct_selftest_preview "$desc" && return 0
+
+  local env_file="${PCT_STATE_DIR}/pct-client.env"
+  if [ ! -f "$env_file" ]; then
+    pct_selftest_fail "$desc" "missing enrolment record ${env_file}"
+    return 0
+  fi
+  if [ "$(pct_selftest_mode "$env_file")" != "600" ]; then
+    pct_selftest_fail "$desc" "${env_file} should be mode 0600 (it holds the bearer token)"
+    return 0
+  fi
+  if ! pct_selftest_env_has "$env_file" PCT_CLIENT_ID; then
+    pct_selftest_fail "$desc" "${env_file} has no PCT_CLIENT_ID"
+    return 0
+  fi
+  if ! pct_selftest_env_has "$env_file" PCT_CLIENT_BEARER_TOKEN; then
+    pct_selftest_fail "$desc" "${env_file} has no PCT_CLIENT_BEARER_TOKEN"
+    return 0
+  fi
+  pct_selftest_pass "$desc"
+}
+
+# --- small probe helpers ---------------------------------------------------
+
+# Octal permission bits of a path (e.g. "600"), or empty if it does not exist.
+pct_selftest_mode() {
+  stat -c '%a' "$1" 2>/dev/null
+}
+
+# True if the env file assigns a non-empty value to KEY (KEY=<something>).
+pct_selftest_env_has() {
+  grep -qE "^${2}=.+" "$1" 2>/dev/null
+}
+
+# Shared "systemd unit is active" check used by several probes above.
+pct_selftest_service() {
+  local desc="$1" unit="$2"
+  pct_selftest_preview "$desc" && return 0
+  local state
+  state="$("$PCT_SYSTEMCTL" is-active "$unit" 2>/dev/null)"
+  if [ "$state" = "active" ]; then
+    pct_selftest_pass "$desc"
+  else
+    pct_selftest_fail "$desc" "${unit} is '${state:-unknown}', expected 'active'"
+  fi
+}
+
+# --- orchestration ---------------------------------------------------------
+
+pct_self_test() {
+  # Args: the supervised Linux usernames whose timekpr status to check.
+  if [ "$#" -eq 0 ]; then
+    pct_err "no supervised users given; pass at least one --supervised-user"
+    return 2
+  fi
+
+  pct_step "Post-install self-test"
+  if pct_is_dry_run; then
+    pct_log "(dry-run: probing nothing; printing the intended checks)"
+  fi
+
+  pct_selftest_agent_user
+  pct_selftest_ssh_key
+  pct_selftest_sshd
+  pct_selftest_sudoers
+  pct_selftest_timekpr_daemon
+  pct_selftest_timekpra_users "$@"
+  pct_selftest_aw_server
+  pct_selftest_e2guardian
+  pct_selftest_enrolment
+
+  local total=$((PCT_SELFTEST_PASSED + PCT_SELFTEST_FAILED))
+  if [ "$PCT_SELFTEST_FAILED" -eq 0 ]; then
+    pct_ok "self-test passed: ${PCT_SELFTEST_PASSED}/${total} checks green"
+    return 0
+  fi
+  pct_err "self-test found problems: ${PCT_SELFTEST_FAILED}/${total} checks failed (see [error] lines above)"
+  return 1
+}
+
+# --- CLI -------------------------------------------------------------------
+
+pct_selftest_usage() {
+  cat >&2 <<'EOF'
+Usage: self-test.sh [--supervised-user USER ...]
+
+Read-only post-install self-test for a supervised client. Reports a pass/fail
+per component (pct-agent + sudoers, SSH key, Timekpr-nExT, ActivityWatch,
+e2guardian, dashboard enrolment) and exits non-zero if any check fails.
+
+Options:
+  --supervised-user USER   A supervised Linux account to check (repeatable).
+                           May also be supplied via PCT_SUPERVISED_LIST (the
+                           orchestrator's space-separated list) or
+                           PCT_SUPERVISED_USERS.
+  -h, --help               Show this help.
+
+Environment:
+  PCT_DRY_RUN=1            Print the intended checks without probing anything.
+EOF
+}
+
+pct_selftest_main() {
+  local users=()
+  # Seed from the orchestrator's list, then the parity env var, then flags.
+  if [ -n "${PCT_SUPERVISED_LIST:-}" ]; then
+    # shellcheck disable=SC2206  # intentional word-split of a space list
+    users=(${PCT_SUPERVISED_LIST})
+  elif [ -n "${PCT_SUPERVISED_USERS:-}" ]; then
+    # shellcheck disable=SC2206  # intentional word-split of a space list
+    users=(${PCT_SUPERVISED_USERS})
+  fi
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --supervised-user)
+      [ "$#" -ge 2 ] || {
+        pct_err "--supervised-user needs a value"
+        return 2
+      }
+      users+=("$2")
+      shift 2
+      ;;
+    --supervised-user=*)
+      users+=("${1#*=}")
+      shift
+      ;;
+    -h | --help)
+      pct_selftest_usage
+      return 0
+      ;;
+    *)
+      pct_err "unknown argument: $1"
+      pct_selftest_usage
+      return 2
+      ;;
+    esac
+  done
+  if [ "${#users[@]}" -eq 0 ]; then
+    pct_err "no supervised users given"
+    pct_selftest_usage
+    return 2
+  fi
+  pct_self_test "${users[@]}"
+}
+
+# Run main only when executed directly, not when sourced (by the orchestrator
+# or the bats suite).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  pct_selftest_main "$@"
+fi

--- a/client/tests/install-client.bats
+++ b/client/tests/install-client.bats
@@ -220,7 +220,11 @@ plan_strict() {
 # --- self-test hook --------------------------------------------------------
 
 @test "notes the self-test is pending when it is not installed" {
-  ok_args
+  # Point at a guaranteed-absent path: now that the self-test (#80) lives at
+  # the orchestrator's default ${PCT_INSTALL_DIR}/self-test.sh, the "pending"
+  # branch must be exercised deterministically rather than relying on the repo
+  # not shipping one.
+  PCT_SELF_TEST="${TMP}/no-such-self-test.sh" ok_args
   [ "$status" -eq 0 ]
   [[ "$output" == *"self-test not installed yet (tracked as #80)"* ]]
 }

--- a/client/tests/self-test.bats
+++ b/client/tests/self-test.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+#
+# Unit tests for client/self-test.sh (issue #80). Every external probe
+# (getent / systemctl / curl / timekpra) is pointed at a tiny stub whose
+# behaviour is env-controlled, and the file-based checks (sudoers, SSH key,
+# enrolment record) read fixtures under a tmpdir — so the full pass/fail logic
+# runs without root, network, or the upstream tools.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../self-test.sh"
+  TMP="$(mktemp -d)"
+  BIN="${TMP}/bin"
+  mkdir -p "$BIN"
+
+  # --- stubs -------------------------------------------------------------
+  # getent passwd <user> -> emit a passwd line with home = $STUB_AGENT_HOME,
+  # or exit non-zero when $STUB_AGENT_EXISTS != 1.
+  cat >"${BIN}/getent" <<'EOF'
+#!/usr/bin/env bash
+[ "${STUB_AGENT_EXISTS:-1}" = "1" ] || exit 2
+printf '%s:x:998:998:pct-agent:%s:/bin/bash\n' "$2" "${STUB_AGENT_HOME}"
+EOF
+
+  # systemctl is-active <unit> -> "active" unless the unit is $STUB_INACTIVE_UNIT.
+  cat >"${BIN}/systemctl" <<'EOF'
+#!/usr/bin/env bash
+if [ "$2" = "${STUB_INACTIVE_UNIT:-}" ]; then echo inactive; exit 3; fi
+echo active
+EOF
+
+  # curl ... -> a JSON object, unless told to fail or return a non-JSON body.
+  cat >"${BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+[ "${STUB_CURL_FAIL:-0}" = "1" ] && exit 22
+if [ "${STUB_CURL_BADBODY:-0}" = "1" ]; then printf '<html>nope</html>'; exit 0; fi
+printf '{"aw-watcher-window_host":{}}'
+EOF
+
+  # timekpra --userinfo <user> -> succeed unless told to fail.
+  cat >"${BIN}/timekpra" <<'EOF'
+#!/usr/bin/env bash
+[ "${STUB_TIMEKPRA_FAIL:-0}" = "1" ] && exit 1
+printf 'TIME_SPENT_DAY: 0\n'
+EOF
+  chmod +x "${BIN}"/*
+
+  # --- passing fixtures --------------------------------------------------
+  STUB_AGENT_HOME="${TMP}/agenthome"
+  mkdir -p "${STUB_AGENT_HOME}/.ssh"
+  printf 'ssh-ed25519 AAAA...dashboard\n' >"${STUB_AGENT_HOME}/.ssh/authorized_keys"
+  chmod 700 "${STUB_AGENT_HOME}/.ssh"
+  chmod 600 "${STUB_AGENT_HOME}/.ssh/authorized_keys"
+
+  SUDOERS_DIR="${TMP}/sudoers.d"
+  mkdir -p "$SUDOERS_DIR"
+  cat >"${SUDOERS_DIR}/pct-agent" <<'EOF'
+# Managed by linux-parental-controls-toolkit — pct-agent service account.
+# DO NOT EDIT BY HAND.
+pct-agent ALL=(root) NOPASSWD: /usr/bin/timekpra
+EOF
+  chmod 440 "${SUDOERS_DIR}/pct-agent"
+
+  STATE_DIR="${TMP}/state"
+  mkdir -p "$STATE_DIR"
+  cat >"${STATE_DIR}/pct-client.env" <<'EOF'
+PCT_SERVER_URL=https://dash.lan
+PCT_CLIENT_ID=7
+PCT_CLIENT_BEARER_TOKEN=deadbeef
+EOF
+  chmod 600 "${STATE_DIR}/pct-client.env"
+
+  # --- wire the script at the stubs/fixtures -----------------------------
+  export PCT_GETENT="${BIN}/getent"
+  export PCT_SYSTEMCTL="${BIN}/systemctl"
+  export PCT_CURL="${BIN}/curl"
+  export PCT_TIMEKPRA="${BIN}/timekpra"
+  export PCT_SUDOERS_DIR="$SUDOERS_DIR"
+  export PCT_STATE_DIR="$STATE_DIR"
+  export STUB_AGENT_HOME
+}
+
+teardown() {
+  [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+run_selftest() { run env bash "$SCRIPT" "$@"; }
+
+@test "requires at least one supervised user" {
+  run_selftest
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no supervised users given"* ]]
+}
+
+@test "--help prints usage and exits 0" {
+  run_selftest --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: self-test.sh"* ]]
+}
+
+@test "all checks green -> exit 0 with a summary" {
+  run_selftest --supervised-user alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"self-test passed"* ]]
+  [[ "$output" == *"checks green"* ]]
+  [[ "$output" == *"[ok] pct-agent service account exists"* ]]
+  [[ "$output" == *"[ok] dashboard SSH key authorized for pct-agent"* ]]
+  [[ "$output" == *"[ok] timekpra reports status for 'alice'"* ]]
+  [[ "$output" == *"[ok] aw-server reachable on 127.0.0.1:5600"* ]]
+  [[ "$output" == *"[ok] client enrolled with the dashboard"* ]]
+}
+
+@test "missing pct-agent account -> failure" {
+  STUB_AGENT_EXISTS=0 run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[error] pct-agent service account exists"* ]]
+}
+
+@test "empty authorized_keys -> SSH key check fails" {
+  : >"${STUB_AGENT_HOME}/.ssh/authorized_keys"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[error] dashboard SSH key authorized for pct-agent"* ]]
+  [[ "$output" == *"enrolment did not authorize the key"* ]]
+}
+
+@test "world-readable authorized_keys -> SSH key check fails on perms" {
+  chmod 644 "${STUB_AGENT_HOME}/.ssh/authorized_keys"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"should be mode 0600"* ]]
+}
+
+@test "inactive sshd -> failure" {
+  STUB_INACTIVE_UNIT=ssh.service run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[error] sshd is active"* ]]
+}
+
+@test "missing sudoers drop-in -> failure" {
+  rm -f "${PCT_SUDOERS_DIR}/pct-agent"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing sudoers drop-in"* ]]
+}
+
+@test "broader sudoers grant -> failure" {
+  printf 'pct-agent ALL=(ALL) NOPASSWD: ALL\n' >>"${PCT_SUDOERS_DIR}/pct-agent"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[error] pct-agent sudoers scoped to timekpra only"* ]]
+  [[ "$output" == *"more than the single timekpra rule"* ]]
+}
+
+@test "wrong sudoers mode -> failure" {
+  chmod 644 "${PCT_SUDOERS_DIR}/pct-agent"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"should be mode 0440"* ]]
+}
+
+@test "timekpra failing for a user -> failure" {
+  STUB_TIMEKPRA_FAIL=1 run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[error] timekpra reports status for 'alice'"* ]]
+}
+
+@test "aw-server unreachable -> failure" {
+  STUB_CURL_FAIL=1 run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no 2xx from"* ]]
+}
+
+@test "aw-server non-JSON body -> failure" {
+  STUB_CURL_BADBODY=1 run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unexpected (non-JSON) response"* ]]
+}
+
+@test "inactive e2guardian -> failure" {
+  STUB_INACTIVE_UNIT=e2guardian.service run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[error] e2guardian is active"* ]]
+}
+
+@test "missing enrolment record -> failure" {
+  rm -f "${PCT_STATE_DIR}/pct-client.env"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing enrolment record"* ]]
+}
+
+@test "enrolment record without bearer token -> failure" {
+  printf 'PCT_CLIENT_ID=7\n' >"${PCT_STATE_DIR}/pct-client.env"
+  chmod 600 "${PCT_STATE_DIR}/pct-client.env"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no PCT_CLIENT_BEARER_TOKEN"* ]]
+}
+
+@test "world-readable enrolment record -> failure on perms" {
+  chmod 644 "${PCT_STATE_DIR}/pct-client.env"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"should be mode 0600"* ]]
+}
+
+@test "checks each supervised user from PCT_SUPERVISED_LIST" {
+  PCT_SUPERVISED_LIST="alice bob" run_selftest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"timekpra reports status for 'alice'"* ]]
+  [[ "$output" == *"timekpra reports status for 'bob'"* ]]
+}
+
+@test "dry-run previews the checks without probing and exits 0" {
+  # Point the probes at a non-existent path: if dry-run actually invoked them
+  # the run would error, proving the preview short-circuits before any probe.
+  PCT_DRY_RUN=1 PCT_GETENT=/nonexistent PCT_SYSTEMCTL=/nonexistent \
+    PCT_CURL=/nonexistent PCT_TIMEKPRA=/nonexistent \
+    run env bash "$SCRIPT" --supervised-user alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dry-run"* ]]
+  [[ "$output" == *"would check: pct-agent service account exists"* ]]
+  [[ "$output" == *"would check: timekpra reports status for 'alice'"* ]]
+}

--- a/client/tests/self-test.bats
+++ b/client/tests/self-test.bats
@@ -136,6 +136,29 @@ run_selftest() { run env bash "$SCRIPT" "$@"; }
   [[ "$output" == *"[error] sshd is active"* ]]
 }
 
+@test "world-traversable .ssh directory -> SSH key check fails on perms" {
+  chmod 755 "${STUB_AGENT_HOME}/.ssh"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"should be mode 0700"* ]]
+}
+
+@test "inactive Timekpr-nExT daemon -> failure" {
+  STUB_INACTIVE_UNIT=timekpr.service run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[error] Timekpr-nExT daemon is active"* ]]
+}
+
+@test "sudoers naming a different timekpra path -> failure" {
+  chmod u+w "${PCT_SUDOERS_DIR}/pct-agent"
+  printf '# header\npct-agent ALL=(root) NOPASSWD: /usr/local/bin/timekpra\n' \
+    >"${PCT_SUDOERS_DIR}/pct-agent"
+  chmod 440 "${PCT_SUDOERS_DIR}/pct-agent"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"expected exactly"* ]]
+}
+
 @test "missing sudoers drop-in -> failure" {
   rm -f "${PCT_SUDOERS_DIR}/pct-agent"
   run_selftest --supervised-user alice
@@ -144,7 +167,12 @@ run_selftest() { run env bash "$SCRIPT" "$@"; }
 }
 
 @test "broader sudoers grant -> failure" {
+  # The fixture is 0440 (read-only even for its owner under a non-root CI
+  # runner), so make it writable to append, then restore 0440 — the script
+  # must still detect the extra rule on a correctly-moded drop-in.
+  chmod u+w "${PCT_SUDOERS_DIR}/pct-agent"
   printf 'pct-agent ALL=(ALL) NOPASSWD: ALL\n' >>"${PCT_SUDOERS_DIR}/pct-agent"
+  chmod 440 "${PCT_SUDOERS_DIR}/pct-agent"
   run_selftest --supervised-user alice
   [ "$status" -eq 1 ]
   [[ "$output" == *"[error] pct-agent sudoers scoped to timekpra only"* ]]
@@ -195,6 +223,14 @@ run_selftest() { run env bash "$SCRIPT" "$@"; }
   run_selftest --supervised-user alice
   [ "$status" -eq 1 ]
   [[ "$output" == *"no PCT_CLIENT_BEARER_TOKEN"* ]]
+}
+
+@test "enrolment record without client id -> failure" {
+  printf 'PCT_CLIENT_BEARER_TOKEN=deadbeef\n' >"${PCT_STATE_DIR}/pct-client.env"
+  chmod 600 "${PCT_STATE_DIR}/pct-client.env"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no PCT_CLIENT_ID"* ]]
 }
 
 @test "world-readable enrolment record -> failure on perms" {

--- a/docs/client-install.md
+++ b/docs/client-install.md
@@ -95,12 +95,24 @@ dashboard, has a short TTL, and is single-use.
    - On success, the dashboard now lists the client in its inventory and
      can run an initial Ansible playbook to push the rest of the
      configuration.
-9. **Self-test**
-   - Verify `timekpra --status` works.
-   - Verify `aw-server` is reachable on `localhost:5600`.
-   - Verify e2guardian is intercepting (test request through curl as the
-     supervised UID).
-   - Print a green checklist to the terminal.
+9. **Self-test** (`client/self-test.sh`, #80)
+   - Read-only pass/fail probes of what the earlier steps laid down; exits
+     non-zero if any check fails so the installer surfaces it, and prints a
+     non-punitive checklist to the terminal. The complement to the admin
+     **Clients** health page (#81), which shows the same state server-side.
+   - Checks: the `pct-agent` account exists; the dashboard SSH key is
+     authorized for it (and `sshd` is up — the authenticated loopback
+     round-trip itself needs the dashboard's private key, so it is verified
+     server-side); the `pct-agent` sudoers drop-in is scoped to exactly
+     `timekpra`; the Timekpr-nExT daemon is active and `timekpra --userinfo
+     <user>` answers for each supervised user; `aw-server` is reachable on
+     `localhost:5600` and returns buckets; e2guardian is active; and the
+     dashboard enrolment record (`/etc/pct/pct-client.env`) is present and
+     `0600`.
+   - e2guardian is checked as *service active* only: the iptables OUTPUT
+     redirect that makes it actually intercept traffic is a Phase 6 Ansible
+     deliverable (#90), not part of the Phase 3 baseline (#79), so an
+     "is it intercepting" probe would not be meaningful yet.
 
 ## Other distributions
 


### PR DESCRIPTION
## Summary

- Adds `client/self-test.sh` — the Phase-3 post-install self-test (`docs/roadmap.md` → Phase 3; `docs/client-install.md` → step 9). Read-only, pass/fail-per-component, exits non-zero if any check fails so the installer surfaces a broken enrolment.
- Matches the orchestrator's hook from PR #158 (`pct_orch_self_test` runs `${PCT_INSTALL_DIR}/self-test.sh` with the supervised users in `PCT_SUPERVISED_LIST`) so the two compose once both land.
- 19 `bats` tests (60 client tests total, no regression); `shellcheck` clean.

## Plan

Linked plan: `.claude/plans/issue-80-post-install-self-test.md`
Roadmap: `docs/roadmap.md` → Phase 3.

## Checks (issue #80's authoritative list)

Each is a read-only probe; every external binary/path is an overridable env var (the established `PCT_*` pattern) so the suite runs without root, network, or the upstream tools, and `PCT_DRY_RUN=1` renders a side-effect-free preview.

1. `pct-agent` service account exists (#78).
2. Dashboard SSH key authorized for `pct-agent` — `authorized_keys` present, non-empty, `0600`; `.ssh` `0700`. *(The authenticated loopback round-trip needs the dashboard's **private** key, which the client never holds — so it's verified server-side by the #81 Clients-health job; here we check the client-side prerequisites + that `sshd` is up.)*
3. `pct-agent` sudoers drop-in scoped to **exactly** `NOPASSWD: timekpra`, mode `0440`, nothing broader (#78).
4. Timekpr-nExT daemon active; `timekpra --userinfo <user>` answers per supervised user (the verified admin-CLI grammar the transport drives).
5. `aw-server` reachable on `127.0.0.1:5600` and returning buckets (JSON).
6. e2guardian active.
7. Dashboard enrolment record `/etc/pct/pct-client.env` present, `0600`, carrying `PCT_CLIENT_ID` + `PCT_CLIENT_BEARER_TOKEN` (what the #158 orchestrator persists).

Reconciles `docs/client-install.md` step 9 with the implemented behaviour: `--userinfo` rather than the informal `--status`, and **e2guardian verified as service-active** — the "is it intercepting" test depends on the iptables OUTPUT redirect, which is a Phase 6 Ansible deliverable (#90), not part of the Phase 3 baseline (#79).

## License-boundary note

Pure bash, read-only probes. The GPL tools are only ever poked as a subprocess (`timekpra`) or over their loopback REST API (`aw-server`) — never linked, never vendored, no binaries added to any image. `license-guard` unaffected. No new dependency.

## Tamper-resistance note

The script only *verifies* the least-privilege baseline (#78/#79) — it adds no hardening beyond the documented ceiling.

## Test plan

- [x] `bats client/tests/self-test.bats` — 19 tests: arg/usage handling, all-green → exit 0 + summary, each check failing independently → exit 1 with its reason, perms violations (sudoers/authorized_keys/enrolment), broader-sudoers rejection, `PCT_SUPERVISED_LIST` parsing, and the dry-run no-probe preview.
- [x] `bats client/tests/` — 60 tests pass (no regression in #78/#79 suites).
- [x] `find client/ -name '*.sh' -print0 | xargs -0 shellcheck` — clean.
- [x] No server/frontend changes; the TypeScript gate is unaffected.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjaF9hd4GzTST1tQ1X415X)_