### PR TITLE
feat(transport/adguard): AdGuard Home REST client (#94)

### DIFF
--- a/.claude/plans/issue-94-adguard-rest-client.md
+++ b/.claude/plans/issue-94-adguard-rest-client.md
@@ -1,0 +1,101 @@
+# Issue #94 — AdGuard Home REST client (`transport/adguard/`)
+
+Roadmap: `docs/roadmap.md` → Phase 7. Design: `docs/server-deployment.md` →
+"AdGuard Home deployment modes" / "What the dashboard expects from an external
+instance". License: REST-only, `docs/licensing-analysis.md`.
+
+## Goal
+
+A typed, REST-only client for the AdGuard Home `/control/*` API covering the
+operations the dashboard needs — **status**, **clients** (list/add/update/
+delete), and **filtering user-rules** (get/set) — with zod-validated responses
+and a typed error taxonomy. Used identically by both `managed` and `external`
+modes (the mode plumbing is #95, the managed supervisor #96, the UI #97).
+
+## Hard constraints
+
+- **License boundary:** pure TypeScript over HTTP. No AdGuard source linked, no
+  GPL binary added to any image. (`CLAUDE.md` rule 4.)
+- **Confine writes to a `pct:`-prefixed client namespace.** Every client write
+  (`addClient`/`updateClient`/`deleteClient`) requires a `pct:`-prefixed name
+  and throws `AdGuardScopeError` *before* issuing a request otherwise, so the
+  dashboard can never clobber a household's own AdGuard clients. The prefix is
+  configurable (default `pct:`). `listManagedClients()` filters to the prefix.
+- **Strict TS**, no `any`/unchecked `as`, validate every response with zod.
+- **No new dependency** — `undici`'s `fetch`/`MockAgent` and `zod` are already
+  in the tree; mirror the ActivityWatch client.
+
+## Auth
+
+The client takes *resolved* credentials (the file reads stay in #95/config):
+- `{ kind: "basic", username, password }` → `Authorization: Basic …`
+- `{ kind: "bearer", token }` → `Authorization: Bearer …`
+- omitted → no auth header (e.g. a freshly-bootstrapped managed instance).
+
+AdGuard Home accepts HTTP Basic Auth on `/control/*`; bearer covers a
+reverse-proxied deployment / the `PCT_ADGUARD_API_TOKEN_FILE` path. (If a
+future AdGuard version drops Basic for cookie-session login, that is an additive
+follow-up — noted in the client doc comment.)
+
+## API surface (AdGuard Home v0.107 `/control`)
+
+| Method | Endpoint | Body | Response |
+|---|---|---|---|
+| `getStatus()` | `GET /control/status` | — | JSON (version, running, protection_enabled, dns_addresses…) |
+| `listClients()` / `listManagedClients()` | `GET /control/clients` | — | JSON `{ clients, auto_clients, supported_tags }` |
+| `addClient(c)` | `POST /control/clients/add` | client object | 200, empty body |
+| `updateClient(name, data)` | `POST /control/clients/update` | `{ name, data }` | 200, empty body |
+| `deleteClient(name)` | `POST /control/clients/delete` | `{ name }` | 200, empty body |
+| `getUserRules()` | `GET /control/filtering/status` | — | JSON (`user_rules: string[]`, …) |
+| `setUserRules(rules)` | `POST /control/filtering/set_rules` | `{ rules }` | 200, empty body |
+
+- **Responses** are zod-validated. **Request bodies** are sent verbatim (we
+  validate inbound, not our own outbound), so a round-tripped client object
+  never loses fields AdGuard added across versions.
+- POSTs return an empty 200 body → those methods return `void` and only assert
+  2xx (never call `.json()` on them).
+
+## Error taxonomy (mirrors `transport/activitywatch/errors.ts`)
+
+- `AdGuardError` — base (`baseUrl`, `path`).
+- `AdGuardUnreachableError` — `fetch` threw / abort timeout (`cause`, `timedOut`).
+- `AdGuardRequestError` — non-2xx (`statusCode`, `statusText`).
+- `AdGuardAuthError extends AdGuardRequestError` — 401/403 (so `instanceof
+  AdGuardRequestError` still catches it; `docs/testing.md` → "401 → AuthError").
+- `AdGuardParseError` — non-JSON body or zod mismatch (`zodError?`).
+- `AdGuardScopeError extends AdGuardError` — a write to a non-`pct:` client name,
+  raised before any request.
+
+## Files
+
+- `server/src/transport/adguard/errors.ts`
+- `server/src/transport/adguard/schemas.ts` — zod response schemas + request
+  body TS interfaces.
+- `server/src/transport/adguard/client.ts` — `AdGuardClient`.
+- `server/src/transport/adguard/index.ts` — barrel (replaces the stub).
+- `server/tests/transport/adguard/client.test.ts` — unit tests (undici
+  `MockAgent`), plus `schemas.test.ts` if useful.
+
+## Test plan (unit, ≥80% gate)
+
+- construction: trailing-slash baseUrl normalisation; default vs custom prefix.
+- auth header: basic (base64 user:pass), bearer, none.
+- `getStatus`: happy parse; non-object body → ParseError; schema mismatch →
+  ParseError.
+- `listClients`/`listManagedClients`: happy; prefix filter; malformed top-level
+  → ParseError.
+- `addClient`/`updateClient`/`deleteClient`: correct path+body+method on 200;
+  prefix guard throws `AdGuardScopeError` and issues **no** request.
+- `getUserRules`/`setUserRules`: happy get; correct set body.
+- error mapping: 401/403 → `AdGuardAuthError`; other non-2xx →
+  `AdGuardRequestError`; `replyWithError` (conn refused) → `AdGuardUnreachableError`;
+  injected abort → `timedOut` true; non-JSON 200 → `AdGuardParseError`.
+
+## Deferred (tracked — not this PR)
+
+- Mode plumbing / preflight (#95), managed supervisor (#96), per-client domain
+  blocklist UI + schedule (#97). Per-client *rule* read-modify-write confinement
+  (preserving foreign global rules) lands with #97; #94 ships the raw `getUserRules`
+  /`setUserRules` building blocks + the client-identity (`pct:`) confinement.
+- Optional `adguard.int.test.ts` against the `adguard/adguardhome` container
+  (the `docs/testing.md` compose env) — integration tier, not the unit gate.

--- a/server/src/transport/adguard/client.ts
+++ b/server/src/transport/adguard/client.ts
@@ -1,0 +1,316 @@
+/**
+ * REST client for an AdGuard Home instance's `/control/*` API.
+ *
+ * The dashboard uses DNS filtering in one of three modes (`PCT_ADGUARD_MODE`):
+ * `disabled`, `external` (an AdGuard the homelab already runs), or `managed`
+ * (a sidecar the dashboard fetches and supervises). **This client is the single
+ * code path for the two non-disabled modes** — the only difference is the base
+ * URL and credentials it is constructed with; the mode plumbing/preflight (#95)
+ * and the managed supervisor (#96) wire those in.
+ *
+ * Confinement: AdGuard Home is treated as a shared service. The dashboard owns
+ * only the clients it names with a stable prefix (`pct:` by default) and never
+ * touches anything else (`docs/server-deployment.md` → "What the dashboard
+ * expects from an external instance"). Every client write therefore requires a
+ * prefixed name and throws {@link AdGuardScopeError} *before* issuing a request
+ * otherwise, so a household's own AdGuard config structurally cannot be
+ * clobbered.
+ *
+ * License boundary: REST-only over HTTP. No AdGuard source is linked in process
+ * and no GPL binary is added to the image — the integration is purely the
+ * documented HTTP API (`CLAUDE.md` → "License boundaries" rule 4;
+ * `docs/licensing-analysis.md`). Note that `managed` mode runs AdGuard as a
+ * separate child process; the dashboard still only speaks to it over this REST
+ * surface.
+ */
+import { z } from "zod";
+import {
+  AdGuardAuthError,
+  AdGuardParseError,
+  AdGuardRequestError,
+  AdGuardScopeError,
+  AdGuardUnreachableError,
+} from "./errors.js";
+import {
+  adGuardClientsResponseSchema,
+  adGuardFilteringStatusSchema,
+  adGuardStatusSchema,
+  type AdGuardClient,
+  type AdGuardClientInput,
+  type AdGuardStatus,
+} from "./schemas.js";
+
+/**
+ * The minimal `fetch` surface this client uses. Deliberately structural rather
+ * than the full global `typeof fetch`: the Node 22 global `fetch` satisfies it
+ * in production, and a test can satisfy it with undici's `fetch` bound to a
+ * `MockAgent` dispatcher — without an `as` cast on either side (`CLAUDE.md` →
+ * "no unchecked `as` casts").
+ */
+export type FetchLike = (
+  input: string | URL,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<unknown>;
+}>;
+
+/**
+ * Resolved credentials for the dedicated AdGuard account. The file reads that
+ * produce these (`PCT_ADGUARD_PASSWORD_FILE` / `PCT_ADGUARD_API_TOKEN_FILE`)
+ * stay in the config layer (#95); this client takes the resolved secret.
+ *
+ * - `basic` → `Authorization: Basic …`. AdGuard Home accepts HTTP Basic Auth on
+ *   `/control/*`; this is the username/password the admin created in AdGuard's
+ *   own UI for the dashboard.
+ * - `bearer` → `Authorization: Bearer …`, for a reverse-proxy-fronted
+ *   deployment or the `PCT_ADGUARD_API_TOKEN_FILE` path.
+ *
+ * (If a future AdGuard version drops Basic for cookie-session login, a session
+ * strategy can be added here additively without changing call sites.)
+ */
+export type AdGuardAuth =
+  | { kind: "basic"; username: string; password: string }
+  | { kind: "bearer"; token: string };
+
+/** The default namespace prefix for dashboard-owned AdGuard clients. */
+export const DEFAULT_CLIENT_PREFIX = "pct:";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Options for constructing an {@link AdGuardHomeClient}. */
+export interface AdGuardClientOptions {
+  /** Base URL of the AdGuard Home instance, e.g. `https://adguard.lan`. A trailing slash is tolerated. */
+  baseUrl: string;
+  /** Credentials for the dedicated AdGuard account; omit for an unauthenticated instance. */
+  auth?: AdGuardAuth;
+  /** Per-request timeout in milliseconds. Defaults to 10_000. */
+  timeoutMs?: number;
+  /** `fetch` implementation to use. Defaults to the global `fetch`; injectable for tests. */
+  fetch?: FetchLike;
+  /** Namespace prefix every dashboard-managed client name must carry. Defaults to `pct:`. */
+  clientPrefix?: string;
+}
+
+/**
+ * Typed, REST-only client for AdGuard Home's status / clients / filtering
+ * endpoints.
+ *
+ * Every JSON response is validated with a zod schema before it is returned.
+ * Failures are distinguished by the error taxonomy in `./errors.ts`:
+ * unreachable (feeds the external-mode preflight / retry), auth (401/403),
+ * non-2xx request failure, and malformed response. Writes are confined to the
+ * `pct:`-prefixed client namespace and rejected with {@link AdGuardScopeError}
+ * before any request otherwise.
+ */
+export class AdGuardHomeClient {
+  readonly #baseUrl: string;
+  readonly #auth: AdGuardAuth | undefined;
+  readonly #timeoutMs: number;
+  readonly #fetch: FetchLike;
+  readonly #clientPrefix: string;
+
+  constructor(options: AdGuardClientOptions) {
+    // Normalize away any trailing slashes so `${baseUrl}${path}` (path starts
+    // with `/control/...`) never produces a double slash.
+    this.#baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.#auth = options.auth;
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.#fetch = options.fetch ?? globalThis.fetch;
+    this.#clientPrefix = options.clientPrefix ?? DEFAULT_CLIENT_PREFIX;
+  }
+
+  /** The normalized base URL this client targets. */
+  get baseUrl(): string {
+    return this.#baseUrl;
+  }
+
+  /** The namespace prefix dashboard-managed client names must carry. */
+  get clientPrefix(): string {
+    return this.#clientPrefix;
+  }
+
+  /** `GET /control/status` — instance identity and protection state. */
+  async getStatus(): Promise<AdGuardStatus> {
+    const body = await this.#getJson("/control/status");
+    return this.#parse(adGuardStatusSchema, body, "/control/status");
+  }
+
+  /** `GET /control/clients` — every persistent client AdGuard has configured. */
+  async listClients(): Promise<AdGuardClient[]> {
+    const path = "/control/clients";
+    const body = await this.#getJson(path);
+    return this.#parse(adGuardClientsResponseSchema, body, path).clients;
+  }
+
+  /**
+   * Persistent clients in the dashboard's `pct:` namespace only — the clients
+   * this dashboard owns and may safely mutate. Foreign clients are filtered out.
+   */
+  async listManagedClients(): Promise<AdGuardClient[]> {
+    const clients = await this.listClients();
+    return clients.filter((client) => client.name.startsWith(this.#clientPrefix));
+  }
+
+  /**
+   * `POST /control/clients/add` — create a dashboard-owned client. The name must
+   * carry the `pct:` prefix or {@link AdGuardScopeError} is thrown before any
+   * request. Returns once AdGuard answers 2xx (the body is empty).
+   */
+  async addClient(client: AdGuardClientInput): Promise<void> {
+    const path = "/control/clients/add";
+    this.#assertManaged(client.name, path);
+    await this.#postOk(path, client);
+  }
+
+  /**
+   * `POST /control/clients/update` — replace a dashboard-owned client's config.
+   * Both the existing `name` and the (possibly renamed) `data.name` must carry
+   * the prefix, so neither a foreign client is edited nor a managed one is
+   * renamed out of the namespace.
+   */
+  async updateClient(name: string, data: AdGuardClientInput): Promise<void> {
+    const path = "/control/clients/update";
+    this.#assertManaged(name, path);
+    this.#assertManaged(data.name, path);
+    await this.#postOk(path, { name, data });
+  }
+
+  /**
+   * `POST /control/clients/delete` — remove a dashboard-owned client. The name
+   * must carry the prefix or {@link AdGuardScopeError} is thrown before any
+   * request, so a household's own clients can never be deleted.
+   */
+  async deleteClient(name: string): Promise<void> {
+    const path = "/control/clients/delete";
+    this.#assertManaged(name, path);
+    await this.#postOk(path, { name });
+  }
+
+  /**
+   * `GET /control/filtering/status` → the global custom-rules list
+   * (`user_rules`). The per-client blocklist composition that decides *which*
+   * rules the dashboard owns (and preserves foreign rules on write) is #97; this
+   * is the building block it reads.
+   */
+  async getUserRules(): Promise<string[]> {
+    const path = "/control/filtering/status";
+    const body = await this.#getJson(path);
+    return this.#parse(adGuardFilteringStatusSchema, body, path).user_rules;
+  }
+
+  /**
+   * `POST /control/filtering/set_rules` — replace the global custom-rules list.
+   * AdGuard has no per-client rule list, so this writes the whole `user_rules`
+   * set; callers (#97) must read-modify-write to preserve rules they do not own.
+   */
+  async setUserRules(rules: readonly string[]): Promise<void> {
+    await this.#postOk("/control/filtering/set_rules", { rules: [...rules] });
+  }
+
+  /** Throw {@link AdGuardScopeError} if `name` is outside the managed namespace. */
+  #assertManaged(name: string, path: string): void {
+    if (!name.startsWith(this.#clientPrefix)) {
+      throw new AdGuardScopeError(this.#baseUrl, path, name, this.#clientPrefix);
+    }
+  }
+
+  /** The `Authorization` header for the configured credentials, if any. */
+  #authHeader(): Record<string, string> {
+    if (this.#auth === undefined) return {};
+    if (this.#auth.kind === "bearer") {
+      return { authorization: `Bearer ${this.#auth.token}` };
+    }
+    const encoded = Buffer.from(`${this.#auth.username}:${this.#auth.password}`).toString("base64");
+    return { authorization: `Basic ${encoded}` };
+  }
+
+  /**
+   * Issue a GET and return the parsed JSON body, mapping every failure to the
+   * error taxonomy: a thrown `fetch` (connection error / abort timeout) →
+   * unreachable; 401/403 → auth; other non-2xx → request error; a non-JSON body
+   * → parse error.
+   */
+  async #getJson(path: string): Promise<unknown> {
+    const response = await this.#send(path, "GET");
+    this.#assertOk(response, path);
+    return this.#readJson(response, path);
+  }
+
+  /**
+   * Issue a POST with a JSON body and assert a 2xx. AdGuard's mutating
+   * `/control/*` endpoints answer 200 with an empty body, so there is nothing to
+   * parse — we only classify failure.
+   */
+  async #postOk(path: string, body: unknown): Promise<void> {
+    const response = await this.#send(path, "POST", JSON.stringify(body));
+    this.#assertOk(response, path);
+  }
+
+  /** Perform the `fetch`, mapping a thrown request to {@link AdGuardUnreachableError}. */
+  async #send(
+    path: string,
+    method: "GET" | "POST",
+    body?: string,
+  ): Promise<Awaited<ReturnType<FetchLike>>> {
+    const headers: Record<string, string> = { accept: "application/json", ...this.#authHeader() };
+    if (body !== undefined) headers["content-type"] = "application/json";
+    try {
+      return await this.#fetch(`${this.#baseUrl}${path}`, {
+        method,
+        headers,
+        ...(body !== undefined ? { body } : {}),
+        signal: AbortSignal.timeout(this.#timeoutMs),
+      });
+    } catch (cause) {
+      throw new AdGuardUnreachableError(this.#baseUrl, path, cause, isTimeout(cause));
+    }
+  }
+
+  /** Map a non-2xx status to {@link AdGuardAuthError} (401/403) or {@link AdGuardRequestError}. */
+  #assertOk(response: Awaited<ReturnType<FetchLike>>, path: string): void {
+    if (response.ok) return;
+    if (response.status === 401 || response.status === 403) {
+      throw new AdGuardAuthError(this.#baseUrl, path, response.status, response.statusText);
+    }
+    throw new AdGuardRequestError(this.#baseUrl, path, response.status, response.statusText);
+  }
+
+  /** Parse a 2xx body as JSON, mapping a non-JSON body to {@link AdGuardParseError}. */
+  async #readJson(response: Awaited<ReturnType<FetchLike>>, path: string): Promise<unknown> {
+    try {
+      return (await response.json()) as unknown;
+    } catch (cause) {
+      throw new AdGuardParseError(
+        this.#baseUrl,
+        path,
+        cause instanceof Error ? cause.message : "response body was not valid JSON",
+      );
+    }
+  }
+
+  /** Validate a body against `schema`, throwing a parse error on mismatch. */
+  #parse<T>(schema: z.ZodType<T>, body: unknown, path: string): T {
+    const result = schema.safeParse(body);
+    if (!result.success) {
+      throw new AdGuardParseError(this.#baseUrl, path, z.prettifyError(result.error), result.error);
+    }
+    return result.data;
+  }
+}
+
+/**
+ * Whether a thrown `fetch` error is the per-request abort timeout.
+ * `AbortSignal.timeout` rejects with a `TimeoutError`; a manual abort yields an
+ * `AbortError`. Both are name-tagged on the thrown `DOMException`/`Error`.
+ */
+function isTimeout(cause: unknown): boolean {
+  return cause instanceof Error && (cause.name === "TimeoutError" || cause.name === "AbortError");
+}

--- a/server/src/transport/adguard/client.ts
+++ b/server/src/transport/adguard/client.ts
@@ -163,6 +163,12 @@ export class AdGuardHomeClient {
    * `POST /control/clients/add` — create a dashboard-owned client. The name must
    * carry the `pct:` prefix or {@link AdGuardScopeError} is thrown before any
    * request. Returns once AdGuard answers 2xx (the body is empty).
+   *
+   * Not idempotent: AdGuard rejects a duplicate name with a 4xx, surfaced as
+   * {@link AdGuardRequestError} (AdGuard does not use 409 for this, so the
+   * generic "409 → idempotent no-op" REST convention in `docs/testing.md` does
+   * not apply). The caller decides whether an "already exists" failure is benign
+   * or should fall back to {@link updateClient}.
    */
   async addClient(client: AdGuardClientInput): Promise<void> {
     const path = "/control/clients/add";
@@ -174,7 +180,9 @@ export class AdGuardHomeClient {
    * `POST /control/clients/update` — replace a dashboard-owned client's config.
    * Both the existing `name` and the (possibly renamed) `data.name` must carry
    * the prefix, so neither a foreign client is edited nor a managed one is
-   * renamed out of the namespace.
+   * renamed out of the namespace. The guard relies on AdGuard keying the target
+   * by the top-level `name` (the existing client) and adopting `data.name` as
+   * the new name — the only identity fields in the documented request shape.
    */
   async updateClient(name: string, data: AdGuardClientInput): Promise<void> {
     const path = "/control/clients/update";
@@ -208,8 +216,15 @@ export class AdGuardHomeClient {
 
   /**
    * `POST /control/filtering/set_rules` — replace the global custom-rules list.
-   * AdGuard has no per-client rule list, so this writes the whole `user_rules`
-   * set; callers (#97) must read-modify-write to preserve rules they do not own.
+   *
+   * AdGuard has no per-client rule list, so this writes the **whole**
+   * `user_rules` set and is **deliberately unconfined** — unlike the client
+   * writes there is no `pct:` guard, because there is no per-rule owner to key
+   * on. Callers must therefore only ever pass a list derived from a fresh
+   * {@link getUserRules} read with the dashboard's own rules swapped in, so a
+   * household's hand-written global rules are preserved. That read-modify-write
+   * confinement (and the marker that identifies dashboard-owned rules) lands
+   * with the per-client blocklist feature (#97); this is only the raw write.
    */
   async setUserRules(rules: readonly string[]): Promise<void> {
     await this.#postOk("/control/filtering/set_rules", { rules: [...rules] });

--- a/server/src/transport/adguard/errors.ts
+++ b/server/src/transport/adguard/errors.ts
@@ -1,0 +1,134 @@
+/**
+ * Error taxonomy for the AdGuard Home REST client.
+ *
+ * The dashboard talks to AdGuard Home only over its `/control/*` REST API in
+ * both `managed` and `external` modes (`docs/server-deployment.md` → "License
+ * posture is identical in both modes"). The client surfaces every failure as
+ * one of these typed errors so callers can branch without parsing prose:
+ *
+ * - {@link AdGuardUnreachableError} — the request never produced an HTTP
+ *   response (connection refused, DNS failure, the instance is down, or the
+ *   per-request timeout fired). For the `external` preflight (#95) this is the
+ *   "your configured AdGuard URL isn't answering" case.
+ * - {@link AdGuardRequestError} — AdGuard answered with a non-2xx status. The
+ *   host is reachable; the request itself failed.
+ * - {@link AdGuardAuthError} — a 401/403 specifically (a subclass of
+ *   {@link AdGuardRequestError}, so a broad `instanceof AdGuardRequestError`
+ *   still catches it; `docs/testing.md` → "401 Unauthorized — rejects with
+ *   `AuthError`"). The dedicated AdGuard account's credentials are wrong or
+ *   lack permission.
+ * - {@link AdGuardParseError} — AdGuard answered 2xx but the body was not JSON,
+ *   or did not match the schema we validate against. We never trust an
+ *   unvalidated payload (`CLAUDE.md` → "Validate all external input").
+ * - {@link AdGuardScopeError} — a write was attempted against a client name
+ *   outside the dashboard's `pct:`-prefixed namespace. Raised *before* any
+ *   request so the dashboard can never edit a client it does not own
+ *   (`docs/server-deployment.md` → "What the dashboard expects from an external
+ *   instance").
+ *
+ * License boundary: none touched — plain TypeScript, no AdGuard code linked
+ * (REST-only integration, `docs/licensing-analysis.md`).
+ */
+import type { z } from "zod";
+
+/** Common base so callers can `instanceof AdGuardError` to catch all. */
+export class AdGuardError extends Error {
+  /** Base URL of the AdGuard instance the failed operation targeted. */
+  readonly baseUrl: string;
+  /** Request path (relative to {@link baseUrl}) the operation targeted. */
+  readonly path: string;
+
+  constructor(baseUrl: string, path: string, message: string) {
+    super(message);
+    this.name = "AdGuardError";
+    this.baseUrl = baseUrl;
+    this.path = path;
+  }
+}
+
+/**
+ * The request never produced an HTTP response. Carries the underlying `cause`
+ * (the error `fetch` threw) and {@link timedOut}, set when the failure was the
+ * per-request abort timeout rather than a connection error.
+ */
+export class AdGuardUnreachableError extends AdGuardError {
+  /** True when the per-request timeout aborted the call. */
+  readonly timedOut: boolean;
+
+  constructor(baseUrl: string, path: string, cause: unknown, timedOut: boolean) {
+    super(
+      baseUrl,
+      path,
+      `AdGuard Home at ${baseUrl} is unreachable${timedOut ? " (request timed out)" : ""}`,
+    );
+    // Preserve the originating error without widening this class's typed API.
+    super.cause = cause;
+    this.name = "AdGuardUnreachableError";
+    this.timedOut = timedOut;
+  }
+}
+
+/** AdGuard answered with a non-2xx status. */
+export class AdGuardRequestError extends AdGuardError {
+  /** The HTTP status code returned. */
+  readonly statusCode: number;
+
+  constructor(baseUrl: string, path: string, statusCode: number, statusText: string) {
+    super(
+      baseUrl,
+      path,
+      `AdGuard request to ${path} failed with ${statusCode} ${statusText}`.trimEnd(),
+    );
+    this.name = "AdGuardRequestError";
+    this.statusCode = statusCode;
+  }
+}
+
+/**
+ * A 401/403: the dedicated AdGuard account's credentials are missing, wrong, or
+ * insufficient. A subclass of {@link AdGuardRequestError} so callers that only
+ * care about "the request failed" still catch it, while the preflight/auth path
+ * can single it out.
+ */
+export class AdGuardAuthError extends AdGuardRequestError {
+  constructor(baseUrl: string, path: string, statusCode: number, statusText: string) {
+    super(baseUrl, path, statusCode, statusText);
+    this.name = "AdGuardAuthError";
+  }
+}
+
+/** The response body was not JSON, or did not match the expected schema. */
+export class AdGuardParseError extends AdGuardError {
+  /** The zod error when a schema rejected the body; absent for non-JSON. */
+  readonly zodError: z.ZodError | undefined;
+
+  constructor(baseUrl: string, path: string, message: string, zodError?: z.ZodError) {
+    super(baseUrl, path, `Malformed AdGuard response from ${path}: ${message}`);
+    this.name = "AdGuardParseError";
+    this.zodError = zodError;
+  }
+}
+
+/**
+ * A write was attempted against a client name outside the dashboard's
+ * `pct:`-prefixed namespace. Raised before any HTTP request is issued, so the
+ * dashboard structurally cannot mutate a client a household configured itself.
+ */
+export class AdGuardScopeError extends AdGuardError {
+  /** The offending client name. */
+  readonly clientName: string;
+  /** The required prefix the name failed to carry. */
+  readonly requiredPrefix: string;
+
+  constructor(baseUrl: string, path: string, clientName: string, requiredPrefix: string) {
+    super(
+      baseUrl,
+      path,
+      `Refusing to write AdGuard client ${JSON.stringify(clientName)}: ` +
+        `the dashboard only manages clients prefixed ${JSON.stringify(requiredPrefix)}`,
+    );
+    this.name = "AdGuardScopeError";
+    this.clientName = clientName;
+    this.requiredPrefix = requiredPrefix;
+  }
+}

--- a/server/src/transport/adguard/index.ts
+++ b/server/src/transport/adguard/index.ts
@@ -1,2 +1,29 @@
 /** AdGuard Home transport: REST client (managed sidecar or external instance). */
 export const moduleName = "transport/adguard";
+
+export {
+  AdGuardHomeClient,
+  DEFAULT_CLIENT_PREFIX,
+  type AdGuardAuth,
+  type AdGuardClientOptions,
+  type FetchLike,
+} from "./client.js";
+export {
+  AdGuardError,
+  AdGuardUnreachableError,
+  AdGuardRequestError,
+  AdGuardAuthError,
+  AdGuardParseError,
+  AdGuardScopeError,
+} from "./errors.js";
+export {
+  adGuardClientSchema,
+  adGuardClientsResponseSchema,
+  adGuardFilteringStatusSchema,
+  adGuardStatusSchema,
+  type AdGuardClient,
+  type AdGuardClientInput,
+  type AdGuardClientsResponse,
+  type AdGuardFilteringStatus,
+  type AdGuardStatus,
+} from "./schemas.js";

--- a/server/src/transport/adguard/schemas.ts
+++ b/server/src/transport/adguard/schemas.ts
@@ -1,0 +1,108 @@
+/**
+ * zod schemas for the AdGuard Home `/control/*` REST responses this client
+ * consumes, plus the TypeScript shapes for the request bodies it sends.
+ *
+ * Everything AdGuard returns is untrusted external input and is validated here
+ * before it crosses into typed code (`CLAUDE.md` → "Validate all external
+ * input"). We validate only the fields the dashboard actually uses; zod strips
+ * unknown keys by default, so AdGuard adding or renaming fields we don't read
+ * never breaks us.
+ *
+ * Request bodies are plain TS interfaces, **not** zod schemas: we send the
+ * caller's object verbatim (we validate what comes *in*, not our own outbound),
+ * so a client object read from AdGuard, modified, and written back never loses
+ * fields a newer AdGuard version added. The interfaces carry an index signature
+ * for exactly that round-trip safety.
+ */
+import { z } from "zod";
+
+/**
+ * `GET /control/status` — instance identity and protection state. The dashboard
+ * reads this for the `external`-mode preflight (#95) and the admin "active
+ * mode" surface (#97). Only the always-present fields are required; the rest
+ * (ports, addresses) are validated-if-present and otherwise ignored.
+ */
+export const adGuardStatusSchema = z.object({
+  version: z.string(),
+  running: z.boolean(),
+  protection_enabled: z.boolean(),
+  dns_addresses: z.array(z.string()).optional(),
+  dns_port: z.number().optional(),
+  http_port: z.number().optional(),
+  language: z.string().optional(),
+  dhcp_available: z.boolean().optional(),
+});
+
+/** Inferred AdGuard instance status. */
+export type AdGuardStatus = z.infer<typeof adGuardStatusSchema>;
+
+/**
+ * One persistent client as returned by `GET /control/clients`. A client is an
+ * AdGuard-side network identity (by IP/MAC/CIDR/ClientID in {@link ids}). Only
+ * `name`/`ids` are required; the per-client filtering toggles and
+ * blocked-services list are validated-if-present.
+ */
+export const adGuardClientSchema = z.object({
+  name: z.string(),
+  ids: z.array(z.string()),
+  use_global_settings: z.boolean().optional(),
+  filtering_enabled: z.boolean().optional(),
+  parental_enabled: z.boolean().optional(),
+  safebrowsing_enabled: z.boolean().optional(),
+  use_global_blocked_services: z.boolean().optional(),
+  blocked_services: z.array(z.string()).optional(),
+  upstreams: z.array(z.string()).optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+/** Inferred persistent client (the validated read shape). */
+export type AdGuardClient = z.infer<typeof adGuardClientSchema>;
+
+/**
+ * `GET /control/clients` — persistent clients plus runtime-discovered
+ * `auto_clients` and the server's `supported_tags`. We only consume the
+ * persistent `clients`; the other two are accepted (validated-if-present) but
+ * not surfaced. A missing `clients` key validates as an empty list.
+ */
+export const adGuardClientsResponseSchema = z.object({
+  clients: z
+    .array(adGuardClientSchema)
+    .nullish()
+    .transform((value) => value ?? []),
+  auto_clients: z.array(z.unknown()).optional(),
+  supported_tags: z.array(z.string()).optional(),
+});
+
+/** Inferred clients listing. */
+export type AdGuardClientsResponse = z.infer<typeof adGuardClientsResponseSchema>;
+
+/**
+ * `GET /control/filtering/status` — global filtering state. The dashboard reads
+ * `user_rules` (the custom-rules list) to compose per-client blocklists (#97);
+ * the rest is validated-if-present. A missing `user_rules` validates as empty.
+ */
+export const adGuardFilteringStatusSchema = z.object({
+  enabled: z.boolean().optional(),
+  interval: z.number().optional(),
+  user_rules: z
+    .array(z.string())
+    .nullish()
+    .transform((value) => value ?? []),
+});
+
+/** Inferred filtering status. */
+export type AdGuardFilteringStatus = z.infer<typeof adGuardFilteringStatusSchema>;
+
+/**
+ * The request-body shape for `POST /control/clients/add` and the `data` of
+ * `POST /control/clients/update`. Sent verbatim; the index signature preserves
+ * any AdGuard fields the caller round-trips that this type does not name.
+ */
+export interface AdGuardClientInput {
+  /** The client name — must carry the dashboard's `pct:` prefix (enforced). */
+  name: string;
+  /** Network identities (IP/MAC/CIDR/ClientID) this client matches. */
+  ids: string[];
+  /** Any other AdGuard client fields, preserved on round-trip. */
+  [key: string]: unknown;
+}

--- a/server/tests/transport/adguard/client.test.ts
+++ b/server/tests/transport/adguard/client.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Unit tests for the AdGuard Home REST client.
+ *
+ * Follows `docs/testing.md` → "Transport — REST": undici's `MockAgent`
+ * intercepts HTTP so no live AdGuard instance is needed for the happy / auth /
+ * non-2xx / malformed paths, and `replyWithError` simulates a connection
+ * failure. The client is driven with undici's `fetch` bound to the mock agent
+ * via its `dispatcher` option (Node's global `fetch` does not honour the npm
+ * undici package's global dispatcher, so per-request injection is both correct
+ * and leak-free across tests). The deterministic timeout path uses an injected
+ * `fetch` that honours the abort signal, avoiding a flaky delayed reply. The
+ * `pct:`-prefix guard is proven with a `fetch` that throws if reached.
+ */
+import { MockAgent, fetch as undiciFetch } from "undici";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  AdGuardAuthError,
+  AdGuardHomeClient,
+  AdGuardParseError,
+  AdGuardRequestError,
+  AdGuardScopeError,
+  AdGuardUnreachableError,
+  DEFAULT_CLIENT_PREFIX,
+  type AdGuardClientOptions,
+  type FetchLike,
+} from "../../../src/transport/adguard/index.js";
+
+const BASE_URL = "http://adguard.lan";
+
+/** A JSON reply with the content-type `Response.json()` expects. */
+const JSON_HEADERS = { headers: { "content-type": "application/json" } } as const;
+
+let agent: MockAgent;
+
+beforeEach(() => {
+  agent = new MockAgent();
+  agent.disableNetConnect();
+});
+
+afterEach(async () => {
+  await agent.close();
+});
+
+/** undici `fetch` bound to the per-test mock agent — satisfies `FetchLike`. */
+function mockFetch(): FetchLike {
+  return (input, init) => undiciFetch(input, { ...init, dispatcher: agent });
+}
+
+/** A client whose fetch is routed through the mock agent. */
+function makeClient(extra: Partial<Omit<AdGuardClientOptions, "baseUrl">> = {}): AdGuardHomeClient {
+  return new AdGuardHomeClient({ baseUrl: BASE_URL, fetch: mockFetch(), ...extra });
+}
+
+/** A fetch that fails the test if it is ever called (proves a pre-request guard fired). */
+const explodingFetch: FetchLike = () => {
+  throw new Error("fetch should not have been called");
+};
+
+describe("AdGuardHomeClient construction", () => {
+  it("strips trailing slashes from the base URL", () => {
+    const client = new AdGuardHomeClient({ baseUrl: "http://adguard.lan///" });
+    expect(client.baseUrl).toBe("http://adguard.lan");
+  });
+
+  it("defaults the managed-client prefix to pct:", () => {
+    expect(makeClient().clientPrefix).toBe(DEFAULT_CLIENT_PREFIX);
+    expect(DEFAULT_CLIENT_PREFIX).toBe("pct:");
+  });
+
+  it("honours a custom client prefix", () => {
+    expect(makeClient({ clientPrefix: "home:" }).clientPrefix).toBe("home:");
+  });
+});
+
+describe("authentication header", () => {
+  it("sends HTTP Basic auth for basic credentials", async () => {
+    let seen: Record<string, unknown> | undefined;
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/status", method: "GET" })
+      .reply(
+        200,
+        (opts) => {
+          seen = opts.headers as Record<string, unknown>;
+          return { version: "v0.107.0", running: true, protection_enabled: true };
+        },
+        JSON_HEADERS,
+      );
+
+    await makeClient({ auth: { kind: "basic", username: "pct", password: "s3cret" } }).getStatus();
+
+    const expected = `Basic ${Buffer.from("pct:s3cret").toString("base64")}`;
+    expect(seen?.authorization).toBe(expected);
+    expect(seen?.accept).toBe("application/json");
+  });
+
+  it("sends a Bearer token for bearer credentials", async () => {
+    let seen: Record<string, unknown> | undefined;
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/status", method: "GET" })
+      .reply(
+        200,
+        (opts) => {
+          seen = opts.headers as Record<string, unknown>;
+          return { version: "v0.107.0", running: true, protection_enabled: true };
+        },
+        JSON_HEADERS,
+      );
+
+    await makeClient({ auth: { kind: "bearer", token: "tok-123" } }).getStatus();
+
+    expect(seen?.authorization).toBe("Bearer tok-123");
+  });
+
+  it("sends no authorization header when no credentials are configured", async () => {
+    let seen: Record<string, unknown> | undefined;
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/status", method: "GET" })
+      .reply(
+        200,
+        (opts) => {
+          seen = opts.headers as Record<string, unknown>;
+          return { version: "v0.107.0", running: true, protection_enabled: true };
+        },
+        JSON_HEADERS,
+      );
+
+    await makeClient().getStatus();
+
+    expect(seen?.authorization).toBeUndefined();
+  });
+});
+
+describe("getStatus", () => {
+  it("returns parsed status on the happy path", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/status", method: "GET" })
+      .reply(
+        200,
+        {
+          version: "v0.107.52",
+          running: true,
+          protection_enabled: false,
+          dns_addresses: ["192.168.1.2"],
+          dns_port: 53,
+          extra_field_we_ignore: 42,
+        },
+        JSON_HEADERS,
+      );
+
+    const status = await makeClient().getStatus();
+
+    expect(status.version).toBe("v0.107.52");
+    expect(status.running).toBe(true);
+    expect(status.protection_enabled).toBe(false);
+    expect(status.dns_addresses).toEqual(["192.168.1.2"]);
+  });
+
+  it("rejects a schema-mismatched body with AdGuardParseError", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/status", method: "GET" })
+      .reply(200, { running: true }, JSON_HEADERS); // missing version + protection_enabled
+
+    await expect(makeClient().getStatus()).rejects.toBeInstanceOf(AdGuardParseError);
+  });
+
+  it("rejects a non-JSON body with AdGuardParseError", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/status", method: "GET" })
+      .reply(200, "not json", { headers: { "content-type": "text/plain" } });
+
+    const error = await makeClient()
+      .getStatus()
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(AdGuardParseError);
+    expect((error as AdGuardParseError).zodError).toBeUndefined();
+  });
+});
+
+describe("listClients / listManagedClients", () => {
+  const body = {
+    clients: [
+      { name: "pct:alice-laptop", ids: ["192.168.1.10"], filtering_enabled: true },
+      { name: "household-tv", ids: ["192.168.1.20"] },
+      { name: "pct:bob-desktop", ids: ["AA:BB:CC:DD:EE:FF"], blocked_services: ["youtube"] },
+    ],
+    auto_clients: [{ name: "auto", ip: "192.168.1.99" }],
+    supported_tags: ["device_phone"],
+  };
+
+  it("returns every persistent client", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/clients", method: "GET" })
+      .reply(200, body, JSON_HEADERS);
+
+    const clients = await makeClient().listClients();
+    expect(clients.map((c) => c.name)).toEqual([
+      "pct:alice-laptop",
+      "household-tv",
+      "pct:bob-desktop",
+    ]);
+    expect(clients[2]?.blocked_services).toEqual(["youtube"]);
+  });
+
+  it("filters managed clients to the pct: prefix", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/clients", method: "GET" })
+      .reply(200, body, JSON_HEADERS);
+
+    const managed = await makeClient().listManagedClients();
+    expect(managed.map((c) => c.name)).toEqual(["pct:alice-laptop", "pct:bob-desktop"]);
+  });
+
+  it("treats a missing clients key as an empty list", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/clients", method: "GET" })
+      .reply(200, {}, JSON_HEADERS);
+
+    expect(await makeClient().listClients()).toEqual([]);
+  });
+
+  it("rejects a non-object body with AdGuardParseError", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/clients", method: "GET" })
+      .reply(200, [], JSON_HEADERS);
+
+    await expect(makeClient().listClients()).rejects.toBeInstanceOf(AdGuardParseError);
+  });
+});
+
+describe("addClient", () => {
+  it("POSTs the client body to /control/clients/add on a managed name", async () => {
+    let seenBody: string | undefined;
+    let seenContentType: unknown;
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/clients/add", method: "POST" })
+      .reply(200, (opts) => {
+        seenBody = opts.body as string;
+        seenContentType = (opts.headers as Record<string, unknown>)["content-type"];
+        return "";
+      });
+
+    const client = { name: "pct:alice-laptop", ids: ["192.168.1.10"], filtering_enabled: true };
+    await makeClient().addClient(client);
+
+    expect(JSON.parse(seenBody ?? "")).toEqual(client);
+    expect(seenContentType).toBe("application/json");
+  });
+
+  it("refuses an unmanaged name without issuing a request", async () => {
+    const client = makeClient({ fetch: explodingFetch });
+    await expect(client.addClient({ name: "household-tv", ids: [] })).rejects.toBeInstanceOf(
+      AdGuardScopeError,
+    );
+  });
+
+  it("surfaces the offending name and required prefix on the scope error", async () => {
+    const error = await makeClient({ fetch: explodingFetch })
+      .addClient({ name: "tv", ids: [] })
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(AdGuardScopeError);
+    expect((error as AdGuardScopeError).clientName).toBe("tv");
+    expect((error as AdGuardScopeError).requiredPrefix).toBe("pct:");
+  });
+});
+
+describe("updateClient", () => {
+  it("POSTs { name, data } to /control/clients/update", async () => {
+    let seenBody: string | undefined;
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/clients/update", method: "POST" })
+      .reply(200, (opts) => {
+        seenBody = opts.body as string;
+        return "";
+      });
+
+    const data = { name: "pct:alice-laptop", ids: ["192.168.1.11"] };
+    await makeClient().updateClient("pct:alice-laptop", data);
+
+    expect(JSON.parse(seenBody ?? "")).toEqual({ name: "pct:alice-laptop", data });
+  });
+
+  it("refuses an unmanaged existing name", async () => {
+    await expect(
+      makeClient({ fetch: explodingFetch }).updateClient("tv", { name: "pct:tv", ids: [] }),
+    ).rejects.toBeInstanceOf(AdGuardScopeError);
+  });
+
+  it("refuses renaming a managed client out of the namespace", async () => {
+    await expect(
+      makeClient({ fetch: explodingFetch }).updateClient("pct:alice", { name: "alice", ids: [] }),
+    ).rejects.toBeInstanceOf(AdGuardScopeError);
+  });
+});
+
+describe("deleteClient", () => {
+  it("POSTs { name } to /control/clients/delete", async () => {
+    let seenBody: string | undefined;
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/clients/delete", method: "POST" })
+      .reply(200, (opts) => {
+        seenBody = opts.body as string;
+        return "";
+      });
+
+    await makeClient().deleteClient("pct:alice-laptop");
+    expect(JSON.parse(seenBody ?? "")).toEqual({ name: "pct:alice-laptop" });
+  });
+
+  it("refuses an unmanaged name", async () => {
+    await expect(
+      makeClient({ fetch: explodingFetch }).deleteClient("household-tv"),
+    ).rejects.toBeInstanceOf(AdGuardScopeError);
+  });
+});
+
+describe("user rules", () => {
+  it("getUserRules returns the user_rules list", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/filtering/status", method: "GET" })
+      .reply(
+        200,
+        { enabled: true, interval: 24, user_rules: ["||ads.example^", "! note"] },
+        JSON_HEADERS,
+      );
+
+    expect(await makeClient().getUserRules()).toEqual(["||ads.example^", "! note"]);
+  });
+
+  it("treats a missing user_rules key as empty", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/filtering/status", method: "GET" })
+      .reply(200, { enabled: false }, JSON_HEADERS);
+
+    expect(await makeClient().getUserRules()).toEqual([]);
+  });
+
+  it("setUserRules POSTs { rules } to /control/filtering/set_rules", async () => {
+    let seenBody: string | undefined;
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/filtering/set_rules", method: "POST" })
+      .reply(200, (opts) => {
+        seenBody = opts.body as string;
+        return "";
+      });
+
+    await makeClient().setUserRules(["||ads.example^"]);
+    expect(JSON.parse(seenBody ?? "")).toEqual({ rules: ["||ads.example^"] });
+  });
+});
+
+describe("error mapping", () => {
+  it("maps 401 to AdGuardAuthError (a subclass of AdGuardRequestError)", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/status", method: "GET" })
+      .reply(401, "Unauthorized");
+
+    const error = await makeClient()
+      .getStatus()
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(AdGuardAuthError);
+    expect(error).toBeInstanceOf(AdGuardRequestError);
+    expect((error as AdGuardAuthError).statusCode).toBe(401);
+  });
+
+  it("maps 403 to AdGuardAuthError", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/status", method: "GET" })
+      .reply(403, "Forbidden");
+    await expect(makeClient().getStatus()).rejects.toBeInstanceOf(AdGuardAuthError);
+  });
+
+  it("maps other non-2xx to AdGuardRequestError (not auth)", async () => {
+    agent.get(BASE_URL).intercept({ path: "/control/status", method: "GET" }).reply(500, "boom");
+
+    const error = await makeClient()
+      .getStatus()
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(AdGuardRequestError);
+    expect(error).not.toBeInstanceOf(AdGuardAuthError);
+    expect((error as AdGuardRequestError).statusCode).toBe(500);
+  });
+
+  it("maps a non-2xx on a write to AdGuardRequestError", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/clients/add", method: "POST" })
+      .reply(400, "bad client");
+
+    await expect(makeClient().addClient({ name: "pct:x", ids: [] })).rejects.toBeInstanceOf(
+      AdGuardRequestError,
+    );
+  });
+
+  it("maps a thrown fetch (connection refused) to AdGuardUnreachableError", async () => {
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/status", method: "GET" })
+      .replyWithError(new Error("ECONNREFUSED"));
+
+    const error = await makeClient()
+      .getStatus()
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(AdGuardUnreachableError);
+    expect((error as AdGuardUnreachableError).timedOut).toBe(false);
+  });
+
+  it("maps the per-request abort timeout to AdGuardUnreachableError with timedOut", async () => {
+    const hangingFetch: FetchLike = (_input, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "TimeoutError";
+          reject(err);
+        });
+      });
+
+    const error = await new AdGuardHomeClient({
+      baseUrl: BASE_URL,
+      fetch: hangingFetch,
+      timeoutMs: 5,
+    })
+      .getStatus()
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(AdGuardUnreachableError);
+    expect((error as AdGuardUnreachableError).timedOut).toBe(true);
+  });
+});

