### PR TITLE
feat(frontend): admin Clients + Activities editors (#189)

### DIFF
--- a/.claude/plans/issue-189-admin-editors.md
+++ b/.claude/plans/issue-189-admin-editors.md
@@ -1,0 +1,61 @@
+# Plan — #189 Admin UI: remaining policy editors (slice: Clients + Activities)
+
+Follow-up to the #53 foundation slice (typed `/api` client + login/session +
+app shell + the **Users** CRUD editor). #189 covers all remaining `/admin`
+editors; this session lands a focused, shippable slice and leaves #189 open to
+track the rest.
+
+## Scope of this PR
+
+Two full CRUD editors, each repeating the exact pattern the Users editor
+established (typed `apiFetch` wrappers over the shared inferred DTOs, an
+in-page `*View.svelte` with list/create/inline-edit/delete, wired into the
+`/admin` shell nav):
+
+1. **Clients** — `/api/clients` (`hostname`, `sshUser`); surface read-only
+   `enrolledAt` + `lastSeen`. The richer health/status view is Phase 3 / #81,
+   not here.
+2. **Activities** — `/api/activities` (`kind` ∈ {app, app_group, domain,
+   domain_group}, `matcher`).
+
+### Deferred — stays tracked on #189 (PR is "Part of #189", not "Closes")
+
+- Activity Groups (+ membership) editor — `/api/activity-groups`.
+- Budgets editor — `/api/budgets`.
+- Schedules / Exceptions editors — `/api/schedules`, `/api/exceptions`
+  (drag-to-order + first-match-wins stays #63; recurring-window authoring #140).
+- User ↔ Client links editor — `/api/users/:userId/clients`.
+- Deep `/admin/*` URL routes + SPA fallback — #59.
+
+## Files
+
+- `server/frontend/src/lib/api/contract.ts` — add type-only re-exports for the
+  client + activity DTOs (`ClientResponse`, `Create/UpdateClientRequest`,
+  `ActivityResponse`, `Create/UpdateActivityRequest`). **Never** hand-write a DTO.
+- `server/frontend/src/lib/api/clients.ts` — `listClients/createClient/
+  updateClient/deleteClient` over `apiFetch`.
+- `server/frontend/src/lib/api/activities.ts` — `listActivities/createActivity/
+  updateActivity/deleteActivity`.
+- `server/frontend/src/lib/views/ClientsView.svelte` — list/create/edit/delete.
+- `server/frontend/src/lib/views/ActivitiesView.svelte` — list/create/edit/delete
+  with a `kind` `<select>` over the four activity kinds.
+- `server/frontend/src/routes/admin/+page.svelte` — add `clients` + `activities`
+  nav items and render the new views in the in-page switcher.
+- `server/frontend/tests/api/clients.test.ts`,
+  `server/frontend/tests/api/activities.test.ts` — vitest unit tests mirroring
+  `tests/api/users.test.ts` (URL/method/body assertions, 204 on delete).
+
+## Constraints honoured
+
+- Frontend talks **only** to `/api/*`; no privileged in-process shortcuts.
+- All `/api` calls are browser-guarded (page is prerendered to a static shell
+  under `adapter-static`).
+- License boundary: type-only DTO imports, plain browser `fetch`. No GPL
+  surface, no transport/packaging change.
+
+## Validation
+
+- `server/frontend`: `npm run check` (svelte-check) + `npm run test` (vitest)
+  + `npm run build` (svelte-kit sync && vite build) all green.
+- The server quality gate is unaffected (no `server/src` change) but re-run
+  `format:check`/`lint`/`typecheck`/`test` from `server/` to be safe.

--- a/server/frontend/src/lib/api/activities.ts
+++ b/server/frontend/src/lib/api/activities.ts
@@ -1,0 +1,36 @@
+/**
+ * CRUD calls for the `Activity` policy entity (#51 contract, #189 editor).
+ *
+ * Same proven shape as `$lib/api/users` (#53): thin typed wrappers over
+ * {@link apiFetch}, with the request/response types imported from the shared
+ * `/api` contract so the frontend never re-declares a DTO. An `Activity` is a
+ * matcher (`kind` + `matcher`) that budgets/schedules can target.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type {
+  ActivityResponse,
+  CreateActivityRequest,
+  UpdateActivityRequest,
+} from "./contract.js";
+
+/** List all activities, in the order `/api` returns them. */
+export function listActivities(): Promise<ActivityResponse[]> {
+  return apiFetch<ActivityResponse[]>("/activities");
+}
+
+/** Create an activity; the server validates `kind`/`matcher` and returns the row. */
+export function createActivity(input: CreateActivityRequest): Promise<ActivityResponse> {
+  return apiFetch<ActivityResponse>("/activities", { method: "POST", body: input });
+}
+
+/** Patch an activity; `input` must carry at least one field (server enforces). */
+export function updateActivity(id: number, input: UpdateActivityRequest): Promise<ActivityResponse> {
+  return apiFetch<ActivityResponse>(`/activities/${id}`, { method: "PATCH", body: input });
+}
+
+/** Delete an activity. Resolves on the server's `204`. */
+export function deleteActivity(id: number): Promise<void> {
+  return apiFetch<void>(`/activities/${id}`, { method: "DELETE" });
+}

--- a/server/frontend/src/lib/api/clients.ts
+++ b/server/frontend/src/lib/api/clients.ts
@@ -1,0 +1,32 @@
+/**
+ * CRUD calls for the `Client` policy entity (#51 contract, #189 editor).
+ *
+ * Same proven shape as `$lib/api/users` (#53): thin typed wrappers over
+ * {@link apiFetch}, with the request/response types imported from the shared
+ * `/api` contract so the frontend never re-declares a DTO. A `Client` is the
+ * supervised Linux desktop record the admin enrols and then attaches policy to.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type { ClientResponse, CreateClientRequest, UpdateClientRequest } from "./contract.js";
+
+/** List all enrolled clients, in the order `/api` returns them. */
+export function listClients(): Promise<ClientResponse[]> {
+  return apiFetch<ClientResponse[]>("/clients");
+}
+
+/** Create a client; the server validates `hostname`/`sshUser` and returns the row. */
+export function createClient(input: CreateClientRequest): Promise<ClientResponse> {
+  return apiFetch<ClientResponse>("/clients", { method: "POST", body: input });
+}
+
+/** Patch a client; `input` must carry at least one field (server enforces). */
+export function updateClient(id: number, input: UpdateClientRequest): Promise<ClientResponse> {
+  return apiFetch<ClientResponse>(`/clients/${id}`, { method: "PATCH", body: input });
+}
+
+/** Delete a client. Resolves on the server's `204`. */
+export function deleteClient(id: number): Promise<void> {
+  return apiFetch<void>(`/clients/${id}`, { method: "DELETE" });
+}

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -25,5 +25,12 @@ export type {
   UserResponse,
   CreateUserRequest,
   UpdateUserRequest,
+  ClientResponse,
+  CreateClientRequest,
+  UpdateClientRequest,
+  ActivityResponse,
+  CreateActivityRequest,
+  UpdateActivityRequest,
 } from "../../../../src/api/policy/dtos.js";
+export type { ActivityKind, MatchType } from "../../../../src/policy/enums.js";
 export type { ErrorEnvelope, ErrorDetail } from "../../../../src/api/errors.js";

--- a/server/frontend/src/lib/views/ActivitiesView.svelte
+++ b/server/frontend/src/lib/views/ActivitiesView.svelte
@@ -1,0 +1,349 @@
+<!--
+  Activities editor (#189): the remaining-editor slice repeating the Users-editor
+  pattern (#53). Loads `/api/activities` on mount (browser only — the page is
+  prerendered to a static shell), supports create, inline edit, and delete. All
+  calls go through the typed `$lib/api/activities` wrappers; errors are surfaced
+  inline rather than thrown away.
+
+  An `Activity` is a matcher that budgets/schedules can target: a `kind` (app /
+  domain, individually or as a named group) plus a `matcher` string interpreted
+  per `matchType` (exact / substring / glob / regex — ADR 0006). A `regex` that
+  does not compile is a 400 from the server, surfaced inline.
+
+  The kind/match-type option lists are declared locally and typed against the
+  inferred `ActivityKind`/`MatchType` so they stay in step with the source enums
+  without importing server runtime values into the bundle.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ApiError } from "$lib/api/client.js";
+  import type { ActivityKind, ActivityResponse, MatchType } from "$lib/api/contract.js";
+  import {
+    createActivity,
+    deleteActivity,
+    listActivities,
+    updateActivity,
+  } from "$lib/api/activities.js";
+
+  const KIND_OPTIONS: ReadonlyArray<{ value: ActivityKind; label: string }> = [
+    { value: "app", label: "App" },
+    { value: "app_group", label: "App group" },
+    { value: "domain", label: "Domain" },
+    { value: "domain_group", label: "Domain group" },
+  ];
+
+  const MATCH_TYPE_OPTIONS: ReadonlyArray<{ value: MatchType; label: string }> = [
+    { value: "exact", label: "Exact" },
+    { value: "substring", label: "Substring" },
+    { value: "glob", label: "Glob" },
+    { value: "regex", label: "Regex" },
+  ];
+
+  function kindLabel(kind: ActivityKind): string {
+    return KIND_OPTIONS.find((o) => o.value === kind)?.label ?? kind;
+  }
+
+  function matchTypeLabel(matchType: MatchType): string {
+    return MATCH_TYPE_OPTIONS.find((o) => o.value === matchType)?.label ?? matchType;
+  }
+
+  let activities = $state<ActivityResponse[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // Create form.
+  let newKind = $state<ActivityKind>("app");
+  let newMatcher = $state("");
+  let newMatchType = $state<MatchType>("exact");
+  let creating = $state(false);
+
+  // Inline edit.
+  let editingId = $state<number | null>(null);
+  let editKind = $state<ActivityKind>("app");
+  let editMatcher = $state("");
+  let editMatchType = $state<MatchType>("exact");
+  let saving = $state(false);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      activities = await listActivities();
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleCreate(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    creating = true;
+    error = null;
+    try {
+      const created = await createActivity({
+        kind: newKind,
+        matcher: newMatcher.trim(),
+        matchType: newMatchType,
+      });
+      activities = [...activities, created];
+      newKind = "app";
+      newMatcher = "";
+      newMatchType = "exact";
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      creating = false;
+    }
+  }
+
+  function startEdit(activity: ActivityResponse): void {
+    editingId = activity.id;
+    editKind = activity.kind;
+    editMatcher = activity.matcher;
+    editMatchType = activity.matchType;
+    error = null;
+  }
+
+  function cancelEdit(): void {
+    editingId = null;
+  }
+
+  async function saveEdit(id: number): Promise<void> {
+    saving = true;
+    error = null;
+    try {
+      const updated = await updateActivity(id, {
+        kind: editKind,
+        matcher: editMatcher.trim(),
+        matchType: editMatchType,
+      });
+      activities = activities.map((a) => (a.id === id ? updated : a));
+      editingId = null;
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleDelete(activity: ActivityResponse): Promise<void> {
+    if (!confirm(`Delete activity "${activity.matcher}"? This cannot be undone.`)) {
+      return;
+    }
+    error = null;
+    try {
+      await deleteActivity(activity.id);
+      activities = activities.filter((a) => a.id !== activity.id);
+    } catch (err) {
+      error = messageOf(err);
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>Activities</h1>
+    <p class="hint">
+      Apps and domains that budgets and schedules can target. The match type
+      controls how the matcher is interpreted.
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  <form class="create" onsubmit={handleCreate}>
+    <select bind:value={newKind} disabled={creating} aria-label="New activity kind">
+      {#each KIND_OPTIONS as option (option.value)}
+        <option value={option.value}>{option.label}</option>
+      {/each}
+    </select>
+    <select bind:value={newMatchType} disabled={creating} aria-label="New activity match type">
+      {#each MATCH_TYPE_OPTIONS as option (option.value)}
+        <option value={option.value}>{option.label}</option>
+      {/each}
+    </select>
+    <input
+      type="text"
+      placeholder="Matcher (e.g. firefox, *.youtube.com)"
+      bind:value={newMatcher}
+      disabled={creating}
+      required
+      aria-label="New activity matcher"
+    />
+    <button type="submit" disabled={creating || newMatcher.trim() === ""}>
+      {creating ? "Adding…" : "Add activity"}
+    </button>
+  </form>
+
+  {#if loading}
+    <p class="muted">Loading activities…</p>
+  {:else if activities.length === 0}
+    <p class="muted">No activities yet. Add one above.</p>
+  {:else}
+    <table>
+      <thead>
+        <tr>
+          <th>Kind</th>
+          <th>Match type</th>
+          <th>Matcher</th>
+          <th class="actions-col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each activities as activity (activity.id)}
+          <tr>
+            {#if editingId === activity.id}
+              <td>
+                <select bind:value={editKind} aria-label="Edit kind">
+                  {#each KIND_OPTIONS as option (option.value)}
+                    <option value={option.value}>{option.label}</option>
+                  {/each}
+                </select>
+              </td>
+              <td>
+                <select bind:value={editMatchType} aria-label="Edit match type">
+                  {#each MATCH_TYPE_OPTIONS as option (option.value)}
+                    <option value={option.value}>{option.label}</option>
+                  {/each}
+                </select>
+              </td>
+              <td><input bind:value={editMatcher} aria-label="Edit matcher" /></td>
+              <td class="actions">
+                <button
+                  onclick={() => saveEdit(activity.id)}
+                  disabled={saving || editMatcher.trim() === ""}
+                >
+                  {saving ? "Saving…" : "Save"}
+                </button>
+                <button class="ghost" onclick={cancelEdit} disabled={saving}>Cancel</button>
+              </td>
+            {:else}
+              <td>{kindLabel(activity.kind)}</td>
+              <td class="muted">{matchTypeLabel(activity.matchType)}</td>
+              <td><code>{activity.matcher}</code></td>
+              <td class="actions">
+                <button class="ghost" onclick={() => startEdit(activity)}>Edit</button>
+                <button class="danger" onclick={() => handleDelete(activity)}>Delete</button>
+              </td>
+            {/if}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+    max-width: 40rem;
+  }
+  .create {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+  }
+  .create input {
+    flex: 1 1 12rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+  }
+  .create select {
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    background: #fff;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+  }
+  th {
+    background: #f9fafb;
+    font-weight: 600;
+    color: #374151;
+  }
+  td input,
+  td select {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.3rem;
+    background: #fff;
+  }
+  code {
+    font-size: 0.85rem;
+    color: #111827;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .actions-col {
+    width: 1%;
+    white-space: nowrap;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  button.danger {
+    background: #dc2626;
+  }
+  .muted {
+    color: #6b7280;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/lib/views/ClientsView.svelte
+++ b/server/frontend/src/lib/views/ClientsView.svelte
@@ -1,0 +1,300 @@
+<!--
+  Clients editor (#189): the remaining-editor slice repeating the Users-editor
+  pattern (#53). Loads `/api/clients` on mount (browser only — the page is
+  prerendered to a static shell), supports create, inline edit, and delete. All
+  calls go through the typed `$lib/api/clients` wrappers; errors are surfaced
+  inline rather than thrown away.
+
+  A `Client` is the supervised Linux desktop record. `enrolledAt`/`lastSeen` are
+  server-owned and read-only here; the richer reachability/health view is
+  Phase 3 / #81.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ApiError } from "$lib/api/client.js";
+  import type { ClientResponse } from "$lib/api/contract.js";
+  import {
+    createClient,
+    deleteClient,
+    listClients,
+    updateClient,
+  } from "$lib/api/clients.js";
+
+  let clients = $state<ClientResponse[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // Create form.
+  let newHostname = $state("");
+  let newSshUser = $state("");
+  let creating = $state(false);
+
+  // Inline edit.
+  let editingId = $state<number | null>(null);
+  let editHostname = $state("");
+  let editSshUser = $state("");
+  let saving = $state(false);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      clients = await listClients();
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleCreate(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    creating = true;
+    error = null;
+    try {
+      const created = await createClient({
+        hostname: newHostname.trim(),
+        sshUser: newSshUser.trim(),
+      });
+      clients = [...clients, created];
+      newHostname = "";
+      newSshUser = "";
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      creating = false;
+    }
+  }
+
+  function startEdit(client: ClientResponse): void {
+    editingId = client.id;
+    editHostname = client.hostname;
+    editSshUser = client.sshUser;
+    error = null;
+  }
+
+  function cancelEdit(): void {
+    editingId = null;
+  }
+
+  async function saveEdit(id: number): Promise<void> {
+    saving = true;
+    error = null;
+    try {
+      const updated = await updateClient(id, {
+        hostname: editHostname.trim(),
+        sshUser: editSshUser.trim(),
+      });
+      clients = clients.map((c) => (c.id === id ? updated : c));
+      editingId = null;
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleDelete(client: ClientResponse): Promise<void> {
+    if (!confirm(`Delete client "${client.hostname}"? This cannot be undone.`)) {
+      return;
+    }
+    error = null;
+    try {
+      await deleteClient(client.id);
+      clients = clients.filter((c) => c.id !== client.id);
+    } catch (err) {
+      error = messageOf(err);
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+
+  /** Format an ISO-8601 UTC timestamp as a short local date, or a dash. */
+  function formatDate(iso: string | null): string {
+    if (iso === null) {
+      return "—";
+    }
+    const date = new Date(iso);
+    return Number.isNaN(date.getTime()) ? iso : date.toLocaleDateString();
+  }
+
+  const canSaveEdit = $derived(editHostname.trim() !== "" && editSshUser.trim() !== "");
+</script>
+
+<section>
+  <header class="head">
+    <h1>Clients</h1>
+    <p class="hint">Supervised Linux desktops the dashboard pushes policy to.</p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  <form class="create" onsubmit={handleCreate}>
+    <input
+      type="text"
+      placeholder="Hostname (e.g. mint-living-room)"
+      bind:value={newHostname}
+      disabled={creating}
+      required
+      aria-label="New client hostname"
+    />
+    <input
+      type="text"
+      placeholder="SSH user (e.g. pct-agent)"
+      bind:value={newSshUser}
+      disabled={creating}
+      required
+      aria-label="New client SSH user"
+    />
+    <button
+      type="submit"
+      disabled={creating || newHostname.trim() === "" || newSshUser.trim() === ""}
+    >
+      {creating ? "Adding…" : "Add client"}
+    </button>
+  </form>
+
+  {#if loading}
+    <p class="muted">Loading clients…</p>
+  {:else if clients.length === 0}
+    <p class="muted">No clients yet. Add one above.</p>
+  {:else}
+    <table>
+      <thead>
+        <tr>
+          <th>Hostname</th>
+          <th>SSH user</th>
+          <th>Enrolled</th>
+          <th>Last seen</th>
+          <th class="actions-col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each clients as client (client.id)}
+          <tr>
+            {#if editingId === client.id}
+              <td><input bind:value={editHostname} aria-label="Edit hostname" /></td>
+              <td><input bind:value={editSshUser} aria-label="Edit SSH user" /></td>
+              <td class="muted">{formatDate(client.enrolledAt)}</td>
+              <td class="muted">{formatDate(client.lastSeen)}</td>
+              <td class="actions">
+                <button onclick={() => saveEdit(client.id)} disabled={saving || !canSaveEdit}>
+                  {saving ? "Saving…" : "Save"}
+                </button>
+                <button class="ghost" onclick={cancelEdit} disabled={saving}>Cancel</button>
+              </td>
+            {:else}
+              <td>{client.hostname}</td>
+              <td class="muted">{client.sshUser}</td>
+              <td class="muted">{formatDate(client.enrolledAt)}</td>
+              <td class="muted">{formatDate(client.lastSeen)}</td>
+              <td class="actions">
+                <button class="ghost" onclick={() => startEdit(client)}>Edit</button>
+                <button class="danger" onclick={() => handleDelete(client)}>Delete</button>
+              </td>
+            {/if}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+  }
+  .create {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+  }
+  .create input {
+    flex: 1 1 12rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+  }
+  th {
+    background: #f9fafb;
+    font-weight: 600;
+    color: #374151;
+  }
+  td input {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.3rem;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .actions-col {
+    width: 1%;
+    white-space: nowrap;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  button.danger {
+    background: #dc2626;
+  }
+  .muted {
+    color: #6b7280;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/lib/views/ClientsView.svelte
+++ b/server/frontend/src/lib/views/ClientsView.svelte
@@ -125,8 +125,6 @@
     const date = new Date(iso);
     return Number.isNaN(date.getTime()) ? iso : date.toLocaleDateString();
   }
-
-  const canSaveEdit = $derived(editHostname.trim() !== "" && editSshUser.trim() !== "");
 </script>
 
 <section>
@@ -188,7 +186,10 @@
               <td class="muted">{formatDate(client.enrolledAt)}</td>
               <td class="muted">{formatDate(client.lastSeen)}</td>
               <td class="actions">
-                <button onclick={() => saveEdit(client.id)} disabled={saving || !canSaveEdit}>
+                <button
+                  onclick={() => saveEdit(client.id)}
+                  disabled={saving || editHostname.trim() === "" || editSshUser.trim() === ""}
+                >
                   {saving ? "Saving…" : "Save"}
                 </button>
                 <button class="ghost" onclick={cancelEdit} disabled={saving}>Cancel</button>

--- a/server/frontend/src/routes/admin/+page.svelte
+++ b/server/frontend/src/routes/admin/+page.svelte
@@ -22,6 +22,8 @@
   import LoginForm from "$lib/components/LoginForm.svelte";
   import DashboardView from "$lib/views/DashboardView.svelte";
   import UsersView from "$lib/views/UsersView.svelte";
+  import ClientsView from "$lib/views/ClientsView.svelte";
+  import ActivitiesView from "$lib/views/ActivitiesView.svelte";
 
   // `null` while the initial session probe is in flight.
   let session = $state<SessionResponse | null>(null);
@@ -33,6 +35,8 @@
   const navItems: NavItem[] = [
     { id: "dashboard", label: "Dashboard" },
     { id: "users", label: "Users" },
+    { id: "clients", label: "Clients" },
+    { id: "activities", label: "Activities" },
   ];
   let activeView = $state<string>("dashboard");
 
@@ -103,6 +107,10 @@
   >
     {#if activeView === "users"}
       <UsersView />
+    {:else if activeView === "clients"}
+      <ClientsView />
+    {:else if activeView === "activities"}
+      <ActivitiesView />
     {:else}
       <DashboardView {username} onnavigate={(id) => (activeView = id)} />
     {/if}

--- a/server/frontend/tests/api/activities.test.ts
+++ b/server/frontend/tests/api/activities.test.ts
@@ -62,6 +62,19 @@ describe("activities API", () => {
     expect((init as RequestInit).body).toBe(JSON.stringify({ matcher: "steam" }));
   });
 
+  it("updateActivity sends a matchType-only PATCH body unchanged", async () => {
+    const updated = { id: 5, kind: "domain", matcher: "*.youtube.com", matchType: "glob" };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, updated));
+
+    const result = await updateActivity(5, { matchType: "glob" });
+
+    expect(result).toEqual(updated);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/activities/5");
+    expect((init as RequestInit).method).toBe("PATCH");
+    expect((init as RequestInit).body).toBe(JSON.stringify({ matchType: "glob" }));
+  });
+
   it("deleteActivity DELETEs /api/activities/:id and resolves on 204", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
 

--- a/server/frontend/tests/api/activities.test.ts
+++ b/server/frontend/tests/api/activities.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createActivity,
+  deleteActivity,
+  listActivities,
+  updateActivity,
+} from "../../src/lib/api/activities.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("activities API", () => {
+  it("listActivities GETs /api/activities", async () => {
+    const rows = [{ id: 1, kind: "app", matcher: "firefox", matchType: "exact" }];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, rows));
+
+    const result = await listActivities();
+
+    expect(result).toEqual(rows);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/activities");
+  });
+
+  it("createActivity POSTs the body to /api/activities", async () => {
+    const created = { id: 2, kind: "domain", matcher: "youtube.com", matchType: "substring" };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(201, created));
+
+    const result = await createActivity({
+      kind: "domain",
+      matcher: "youtube.com",
+      matchType: "substring",
+    });
+
+    expect(result).toEqual(created);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/activities");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBe(
+      JSON.stringify({ kind: "domain", matcher: "youtube.com", matchType: "substring" }),
+    );
+  });
+
+  it("updateActivity PATCHes /api/activities/:id", async () => {
+    const updated = { id: 3, kind: "app", matcher: "steam", matchType: "exact" };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, updated));
+
+    const result = await updateActivity(3, { matcher: "steam" });
+
+    expect(result).toEqual(updated);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/activities/3");
+    expect((init as RequestInit).method).toBe("PATCH");
+    expect((init as RequestInit).body).toBe(JSON.stringify({ matcher: "steam" }));
+  });
+
+  it("deleteActivity DELETEs /api/activities/:id and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(deleteActivity(4)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/activities/4");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+});

--- a/server/frontend/tests/api/clients.test.ts
+++ b/server/frontend/tests/api/clients.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createClient, deleteClient, listClients, updateClient } from "../../src/lib/api/clients.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("clients API", () => {
+  it("listClients GETs /api/clients", async () => {
+    const rows = [
+      {
+        id: 1,
+        hostname: "mint-01",
+        sshUser: "pct-agent",
+        enrolledAt: "2026-01-01T00:00:00.000Z",
+        lastSeen: null,
+      },
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, rows));
+
+    const result = await listClients();
+
+    expect(result).toEqual(rows);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/clients");
+  });
+
+  it("createClient POSTs the body to /api/clients", async () => {
+    const created = {
+      id: 2,
+      hostname: "mint-02",
+      sshUser: "pct-agent",
+      enrolledAt: "x",
+      lastSeen: null,
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(201, created));
+
+    const result = await createClient({ hostname: "mint-02", sshUser: "pct-agent" });
+
+    expect(result).toEqual(created);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/clients");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBe(
+      JSON.stringify({ hostname: "mint-02", sshUser: "pct-agent" }),
+    );
+  });
+
+  it("updateClient PATCHes /api/clients/:id", async () => {
+    const updated = {
+      id: 3,
+      hostname: "mint-03",
+      sshUser: "pct-agent",
+      enrolledAt: "x",
+      lastSeen: null,
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, updated));
+
+    const result = await updateClient(3, { hostname: "mint-03" });
+
+    expect(result).toEqual(updated);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/clients/3");
+    expect((init as RequestInit).method).toBe("PATCH");
+    expect((init as RequestInit).body).toBe(JSON.stringify({ hostname: "mint-03" }));
+  });
+
+  it("deleteClient DELETEs /api/clients/:id and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(deleteClient(4)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/clients/4");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the next two `/admin` CRUD editors on the #53 foundation slice, each repeating the **exact** pattern the shipped Users editor established — a typed `apiFetch` wrapper over the shared inferred zod DTOs (no hand-written DTOs) plus an in-page `*View.svelte` (list / create / inline-edit / delete) wired into the shell nav switcher:

- **Clients** (`/api/clients`) — `hostname` + `sshUser`, with read-only `enrolledAt` / `lastSeen`. The richer reachability/health view stays Phase 3 / #81.
- **Activities** (`/api/activities`) — `kind` + `matcher` + `matchType`. Picks up the matcher contract just merged in #197 (ADR 0006): `matchType` ∈ {exact, substring, glob, regex} via a `<select>`, alongside the `kind` select. An uncompilable `regex` is a server 400, surfaced inline.

The `kind` / `match-type` option lists are declared in the view and **typed against** the inferred `ActivityKind` / `MatchType`, so they track the source enums without importing server runtime values into the frontend bundle.

## Plan

Linked plan: `.claude/plans/issue-189-admin-editors.md`
Roadmap: `docs/roadmap.md` → Phase 2 ("SvelteKit admin UI on `/admin/*`").

## License-boundary note

N/A — frontend-only, type-only DTO imports + plain browser `fetch` over the JSON API. No GPL surface, no transport/packaging change, no `server/src` change. `license-guard` unaffected. No new dependency.

## Deferred — stays tracked on #189

This PR is **Part of #189**, not "Closes": the remaining editors stay tracked there.

- Activity Groups (+ membership) — `/api/activity-groups`.
- Budgets — `/api/budgets`.
- Schedules / Exceptions — `/api/schedules`, `/api/exceptions` (drag-to-order + first-match-wins stays #63; recurring-window authoring #140).
- User ↔ Client links — `/api/users/:userId/clients`.
- Deep `/admin/*` URL routes + SPA fallback — #59.

## Test plan

- [x] `cd server/frontend && npm run check` (svelte-check) — 0 errors / 0 warnings.
- [x] `npm test` (vitest) — 22 passing, incl. new `tests/api/{clients,activities}.test.ts` (URL/method/body + 204-on-delete).
- [x] `npm run build` (`svelte-kit sync && vite build`, `adapter-static`) — green; no build artifacts committed.
- [x] Mirrors the CI `frontend-build` job (install server deps → check → test → build).

Part of #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3UNmVVHGor3GMsLjdqWgS)_