### PR TITLE
feat(api): policy CRUD for activities, groups, budgets, schedules, exceptions (#148)

### DIFF
--- a/.claude/plans/issue-148-policy-crud-remaining.md
+++ b/.claude/plans/issue-148-policy-crud-remaining.md
@@ -1,52 +1,68 @@
 # Plan — #148 `/api/*` policy CRUD, remaining entities
 
 Follow-up slice of the #51 umbrella. Slice 1 (`User`/`Client`/`UserOnClient`)
-landed. This PR adds CRUD for **all** remaining policy-model entities, so #148
-(and the #51 umbrella) can close:
+landed. This PR adds CRUD for **all** remaining policy-model entities, so it
+closes #148 and #51:
 
 - `Activity`
 - `ActivityGroup` + `activities_to_groups` membership
 - `Budget`
-- `Schedule` — against the recurrence + date-scoping shape finalized by #146
-  (PR #156, merged), reusing `policy/recurrence.ts`' `scheduleRecurrenceSchema`
-- `Exception` — `effective_from`/`expires_at` window per ADR 0005
+- `Schedule` — built against the recurrence + date-scoping shape finalized by
+  #146 / PR #156 (merged mid-session); reuses `scheduleRecurrenceSchema`.
+- `Exception` — `effective_from`/`expires_at` window per ADR 0005.
 
-> Scope history: an earlier revision deferred Schedule/Exception while PR #156
-> was reshaping those tables. #156 merged mid-session, so this PR was rebased
-> onto it and expanded to the full slice.
+> **Scope note.** This PR was initially scoped to Activity/ActivityGroup/Budget
+> while #146 (PR #156) was reshaping the `schedules`/`exceptions` tables. #156
+> merged during the session, so Schedule/Exception were folded back in against
+> the final shape (the branch was rebased onto the merge).
 
 ## Conventions reused (from slice 1)
 
-- DTOs in `server/src/api/policy/dtos.ts`, reusing `policy/enums.ts` +
-  `policy/recurrence.ts` and the shared error envelope. Types inferred.
-- Repository in `server/src/policy/repository.ts` over `app.db`; `isUniqueViolation()`
-  (→ 409) plus a new `isCheckViolation()` (→ 400) for storage-CHECK backstops.
+- DTOs in `server/src/api/policy/dtos.ts`, reusing `policy/enums.ts`
+  (`activityKindSchema`, `scopeSchema`, `budgetWindowSchema`,
+  `scheduleActionSchema`) and `policy/recurrence.ts`
+  (`scheduleRecurrenceSchema`). Types inferred, never hand-written twice.
+- Repository in `server/src/policy/repository.ts` over `app.db`; reuse
+  `isUniqueViolation()` (→ 409) and add `isCheckViolation()` (→ 400).
 - Routes in `server/src/api/policy/routes.ts`, behind `requireAdmin`. Thin
   handlers: validate via DTO, delegate to repo, map missing → 404, unique
-  collision → 409, coherence/CHECK violation → 400.
-- Barrels re-export new DTOs from `api/policy/index.ts` and `api/index.ts`.
-- Push stub (#54): `budget.*` / `schedule.*` / `exception.*` are user-scoped
+  collision → 409, CHECK/coherence violation → 400.
+- Barrels re-export the new DTOs from `api/policy/index.ts` and `api/index.ts`.
+- Push stub (#54): `budget.*`/`schedule.*`/`exception.*` are user-scoped
   reasons (fan out to the user's linked clients). Activity/ActivityGroup are
-  definitions with no per-client effect → no push.
+  definitions and do not push.
 
 ## Validation strategy
 
-- **Create** bodies validate fully at the DTO (enum/bounds, recurrence
-  invariants via `scheduleRecurrenceSchema`, exception `effectiveFrom < expiresAt`).
-- **Target coherence + referent existence** (polymorphic `target_id`) is one
-  route helper `assertTarget(db, kind, targetId)` shared by create and PATCH →
-  precise 400.
-- **PATCH** cross-field invariants that depend on the merged row (half-open
-  recurrence pair, exception window) are backstopped by the storage `CHECK`
-  mapped to 400 via `asValidated()`, so a partial update can never 500.
+- **Coherence + referent** (`scope`/`target_kind` ↔ `target_id`, and the
+  referenced activity/group must exist) is one route helper, `assertTarget`,
+  shared by create and PATCH so the rule lives in one place.
+- **Create** bodies validate fully at the DTO (enum bounds, recurrence
+  invariants via `scheduleRecurrenceSchema`, exception window via superRefine).
+- **PATCH** validates per-field bounds at the DTO and re-checks coherence on
+  the merged row in the route; the cross-field recurrence/window invariants a
+  partial PATCH can break are backstopped by the storage `CHECK` constraints,
+  mapped to a clear 400 (`asValidated`) rather than a generic 500.
 
-## Phases
+## Route surface
 
-1. Repository + DTOs + push-stub + barrels (this PR's source).
-2. Tests: repository unit (incl. FK/cascade + CHECK), `app.inject()` route
-   tests per entity (happy + validation + 404 + 409 + coherence + merged-row
-   backstop), DTO mappers, push-stub assertions.
-3. Quality gate + finalize, ready-for-review.
+- `GET/POST /api/activities`, `GET/PATCH/DELETE /api/activities/:id`
+- `GET/POST /api/activity-groups`, `GET/PATCH/DELETE /api/activity-groups/:id`
+- `GET /api/activity-groups/:groupId/activities`,
+  `PUT/DELETE /api/activity-groups/:groupId/activities/:activityId`
+- `GET/POST /api/budgets` (`?userId=` filter), `GET/PATCH/DELETE /api/budgets/:id`
+- `GET/POST /api/schedules` (`?userId=`), `GET/PATCH/DELETE /api/schedules/:id`
+- `GET/POST /api/exceptions` (`?userId=`), `GET/PATCH/DELETE /api/exceptions/:id`
+
+## Tests
+
+- Repository unit tests (CRUD round-trips, FK/cascade, idempotent membership,
+  ordering, `CHECK` backstops) in `tests/policy/repository.test.ts`.
+- `app.inject()` route tests (happy + validation + 404 + 409 + coherence +
+  PATCH CHECK backstops) in `tests/api/policy.test.ts`.
+- DTO mapper tests in `tests/api/policy-dtos.test.ts`.
+- Push-stub tests for the new user-scoped reasons in
+  `tests/api/policy-push-stub.test.ts`.
 
 ## License boundary
 

--- a/.claude/plans/issue-148-policy-crud-remaining.md
+++ b/.claude/plans/issue-148-policy-crud-remaining.md
@@ -1,0 +1,55 @@
+# Plan — #148 `/api/*` policy CRUD, remaining entities
+
+Follow-up slice of the #51 umbrella. Slice 1 (`User`/`Client`/`UserOnClient`)
+landed. This PR adds CRUD for **all** remaining policy-model entities, so #148
+(and the #51 umbrella) can close:
+
+- `Activity`
+- `ActivityGroup` + `activities_to_groups` membership
+- `Budget`
+- `Schedule` — against the recurrence + date-scoping shape finalized by #146
+  (PR #156, merged), reusing `policy/recurrence.ts`' `scheduleRecurrenceSchema`
+- `Exception` — `effective_from`/`expires_at` window per ADR 0005
+
+> Scope history: an earlier revision deferred Schedule/Exception while PR #156
+> was reshaping those tables. #156 merged mid-session, so this PR was rebased
+> onto it and expanded to the full slice.
+
+## Conventions reused (from slice 1)
+
+- DTOs in `server/src/api/policy/dtos.ts`, reusing `policy/enums.ts` +
+  `policy/recurrence.ts` and the shared error envelope. Types inferred.
+- Repository in `server/src/policy/repository.ts` over `app.db`; `isUniqueViolation()`
+  (→ 409) plus a new `isCheckViolation()` (→ 400) for storage-CHECK backstops.
+- Routes in `server/src/api/policy/routes.ts`, behind `requireAdmin`. Thin
+  handlers: validate via DTO, delegate to repo, map missing → 404, unique
+  collision → 409, coherence/CHECK violation → 400.
+- Barrels re-export new DTOs from `api/policy/index.ts` and `api/index.ts`.
+- Push stub (#54): `budget.*` / `schedule.*` / `exception.*` are user-scoped
+  reasons (fan out to the user's linked clients). Activity/ActivityGroup are
+  definitions with no per-client effect → no push.
+
+## Validation strategy
+
+- **Create** bodies validate fully at the DTO (enum/bounds, recurrence
+  invariants via `scheduleRecurrenceSchema`, exception `effectiveFrom < expiresAt`).
+- **Target coherence + referent existence** (polymorphic `target_id`) is one
+  route helper `assertTarget(db, kind, targetId)` shared by create and PATCH →
+  precise 400.
+- **PATCH** cross-field invariants that depend on the merged row (half-open
+  recurrence pair, exception window) are backstopped by the storage `CHECK`
+  mapped to 400 via `asValidated()`, so a partial update can never 500.
+
+## Phases
+
+1. Repository + DTOs + push-stub + barrels (this PR's source).
+2. Tests: repository unit (incl. FK/cascade + CHECK), `app.inject()` route
+   tests per entity (happy + validation + 404 + 409 + coherence + merged-row
+   backstop), DTO mappers, push-stub assertions.
+3. Quality gate + finalize, ready-for-review.
+
+## License boundary
+
+N/A — plain TypeScript + zod + Drizzle (Apache-2.0) + better-sqlite3 (MIT).
+No transport, packaging, Docker-image, or GPL surface. `license-guard`
+unaffected.

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -23,10 +23,11 @@ export {
 export { metaResponseSchema, type MetaResponse } from "./meta.js";
 export type { ZodTypeProvider } from "./validation.js";
 
-// Policy CRUD DTOs (#51): the account/device-core contract shared with the
+// Policy CRUD DTOs (#51/#148): the policy-model contract shared with the
 // frontend and integrators. Schemas live in `./policy/dtos.ts` next to the
 // routes; surfaced here so the whole `/api` contract imports from one barrel.
 export {
+  // Account/device core (#51)
   clientResponseSchema,
   createClientSchema,
   createUserSchema,
@@ -47,6 +48,43 @@ export {
   type UpdateUserRequest,
   type UpsertLinkRequest,
   type UserResponse,
+  // Activities, groups + membership (#148)
+  activityResponseSchema,
+  createActivitySchema,
+  updateActivitySchema,
+  activityGroupResponseSchema,
+  createActivityGroupSchema,
+  updateActivityGroupSchema,
+  groupIdParamsSchema,
+  groupActivityParamsSchema,
+  type ActivityResponse,
+  type CreateActivityRequest,
+  type UpdateActivityRequest,
+  type ActivityGroupResponse,
+  type CreateActivityGroupRequest,
+  type UpdateActivityGroupRequest,
+  // Budgets (#148)
+  budgetResponseSchema,
+  createBudgetSchema,
+  updateBudgetSchema,
+  userIdQuerySchema,
+  type BudgetResponse,
+  type CreateBudgetRequest,
+  type UpdateBudgetRequest,
+  // Schedules (#148)
+  scheduleResponseSchema,
+  createScheduleSchema,
+  updateScheduleSchema,
+  type ScheduleResponse,
+  type CreateScheduleRequest,
+  type UpdateScheduleRequest,
+  // Exceptions (#148)
+  exceptionResponseSchema,
+  createExceptionSchema,
+  updateExceptionSchema,
+  type ExceptionResponse,
+  type CreateExceptionRequest,
+  type UpdateExceptionRequest,
 } from "./policy/index.js";
 
 // Client-enrolment DTOs (#77): the admin token-mint + install-script enrol

--- a/server/src/api/policy/dtos.ts
+++ b/server/src/api/policy/dtos.ts
@@ -1,9 +1,13 @@
 /**
- * zod DTOs for the account/device-core CRUD surface (#51): request bodies,
- * URL params, and response shapes for `User`, `Client`, and the `UserOnClient`
- * link. As with every `/api/*` DTO these are the single contract shared with
- * the SvelteKit frontend and external integrators — types are inferred from the
- * schemas, never hand-written twice (`CLAUDE.md` → "api/ — zod DTOs ...").
+ * zod DTOs for the policy-model CRUD surface: request bodies, URL params, and
+ * response shapes for `User` / `Client` / `UserOnClient` (slice 1, #51) and
+ * `Activity` / `ActivityGroup` (+ membership) / `Budget` / `Schedule` /
+ * `Exception` (slice 2, #148). As with every `/api/*` DTO these are the single
+ * contract shared with the SvelteKit frontend and external integrators — types
+ * are inferred from the schemas, never hand-written twice (`CLAUDE.md` → "api/
+ * — zod DTOs ..."). Enum and recurrence invariants are imported from
+ * `policy/enums.ts` and `policy/recurrence.ts` so the storage `CHECK`
+ * constraints and the request validation share one source.
  *
  * Storage uses epoch-second `Date` columns (see `policy/schema.ts`); the
  * response mappers below serialize them as ISO-8601 UTC strings so the wire
@@ -14,7 +18,23 @@
 import { z } from "zod";
 
 import { isValidTimeZone } from "../../policy/budget-window.js";
-import type { ClientRow, UserOnClientRow, UserRow } from "../../policy/repository.js";
+import {
+  activityKindSchema,
+  budgetWindowSchema,
+  scheduleActionSchema,
+  scopeSchema,
+} from "../../policy/enums.js";
+import { scheduleRecurrenceSchema } from "../../policy/recurrence.js";
+import type {
+  ActivityGroupRow,
+  ActivityRow,
+  BudgetRow,
+  ClientRow,
+  ExceptionRow,
+  ScheduleRow,
+  UserOnClientRow,
+  UserRow,
+} from "../../policy/repository.js";
 
 /** An IANA timezone name, validated against the host's tz database (ADR-0001). */
 export const tzSchema = z.string().refine(isValidTimeZone, { message: "Unknown IANA timezone" });
@@ -134,5 +154,287 @@ export function toLinkResponse(row: UserOnClientRow): LinkResponse {
     clientId: row.clientId,
     linuxUsername: row.linuxUsername,
     linuxUid: row.linuxUid,
+  };
+}
+
+// --- Shared policy-target field --------------------------------------------
+
+/**
+ * The polymorphic `target_id`: an `activity.id` (scope `activity`), an
+ * `activity_group.id` (scope `group`), or `null` (scope `overall`). JSON
+ * bodies carry real numbers, so no coercion. Coherence with the scope and the
+ * existence of the referent are enforced in the route layer (it needs DB
+ * access), shared by create and PATCH so the rule lives in one place.
+ */
+const targetIdSchema = z.number().int().positive().nullable();
+
+// --- Activities ------------------------------------------------------------
+
+export const createActivitySchema = z.object({
+  kind: activityKindSchema,
+  matcher: z.string().trim().min(1).max(512),
+});
+
+export const updateActivitySchema = z
+  .object({
+    kind: activityKindSchema.optional(),
+    matcher: z.string().trim().min(1).max(512).optional(),
+  })
+  .refine(nonEmpty, { message: "At least one field must be provided" });
+
+export const activityResponseSchema = z.object({
+  id: z.number().int(),
+  kind: activityKindSchema,
+  matcher: z.string(),
+});
+
+export type CreateActivityRequest = z.infer<typeof createActivitySchema>;
+export type UpdateActivityRequest = z.infer<typeof updateActivitySchema>;
+export type ActivityResponse = z.infer<typeof activityResponseSchema>;
+
+/** Map a stored activity row to its wire DTO. */
+export function toActivityResponse(row: ActivityRow): ActivityResponse {
+  return { id: row.id, kind: row.kind, matcher: row.matcher };
+}
+
+// --- Activity groups -------------------------------------------------------
+
+export const createActivityGroupSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+});
+
+export const updateActivityGroupSchema = z
+  .object({
+    name: z.string().trim().min(1).max(200).optional(),
+  })
+  .refine(nonEmpty, { message: "At least one field must be provided" });
+
+export const activityGroupResponseSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+});
+
+export type CreateActivityGroupRequest = z.infer<typeof createActivityGroupSchema>;
+export type UpdateActivityGroupRequest = z.infer<typeof updateActivityGroupSchema>;
+export type ActivityGroupResponse = z.infer<typeof activityGroupResponseSchema>;
+
+/** Map a stored activity-group row to its wire DTO. */
+export function toActivityGroupResponse(row: ActivityGroupRow): ActivityGroupResponse {
+  return { id: row.id, name: row.name };
+}
+
+/** `:groupId` path param for the membership routes. */
+export const groupIdParamsSchema = z.object({ groupId: z.coerce.number().int().positive() });
+
+/** `:groupId`/`:activityId` path params for a single membership. */
+export const groupActivityParamsSchema = z.object({
+  groupId: z.coerce.number().int().positive(),
+  activityId: z.coerce.number().int().positive(),
+});
+
+/**
+ * `?userId=` filter shared by the user-scoped policy collections (budgets,
+ * schedules, exceptions): present ⇒ restrict to that user, absent ⇒ list all.
+ */
+export const userIdQuerySchema = z.object({
+  userId: z.coerce.number().int().positive().optional(),
+});
+
+// --- Budgets ---------------------------------------------------------------
+
+export const createBudgetSchema = z.object({
+  userId: z.number().int().positive(),
+  scope: scopeSchema,
+  targetId: targetIdSchema.default(null),
+  window: budgetWindowSchema,
+  secondsAllowed: z.number().int().min(0),
+});
+
+export const updateBudgetSchema = z
+  .object({
+    scope: scopeSchema.optional(),
+    // Present (incl. explicit null) ⇒ change; absent ⇒ leave unchanged. No
+    // default, so the route can tell "not provided" from "set to null".
+    targetId: targetIdSchema.optional(),
+    window: budgetWindowSchema.optional(),
+    secondsAllowed: z.number().int().min(0).optional(),
+  })
+  .refine(nonEmpty, { message: "At least one field must be provided" });
+
+export const budgetResponseSchema = z.object({
+  id: z.number().int(),
+  userId: z.number().int(),
+  scope: scopeSchema,
+  targetId: z.number().int().nullable(),
+  window: budgetWindowSchema,
+  secondsAllowed: z.number().int(),
+});
+
+export type CreateBudgetRequest = z.infer<typeof createBudgetSchema>;
+export type UpdateBudgetRequest = z.infer<typeof updateBudgetSchema>;
+export type BudgetResponse = z.infer<typeof budgetResponseSchema>;
+
+/** Map a stored budget row to its wire DTO. */
+export function toBudgetResponse(row: BudgetRow): BudgetResponse {
+  return {
+    id: row.id,
+    userId: row.userId,
+    scope: row.scope,
+    targetId: row.targetId,
+    window: row.window,
+    secondsAllowed: row.secondsAllowed,
+  };
+}
+
+// --- Schedules -------------------------------------------------------------
+
+/**
+ * Schedule create body: the rule's target/action/order, intersected with the
+ * shared recurrence + date-scoping fields ({@link scheduleRecurrenceSchema},
+ * #146). The intersection runs both validators, so the recurrence invariants
+ * (both-or-neither minutes, `start < end`, `effectiveFrom < effectiveTo`) are
+ * enforced here from their single source. `ordinal` is optional (defaults to
+ * the column default); the drag-reorder editor (#63) owns reordering.
+ */
+export const createScheduleSchema = z.intersection(
+  z.object({
+    userId: z.number().int().positive(),
+    targetKind: scopeSchema,
+    targetId: targetIdSchema.default(null),
+    action: scheduleActionSchema,
+    ordinal: z.number().int().min(0).optional(),
+  }),
+  scheduleRecurrenceSchema,
+);
+
+/**
+ * Schedule PATCH body: each field optional. Per-field bounds are enforced here;
+ * the cross-field recurrence invariants are re-checked against the merged row
+ * by the storage `CHECK` constraints (mapped to a 400), since a PATCH may set
+ * only one half of a pair.
+ */
+export const updateScheduleSchema = z
+  .object({
+    targetKind: scopeSchema.optional(),
+    targetId: targetIdSchema.optional(),
+    action: scheduleActionSchema.optional(),
+    recurrenceDays: z.number().int().min(1).max(127).nullable().optional(),
+    recurrenceStartMinute: z.number().int().min(0).max(1440).nullable().optional(),
+    recurrenceEndMinute: z.number().int().min(0).max(1440).nullable().optional(),
+    effectiveFrom: z.string().datetime().nullable().optional(),
+    effectiveTo: z.string().datetime().nullable().optional(),
+    ordinal: z.number().int().min(0).optional(),
+  })
+  .refine(nonEmpty, { message: "At least one field must be provided" });
+
+export const scheduleResponseSchema = z.object({
+  id: z.number().int(),
+  userId: z.number().int(),
+  targetKind: scopeSchema,
+  targetId: z.number().int().nullable(),
+  action: scheduleActionSchema,
+  recurrenceDays: z.number().int().nullable(),
+  recurrenceStartMinute: z.number().int().nullable(),
+  recurrenceEndMinute: z.number().int().nullable(),
+  effectiveFrom: z.string().nullable(),
+  effectiveTo: z.string().nullable(),
+  ordinal: z.number().int(),
+});
+
+export type CreateScheduleRequest = z.infer<typeof createScheduleSchema>;
+export type UpdateScheduleRequest = z.infer<typeof updateScheduleSchema>;
+export type ScheduleResponse = z.infer<typeof scheduleResponseSchema>;
+
+/** Map a stored schedule row to its wire DTO (timestamps → ISO-8601 UTC). */
+export function toScheduleResponse(row: ScheduleRow): ScheduleResponse {
+  return {
+    id: row.id,
+    userId: row.userId,
+    targetKind: row.targetKind,
+    targetId: row.targetId,
+    action: row.action,
+    recurrenceDays: row.recurrenceDays,
+    recurrenceStartMinute: row.recurrenceStartMinute,
+    recurrenceEndMinute: row.recurrenceEndMinute,
+    effectiveFrom: row.effectiveFrom === null ? null : row.effectiveFrom.toISOString(),
+    effectiveTo: row.effectiveTo === null ? null : row.effectiveTo.toISOString(),
+    ordinal: row.ordinal,
+  };
+}
+
+// --- Exceptions ------------------------------------------------------------
+
+/**
+ * Exception create body. The override is active during
+ * `[effectiveFrom ?? createdAt, expiresAt)` (ADR 0005 §2); the superRefine
+ * enforces `effectiveFrom < expiresAt` when a pre-schedule instant is given.
+ */
+export const createExceptionSchema = z
+  .object({
+    userId: z.number().int().positive(),
+    targetKind: scopeSchema,
+    targetId: targetIdSchema.default(null),
+    action: scheduleActionSchema,
+    reason: z.string().trim().min(1).max(500).nullable().default(null),
+    effectiveFrom: z.string().datetime().nullable().default(null),
+    expiresAt: z.string().datetime(),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.effectiveFrom !== null &&
+      Date.parse(value.effectiveFrom) >= Date.parse(value.expiresAt)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "expiresAt must be after effectiveFrom",
+        path: ["expiresAt"],
+      });
+    }
+  });
+
+/**
+ * Exception PATCH body: each field optional. The `effectiveFrom < expiresAt`
+ * window is re-checked against the merged row by the storage `CHECK` (mapped to
+ * a 400), since a PATCH may move only one bound.
+ */
+export const updateExceptionSchema = z
+  .object({
+    targetKind: scopeSchema.optional(),
+    targetId: targetIdSchema.optional(),
+    action: scheduleActionSchema.optional(),
+    reason: z.string().trim().min(1).max(500).nullable().optional(),
+    effectiveFrom: z.string().datetime().nullable().optional(),
+    expiresAt: z.string().datetime().optional(),
+  })
+  .refine(nonEmpty, { message: "At least one field must be provided" });
+
+export const exceptionResponseSchema = z.object({
+  id: z.number().int(),
+  userId: z.number().int(),
+  targetKind: scopeSchema,
+  targetId: z.number().int().nullable(),
+  action: scheduleActionSchema,
+  reason: z.string().nullable(),
+  effectiveFrom: z.string().nullable(),
+  expiresAt: z.string(),
+  createdAt: z.string(),
+});
+
+export type CreateExceptionRequest = z.infer<typeof createExceptionSchema>;
+export type UpdateExceptionRequest = z.infer<typeof updateExceptionSchema>;
+export type ExceptionResponse = z.infer<typeof exceptionResponseSchema>;
+
+/** Map a stored exception row to its wire DTO (timestamps → ISO-8601 UTC). */
+export function toExceptionResponse(row: ExceptionRow): ExceptionResponse {
+  return {
+    id: row.id,
+    userId: row.userId,
+    targetKind: row.targetKind,
+    targetId: row.targetId,
+    action: row.action,
+    reason: row.reason,
+    effectiveFrom: row.effectiveFrom === null ? null : row.effectiveFrom.toISOString(),
+    expiresAt: row.expiresAt.toISOString(),
+    createdAt: row.createdAt.toISOString(),
   };
 }

--- a/server/src/api/policy/dtos.ts
+++ b/server/src/api/policy/dtos.ts
@@ -24,7 +24,11 @@ import {
   scheduleActionSchema,
   scopeSchema,
 } from "../../policy/enums.js";
-import { scheduleRecurrenceSchema } from "../../policy/recurrence.js";
+import {
+  scheduleRecurrenceSchema,
+  minuteOfDaySchema,
+  weekdayMaskSchema,
+} from "../../policy/recurrence.js";
 import type {
   ActivityGroupRow,
   ActivityRow,
@@ -318,9 +322,11 @@ export const updateScheduleSchema = z
     targetKind: scopeSchema.optional(),
     targetId: targetIdSchema.optional(),
     action: scheduleActionSchema.optional(),
-    recurrenceDays: z.number().int().min(1).max(127).nullable().optional(),
-    recurrenceStartMinute: z.number().int().min(0).max(1440).nullable().optional(),
-    recurrenceEndMinute: z.number().int().min(0).max(1440).nullable().optional(),
+    // Reuse the single-source recurrence bounds (recurrence.ts), so the PATCH
+    // per-field checks can't drift from the create path or the storage CHECK.
+    recurrenceDays: weekdayMaskSchema.nullable().optional(),
+    recurrenceStartMinute: minuteOfDaySchema.nullable().optional(),
+    recurrenceEndMinute: minuteOfDaySchema.nullable().optional(),
     effectiveFrom: z.string().datetime().nullable().optional(),
     effectiveTo: z.string().datetime().nullable().optional(),
     ordinal: z.number().int().min(0).optional(),

--- a/server/src/api/policy/index.ts
+++ b/server/src/api/policy/index.ts
@@ -1,10 +1,11 @@
 /**
- * Policy CRUD surface (#51): the route registrar plus the zod DTOs and inferred
- * types the frontend and integrators consume. Re-exported from the top-level
- * `api/` barrel so the contract is imported from one place.
+ * Policy CRUD surface (#51/#148): the route registrar plus the zod DTOs and
+ * inferred types the frontend and integrators consume. Re-exported from the
+ * top-level `api/` barrel so the contract is imported from one place.
  */
 export { registerPolicyRoutes } from "./routes.js";
 export {
+  // Account/device core (#51)
   clientResponseSchema,
   createClientSchema,
   createUserSchema,
@@ -25,4 +26,41 @@ export {
   type UpdateUserRequest,
   type UpsertLinkRequest,
   type UserResponse,
+  // Activities, groups + membership (#148)
+  activityResponseSchema,
+  createActivitySchema,
+  updateActivitySchema,
+  activityGroupResponseSchema,
+  createActivityGroupSchema,
+  updateActivityGroupSchema,
+  groupIdParamsSchema,
+  groupActivityParamsSchema,
+  type ActivityResponse,
+  type CreateActivityRequest,
+  type UpdateActivityRequest,
+  type ActivityGroupResponse,
+  type CreateActivityGroupRequest,
+  type UpdateActivityGroupRequest,
+  // Budgets (#148)
+  budgetResponseSchema,
+  createBudgetSchema,
+  updateBudgetSchema,
+  userIdQuerySchema,
+  type BudgetResponse,
+  type CreateBudgetRequest,
+  type UpdateBudgetRequest,
+  // Schedules (#148)
+  scheduleResponseSchema,
+  createScheduleSchema,
+  updateScheduleSchema,
+  type ScheduleResponse,
+  type CreateScheduleRequest,
+  type UpdateScheduleRequest,
+  // Exceptions (#148)
+  exceptionResponseSchema,
+  createExceptionSchema,
+  updateExceptionSchema,
+  type ExceptionResponse,
+  type CreateExceptionRequest,
+  type UpdateExceptionRequest,
 } from "./dtos.js";

--- a/server/src/api/policy/routes.ts
+++ b/server/src/api/policy/routes.ts
@@ -14,6 +14,8 @@
  */
 import type { FastifyInstance } from "fastify";
 
+import type { PolicyDb } from "../../policy/db.js";
+import type { Scope } from "../../policy/enums.js";
 import * as repo from "../../policy/repository.js";
 import {
   clientPushCommands,
@@ -24,19 +26,42 @@ import {
 import { ApiError } from "../errors.js";
 import type { ZodTypeProvider } from "../validation.js";
 import {
+  createActivityGroupSchema,
+  createActivitySchema,
+  createBudgetSchema,
   createClientSchema,
+  createExceptionSchema,
+  createScheduleSchema,
   createUserSchema,
+  groupActivityParamsSchema,
+  groupIdParamsSchema,
   idParamsSchema,
+  toActivityGroupResponse,
+  toActivityResponse,
+  toBudgetResponse,
   toClientResponse,
+  toExceptionResponse,
   toLinkResponse,
+  toScheduleResponse,
   toUserResponse,
+  updateActivityGroupSchema,
+  updateActivitySchema,
+  updateBudgetSchema,
   updateClientSchema,
+  updateExceptionSchema,
+  updateScheduleSchema,
   updateUserSchema,
   upsertLinkSchema,
   userClientParamsSchema,
   userIdParamsSchema,
+  userIdQuerySchema,
+  type ActivityGroupResponse,
+  type ActivityResponse,
+  type BudgetResponse,
   type ClientResponse,
+  type ExceptionResponse,
   type LinkResponse,
+  type ScheduleResponse,
   type UserResponse,
 } from "./dtos.js";
 
@@ -49,6 +74,54 @@ function asConflict<T>(write: () => T, message: string): T {
       throw new ApiError(409, "conflict", message);
     }
     throw err;
+  }
+}
+
+/**
+ * Run a repository write, mapping a storage `CHECK` violation to a
+ * `400 validation_error`. Backstops the merged-row invariants a PATCH can break
+ * without the DTO seeing them (budget non-negativity / target coherence,
+ * schedule recurrence bounds, the exception effective window) — #148: "map the
+ * schema's CHECK constraints to clear 400/409s rather than a generic 500".
+ */
+function asValidated<T>(write: () => T, message: string): T {
+  try {
+    return write();
+  } catch (err) {
+    if (repo.isCheckViolation(err)) {
+      throw new ApiError(400, "validation_error", message);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Enforce the polymorphic-target invariant for a Budget/Schedule/Exception
+ * write: a row is `overall` exactly when it has no `target_id`, and an
+ * `activity`/`group` target must reference an existing row. Throws a precise
+ * `400 validation_error` instead of letting a coherence break hit the storage
+ * `CHECK` as an opaque error or a budget dangle against a deleted activity.
+ * Shared by create and PATCH so the rule lives in one place.
+ */
+function assertTarget(db: PolicyDb, kind: Scope, targetId: number | null): void {
+  if (kind === "overall") {
+    if (targetId !== null) {
+      throw new ApiError(
+        400,
+        "validation_error",
+        "targetId must be null when the scope is 'overall'",
+      );
+    }
+    return;
+  }
+  if (targetId === null) {
+    throw new ApiError(400, "validation_error", `targetId is required when the scope is '${kind}'`);
+  }
+  if (kind === "activity" && repo.getActivity(db, targetId) === undefined) {
+    throw new ApiError(400, "validation_error", `Activity ${targetId} not found`);
+  }
+  if (kind === "group" && repo.getActivityGroup(db, targetId) === undefined) {
+    throw new ApiError(400, "validation_error", `Activity group ${targetId} not found`);
   }
 }
 
@@ -256,6 +329,553 @@ export function registerPolicyRoutes(scope: FastifyInstance): void {
         );
       }
       pushStub.push(linkPushCommands("link.deleted", userId, clientId, {}));
+      return reply.code(204).send();
+    },
+  );
+
+  // --- Activities ----------------------------------------------------------
+  // Definitions (a matchable app/domain). No push: an activity has no
+  // per-client effect until a budget/schedule references it.
+
+  typed.get(
+    "/activities",
+    guard,
+    async (): Promise<ActivityResponse[]> => repo.listActivities(scope.db).map(toActivityResponse),
+  );
+
+  typed.post(
+    "/activities",
+    { ...guard, schema: { body: createActivitySchema } },
+    async (request, reply): Promise<ActivityResponse> => {
+      const row = repo.createActivity(scope.db, request.body);
+      reply.code(201);
+      return toActivityResponse(row);
+    },
+  );
+
+  typed.get(
+    "/activities/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request): Promise<ActivityResponse> => {
+      const row = repo.getActivity(scope.db, request.params.id);
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Activity ${request.params.id} not found`);
+      }
+      return toActivityResponse(row);
+    },
+  );
+
+  typed.patch(
+    "/activities/:id",
+    { ...guard, schema: { params: idParamsSchema, body: updateActivitySchema } },
+    async (request): Promise<ActivityResponse> => {
+      const row = repo.updateActivity(scope.db, request.params.id, request.body);
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Activity ${request.params.id} not found`);
+      }
+      return toActivityResponse(row);
+    },
+  );
+
+  typed.delete(
+    "/activities/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request, reply) => {
+      if (!repo.deleteActivity(scope.db, request.params.id)) {
+        throw new ApiError(404, "not_found", `Activity ${request.params.id} not found`);
+      }
+      return reply.code(204).send();
+    },
+  );
+
+  // --- Activity groups -----------------------------------------------------
+
+  typed.get(
+    "/activity-groups",
+    guard,
+    async (): Promise<ActivityGroupResponse[]> =>
+      repo.listActivityGroups(scope.db).map(toActivityGroupResponse),
+  );
+
+  typed.post(
+    "/activity-groups",
+    { ...guard, schema: { body: createActivityGroupSchema } },
+    async (request, reply): Promise<ActivityGroupResponse> => {
+      const row = asConflict(
+        () => repo.createActivityGroup(scope.db, request.body),
+        `An activity group named "${request.body.name}" already exists`,
+      );
+      reply.code(201);
+      return toActivityGroupResponse(row);
+    },
+  );
+
+  typed.get(
+    "/activity-groups/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request): Promise<ActivityGroupResponse> => {
+      const row = repo.getActivityGroup(scope.db, request.params.id);
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Activity group ${request.params.id} not found`);
+      }
+      return toActivityGroupResponse(row);
+    },
+  );
+
+  typed.patch(
+    "/activity-groups/:id",
+    { ...guard, schema: { params: idParamsSchema, body: updateActivityGroupSchema } },
+    async (request): Promise<ActivityGroupResponse> => {
+      const row = asConflict(
+        () => repo.updateActivityGroup(scope.db, request.params.id, request.body),
+        "That activity-group name is already in use",
+      );
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Activity group ${request.params.id} not found`);
+      }
+      return toActivityGroupResponse(row);
+    },
+  );
+
+  typed.delete(
+    "/activity-groups/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request, reply) => {
+      if (!repo.deleteActivityGroup(scope.db, request.params.id)) {
+        throw new ApiError(404, "not_found", `Activity group ${request.params.id} not found`);
+      }
+      return reply.code(204).send();
+    },
+  );
+
+  // --- Activity-group membership (activities ↔ groups) ---------------------
+
+  typed.get(
+    "/activity-groups/:groupId/activities",
+    { ...guard, schema: { params: groupIdParamsSchema } },
+    async (request): Promise<ActivityResponse[]> => {
+      const { groupId } = request.params;
+      if (repo.getActivityGroup(scope.db, groupId) === undefined) {
+        throw new ApiError(404, "not_found", `Activity group ${groupId} not found`);
+      }
+      return repo.listGroupActivities(scope.db, groupId).map(toActivityResponse);
+    },
+  );
+
+  typed.put(
+    "/activity-groups/:groupId/activities/:activityId",
+    { ...guard, schema: { params: groupActivityParamsSchema } },
+    async (request, reply) => {
+      const { groupId, activityId } = request.params;
+      // Confirm both ends exist so the caller gets a precise 404 rather than an
+      // opaque foreign-key failure.
+      if (repo.getActivityGroup(scope.db, groupId) === undefined) {
+        throw new ApiError(404, "not_found", `Activity group ${groupId} not found`);
+      }
+      if (repo.getActivity(scope.db, activityId) === undefined) {
+        throw new ApiError(404, "not_found", `Activity ${activityId} not found`);
+      }
+      repo.addActivityToGroup(scope.db, groupId, activityId);
+      return reply.code(204).send();
+    },
+  );
+
+  typed.delete(
+    "/activity-groups/:groupId/activities/:activityId",
+    { ...guard, schema: { params: groupActivityParamsSchema } },
+    async (request, reply) => {
+      const { groupId, activityId } = request.params;
+      if (!repo.removeActivityFromGroup(scope.db, groupId, activityId)) {
+        throw new ApiError(
+          404,
+          "not_found",
+          `Activity ${activityId} is not a member of group ${groupId}`,
+        );
+      }
+      return reply.code(204).send();
+    },
+  );
+
+  // --- Budgets -------------------------------------------------------------
+  // User-scoped: every mutation pushes to the clients that user is linked to.
+
+  typed.get(
+    "/budgets",
+    { ...guard, schema: { querystring: userIdQuerySchema } },
+    async (request): Promise<BudgetResponse[]> => {
+      const { userId } = request.query;
+      const rows =
+        userId === undefined ? repo.listBudgets(scope.db) : repo.listUserBudgets(scope.db, userId);
+      return rows.map(toBudgetResponse);
+    },
+  );
+
+  typed.post(
+    "/budgets",
+    { ...guard, schema: { body: createBudgetSchema } },
+    async (request, reply): Promise<BudgetResponse> => {
+      const { userId, scope: budgetScope, targetId } = request.body;
+      if (repo.getUser(scope.db, userId) === undefined) {
+        throw new ApiError(404, "not_found", `User ${userId} not found`);
+      }
+      assertTarget(scope.db, budgetScope, targetId);
+      const row = asValidated(
+        () => repo.createBudget(scope.db, request.body),
+        "The budget violates a storage constraint (target coherence or a negative allowance)",
+      );
+      pushStub.push(
+        userPushCommands("budget.created", userId, repo.listUserClientIds(scope.db, userId), {
+          budgetId: row.id,
+          scope: row.scope,
+          targetId: row.targetId,
+          window: row.window,
+          secondsAllowed: row.secondsAllowed,
+        }),
+      );
+      reply.code(201);
+      return toBudgetResponse(row);
+    },
+  );
+
+  typed.get(
+    "/budgets/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request): Promise<BudgetResponse> => {
+      const row = repo.getBudget(scope.db, request.params.id);
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Budget ${request.params.id} not found`);
+      }
+      return toBudgetResponse(row);
+    },
+  );
+
+  typed.patch(
+    "/budgets/:id",
+    { ...guard, schema: { params: idParamsSchema, body: updateBudgetSchema } },
+    async (request): Promise<BudgetResponse> => {
+      const existing = repo.getBudget(scope.db, request.params.id);
+      if (existing === undefined) {
+        throw new ApiError(404, "not_found", `Budget ${request.params.id} not found`);
+      }
+      // Re-validate coherence against the merged row: a PATCH may change only
+      // the scope or only the target.
+      const nextScope = request.body.scope ?? existing.scope;
+      const nextTargetId =
+        request.body.targetId !== undefined ? request.body.targetId : existing.targetId;
+      assertTarget(scope.db, nextScope, nextTargetId);
+      const row = asValidated(
+        () => repo.updateBudget(scope.db, request.params.id, request.body),
+        "The budget update violates a storage constraint",
+      );
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Budget ${request.params.id} not found`);
+      }
+      pushStub.push(
+        userPushCommands(
+          "budget.updated",
+          row.userId,
+          repo.listUserClientIds(scope.db, row.userId),
+          {
+            budgetId: row.id,
+            ...request.body,
+          },
+        ),
+      );
+      return toBudgetResponse(row);
+    },
+  );
+
+  typed.delete(
+    "/budgets/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request, reply) => {
+      // Resolve the owner (and their clients) before deleting so the push can
+      // still fan out to the right clients.
+      const existing = repo.getBudget(scope.db, request.params.id);
+      if (existing === undefined) {
+        throw new ApiError(404, "not_found", `Budget ${request.params.id} not found`);
+      }
+      const clientIds = repo.listUserClientIds(scope.db, existing.userId);
+      repo.deleteBudget(scope.db, request.params.id);
+      pushStub.push(
+        userPushCommands("budget.deleted", existing.userId, clientIds, { budgetId: existing.id }),
+      );
+      return reply.code(204).send();
+    },
+  );
+
+  // --- Schedules -----------------------------------------------------------
+  // User-scoped recurring rules. Timestamps cross the wire as ISO-8601 strings
+  // and are stored as epoch-second Dates.
+
+  typed.get(
+    "/schedules",
+    { ...guard, schema: { querystring: userIdQuerySchema } },
+    async (request): Promise<ScheduleResponse[]> => {
+      const { userId } = request.query;
+      const rows =
+        userId === undefined
+          ? repo.listSchedules(scope.db)
+          : repo.listUserSchedules(scope.db, userId);
+      return rows.map(toScheduleResponse);
+    },
+  );
+
+  typed.post(
+    "/schedules",
+    { ...guard, schema: { body: createScheduleSchema } },
+    async (request, reply): Promise<ScheduleResponse> => {
+      const body = request.body;
+      if (repo.getUser(scope.db, body.userId) === undefined) {
+        throw new ApiError(404, "not_found", `User ${body.userId} not found`);
+      }
+      assertTarget(scope.db, body.targetKind, body.targetId);
+      const row = asValidated(
+        () =>
+          repo.createSchedule(scope.db, {
+            userId: body.userId,
+            targetKind: body.targetKind,
+            targetId: body.targetId,
+            action: body.action,
+            recurrenceDays: body.recurrenceDays,
+            recurrenceStartMinute: body.recurrenceStartMinute,
+            recurrenceEndMinute: body.recurrenceEndMinute,
+            effectiveFrom: body.effectiveFrom === null ? null : new Date(body.effectiveFrom),
+            effectiveTo: body.effectiveTo === null ? null : new Date(body.effectiveTo),
+            ordinal: body.ordinal,
+          }),
+        "The schedule violates a recurrence or target constraint",
+      );
+      pushStub.push(
+        userPushCommands(
+          "schedule.created",
+          row.userId,
+          repo.listUserClientIds(scope.db, row.userId),
+          {
+            scheduleId: row.id,
+            targetKind: row.targetKind,
+            targetId: row.targetId,
+            action: row.action,
+            ordinal: row.ordinal,
+          },
+        ),
+      );
+      reply.code(201);
+      return toScheduleResponse(row);
+    },
+  );
+
+  typed.get(
+    "/schedules/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request): Promise<ScheduleResponse> => {
+      const row = repo.getSchedule(scope.db, request.params.id);
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Schedule ${request.params.id} not found`);
+      }
+      return toScheduleResponse(row);
+    },
+  );
+
+  typed.patch(
+    "/schedules/:id",
+    { ...guard, schema: { params: idParamsSchema, body: updateScheduleSchema } },
+    async (request): Promise<ScheduleResponse> => {
+      const existing = repo.getSchedule(scope.db, request.params.id);
+      if (existing === undefined) {
+        throw new ApiError(404, "not_found", `Schedule ${request.params.id} not found`);
+      }
+      const body = request.body;
+      const nextKind = body.targetKind ?? existing.targetKind;
+      const nextTargetId = body.targetId !== undefined ? body.targetId : existing.targetId;
+      assertTarget(scope.db, nextKind, nextTargetId);
+      // Translate only the timestamp fields the PATCH actually carries; the
+      // merged-row recurrence invariants are backstopped by the storage CHECK.
+      const patch: repo.ScheduleUpdate = {
+        ...(body.targetKind !== undefined ? { targetKind: body.targetKind } : {}),
+        ...(body.targetId !== undefined ? { targetId: body.targetId } : {}),
+        ...(body.action !== undefined ? { action: body.action } : {}),
+        ...(body.recurrenceDays !== undefined ? { recurrenceDays: body.recurrenceDays } : {}),
+        ...(body.recurrenceStartMinute !== undefined
+          ? { recurrenceStartMinute: body.recurrenceStartMinute }
+          : {}),
+        ...(body.recurrenceEndMinute !== undefined
+          ? { recurrenceEndMinute: body.recurrenceEndMinute }
+          : {}),
+        ...(body.effectiveFrom !== undefined
+          ? { effectiveFrom: body.effectiveFrom === null ? null : new Date(body.effectiveFrom) }
+          : {}),
+        ...(body.effectiveTo !== undefined
+          ? { effectiveTo: body.effectiveTo === null ? null : new Date(body.effectiveTo) }
+          : {}),
+        ...(body.ordinal !== undefined ? { ordinal: body.ordinal } : {}),
+      };
+      const row = asValidated(
+        () => repo.updateSchedule(scope.db, request.params.id, patch),
+        "The schedule update violates a recurrence or target constraint",
+      );
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Schedule ${request.params.id} not found`);
+      }
+      pushStub.push(
+        userPushCommands(
+          "schedule.updated",
+          row.userId,
+          repo.listUserClientIds(scope.db, row.userId),
+          {
+            scheduleId: row.id,
+          },
+        ),
+      );
+      return toScheduleResponse(row);
+    },
+  );
+
+  typed.delete(
+    "/schedules/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request, reply) => {
+      const existing = repo.getSchedule(scope.db, request.params.id);
+      if (existing === undefined) {
+        throw new ApiError(404, "not_found", `Schedule ${request.params.id} not found`);
+      }
+      const clientIds = repo.listUserClientIds(scope.db, existing.userId);
+      repo.deleteSchedule(scope.db, request.params.id);
+      pushStub.push(
+        userPushCommands("schedule.deleted", existing.userId, clientIds, {
+          scheduleId: existing.id,
+        }),
+      );
+      return reply.code(204).send();
+    },
+  );
+
+  // --- Exceptions ----------------------------------------------------------
+  // User-scoped one-off overrides active over `[effectiveFrom ?? createdAt,
+  // expiresAt)`.
+
+  typed.get(
+    "/exceptions",
+    { ...guard, schema: { querystring: userIdQuerySchema } },
+    async (request): Promise<ExceptionResponse[]> => {
+      const { userId } = request.query;
+      const rows =
+        userId === undefined
+          ? repo.listExceptions(scope.db)
+          : repo.listUserExceptions(scope.db, userId);
+      return rows.map(toExceptionResponse);
+    },
+  );
+
+  typed.post(
+    "/exceptions",
+    { ...guard, schema: { body: createExceptionSchema } },
+    async (request, reply): Promise<ExceptionResponse> => {
+      const body = request.body;
+      if (repo.getUser(scope.db, body.userId) === undefined) {
+        throw new ApiError(404, "not_found", `User ${body.userId} not found`);
+      }
+      assertTarget(scope.db, body.targetKind, body.targetId);
+      const row = asValidated(
+        () =>
+          repo.createException(scope.db, {
+            userId: body.userId,
+            targetKind: body.targetKind,
+            targetId: body.targetId,
+            action: body.action,
+            reason: body.reason,
+            effectiveFrom: body.effectiveFrom === null ? null : new Date(body.effectiveFrom),
+            expiresAt: new Date(body.expiresAt),
+          }),
+        "The exception violates a target or effective-window constraint",
+      );
+      pushStub.push(
+        userPushCommands(
+          "exception.created",
+          row.userId,
+          repo.listUserClientIds(scope.db, row.userId),
+          {
+            exceptionId: row.id,
+            targetKind: row.targetKind,
+            targetId: row.targetId,
+            action: row.action,
+            expiresAt: row.expiresAt.toISOString(),
+          },
+        ),
+      );
+      reply.code(201);
+      return toExceptionResponse(row);
+    },
+  );
+
+  typed.get(
+    "/exceptions/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request): Promise<ExceptionResponse> => {
+      const row = repo.getException(scope.db, request.params.id);
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Exception ${request.params.id} not found`);
+      }
+      return toExceptionResponse(row);
+    },
+  );
+
+  typed.patch(
+    "/exceptions/:id",
+    { ...guard, schema: { params: idParamsSchema, body: updateExceptionSchema } },
+    async (request): Promise<ExceptionResponse> => {
+      const existing = repo.getException(scope.db, request.params.id);
+      if (existing === undefined) {
+        throw new ApiError(404, "not_found", `Exception ${request.params.id} not found`);
+      }
+      const body = request.body;
+      const nextKind = body.targetKind ?? existing.targetKind;
+      const nextTargetId = body.targetId !== undefined ? body.targetId : existing.targetId;
+      assertTarget(scope.db, nextKind, nextTargetId);
+      const patch: repo.ExceptionUpdate = {
+        ...(body.targetKind !== undefined ? { targetKind: body.targetKind } : {}),
+        ...(body.targetId !== undefined ? { targetId: body.targetId } : {}),
+        ...(body.action !== undefined ? { action: body.action } : {}),
+        ...(body.reason !== undefined ? { reason: body.reason } : {}),
+        ...(body.effectiveFrom !== undefined
+          ? { effectiveFrom: body.effectiveFrom === null ? null : new Date(body.effectiveFrom) }
+          : {}),
+        ...(body.expiresAt !== undefined ? { expiresAt: new Date(body.expiresAt) } : {}),
+      };
+      const row = asValidated(
+        () => repo.updateException(scope.db, request.params.id, patch),
+        "The exception update violates a target or effective-window constraint",
+      );
+      if (row === undefined) {
+        throw new ApiError(404, "not_found", `Exception ${request.params.id} not found`);
+      }
+      pushStub.push(
+        userPushCommands(
+          "exception.updated",
+          row.userId,
+          repo.listUserClientIds(scope.db, row.userId),
+          { exceptionId: row.id },
+        ),
+      );
+      return toExceptionResponse(row);
+    },
+  );
+
+  typed.delete(
+    "/exceptions/:id",
+    { ...guard, schema: { params: idParamsSchema } },
+    async (request, reply) => {
+      const existing = repo.getException(scope.db, request.params.id);
+      if (existing === undefined) {
+        throw new ApiError(404, "not_found", `Exception ${request.params.id} not found`);
+      }
+      const clientIds = repo.listUserClientIds(scope.db, existing.userId);
+      repo.deleteException(scope.db, request.params.id);
+      pushStub.push(
+        userPushCommands("exception.deleted", existing.userId, clientIds, {
+          exceptionId: existing.id,
+        }),
+      );
       return reply.code(204).send();
     },
   );

--- a/server/src/policy/repository.ts
+++ b/server/src/policy/repository.ts
@@ -9,9 +9,10 @@
  * schema, policy model, DB access" and #51's "reads and writes go through the
  * policy service over `app.db`".
  *
- * Scope: `User`, `Client`, and the `UserOnClient` link. The remaining policy
- * entities (Activity/ActivityGroup, Budget, Schedule, Exception) land in their
- * own follow-up modules under the #51 umbrella.
+ * Scope: `User`, `Client`, the `UserOnClient` link (slice 1, #51), and the
+ * `Activity` / `ActivityGroup` (+ membership) / `Budget` / `Schedule` /
+ * `Exception` entities (slice 2, #148), the latter two against the recurrence +
+ * date-scoping shape finalized in #146.
  *
  * License boundary: none touched — Drizzle (Apache-2.0) and better-sqlite3
  * (MIT) only.
@@ -19,7 +20,18 @@
 import { and, eq } from "drizzle-orm";
 
 import type { PolicyDb } from "./db.js";
-import { clients, users, usersOnClients } from "./schema.js";
+import type { ActivityKind, BudgetWindow, ScheduleAction, Scope } from "./enums.js";
+import {
+  activities,
+  activitiesToGroups,
+  activityGroups,
+  budgets,
+  clients,
+  exceptions,
+  schedules,
+  users,
+  usersOnClients,
+} from "./schema.js";
 
 /** A persisted {@link users} row. */
 export type UserRow = typeof users.$inferSelect;
@@ -197,6 +209,459 @@ export function deleteLink(db: PolicyDb, userId: number, clientId: number): bool
   );
 }
 
+// --- Activities ------------------------------------------------------------
+
+/** A persisted {@link activities} row. */
+export type ActivityRow = typeof activities.$inferSelect;
+/** A persisted {@link activityGroups} row. */
+export type ActivityGroupRow = typeof activityGroups.$inferSelect;
+/** A persisted {@link activitiesToGroups} membership row. */
+export type ActivityGroupMembershipRow = typeof activitiesToGroups.$inferSelect;
+
+/** Fields accepted when creating an {@link activities} row. */
+export interface ActivityCreate {
+  kind: ActivityKind;
+  matcher: string;
+}
+
+/** Mutable fields on an {@link activities} row; omitted keys are unchanged. */
+export interface ActivityUpdate {
+  kind?: ActivityKind | undefined;
+  matcher?: string | undefined;
+}
+
+/** All activities, ascending by id. */
+export function listActivities(db: PolicyDb): ActivityRow[] {
+  return db.select().from(activities).orderBy(activities.id).all();
+}
+
+/** One activity by id, or `undefined` if absent. */
+export function getActivity(db: PolicyDb, id: number): ActivityRow | undefined {
+  return db.select().from(activities).where(eq(activities.id, id)).get();
+}
+
+/** Insert an activity and return the stored row. */
+export function createActivity(db: PolicyDb, input: ActivityCreate): ActivityRow {
+  return db
+    .insert(activities)
+    .values({ kind: input.kind, matcher: input.matcher })
+    .returning()
+    .get();
+}
+
+/**
+ * Apply a partial update and return the stored row, or `undefined` if no
+ * activity with `id` exists. `patch` must carry at least one key (the route
+ * enforces this).
+ */
+export function updateActivity(
+  db: PolicyDb,
+  id: number,
+  patch: ActivityUpdate,
+): ActivityRow | undefined {
+  return db.update(activities).set(patch).where(eq(activities.id, id)).returning().get();
+}
+
+/**
+ * Delete an activity. Returns whether a row was removed. Its group memberships
+ * cascade away with it (`activities_to_groups.activity_id` ON DELETE CASCADE).
+ */
+export function deleteActivity(db: PolicyDb, id: number): boolean {
+  return (
+    db.delete(activities).where(eq(activities.id, id)).returning({ id: activities.id }).get() !==
+    undefined
+  );
+}
+
+// --- Activity groups -------------------------------------------------------
+
+/** Fields accepted when creating an {@link activityGroups} row. */
+export interface ActivityGroupCreate {
+  name: string;
+}
+
+/** Mutable fields on an {@link activityGroups} row. */
+export interface ActivityGroupUpdate {
+  name?: string | undefined;
+}
+
+/** All activity groups, ascending by id. */
+export function listActivityGroups(db: PolicyDb): ActivityGroupRow[] {
+  return db.select().from(activityGroups).orderBy(activityGroups.id).all();
+}
+
+/** One activity group by id, or `undefined` if absent. */
+export function getActivityGroup(db: PolicyDb, id: number): ActivityGroupRow | undefined {
+  return db.select().from(activityGroups).where(eq(activityGroups.id, id)).get();
+}
+
+/**
+ * Insert an activity group and return the stored row. Throws the underlying
+ * unique-constraint error on a duplicate `name` — see {@link isUniqueViolation}.
+ */
+export function createActivityGroup(db: PolicyDb, input: ActivityGroupCreate): ActivityGroupRow {
+  return db.insert(activityGroups).values({ name: input.name }).returning().get();
+}
+
+/**
+ * Apply a partial update and return the stored row, or `undefined` if no group
+ * with `id` exists. Throws on a `name` collision (see {@link isUniqueViolation}).
+ */
+export function updateActivityGroup(
+  db: PolicyDb,
+  id: number,
+  patch: ActivityGroupUpdate,
+): ActivityGroupRow | undefined {
+  return db.update(activityGroups).set(patch).where(eq(activityGroups.id, id)).returning().get();
+}
+
+/**
+ * Delete an activity group. Returns whether a row was removed. Its memberships
+ * cascade away (`activities_to_groups.group_id` ON DELETE CASCADE).
+ */
+export function deleteActivityGroup(db: PolicyDb, id: number): boolean {
+  return (
+    db
+      .delete(activityGroups)
+      .where(eq(activityGroups.id, id))
+      .returning({ id: activityGroups.id })
+      .get() !== undefined
+  );
+}
+
+// --- Activity-group membership (activities ↔ groups M2M) -------------------
+
+/** The activities belonging to a group, ascending by activity id. */
+export function listGroupActivities(db: PolicyDb, groupId: number): ActivityRow[] {
+  return db
+    .select({
+      id: activities.id,
+      kind: activities.kind,
+      matcher: activities.matcher,
+    })
+    .from(activitiesToGroups)
+    .innerJoin(activities, eq(activitiesToGroups.activityId, activities.id))
+    .where(eq(activitiesToGroups.groupId, groupId))
+    .orderBy(activities.id)
+    .all();
+}
+
+/**
+ * Whether an activity is a member of a group. Lets the route layer return a
+ * precise `404` on an attempt to remove a non-membership.
+ */
+export function isGroupMember(db: PolicyDb, groupId: number, activityId: number): boolean {
+  return (
+    db
+      .select({ activityId: activitiesToGroups.activityId })
+      .from(activitiesToGroups)
+      .where(
+        and(eq(activitiesToGroups.groupId, groupId), eq(activitiesToGroups.activityId, activityId)),
+      )
+      .get() !== undefined
+  );
+}
+
+/**
+ * Add an activity to a group, idempotently (a repeated add is a no-op, not a
+ * conflict). The caller is responsible for confirming both ends exist first —
+ * FK violations otherwise surface as opaque errors.
+ */
+export function addActivityToGroup(db: PolicyDb, groupId: number, activityId: number): void {
+  db.insert(activitiesToGroups).values({ groupId, activityId }).onConflictDoNothing().run();
+}
+
+/** Remove an activity from a group. Returns whether a membership was removed. */
+export function removeActivityFromGroup(
+  db: PolicyDb,
+  groupId: number,
+  activityId: number,
+): boolean {
+  return (
+    db
+      .delete(activitiesToGroups)
+      .where(
+        and(eq(activitiesToGroups.groupId, groupId), eq(activitiesToGroups.activityId, activityId)),
+      )
+      .returning({ activityId: activitiesToGroups.activityId })
+      .get() !== undefined
+  );
+}
+
+// --- Budgets ---------------------------------------------------------------
+
+/** A persisted {@link budgets} row. */
+export type BudgetRow = typeof budgets.$inferSelect;
+
+/**
+ * Fields accepted when creating a {@link budgets} row. `targetId` is the
+ * polymorphic referent: an `activity.id` (scope `activity`), an
+ * `activity_group.id` (scope `group`), or `null` (scope `overall`). The
+ * route layer enforces scope/target coherence and referent existence before
+ * this is called, so the storage `CHECK` is a backstop, not the primary guard.
+ */
+export interface BudgetCreate {
+  userId: number;
+  scope: Scope;
+  targetId?: number | null | undefined;
+  window: BudgetWindow;
+  secondsAllowed: number;
+}
+
+/** Mutable fields on a {@link budgets} row; omitted keys are left unchanged. */
+export interface BudgetUpdate {
+  scope?: Scope | undefined;
+  targetId?: number | null | undefined;
+  window?: BudgetWindow | undefined;
+  secondsAllowed?: number | undefined;
+}
+
+/** All budgets, ascending by id. */
+export function listBudgets(db: PolicyDb): BudgetRow[] {
+  return db.select().from(budgets).orderBy(budgets.id).all();
+}
+
+/** All budgets for one user, ascending by id. */
+export function listUserBudgets(db: PolicyDb, userId: number): BudgetRow[] {
+  return db.select().from(budgets).where(eq(budgets.userId, userId)).orderBy(budgets.id).all();
+}
+
+/** One budget by id, or `undefined` if absent. */
+export function getBudget(db: PolicyDb, id: number): BudgetRow | undefined {
+  return db.select().from(budgets).where(eq(budgets.id, id)).get();
+}
+
+/**
+ * Insert a budget and return the stored row. The caller confirms the user
+ * exists first (an FK violation otherwise surfaces opaquely).
+ */
+export function createBudget(db: PolicyDb, input: BudgetCreate): BudgetRow {
+  return db
+    .insert(budgets)
+    .values({
+      userId: input.userId,
+      scope: input.scope,
+      targetId: input.targetId ?? null,
+      window: input.window,
+      secondsAllowed: input.secondsAllowed,
+    })
+    .returning()
+    .get();
+}
+
+/**
+ * Apply a partial update and return the stored row, or `undefined` if no
+ * budget with `id` exists. The route layer re-validates scope/target coherence
+ * on the merged row before calling this.
+ */
+export function updateBudget(db: PolicyDb, id: number, patch: BudgetUpdate): BudgetRow | undefined {
+  return db.update(budgets).set(patch).where(eq(budgets.id, id)).returning().get();
+}
+
+/** Delete a budget. Returns whether a row was removed. */
+export function deleteBudget(db: PolicyDb, id: number): boolean {
+  return (
+    db.delete(budgets).where(eq(budgets.id, id)).returning({ id: budgets.id }).get() !== undefined
+  );
+}
+
+// --- Schedules -------------------------------------------------------------
+
+/** A persisted {@link schedules} row. */
+export type ScheduleRow = typeof schedules.$inferSelect;
+
+/**
+ * Fields accepted when creating a {@link schedules} row. The recurrence +
+ * date-scoping fields (reserved by #146, ADR 0005) all default to `null` — the
+ * always-on degenerate. Timestamps are `Date`s (epoch-second storage); the
+ * route layer converts the DTO's ISO-8601 strings. `targetId` is the
+ * polymorphic referent (see {@link BudgetCreate}). `ordinal` defaults to the
+ * column default when omitted; the drag-reorder editor (#63) owns reordering.
+ */
+export interface ScheduleCreate {
+  userId: number;
+  targetKind: Scope;
+  targetId?: number | null | undefined;
+  action: ScheduleAction;
+  recurrenceDays?: number | null | undefined;
+  recurrenceStartMinute?: number | null | undefined;
+  recurrenceEndMinute?: number | null | undefined;
+  effectiveFrom?: Date | null | undefined;
+  effectiveTo?: Date | null | undefined;
+  ordinal?: number | undefined;
+}
+
+/** Mutable fields on a {@link schedules} row; omitted keys are left unchanged. */
+export interface ScheduleUpdate {
+  targetKind?: Scope | undefined;
+  targetId?: number | null | undefined;
+  action?: ScheduleAction | undefined;
+  recurrenceDays?: number | null | undefined;
+  recurrenceStartMinute?: number | null | undefined;
+  recurrenceEndMinute?: number | null | undefined;
+  effectiveFrom?: Date | null | undefined;
+  effectiveTo?: Date | null | undefined;
+  ordinal?: number | undefined;
+}
+
+/** All schedules, ascending by id. */
+export function listSchedules(db: PolicyDb): ScheduleRow[] {
+  return db.select().from(schedules).orderBy(schedules.id).all();
+}
+
+/** All schedules for one user, in evaluation order (ascending `ordinal`, then id). */
+export function listUserSchedules(db: PolicyDb, userId: number): ScheduleRow[] {
+  return db
+    .select()
+    .from(schedules)
+    .where(eq(schedules.userId, userId))
+    .orderBy(schedules.ordinal, schedules.id)
+    .all();
+}
+
+/** One schedule by id, or `undefined` if absent. */
+export function getSchedule(db: PolicyDb, id: number): ScheduleRow | undefined {
+  return db.select().from(schedules).where(eq(schedules.id, id)).get();
+}
+
+/**
+ * Insert a schedule and return the stored row. The caller confirms the user
+ * (and any activity/group referent) exists first; the recurrence + coherence
+ * invariants are validated by the DTO and the route before this is called.
+ */
+export function createSchedule(db: PolicyDb, input: ScheduleCreate): ScheduleRow {
+  return db
+    .insert(schedules)
+    .values({
+      userId: input.userId,
+      targetKind: input.targetKind,
+      targetId: input.targetId ?? null,
+      action: input.action,
+      recurrenceDays: input.recurrenceDays ?? null,
+      recurrenceStartMinute: input.recurrenceStartMinute ?? null,
+      recurrenceEndMinute: input.recurrenceEndMinute ?? null,
+      effectiveFrom: input.effectiveFrom ?? null,
+      effectiveTo: input.effectiveTo ?? null,
+      // Omit when undefined so the column default (0) applies.
+      ...(input.ordinal === undefined ? {} : { ordinal: input.ordinal }),
+    })
+    .returning()
+    .get();
+}
+
+/**
+ * Apply a partial update and return the stored row, or `undefined` if no
+ * schedule with `id` exists. The route re-validates coherence + recurrence on
+ * the merged row before calling this.
+ */
+export function updateSchedule(
+  db: PolicyDb,
+  id: number,
+  patch: ScheduleUpdate,
+): ScheduleRow | undefined {
+  return db.update(schedules).set(patch).where(eq(schedules.id, id)).returning().get();
+}
+
+/** Delete a schedule. Returns whether a row was removed. */
+export function deleteSchedule(db: PolicyDb, id: number): boolean {
+  return (
+    db.delete(schedules).where(eq(schedules.id, id)).returning({ id: schedules.id }).get() !==
+    undefined
+  );
+}
+
+// --- Exceptions ------------------------------------------------------------
+
+/** A persisted {@link exceptions} row. */
+export type ExceptionRow = typeof exceptions.$inferSelect;
+
+/**
+ * Fields accepted when creating an {@link exceptions} row. The override is
+ * active during `[effectiveFrom ?? createdAt, expiresAt)` (ADR 0005 §2);
+ * `effectiveFrom` NULL means active from creation. Timestamps are `Date`s.
+ */
+export interface ExceptionCreate {
+  userId: number;
+  targetKind: Scope;
+  targetId?: number | null | undefined;
+  action: ScheduleAction;
+  reason?: string | null | undefined;
+  effectiveFrom?: Date | null | undefined;
+  expiresAt: Date;
+}
+
+/** Mutable fields on an {@link exceptions} row; omitted keys are left unchanged. */
+export interface ExceptionUpdate {
+  targetKind?: Scope | undefined;
+  targetId?: number | null | undefined;
+  action?: ScheduleAction | undefined;
+  reason?: string | null | undefined;
+  effectiveFrom?: Date | null | undefined;
+  expiresAt?: Date | undefined;
+}
+
+/** All exceptions, ascending by id. */
+export function listExceptions(db: PolicyDb): ExceptionRow[] {
+  return db.select().from(exceptions).orderBy(exceptions.id).all();
+}
+
+/** All exceptions for one user, ascending by `expiresAt` (the hot lookup order). */
+export function listUserExceptions(db: PolicyDb, userId: number): ExceptionRow[] {
+  return db
+    .select()
+    .from(exceptions)
+    .where(eq(exceptions.userId, userId))
+    .orderBy(exceptions.expiresAt, exceptions.id)
+    .all();
+}
+
+/** One exception by id, or `undefined` if absent. */
+export function getException(db: PolicyDb, id: number): ExceptionRow | undefined {
+  return db.select().from(exceptions).where(eq(exceptions.id, id)).get();
+}
+
+/**
+ * Insert an exception and return the stored row. The caller confirms the user
+ * (and any activity/group referent) exists first; coherence and the
+ * `effectiveFrom < expiresAt` window are validated by the DTO/route.
+ */
+export function createException(db: PolicyDb, input: ExceptionCreate): ExceptionRow {
+  return db
+    .insert(exceptions)
+    .values({
+      userId: input.userId,
+      targetKind: input.targetKind,
+      targetId: input.targetId ?? null,
+      action: input.action,
+      reason: input.reason ?? null,
+      effectiveFrom: input.effectiveFrom ?? null,
+      expiresAt: input.expiresAt,
+    })
+    .returning()
+    .get();
+}
+
+/**
+ * Apply a partial update and return the stored row, or `undefined` if no
+ * exception with `id` exists. The route re-validates coherence and the
+ * effective window on the merged row before calling this.
+ */
+export function updateException(
+  db: PolicyDb,
+  id: number,
+  patch: ExceptionUpdate,
+): ExceptionRow | undefined {
+  return db.update(exceptions).set(patch).where(eq(exceptions.id, id)).returning().get();
+}
+
+/** Delete an exception. Returns whether a row was removed. */
+export function deleteException(db: PolicyDb, id: number): boolean {
+  return (
+    db.delete(exceptions).where(eq(exceptions.id, id)).returning({ id: exceptions.id }).get() !==
+    undefined
+  );
+}
+
 /**
  * Whether an error thrown by better-sqlite3 is a UNIQUE/PRIMARY-KEY constraint
  * violation, which the route layer maps to `409 conflict`. Reads `.code`
@@ -206,4 +671,18 @@ export function isUniqueViolation(err: unknown): boolean {
   if (typeof err !== "object" || err === null) return false;
   const code = Reflect.get(err, "code");
   return code === "SQLITE_CONSTRAINT_UNIQUE" || code === "SQLITE_CONSTRAINT_PRIMARYKEY";
+}
+
+/**
+ * Whether an error thrown by better-sqlite3 is a `CHECK` constraint violation,
+ * which the route layer maps to `400 validation_error` rather than leaking a
+ * generic 500 (#148: "map the schema's CHECK constraints to clear 400/409s").
+ * This backstops the storage invariants — budget non-negativity / target
+ * coherence, schedule recurrence bounds, the exception effective window — for
+ * the cases a PATCH merge can violate without the DTO seeing the merged row.
+ * Reads `.code` structurally so no `as` cast or `any` is needed.
+ */
+export function isCheckViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  return Reflect.get(err, "code") === "SQLITE_CONSTRAINT_CHECK";
 }

--- a/server/src/transport/stub.ts
+++ b/server/src/transport/stub.ts
@@ -30,8 +30,14 @@ export const PUSH_STUB_COMPONENT = "transport/stub";
 export const PUSH_STUB_MESSAGE = "stub transport: would push policy change to client";
 
 /**
- * Which policy mutation triggered a would-be push. Mirrors the #51 CRUD
+ * Which policy mutation triggered a would-be push. Mirrors the #51/#148 CRUD
  * operations one-to-one so a log reader can trace a line back to its cause.
+ *
+ * `budget.*`, `schedule.*`, and `exception.*` are user-scoped (#148): they
+ * change what is enforced for one supervised user, so a real transport would
+ * push to every client that user is linked to — exactly like `user.*`.
+ * Activity / ActivityGroup / membership are *definitions* with no per-client
+ * effect until a budget or schedule references them, so they do not push.
  */
 export type PolicyPushReason =
   | "user.created"
@@ -41,7 +47,16 @@ export type PolicyPushReason =
   | "client.updated"
   | "client.deleted"
   | "link.upserted"
-  | "link.deleted";
+  | "link.deleted"
+  | "budget.created"
+  | "budget.updated"
+  | "budget.deleted"
+  | "schedule.created"
+  | "schedule.updated"
+  | "schedule.deleted"
+  | "exception.created"
+  | "exception.updated"
+  | "exception.deleted";
 
 /**
  * The intended effect of one policy mutation on **one** client — the unit a
@@ -62,8 +77,15 @@ export interface PolicyPushCommand {
   readonly detail: Readonly<Record<string, unknown>>;
 }
 
-/** A user-scoped change reason (affects every client the user is linked to). */
-export type UserPushReason = Extract<PolicyPushReason, `user.${string}`>;
+/**
+ * A change reason that affects every client a single user is linked to: the
+ * `user.*` account changes plus the user-scoped policy changes (`budget.*`,
+ * `schedule.*`, `exception.*`). All fan out the same way.
+ */
+export type UserPushReason = Extract<
+  PolicyPushReason,
+  `user.${string}` | `budget.${string}` | `schedule.${string}` | `exception.${string}`
+>;
 /** A client-scoped change reason (affects that one client). */
 export type ClientPushReason = Extract<PolicyPushReason, `client.${string}`>;
 /** A link-scoped change reason (affects that one user/client pair). */
@@ -73,8 +95,10 @@ export type LinkPushReason = Extract<PolicyPushReason, `link.${string}`>;
  * Commands for a user-level change: one per client the user is linked to.
  *
  * `clientIds` must be resolved by the caller *before* a delete, since the
- * `UserOnClient` links cascade away with the user. A user with no links yields
- * an empty list (nothing is enforced anywhere yet → no push).
+ * `UserOnClient` links cascade away with the user (and a budget/schedule/
+ * exception delete needs its owner's clients resolved before the row is gone).
+ * A user with no links yields an empty list (nothing is enforced anywhere yet →
+ * no push).
  */
 export function userPushCommands(
   reason: UserPushReason,

--- a/server/tests/api/policy-dtos.test.ts
+++ b/server/tests/api/policy-dtos.test.ts
@@ -6,8 +6,20 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { toClientResponse, toUserResponse } from "../../src/api/policy/dtos.js";
-import type { ClientRow, UserRow } from "../../src/policy/repository.js";
+import {
+  toBudgetResponse,
+  toClientResponse,
+  toExceptionResponse,
+  toScheduleResponse,
+  toUserResponse,
+} from "../../src/api/policy/dtos.js";
+import type {
+  BudgetRow,
+  ClientRow,
+  ExceptionRow,
+  ScheduleRow,
+  UserRow,
+} from "../../src/policy/repository.js";
 
 describe("policy DTO mappers", () => {
   it("maps a user row, preserving a null tz", () => {
@@ -53,5 +65,78 @@ describe("policy DTO mappers", () => {
       lastSeen: null,
     };
     expect(toClientResponse(row).lastSeen).toBeNull();
+  });
+
+  it("maps a budget row, preserving the polymorphic target", () => {
+    const row: BudgetRow = {
+      id: 4,
+      userId: 1,
+      scope: "activity",
+      targetId: 9,
+      window: "weekly",
+      secondsAllowed: 3600,
+    };
+    expect(toBudgetResponse(row)).toEqual({
+      id: 4,
+      userId: 1,
+      scope: "activity",
+      targetId: 9,
+      window: "weekly",
+      secondsAllowed: 3600,
+    });
+  });
+
+  it("maps a schedule row, serializing the effective window and keeping null recurrence", () => {
+    const row: ScheduleRow = {
+      id: 5,
+      userId: 1,
+      targetKind: "overall",
+      targetId: null,
+      recurrenceDays: 31,
+      recurrenceStartMinute: 540,
+      recurrenceEndMinute: 1020,
+      effectiveFrom: new Date("2026-09-01T00:00:00.000Z"),
+      effectiveTo: null,
+      action: "allow",
+      ordinal: 2,
+    };
+    expect(toScheduleResponse(row)).toEqual({
+      id: 5,
+      userId: 1,
+      targetKind: "overall",
+      targetId: null,
+      recurrenceDays: 31,
+      recurrenceStartMinute: 540,
+      recurrenceEndMinute: 1020,
+      effectiveFrom: "2026-09-01T00:00:00.000Z",
+      effectiveTo: null,
+      action: "allow",
+      ordinal: 2,
+    });
+  });
+
+  it("maps an exception row, serializing timestamps and a null effectiveFrom", () => {
+    const row: ExceptionRow = {
+      id: 6,
+      userId: 1,
+      targetKind: "overall",
+      targetId: null,
+      action: "allow",
+      reason: "Birthday",
+      effectiveFrom: null,
+      expiresAt: new Date("2026-07-01T21:00:00.000Z"),
+      createdAt: new Date("2026-06-30T10:00:00.000Z"),
+    };
+    expect(toExceptionResponse(row)).toEqual({
+      id: 6,
+      userId: 1,
+      targetKind: "overall",
+      targetId: null,
+      action: "allow",
+      reason: "Birthday",
+      effectiveFrom: null,
+      expiresAt: "2026-07-01T21:00:00.000Z",
+      createdAt: "2026-06-30T10:00:00.000Z",
+    });
   });
 });

--- a/server/tests/api/policy-push-stub.test.ts
+++ b/server/tests/api/policy-push-stub.test.ts
@@ -272,6 +272,54 @@ describe("stub transport push on policy change (#54)", () => {
     expect(pushed[0]).toMatchObject({ clientId, userId, reason: "budget.deleted" });
   });
 
+  it("logs a budget.updated push carrying the budget id to each linked client", async () => {
+    const { userId, clientId } = await linkedUser();
+    const budget = (
+      await auth({
+        method: "POST",
+        url: "/api/budgets",
+        payload: { userId, scope: "overall", window: "daily", secondsAllowed: 7200 },
+      })
+    ).json();
+
+    await auth({
+      method: "PATCH",
+      url: `/api/budgets/${budget.id}`,
+      payload: { secondsAllowed: 3600 },
+    });
+
+    const pushed = pushLines("budget.updated");
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).toMatchObject({
+      clientId,
+      userId,
+      reason: "budget.updated",
+      detail: { budgetId: budget.id, secondsAllowed: 3600 },
+    });
+  });
+
+  it("logs a schedule.deleted push (clients resolved before the row is gone)", async () => {
+    const { userId, clientId } = await linkedUser();
+    const schedule = (
+      await auth({
+        method: "POST",
+        url: "/api/schedules",
+        payload: { userId, targetKind: "overall", action: "deny" },
+      })
+    ).json();
+
+    await auth({ method: "DELETE", url: `/api/schedules/${schedule.id}` });
+
+    const pushed = pushLines("schedule.deleted");
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).toMatchObject({
+      clientId,
+      userId,
+      reason: "schedule.deleted",
+      detail: { scheduleId: schedule.id },
+    });
+  });
+
   it("logs schedule.created and exception.created pushes to the linked client", async () => {
     const { userId, clientId } = await linkedUser();
     await auth({

--- a/server/tests/api/policy-push-stub.test.ts
+++ b/server/tests/api/policy-push-stub.test.ts
@@ -224,6 +224,87 @@ describe("stub transport push on policy change (#54)", () => {
     expect(pushed[0]).toMatchObject({ clientId, userId, reason: "link.deleted" });
   });
 
+  /** A user linked to one client, ready for user-scoped policy pushes (#148). */
+  async function linkedUser(): Promise<{ userId: number; clientId: number }> {
+    const { userId, clientId } = await makeUserAndClient();
+    await auth({
+      method: "PUT",
+      url: `/api/users/${userId}/clients/${clientId}`,
+      payload: { linuxUsername: "alice", linuxUid: 1001 },
+    });
+    return { userId, clientId };
+  }
+
+  it("logs a budget.created push to each linked client (#148)", async () => {
+    const { userId, clientId } = await linkedUser();
+    const budget = (
+      await auth({
+        method: "POST",
+        url: "/api/budgets",
+        payload: { userId, scope: "overall", window: "daily", secondsAllowed: 7200 },
+      })
+    ).json();
+
+    const pushed = pushLines("budget.created");
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).toMatchObject({
+      clientId,
+      userId,
+      reason: "budget.created",
+      detail: { budgetId: budget.id, scope: "overall", secondsAllowed: 7200 },
+    });
+  });
+
+  it("logs a budget.deleted push (clients resolved before the row is gone)", async () => {
+    const { userId, clientId } = await linkedUser();
+    const budget = (
+      await auth({
+        method: "POST",
+        url: "/api/budgets",
+        payload: { userId, scope: "overall", window: "daily", secondsAllowed: 1 },
+      })
+    ).json();
+
+    await auth({ method: "DELETE", url: `/api/budgets/${budget.id}` });
+
+    const pushed = pushLines("budget.deleted");
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).toMatchObject({ clientId, userId, reason: "budget.deleted" });
+  });
+
+  it("logs schedule.created and exception.created pushes to the linked client", async () => {
+    const { userId, clientId } = await linkedUser();
+    await auth({
+      method: "POST",
+      url: "/api/schedules",
+      payload: { userId, targetKind: "overall", action: "deny" },
+    });
+    await auth({
+      method: "POST",
+      url: "/api/exceptions",
+      payload: {
+        userId,
+        targetKind: "overall",
+        action: "allow",
+        expiresAt: "2026-07-01T00:00:00.000Z",
+      },
+    });
+
+    const sched = pushLines("schedule.created");
+    expect(sched).toHaveLength(1);
+    expect(sched[0]).toMatchObject({ clientId, userId, reason: "schedule.created" });
+
+    const exc = pushLines("exception.created");
+    expect(exc).toHaveLength(1);
+    expect(exc[0]).toMatchObject({ clientId, userId, reason: "exception.created" });
+  });
+
+  it("does not push for activity/group definitions (no per-client effect)", async () => {
+    await auth({ method: "POST", url: "/api/activities", payload: { kind: "app", matcher: "x" } });
+    await auth({ method: "POST", url: "/api/activity-groups", payload: { name: "G" } });
+    expect(pushLines().length).toBe(0);
+  });
+
   it("does not emit a stub line for reads or rejected writes", async () => {
     const before = pushLines().length;
 

--- a/server/tests/api/policy.test.ts
+++ b/server/tests/api/policy.test.ts
@@ -360,3 +360,481 @@ describe("policy CRUD routes", () => {
     expect(again.statusCode).toBe(404);
   });
 });
+
+describe("policy CRUD routes — policy model (#148)", () => {
+  let harness: TestApp;
+  let cookie: string;
+
+  beforeEach(async () => {
+    harness = buildTestApp({ appOptions: { settings: configuredSettings() } });
+    await harness.app.ready();
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    cookie = sessionCookie(login);
+  });
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  function auth(opts: InjectOptions) {
+    return harness.app.inject({ ...opts, headers: { ...opts.headers, cookie } });
+  }
+
+  async function makeUser(displayName = "Alice"): Promise<number> {
+    return (await auth({ method: "POST", url: "/api/users", payload: { displayName } })).json().id;
+  }
+
+  async function makeActivity(matcher = "firefox"): Promise<number> {
+    return (
+      await auth({ method: "POST", url: "/api/activities", payload: { kind: "app", matcher } })
+    ).json().id;
+  }
+
+  // --- auth guard ----------------------------------------------------------
+
+  it("rejects anonymous access to the new collections with a 401", async () => {
+    for (const url of [
+      "/api/activities",
+      "/api/activity-groups",
+      "/api/budgets",
+      "/api/schedules",
+      "/api/exceptions",
+    ]) {
+      const res = await harness.app.inject({ method: "GET", url });
+      expect(res.statusCode).toBe(401);
+      expect(res.json().error.code).toBe("unauthorized");
+    }
+  });
+
+  // --- activities ----------------------------------------------------------
+
+  it("CRUDs an activity", async () => {
+    const created = await auth({
+      method: "POST",
+      url: "/api/activities",
+      payload: { kind: "domain", matcher: "youtube.com" },
+    });
+    expect(created.statusCode).toBe(201);
+    const body = created.json();
+    expect(body).toMatchObject({ kind: "domain", matcher: "youtube.com" });
+
+    const patched = await auth({
+      method: "PATCH",
+      url: `/api/activities/${body.id}`,
+      payload: { matcher: "m.youtube.com" },
+    });
+    expect(patched.json().matcher).toBe("m.youtube.com");
+
+    expect((await auth({ method: "GET", url: "/api/activities" })).json()).toHaveLength(1);
+
+    const del = await auth({ method: "DELETE", url: `/api/activities/${body.id}` });
+    expect(del.statusCode).toBe(204);
+    expect((await auth({ method: "GET", url: `/api/activities/${body.id}` })).statusCode).toBe(404);
+  });
+
+  it("rejects an invalid activity kind (400) and an empty PATCH (400)", async () => {
+    const bad = await auth({
+      method: "POST",
+      url: "/api/activities",
+      payload: { kind: "nonsense", matcher: "x" },
+    });
+    expect(bad.statusCode).toBe(400);
+    expect(bad.json().error.code).toBe("validation_error");
+
+    const id = await makeActivity();
+    const empty = await auth({ method: "PATCH", url: `/api/activities/${id}`, payload: {} });
+    expect(empty.statusCode).toBe(400);
+  });
+
+  // --- activity groups + membership ----------------------------------------
+
+  it("CRUDs a group and manages its membership", async () => {
+    const group = (
+      await auth({ method: "POST", url: "/api/activity-groups", payload: { name: "Social" } })
+    ).json();
+    expect(group.name).toBe("Social");
+
+    const dup = await auth({
+      method: "POST",
+      url: "/api/activity-groups",
+      payload: { name: "Social" },
+    });
+    expect(dup.statusCode).toBe(409);
+
+    const fb = await makeActivity("facebook.com");
+    const put = await auth({
+      method: "PUT",
+      url: `/api/activity-groups/${group.id}/activities/${fb}`,
+    });
+    expect(put.statusCode).toBe(204);
+    // Idempotent re-add.
+    expect(
+      (await auth({ method: "PUT", url: `/api/activity-groups/${group.id}/activities/${fb}` }))
+        .statusCode,
+    ).toBe(204);
+
+    const members = await auth({
+      method: "GET",
+      url: `/api/activity-groups/${group.id}/activities`,
+    });
+    expect(members.json()).toHaveLength(1);
+    expect(members.json()[0].id).toBe(fb);
+
+    const del = await auth({
+      method: "DELETE",
+      url: `/api/activity-groups/${group.id}/activities/${fb}`,
+    });
+    expect(del.statusCode).toBe(204);
+    // Removing a non-membership 404s.
+    expect(
+      (await auth({ method: "DELETE", url: `/api/activity-groups/${group.id}/activities/${fb}` }))
+        .statusCode,
+    ).toBe(404);
+  });
+
+  it("404s membership ops against a missing group or activity", async () => {
+    const group = (
+      await auth({ method: "POST", url: "/api/activity-groups", payload: { name: "G" } })
+    ).json();
+    const activity = await makeActivity();
+    expect(
+      (await auth({ method: "GET", url: `/api/activity-groups/999/activities` })).statusCode,
+    ).toBe(404);
+    expect(
+      (await auth({ method: "PUT", url: `/api/activity-groups/999/activities/${activity}` }))
+        .statusCode,
+    ).toBe(404);
+    expect(
+      (await auth({ method: "PUT", url: `/api/activity-groups/${group.id}/activities/999` }))
+        .statusCode,
+    ).toBe(404);
+  });
+
+  // --- budgets -------------------------------------------------------------
+
+  it("creates an overall budget and reads it back, filtered by user", async () => {
+    const userId = await makeUser();
+    const created = await auth({
+      method: "POST",
+      url: "/api/budgets",
+      payload: { userId, scope: "overall", window: "daily", secondsAllowed: 7200 },
+    });
+    expect(created.statusCode).toBe(201);
+    const body = created.json();
+    expect(body).toMatchObject({ scope: "overall", targetId: null, secondsAllowed: 7200 });
+
+    const filtered = await auth({ method: "GET", url: `/api/budgets?userId=${userId}` });
+    expect(filtered.json()).toHaveLength(1);
+    expect((await auth({ method: "GET", url: `/api/budgets?userId=999` })).json()).toEqual([]);
+
+    const patched = await auth({
+      method: "PATCH",
+      url: `/api/budgets/${body.id}`,
+      payload: { secondsAllowed: 3600 },
+    });
+    expect(patched.json().secondsAllowed).toBe(3600);
+
+    expect((await auth({ method: "DELETE", url: `/api/budgets/${body.id}` })).statusCode).toBe(204);
+  });
+
+  it("creates an activity-scoped budget against an existing target", async () => {
+    const userId = await makeUser();
+    const activityId = await makeActivity("steam");
+    const res = await auth({
+      method: "POST",
+      url: "/api/budgets",
+      payload: {
+        userId,
+        scope: "activity",
+        targetId: activityId,
+        window: "weekly",
+        secondsAllowed: 3600,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({ scope: "activity", targetId: activityId });
+  });
+
+  it("enforces budget target coherence and referent existence (400)", async () => {
+    const userId = await makeUser();
+    const overallWithTarget = await auth({
+      method: "POST",
+      url: "/api/budgets",
+      payload: { userId, scope: "overall", targetId: 1, window: "daily", secondsAllowed: 1 },
+    });
+    expect(overallWithTarget.statusCode).toBe(400);
+
+    const activityNoTarget = await auth({
+      method: "POST",
+      url: "/api/budgets",
+      payload: { userId, scope: "activity", window: "daily", secondsAllowed: 1 },
+    });
+    expect(activityNoTarget.statusCode).toBe(400);
+
+    const danglingTarget = await auth({
+      method: "POST",
+      url: "/api/budgets",
+      payload: { userId, scope: "activity", targetId: 999, window: "daily", secondsAllowed: 1 },
+    });
+    expect(danglingTarget.statusCode).toBe(400);
+  });
+
+  it("404s a budget for a missing user and 400s a negative allowance", async () => {
+    const missingUser = await auth({
+      method: "POST",
+      url: "/api/budgets",
+      payload: { userId: 999, scope: "overall", window: "daily", secondsAllowed: 1 },
+    });
+    expect(missingUser.statusCode).toBe(404);
+
+    const userId = await makeUser();
+    const negative = await auth({
+      method: "POST",
+      url: "/api/budgets",
+      payload: { userId, scope: "overall", window: "daily", secondsAllowed: -1 },
+    });
+    expect(negative.statusCode).toBe(400);
+  });
+
+  it("re-checks budget coherence on PATCH against the merged row (400)", async () => {
+    const userId = await makeUser();
+    const activityId = await makeActivity("steam");
+    const budget = (
+      await auth({
+        method: "POST",
+        url: "/api/budgets",
+        payload: {
+          userId,
+          scope: "activity",
+          targetId: activityId,
+          window: "daily",
+          secondsAllowed: 60,
+        },
+      })
+    ).json();
+    const bad = await auth({
+      method: "PATCH",
+      url: `/api/budgets/${budget.id}`,
+      payload: { scope: "overall" },
+    });
+    expect(bad.statusCode).toBe(400);
+    const ok = await auth({
+      method: "PATCH",
+      url: `/api/budgets/${budget.id}`,
+      payload: { scope: "overall", targetId: null },
+    });
+    expect(ok.statusCode).toBe(200);
+    expect(ok.json()).toMatchObject({ scope: "overall", targetId: null });
+  });
+
+  it("404s budget GET/PATCH/DELETE for a missing id", async () => {
+    expect((await auth({ method: "GET", url: "/api/budgets/999" })).statusCode).toBe(404);
+    expect(
+      (await auth({ method: "PATCH", url: "/api/budgets/999", payload: { secondsAllowed: 1 } }))
+        .statusCode,
+    ).toBe(404);
+    expect((await auth({ method: "DELETE", url: "/api/budgets/999" })).statusCode).toBe(404);
+  });
+
+  // --- schedules -----------------------------------------------------------
+
+  it("creates an always-on schedule and a recurring window", async () => {
+    const userId = await makeUser();
+    const alwaysOn = await auth({
+      method: "POST",
+      url: "/api/schedules",
+      payload: { userId, targetKind: "overall", action: "deny" },
+    });
+    expect(alwaysOn.statusCode).toBe(201);
+    expect(alwaysOn.json()).toMatchObject({
+      targetKind: "overall",
+      action: "deny",
+      recurrenceDays: null,
+      effectiveFrom: null,
+      ordinal: 0,
+    });
+
+    const window = await auth({
+      method: "POST",
+      url: "/api/schedules",
+      payload: {
+        userId,
+        targetKind: "overall",
+        action: "allow",
+        recurrenceDays: 31,
+        recurrenceStartMinute: 540,
+        recurrenceEndMinute: 1020,
+        effectiveFrom: "2026-09-01T00:00:00.000Z",
+      },
+    });
+    expect(window.statusCode).toBe(201);
+    expect(window.json()).toMatchObject({
+      recurrenceStartMinute: 540,
+      recurrenceEndMinute: 1020,
+      effectiveFrom: "2026-09-01T00:00:00.000Z",
+    });
+
+    expect(
+      (await auth({ method: "GET", url: `/api/schedules?userId=${userId}` })).json(),
+    ).toHaveLength(2);
+  });
+
+  it("rejects a half-open recurrence pair on create (400)", async () => {
+    const userId = await makeUser();
+    const res = await auth({
+      method: "POST",
+      url: "/api/schedules",
+      payload: { userId, targetKind: "overall", action: "allow", recurrenceStartMinute: 540 },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("enforces schedule coherence and a missing user", async () => {
+    const userId = await makeUser();
+    const incoherent = await auth({
+      method: "POST",
+      url: "/api/schedules",
+      payload: { userId, targetKind: "activity", action: "allow" },
+    });
+    expect(incoherent.statusCode).toBe(400);
+
+    const missingUser = await auth({
+      method: "POST",
+      url: "/api/schedules",
+      payload: { userId: 999, targetKind: "overall", action: "allow" },
+    });
+    expect(missingUser.statusCode).toBe(404);
+  });
+
+  it("PATCHes a schedule and backstops a merged-row recurrence break (400)", async () => {
+    const userId = await makeUser();
+    const schedule = (
+      await auth({
+        method: "POST",
+        url: "/api/schedules",
+        payload: { userId, targetKind: "overall", action: "deny" },
+      })
+    ).json();
+
+    const ok = await auth({
+      method: "PATCH",
+      url: `/api/schedules/${schedule.id}`,
+      payload: { action: "allow", ordinal: 3 },
+    });
+    expect(ok.json()).toMatchObject({ action: "allow", ordinal: 3 });
+
+    const halfOpen = await auth({
+      method: "PATCH",
+      url: `/api/schedules/${schedule.id}`,
+      payload: { recurrenceStartMinute: 540 },
+    });
+    expect(halfOpen.statusCode).toBe(400);
+
+    expect(
+      (await auth({ method: "DELETE", url: `/api/schedules/${schedule.id}` })).statusCode,
+    ).toBe(204);
+    expect((await auth({ method: "GET", url: `/api/schedules/${schedule.id}` })).statusCode).toBe(
+      404,
+    );
+  });
+
+  // --- exceptions ----------------------------------------------------------
+
+  it("creates an exception, reads it, and filters by user", async () => {
+    const userId = await makeUser();
+    const created = await auth({
+      method: "POST",
+      url: "/api/exceptions",
+      payload: {
+        userId,
+        targetKind: "overall",
+        action: "allow",
+        reason: "Birthday",
+        expiresAt: "2026-07-01T21:00:00.000Z",
+      },
+    });
+    expect(created.statusCode).toBe(201);
+    const body = created.json();
+    expect(body).toMatchObject({
+      reason: "Birthday",
+      expiresAt: "2026-07-01T21:00:00.000Z",
+      effectiveFrom: null,
+    });
+    expect(typeof body.createdAt).toBe("string");
+
+    expect(
+      (await auth({ method: "GET", url: `/api/exceptions?userId=${userId}` })).json(),
+    ).toHaveLength(1);
+    expect((await auth({ method: "GET", url: `/api/exceptions/${body.id}` })).statusCode).toBe(200);
+  });
+
+  it("rejects an exception whose window is empty (400) and a missing user (404)", async () => {
+    const userId = await makeUser();
+    const emptyWindow = await auth({
+      method: "POST",
+      url: "/api/exceptions",
+      payload: {
+        userId,
+        targetKind: "overall",
+        action: "allow",
+        effectiveFrom: "2026-07-02T00:00:00.000Z",
+        expiresAt: "2026-07-01T00:00:00.000Z",
+      },
+    });
+    expect(emptyWindow.statusCode).toBe(400);
+
+    const missingUser = await auth({
+      method: "POST",
+      url: "/api/exceptions",
+      payload: {
+        userId: 999,
+        targetKind: "overall",
+        action: "allow",
+        expiresAt: "2026-07-01T00:00:00.000Z",
+      },
+    });
+    expect(missingUser.statusCode).toBe(404);
+  });
+
+  it("PATCHes an exception and backstops a merged-row window break (400)", async () => {
+    const userId = await makeUser();
+    const exception = (
+      await auth({
+        method: "POST",
+        url: "/api/exceptions",
+        payload: {
+          userId,
+          targetKind: "overall",
+          action: "allow",
+          expiresAt: "2026-07-10T00:00:00.000Z",
+        },
+      })
+    ).json();
+
+    const ok = await auth({
+      method: "PATCH",
+      url: `/api/exceptions/${exception.id}`,
+      payload: { reason: "Updated" },
+    });
+    expect(ok.json().reason).toBe("Updated");
+
+    const bad = await auth({
+      method: "PATCH",
+      url: `/api/exceptions/${exception.id}`,
+      payload: { effectiveFrom: "2026-07-20T00:00:00.000Z" },
+    });
+    expect(bad.statusCode).toBe(400);
+
+    expect(
+      (await auth({ method: "DELETE", url: `/api/exceptions/${exception.id}` })).statusCode,
+    ).toBe(204);
+    expect((await auth({ method: "GET", url: `/api/exceptions/${exception.id}` })).statusCode).toBe(
+      404,
+    );
+  });
+});

--- a/server/tests/policy/repository.test.ts
+++ b/server/tests/policy/repository.test.ts
@@ -176,3 +176,295 @@ describe("isUniqueViolation", () => {
     expect(repo.isUniqueViolation({ code: "SQLITE_CONSTRAINT_PRIMARYKEY" })).toBe(true);
   });
 });
+
+describe("isCheckViolation", () => {
+  it("is false for non-CHECK values", () => {
+    expect(repo.isCheckViolation(null)).toBe(false);
+    expect(repo.isCheckViolation(new Error("boom"))).toBe(false);
+    expect(repo.isCheckViolation({ code: "SQLITE_CONSTRAINT_UNIQUE" })).toBe(false);
+  });
+
+  it("is true for the CHECK constraint code", () => {
+    expect(repo.isCheckViolation({ code: "SQLITE_CONSTRAINT_CHECK" })).toBe(true);
+  });
+});
+
+describe("policy repository — activities & groups", () => {
+  let db: TestDb;
+  beforeEach(() => {
+    db = testDb();
+  });
+  afterEach(() => {
+    db.$client.close();
+  });
+
+  it("creates, reads, lists, updates, and deletes an activity", () => {
+    const created = repo.createActivity(db, { kind: "app", matcher: "firefox" });
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.kind).toBe("app");
+
+    expect(repo.getActivity(db, created.id)).toEqual(created);
+    expect(repo.listActivities(db)).toEqual([created]);
+
+    const updated = repo.updateActivity(db, created.id, { matcher: "firefox-esr" });
+    expect(updated?.matcher).toBe("firefox-esr");
+    expect(updated?.kind).toBe("app");
+
+    expect(repo.deleteActivity(db, created.id)).toBe(true);
+    expect(repo.getActivity(db, created.id)).toBeUndefined();
+    expect(repo.deleteActivity(db, created.id)).toBe(false);
+  });
+
+  it("returns undefined for a missing activity update", () => {
+    expect(repo.updateActivity(db, 999, { matcher: "x" })).toBeUndefined();
+  });
+
+  it("creates a group and surfaces a duplicate name as a unique violation", () => {
+    const group = repo.createActivityGroup(db, { name: "Social" });
+    expect(group.name).toBe("Social");
+    expect(repo.listActivityGroups(db)).toEqual([group]);
+
+    let caught: unknown;
+    try {
+      repo.createActivityGroup(db, { name: "Social" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(repo.isUniqueViolation(caught)).toBe(true);
+  });
+
+  it("renames a group and surfaces a missing one as undefined", () => {
+    const group = repo.createActivityGroup(db, { name: "Social" });
+    const renamed = repo.updateActivityGroup(db, group.id, { name: "Socials" });
+    expect(renamed?.name).toBe("Socials");
+    expect(repo.updateActivityGroup(db, 999, { name: "x" })).toBeUndefined();
+  });
+
+  it("manages membership idempotently and cascades on delete", () => {
+    const group = repo.createActivityGroup(db, { name: "Social" });
+    const fb = repo.createActivity(db, { kind: "domain", matcher: "facebook.com" });
+    const ig = repo.createActivity(db, { kind: "domain", matcher: "instagram.com" });
+
+    repo.addActivityToGroup(db, group.id, fb.id);
+    repo.addActivityToGroup(db, group.id, fb.id); // idempotent — no throw, no dup
+    repo.addActivityToGroup(db, group.id, ig.id);
+
+    expect(repo.isGroupMember(db, group.id, fb.id)).toBe(true);
+    expect(repo.listGroupActivities(db, group.id)).toEqual([fb, ig]);
+
+    expect(repo.removeActivityFromGroup(db, group.id, fb.id)).toBe(true);
+    expect(repo.removeActivityFromGroup(db, group.id, fb.id)).toBe(false);
+    expect(repo.isGroupMember(db, group.id, fb.id)).toBe(false);
+
+    // Deleting the group cascades its memberships away.
+    repo.deleteActivityGroup(db, group.id);
+    expect(repo.listGroupActivities(db, group.id)).toEqual([]);
+    // The activity itself survives the group deletion.
+    expect(repo.getActivity(db, ig.id)).toBeDefined();
+  });
+
+  it("cascades membership when the activity is deleted", () => {
+    const group = repo.createActivityGroup(db, { name: "Games" });
+    const steam = repo.createActivity(db, { kind: "app", matcher: "steam" });
+    repo.addActivityToGroup(db, group.id, steam.id);
+    repo.deleteActivity(db, steam.id);
+    expect(repo.listGroupActivities(db, group.id)).toEqual([]);
+  });
+});
+
+describe("policy repository — budgets", () => {
+  let db: TestDb;
+  let userId: number;
+  beforeEach(() => {
+    db = testDb();
+    userId = repo.createUser(db, { displayName: "Alice" }).id;
+  });
+  afterEach(() => {
+    db.$client.close();
+  });
+
+  it("creates, reads, lists (all + per-user), updates, and deletes", () => {
+    const overall = repo.createBudget(db, {
+      userId,
+      scope: "overall",
+      window: "daily",
+      secondsAllowed: 7200,
+    });
+    expect(overall.targetId).toBeNull();
+    expect(repo.getBudget(db, overall.id)).toEqual(overall);
+    expect(repo.listBudgets(db)).toEqual([overall]);
+    expect(repo.listUserBudgets(db, userId)).toEqual([overall]);
+    expect(repo.listUserBudgets(db, 999)).toEqual([]);
+
+    const updated = repo.updateBudget(db, overall.id, { secondsAllowed: 3600 });
+    expect(updated?.secondsAllowed).toBe(3600);
+
+    expect(repo.deleteBudget(db, overall.id)).toBe(true);
+    expect(repo.deleteBudget(db, overall.id)).toBe(false);
+  });
+
+  it("stores an activity-scoped budget with its target", () => {
+    const activity = repo.createActivity(db, { kind: "app", matcher: "steam" });
+    const row = repo.createBudget(db, {
+      userId,
+      scope: "activity",
+      targetId: activity.id,
+      window: "weekly",
+      secondsAllowed: 3600,
+    });
+    expect(row.scope).toBe("activity");
+    expect(row.targetId).toBe(activity.id);
+  });
+
+  it("cascades budgets when the user is deleted", () => {
+    repo.createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 1 });
+    repo.deleteUser(db, userId);
+    expect(repo.listBudgets(db)).toEqual([]);
+  });
+
+  it("rejects a negative allowance at the storage CHECK", () => {
+    let caught: unknown;
+    try {
+      repo.createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: -1 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(repo.isCheckViolation(caught)).toBe(true);
+  });
+
+  it("rejects an incoherent target at the storage CHECK", () => {
+    let caught: unknown;
+    try {
+      // overall scope must not carry a target_id.
+      repo.createBudget(db, {
+        userId,
+        scope: "overall",
+        targetId: 5,
+        window: "daily",
+        secondsAllowed: 1,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(repo.isCheckViolation(caught)).toBe(true);
+  });
+});
+
+describe("policy repository — schedules & exceptions", () => {
+  let db: TestDb;
+  let userId: number;
+  beforeEach(() => {
+    db = testDb();
+    userId = repo.createUser(db, { displayName: "Alice" }).id;
+  });
+  afterEach(() => {
+    db.$client.close();
+  });
+
+  it("stores the always-on degenerate schedule (all recurrence null)", () => {
+    const row = repo.createSchedule(db, {
+      userId,
+      targetKind: "overall",
+      action: "deny",
+    });
+    expect(row.recurrenceDays).toBeNull();
+    expect(row.recurrenceStartMinute).toBeNull();
+    expect(row.effectiveFrom).toBeNull();
+    expect(row.ordinal).toBe(0); // column default
+  });
+
+  it("stores a recurring window and orders by (ordinal, id)", () => {
+    const second = repo.createSchedule(db, {
+      userId,
+      targetKind: "overall",
+      action: "allow",
+      recurrenceDays: 0b0011111, // Mon–Fri
+      recurrenceStartMinute: 9 * 60,
+      recurrenceEndMinute: 17 * 60,
+      ordinal: 5,
+    });
+    const first = repo.createSchedule(db, {
+      userId,
+      targetKind: "overall",
+      action: "deny",
+      ordinal: 1,
+    });
+    expect(repo.listUserSchedules(db, userId).map((r) => r.id)).toEqual([first.id, second.id]);
+    expect(repo.listSchedules(db).map((r) => r.id)).toEqual(
+      [first.id, second.id].sort((a, b) => a - b),
+    );
+
+    const updated = repo.updateSchedule(db, second.id, { ordinal: 0 });
+    expect(updated?.ordinal).toBe(0);
+    expect(repo.deleteSchedule(db, second.id)).toBe(true);
+    expect(repo.deleteSchedule(db, second.id)).toBe(false);
+  });
+
+  it("rejects a half-open minute pair at the storage CHECK", () => {
+    let caught: unknown;
+    try {
+      repo.createSchedule(db, {
+        userId,
+        targetKind: "overall",
+        action: "allow",
+        recurrenceStartMinute: 540, // start without end
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(repo.isCheckViolation(caught)).toBe(true);
+  });
+
+  it("creates an exception with a pre-schedule window and orders by expiry", () => {
+    const later = repo.createException(db, {
+      userId,
+      targetKind: "overall",
+      action: "allow",
+      expiresAt: new Date("2026-07-02T00:00:00.000Z"),
+    });
+    const sooner = repo.createException(db, {
+      userId,
+      targetKind: "overall",
+      action: "allow",
+      effectiveFrom: new Date("2026-07-01T00:00:00.000Z"),
+      expiresAt: new Date("2026-07-01T12:00:00.000Z"),
+    });
+    expect(sooner.effectiveFrom).toEqual(new Date("2026-07-01T00:00:00.000Z"));
+    expect(repo.listUserExceptions(db, userId).map((r) => r.id)).toEqual([sooner.id, later.id]);
+    expect(repo.listExceptions(db).map((r) => r.id)).toEqual(
+      [sooner.id, later.id].sort((a, b) => a - b),
+    );
+
+    expect(repo.deleteException(db, sooner.id)).toBe(true);
+    expect(repo.deleteException(db, sooner.id)).toBe(false);
+  });
+
+  it("rejects effectiveFrom >= expiresAt at the storage CHECK", () => {
+    let caught: unknown;
+    try {
+      repo.createException(db, {
+        userId,
+        targetKind: "overall",
+        action: "allow",
+        effectiveFrom: new Date("2026-07-02T00:00:00.000Z"),
+        expiresAt: new Date("2026-07-01T00:00:00.000Z"),
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(repo.isCheckViolation(caught)).toBe(true);
+  });
+
+  it("cascades schedules and exceptions when the user is deleted", () => {
+    repo.createSchedule(db, { userId, targetKind: "overall", action: "deny" });
+    repo.createException(db, {
+      userId,
+      targetKind: "overall",
+      action: "allow",
+      expiresAt: new Date("2026-07-01T00:00:00.000Z"),
+    });
+    repo.deleteUser(db, userId);
+    expect(repo.listSchedules(db)).toEqual([]);
+    expect(repo.listExceptions(db)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the #51 policy-model CRUD umbrella with the remaining entities, all behind `requireAdmin` and following the slice-1 conventions (zod DTOs sharing `policy/enums.ts` + `policy/recurrence.ts`, repository over `app.db`, the shared error envelope):

- **`Activity`** CRUD.
- **`ActivityGroup`** CRUD + `activities_to_groups` membership management (idempotent add, `404` on non-membership removal, cascade on either-end delete).
- **`Budget`** CRUD with scope/target coherence + referent existence and a non-negative allowance, plus a user-scoped stub-transport push (#54).
- **`Schedule`** CRUD against the recurrence + date-scoping shape finalized by #146 (PR #156), reusing `scheduleRecurrenceSchema`; `(user_id, ordinal)` precedence per ADR 0004.
- **`Exception`** CRUD with the `effective_from`/`expires_at` window (ADR 0005).

This was started while #156 was still open (initially deferring Schedule/Exception); when #156 merged mid-session the branch was rebased onto it and the scope expanded to the full slice, so this PR closes both #148 and #51.

## Design notes

- **Target coherence + referent existence** (the polymorphic `target_id`) is one shared route helper `assertTarget(db, kind, targetId)` used by create and PATCH → precise `400`.
- **PATCH** cross-field invariants that depend on the merged row (half-open recurrence pair, exception window) are backstopped by the storage `CHECK` mapped to `400` via a new `isCheckViolation()` / `asValidated()`, so a partial update can never leak a generic `500` (#148 AC).
- **Push stub (#54):** `budget.*` / `schedule.*` / `exception.*` are user-scoped reasons (fan out to the user's linked clients, resolved before a delete). Activity/ActivityGroup are *definitions* with no per-client effect → no push.
- Schedule/Exception flat collections support `?userId=` filtering, mirroring budgets.

## Plan

Linked plan: `.claude/plans/issue-148-policy-crud-remaining.md`
Roadmap: `docs/roadmap.md` → Phase 2 (`/api/*` JSON endpoints for the full policy model)

## License-boundary note

N/A — plain TypeScript + zod + Drizzle (Apache-2.0) + better-sqlite3 (MIT). No transport, packaging, Docker-image, or GPL surface. `license-guard` unaffected. No new dependency.

## Test plan

- [x] `format:check`, `lint`, `typecheck` clean.
- [x] `npm test` — **537 passing**; coverage gate (80%) green; new `repository.ts` paths at 100%.
- [x] Repository units: CRUD round-trips, ON DELETE CASCADE (user→budget/schedule/exception, group/activity→membership), idempotent membership, `isUniqueViolation`/`isCheckViolation`, and storage-CHECK rejections (negative allowance, incoherent target, half-open recurrence, empty exception window).
- [x] `app.inject()` route tests per entity: happy path, validation-failure (`400`), `401` guard, `404`, `409` (group name), target coherence + referent (`400`), and the merged-row CHECK backstop on PATCH.
- [x] DTO mappers (budget/schedule/exception, incl. timestamp serialization and null recurrence/effective fields).
- [x] Push-stub assertions for `budget.*`/`schedule.*`/`exception.*`, plus "no push for activity/group definitions".

Closes #148
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017DNi6TVQvhWyKRapVqv65E)_