--- a/server/tests/transport/adguard/client.test.ts
+++ b/server/tests/transport/adguard/client.test.ts
@@ -362,6 +362,20 @@ describe("user rules", () => {
     await makeClient().setUserRules(["||ads.example^"]);
     expect(JSON.parse(seenBody ?? "")).toEqual({ rules: ["||ads.example^"] });
   });
+
+  it("setUserRules can clear the list (sends { rules: [] })", async () => {
+    let seenBody: string | undefined;
+    agent
+      .get(BASE_URL)
+      .intercept({ path: "/control/filtering/set_rules", method: "POST" })
+      .reply(200, (opts) => {
+        seenBody = opts.body as string;
+        return "";
+      });
+
+    await makeClient().setUserRules([]);
+    expect(JSON.parse(seenBody ?? "")).toEqual({ rules: [] });
+  });
 });
 
 describe("error mapping", () => {


### PR DESCRIPTION
## Summary

- Adds the typed, REST-only `transport/adguard` client — the **single code path** for both `managed` and `external` AdGuard Home modes (mode plumbing #95, managed supervisor #96, UI #97 land separately).
- Covers the operations the dashboard needs: **status**, **clients** (list / listManaged / add / update / delete), and **filtering user-rules** (get / set), with zod-validated responses and a typed error taxonomy mirroring `transport/activitywatch`.
- **Confines writes to the `pct:`-prefixed client namespace**: every client write asserts the prefix and throws `AdGuardScopeError` *before* issuing a request, so a household's own AdGuard config structurally cannot be clobbered (`docs/server-deployment.md` → "What the dashboard expects from an external instance").

## Plan

Linked plan: `.claude/plans/issue-94-adguard-rest-client.md`
Roadmap: `docs/roadmap.md` → Phase 7.

### Design notes

- **Auth** takes *resolved* credentials — `{ kind: "basic", username, password }` (AdGuard accepts HTTP Basic on `/control/*`) or `{ kind: "bearer", token }` (reverse-proxy / `PCT_ADGUARD_API_TOKEN_FILE`). The file reads stay in the config layer (#95); the client never touches the filesystem. A doc comment notes a cookie-session strategy can be added additively if a future AdGuard drops Basic.
- **Responses validated, request bodies sent verbatim.** zod validates everything inbound (`CLAUDE.md` → "Validate all external input"); request bodies are sent as-is so a client object read → modified → written back never loses fields a newer AdGuard added (the `AdGuardClientInput` index signature).
- Mutating `/control/*` endpoints answer `200` with an empty body, so those methods return `void` and only classify failure (never call `.json()`).
- `getUserRules` / `setUserRules` are the raw building blocks; the per-client blocklist composition that decides which rules the dashboard *owns* (and preserves foreign global rules on write) is #97 — AdGuard has no per-client rule list, so that read-modify-write merge belongs there.

## License-boundary note

Pure TypeScript over HTTP — REST-only integration per `CLAUDE.md` rule 4 / `docs/licensing-analysis.md`. No AdGuard source linked in-process, no GPL binary added to any image. `license-guard` unaffected. **No new dependency** (`undici`'s `fetch`/`MockAgent` and `zod` are already in the tree).

## Test plan

- [x] `format:check` / `lint` / `typecheck` clean.
- [x] `npm test` — **710 passing**; `src/transport/adguard` at 100% lines/functions/statements (98.4% branches; the one uncovered branch is the same defensive `cause instanceof Error` else-arm the existing ActivityWatch client leaves uncovered). Global gate (80%) satisfied.
- [x] Construction: trailing-slash normalisation; default vs custom prefix.
- [x] Auth header: Basic (base64 `user:pass`), Bearer, none.
- [x] `getStatus`: happy parse; schema mismatch → `AdGuardParseError`; non-JSON → `AdGuardParseError`.
- [x] `listClients` / `listManagedClients`: happy, prefix filter, missing-`clients` → `[]`, non-object body → parse error.
- [x] `addClient` / `updateClient` / `deleteClient`: correct path + body on 200; prefix guard throws `AdGuardScopeError` and issues **no** request (proven with a fetch that throws if reached); rename-out-of-namespace rejected.
- [x] `getUserRules` / `setUserRules`: happy get, missing-key → `[]`, correct set body.
- [x] Error mapping: 401/403 → `AdGuardAuthError` (subclass of `AdGuardRequestError`); other non-2xx → `AdGuardRequestError`; connection refused → `AdGuardUnreachableError`; abort timeout → `timedOut: true`.

## Deferred (tracked)

- Mode plumbing / external preflight — **#95**.
- Managed-mode supervisor — **#96**.
- Per-client domain-blocklist UI + schedule, incl. the user-rule read-modify-write confinement that preserves foreign global rules — **#97**.
- Optional `adguard.int.test.ts` against the `adguard/adguardhome` container (`docs/testing.md` compose env) — integration tier, not the unit gate.

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYugDogKrXjp8rpQNeYvcS)_