### PR TITLE
fix(ansible): make the ActivityWatch playbook actually converge (#218)

### DIFF
--- a/client/ansible/playbooks/activitywatch.yml
+++ b/client/ansible/playbooks/activitywatch.yml
@@ -34,9 +34,12 @@
     aw_port: 5600
     aw_arch: linux-x86_64
     aw_release_base: https://github.com/ActivityWatch/activitywatch/releases/download
-    # The supervised Linux usernames to manage on this host. The dashboard
-    # passes this from the host's UserOnClient links; empty = bundle-only.
-    aw_supervised_users: []
+    # `aw_supervised_users` is intentionally not declared as a play var: play
+    # vars beat inventory group_vars in Ansible's precedence, so a default of
+    # `[]` here would silently mask the list Molecule's group_vars and the
+    # dashboard's `--extra-vars` pass in. The empty-list safety net is applied
+    # below via `set_fact ... when: ... is not defined`, which only fires when
+    # no caller provided a value at all.
     # The three per-user units. Content differs by unit; the path layout is the
     # extracted bundle's, matching the baseline's ExecStart lines.
     aw_units:
@@ -51,6 +54,11 @@
         exec: "{{ aw_prefix }}/activitywatch/aw-watcher-window/aw-watcher-window"
 
   tasks:
+    - name: Apply the empty-list default for aw_supervised_users when unset
+      ansible.builtin.set_fact:
+        aw_supervised_users: []
+      when: aw_supervised_users is not defined
+
     - name: Read the passwd database for supervised-user home/uid lookup
       ansible.builtin.getent:
         database: passwd
@@ -81,6 +89,18 @@
         owner: root
         group: root
         mode: "0755"
+
+    # Mint ships unzip by default, but a freshly imaged client (or the Molecule
+    # converge image) may not — the bundle is a .zip and `ansible.builtin.
+    # unarchive` requires `unzip` on the target. Ensure it's present before the
+    # upgrade step so the playbook converges on a stock distro image.
+    - name: Ensure the unzip binary is present (needed by the unarchive step)
+      ansible.builtin.apt:
+        name: unzip
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+      when: aw_upgrade_required
 
     # --- bundle deploy/upgrade (idempotent via the version stamp) -----------
 


### PR DESCRIPTION
## Summary

First live `molecule test` run of the AW scenario added in #218 (which only
had static `ansible-lint` coverage before this session) surfaced two real
playbook defects:

1. **`unarchive` needs `unzip` on the target** — the bundle is a `.zip`,
   and the Molecule converge image (`geerlingguy/docker-ubuntu2204-ansible`)
   doesn't ship `unzip`. Mint does, but the playbook should not assume that.
   Install `unzip` before the upgrade step.

2. **`aw_supervised_users: []` in play vars silently shadowed group_vars** —
   in Ansible's variable precedence, **play vars beat inventory group_vars**,
   so Molecule's `inventory/group_vars/all: aw_supervised_users: [alice]`
   was being thrown away by the play's empty default. The
   `Reconcile per-user ActivityWatch configuration and units` block
   (`when: aw_supervised_users | length > 0`) was therefore always skipped,
   no per-user config was rendered, and verify failed asserting the
   per-user `config.toml` doesn't exist.

   Fix: drop the play-var default; apply the empty-list safety net via
   `set_fact … when: aw_supervised_users is not defined`, which only fires
   when nobody provided a value at all — so Molecule's `group_vars` *and*
   the dashboard's `--extra-vars` (#83) both override it as intended.

The dashboard's runner already passes the list via `--extra-vars` (the
playbook's docstring documents this), and `--extra-vars` has always
out-ranked play vars in precedence, so this fix has no effect on real
dashboard runs — it only unbreaks the Molecule path and any future
group_vars-based callers.

## Plan

Linked work: this is the follow-up the user asked me to file from the
in-session #218 verification (the scenario had never been live-run before
this session — see `docs/testing.md` "Ansible playbooks — Molecule").

## License-boundary note

Unchanged — playbook still drives `apt`/`unarchive`/`systemd_service` on
the client only. No GPL code linked, no GPL binary added to the dashboard
image.

## Verification

`molecule test` (full `create → prepare → converge → idempotence →
verify → destroy` cycle) green locally:

- converge: `ok=17 changed=12 failed=0` (per-user tasks now actually
  fire — previously all skipped due to the play-vars shadow)
- idempotence: `changed=0`
- verify: `ok=8` — every assertion (version stamp, binary extracted,
  per-user `config.toml` loopback-bound, all three `systemd --user` unit
  files rendered) passes
- destroy: clean

Static `ansible-lint --production` still green (no syntax/style
changes).

## Test plan

- [ ] `ci.yml` static gates green (`ansible-lint`, etc.).
- [ ] Next session: wire #219 (CI job running `molecule test`) so this
      defect class is caught in CI, not only locally.

Addresses #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)