### PR TITLE
feat(web): SPA fallback for deep /admin/* and /app/* routes (#59)

### DIFF
--- a/.claude/plans/issue-59-spa-fallback-deep-routes.md
+++ b/.claude/plans/issue-59-spa-fallback-deep-routes.md
@@ -1,0 +1,88 @@
+# Issue #59 — SPA fallback for deep `/admin/*` and `/app/*` routes on hard refresh
+
+Roadmap: `docs/roadmap.md` → Phase 2 (admin UI / static mount follow-up to #40).
+
+## Problem
+
+The `@fastify/static` mount (`server/src/web/frontend.ts`, #40) serves the two
+prerendered surface entry pages (`admin.html`, `app.html`) at the slash-free
+surface URLs and the shared `/_app/…` assets. A **deep** client-side route on a
+hard refresh — e.g. `GET /admin/settings`, a path that exists only inside the
+hydrated SvelteKit app, not as a prerendered file — currently returns `404`
+instead of falling back to the surface entry page so the client router can take
+over.
+
+The current design avoids serving the entry page at a deep URL because the
+prerendered pages reference assets **relatively** (`./_app/…`), which only
+resolve to `/_app/…` when the document is served at the canonical slash-free
+URL. That is why `/admin/` 308-redirects to `/admin` today.
+
+## Decision
+
+Two coordinated changes (the issue lists both as candidate directions; this is
+the one that fits the current two-surface, prerendered architecture):
+
+1. **Root-absolute asset paths** — set `kit.paths.relative = false` in
+   `server/frontend/svelte.config.js`. The prerendered pages then reference
+   `/_app/…` absolutely, so the entry HTML loads its assets regardless of the
+   document URL depth. This removes the *reason* the trailing-slash redirect
+   existed.
+
+2. **Per-surface SPA fallback in Fastify** — in `registerFrontend`, serve the
+   surface entry page for any unmatched deep path under that surface:
+   `GET /admin` **and** `GET /admin/*` → `admin.html`; `GET /app` **and**
+   `GET /app/*` → `app.html`. `/`, `/healthz`, `/api/*`, the `/_app/…` assets,
+   and root-level static files (`favicon.png`, `/service-worker.js`,
+   `/app.webmanifest`, `/app-icons/…`) stay exactly as they are — none of them
+   live under the `/admin/` or `/app/` path prefixes, so the wildcard never
+   shadows them, and more-specific static routes win over `@fastify/static`'s
+   `GET /*` wildcard (already relied on for the surface routes).
+
+   The trailing-slash 308 redirect routes are removed: `/admin/` and `/app/`
+   are now covered by the `…/*` fallback (which serves the page), and with
+   absolute assets there is no asset-resolution reason to canonicalise.
+
+Per-surface fallback (not `adapter-static`'s single SPA `fallback` page) is
+required because we have two distinct surfaces that must fall back to *their
+own* entry page.
+
+## Scope / non-scope
+
+- In scope: server-side fallback + absolute asset base so a deep-link hard
+  refresh returns the entry page (HTTP 200) and its assets load. This is the
+  enabling infrastructure.
+- Not in scope: introducing actual URL-addressable deep routes inside the
+  editors (the `/admin` surface is still a single prerendered page with an
+  in-page view switcher). Adopting deep routes is the #189 follow-up; drag-to-
+  order schedule authoring stays #63. The fallback is harmless until then —
+  an unknown deep path hydrates the shell and the client router decides.
+
+## Files
+
+- `server/frontend/svelte.config.js` — add `paths: { relative: false }`.
+- `server/src/web/frontend.ts` — replace the two trailing-slash redirect
+  routes with the `…/*` fallback; rewrite the module doc comment (absolute
+  assets + SPA fallback, no more relative-asset/redirect rationale).
+- `server/frontend/README.md` — update the trailing-slash paragraph.
+- `server/tests/web/frontend.test.ts` — replace the two 308 redirect tests
+  with fallback assertions; add deep-route fallback tests for both surfaces;
+  keep the assertions that `/`, `/healthz`, `/_app/…`, root static files, and a
+  bogus root path are unaffected.
+
+## License boundary
+
+None touched — plain Fastify static file serving + a SvelteKit build-config
+flag. No GPL linkage, no subprocess/REST boundary, no Docker-image change.
+
+## Test plan
+
+- `GET /admin/settings` and `GET /app/anything/deep` → 200, HTML, surface marker.
+- `GET /admin/` and `GET /app/` → 200 surface page (no longer 308).
+- `GET /admin`, `GET /app` → 200 surface page (unchanged).
+- `GET /_app/immutable/chunk.js` → 200 JS (unaffected).
+- `GET /favicon.png` → 200 (unaffected).
+- `GET /`, `/healthz` → backend routes (unaffected).
+- `GET /nope` (root, no surface prefix) → 404 (unaffected).
+- HEAD on a surface URL → 200; non-GET on a surface URL → 404.
+- Build-absent path still warns + 404s (unchanged).
+- `cd server/frontend && npm ci && npm run build` succeeds with absolute paths.

--- a/server/frontend/README.md
+++ b/server/frontend/README.md
@@ -30,11 +30,15 @@ stage (#6) runs this build and copies the output into the runtime image
 landed in Phase 2, #40 — see `server/src/web/frontend.ts`).
 
 The mount root is `PCT_FRONTEND_ROOT` (default `/app/frontend`), so local dev
-can point it at `server/frontend/build`. The slash-free surface URLs
-(`/admin`, `/app`) serve `admin.html` / `app.html`; the trailing-slash forms
-redirect to them so the pages' relative asset paths (`./_app/…`) resolve
-correctly. If the directory is absent the mount is skipped (the surfaces 404)
-rather than failing startup. `/` and `/api/*` stay owned by the backend.
+can point it at `server/frontend/build`. The surface URLs (`/admin`, `/app`)
+serve `admin.html` / `app.html`, and each surface also owns a `…/*` fallback so
+a deep client-side route on a hard refresh (e.g. `/admin/settings`) serves the
+entry page rather than 404ing — letting the client router take over (#59). That
+works because asset references are **root-absolute** (`/_app/…`, via
+`kit.paths.relative = false`), so they resolve at any document depth; the
+trailing-slash form just falls through the same fallback (no redirect). If the
+directory is absent the mount is skipped (the surfaces 404) rather than failing
+startup. `/`, `/healthz`, and `/api/*` stay owned by the backend.
 
 `build/` is git-ignored (by both the repo-root `.gitignore` and the local
 `server/frontend/.gitignore`) — it is a build artefact, produced at

--- a/server/frontend/svelte.config.js
+++ b/server/frontend/svelte.config.js
@@ -31,6 +31,16 @@ const config = {
     prerender: {
       entries: ["/admin", "/app"],
     },
+    paths: {
+      // Root-absolute asset references (`/_app/…`) rather than the default
+      // page-relative ones (`./_app/…`). The Fastify mount serves each surface
+      // entry page as an SPA fallback for *deep* client-side routes too (e.g. a
+      // hard refresh of `/admin/settings`; #59) — a relative `./_app/…` URL
+      // would resolve against that deep document base and 404, so assets must be
+      // addressed from the root. This also removes the need for the old
+      // trailing-slash → canonical redirect (see `server/src/web/frontend.ts`).
+      relative: false,
+    },
     // The service worker (`src/service-worker.ts`) is still bundled, but we
     // register it manually from the `/app` layout (prod-only) so the `/admin`
     // surface — which is not a PWA — never installs a worker unless the user

--- a/server/src/web/frontend.ts
+++ b/server/src/web/frontend.ts
@@ -12,19 +12,32 @@
  *
  * `@fastify/static` serves files by URL path, so the hashed assets and static
  * files map one-to-one (`GET /_app/immutable/x.js` → `<root>/_app/immutable/x.js`).
- * The two extensionless surface URLs do not, so they get explicit routes that
- * send the matching `*.html`. `/` and `/healthz` (and, in a later phase,
+ * The extensionless surface URLs do not, so each surface gets explicit routes
+ * that send the matching `*.html`. `/` and `/healthz` (and, in a later phase,
  * `/api/*`) stay owned by the backend: the exact and more-specific routes win
  * over the static plugin's `GET /*` wildcard, and `index: false` stops the
  * plugin from registering its own `GET /` (which would collide with the
  * landing route).
  *
- * The prerendered pages reference their assets with **relative** URLs
- * (`./_app/…`), which only resolve to `/_app/…` when the document is served at
- * the canonical, slash-free surface URL. So the trailing-slash form redirects
- * to the canonical one (a permanent 308) rather than serving the same HTML
- * under a base path that would make every asset 404 in the browser. This also
- * matches the frontend's `trailingSlash: 'never'` default.
+ * SPA fallback (#59): a *deep* client-side route on a hard refresh — e.g.
+ * `GET /admin/settings`, a path that exists only inside the hydrated SvelteKit
+ * app, not as a prerendered file — must serve the surface entry page so the
+ * client router can take over, rather than 404. So beyond the exact surface
+ * URL, each surface also owns a `…/*` wildcard that sends the same entry page.
+ * Per-surface (not a single shared SPA fallback page) because `/admin` and
+ * `/app` must fall back to *their own* entry page. The fallback only ever
+ * shadows paths under the surface prefix; the shared `/_app/…` assets and the
+ * root-level static files (`favicon.png`, `/service-worker.js`,
+ * `/app.webmanifest`, `/app-icons/…`) live at the root, not under `/admin/` or
+ * `/app/`, so they are untouched.
+ *
+ * This works because the prerendered pages reference their assets with
+ * **root-absolute** URLs (`/_app/…`, via `kit.paths.relative = false` in
+ * `svelte.config.js`), so the entry HTML loads its assets regardless of the
+ * document URL's depth. With absolute assets there is no asset-resolution
+ * reason to canonicalise the trailing slash, so `/admin/` and `/app/` simply
+ * fall through the `…/*` wildcard and serve the entry page like any other deep
+ * path (no redirect).
  *
  * Static-asset requests flow through the same pino request logging the app
  * already configures (`./logger.ts`, #11) — there is no frontend-specific
@@ -80,19 +93,17 @@ export function registerFrontend(app: FastifyInstance, settings: Settings): void
     });
 
     for (const { url, page } of SURFACES) {
+      const sendEntryPage = (_request: FastifyRequest, reply: FastifyReply): FastifyReply =>
+        reply.sendFile(page);
       // Canonical URL: serve the prerendered entry page.
-      scope.get(
-        url,
-        (_request: FastifyRequest, reply: FastifyReply): FastifyReply => reply.sendFile(page),
-      );
-      // Trailing-slash form: redirect to the canonical URL so the page's
-      // relative asset paths resolve against `/` rather than `/<surface>/`.
-      // Preserve any query string so client-side state survives the redirect.
-      scope.get(`${url}/`, (request: FastifyRequest, reply: FastifyReply): FastifyReply => {
-        const queryStart = request.url.indexOf("?");
-        const target = queryStart === -1 ? url : url + request.url.slice(queryStart);
-        return reply.redirect(target, 308);
-      });
+      scope.get(url, sendEntryPage);
+      // SPA fallback (#59): any deeper path under the surface — including the
+      // trailing-slash form `/<surface>/` — serves the same entry page so a
+      // hard refresh of a client-side route hands off to the router instead of
+      // 404ing. The `…/*` wildcard is more specific than the static plugin's
+      // root `GET /*`, so it wins; the root-absolute asset URLs (#59) keep the
+      // page's `/_app/…` references working at any document depth.
+      scope.get(`${url}/*`, sendEntryPage);
     }
   });
 }

--- a/server/src/web/frontend.ts
+++ b/server/src/web/frontend.ts
@@ -27,9 +27,9 @@
  * Per-surface (not a single shared SPA fallback page) because `/admin` and
  * `/app` must fall back to *their own* entry page. The fallback only ever
  * shadows paths under the surface prefix; the shared `/_app/…` assets and the
- * root-level static files (`favicon.png`, `/service-worker.js`,
- * `/app.webmanifest`, `/app-icons/…`) live at the root, not under `/admin/` or
- * `/app/`, so they are untouched.
+ * root-level static files (`/service-worker.js`, `/app.webmanifest`,
+ * `/app-icons/…`) live at the root, not under `/admin/` or `/app/`, so they are
+ * untouched.
  *
  * This works because the prerendered pages reference their assets with
  * **root-absolute** URLs (`/_app/…`, via `kit.paths.relative = false` in

--- a/server/tests/web/frontend.test.ts
+++ b/server/tests/web/frontend.test.ts
@@ -117,6 +117,13 @@ describe("frontend static mount (build present)", () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it("404s a non-GET method on a deep surface route (fallback is GET-only)", async () => {
+    // The `…/*` fallback only registers `scope.get`, so a write verb to a deep
+    // client-side path is not silently absorbed into the entry page.
+    const res = await app.inject({ method: "POST", url: "/admin/settings" });
+    expect(res.statusCode).toBe(404);
+  });
+
   it("serves root-level static files (e.g. favicon.png)", async () => {
     const res = await app.inject({ method: "GET", url: "/favicon.png" });
     expect(res.statusCode).toBe(200);

--- a/server/tests/web/frontend.test.ts
+++ b/server/tests/web/frontend.test.ts
@@ -65,22 +65,38 @@ describe("frontend static mount (build present)", () => {
     expect(res.body).toContain("app-marker");
   });
 
-  it("redirects the trailing-slash form to the canonical surface URL", async () => {
-    // The pages reference assets relatively (`./_app/…`); a redirect keeps the
-    // browser at the slash-free URL so those resolve to `/_app/…`, not 404.
-    const admin = await app.inject({ method: "GET", url: "/admin/" });
-    expect(admin.statusCode).toBe(308);
-    expect(admin.headers["location"]).toBe("/admin");
+  it("serves the surface entry page for a deep client-side route (#59 SPA fallback)", async () => {
+    // A hard refresh of a route that exists only inside the hydrated app must
+    // get the entry page (so the client router can take over), not a 404.
+    const admin = await app.inject({ method: "GET", url: "/admin/settings" });
+    expect(admin.statusCode).toBe(200);
+    expect(admin.headers["content-type"]).toContain("text/html");
+    expect(admin.body).toContain("admin-marker");
 
-    const appSurface = await app.inject({ method: "GET", url: "/app/" });
-    expect(appSurface.statusCode).toBe(308);
-    expect(appSurface.headers["location"]).toBe("/app");
+    const appSurface = await app.inject({ method: "GET", url: "/app/time/today" });
+    expect(appSurface.statusCode).toBe(200);
+    expect(appSurface.headers["content-type"]).toContain("text/html");
+    expect(appSurface.body).toContain("app-marker");
   });
 
-  it("redirects the trailing-slash form preserving the query string", async () => {
-    const res = await app.inject({ method: "GET", url: "/admin/?tab=users" });
-    expect(res.statusCode).toBe(308);
-    expect(res.headers["location"]).toBe("/admin?tab=users");
+  it("serves the surface entry page for the trailing-slash form (no redirect)", async () => {
+    // With root-absolute asset paths there is no asset-resolution reason to
+    // canonicalise; `/<surface>/` just falls through the `…/*` fallback.
+    const admin = await app.inject({ method: "GET", url: "/admin/" });
+    expect(admin.statusCode).toBe(200);
+    expect(admin.body).toContain("admin-marker");
+
+    const appSurface = await app.inject({ method: "GET", url: "/app/" });
+    expect(appSurface.statusCode).toBe(200);
+    expect(appSurface.body).toContain("app-marker");
+  });
+
+  it("does not let the /admin fallback shadow shared root-level assets", async () => {
+    // The fallback only owns the `/admin/*` and `/app/*` prefixes; the shared
+    // hashed chunk lives at the root and must still be served as itself.
+    const res = await app.inject({ method: "GET", url: "/_app/immutable/chunk.js" });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe(CHUNK_JS);
   });
 
   it("serves shared _app assets with a JS content-type", async () => {


### PR DESCRIPTION
## Summary

- A deep client-side route on a hard refresh — e.g. `GET /admin/settings`, a path that exists only inside the hydrated SvelteKit app, not as a prerendered file — hit `@fastify/static`'s `GET /*` and **404'd** instead of serving the surface entry page so the client router could take over.
- Each surface now owns a `…/*` SPA fallback (`GET /admin/*` → `admin.html`, `GET /app/*` → `app.html`); the trailing-slash → canonical **308 redirect is removed** (it only existed for relative-asset resolution, which no longer applies).
- Asset references are made **root-absolute** (`/_app/…`, via `kit.paths.relative = false`), so the entry HTML loads its assets regardless of the document URL's depth — the precondition for the fallback to be correct.

## Plan

Linked plan: `.claude/plans/issue-59-spa-fallback-deep-routes.md`
Roadmap: `docs/roadmap.md` → Phase 2 (static-mount follow-up to #40).

## What changed

- **`server/frontend/svelte.config.js`** — `kit.paths.relative = false`. Verified the build now emits `href="/_app/…"` (root-absolute) with zero remaining `"./_app` references.
- **`server/src/web/frontend.ts`** — per-surface `…/*` fallback replacing the two trailing-slash redirect routes; rewritten module doc. `/`, `/healthz`, `/api/*`, the shared `/_app/…` chunks, and root-level static files (`favicon.png`, `/service-worker.js`, `/app.webmanifest`, `/app-icons/…`) all stay where they were — none live under the `/admin/` or `/app/` prefixes, so the wildcard never shadows them, and the more-specific `…/*` route beats the static plugin's root `GET /*`.
- **`server/frontend/README.md`** — updated the asset-paths / fallback paragraph.
- **`server/tests/web/frontend.test.ts`** — the two 308-redirect tests are replaced (the redirect behaviour they asserted was tied to the now-removed relative-asset constraint, not a behavioural guarantee) with: deep-route fallback for both surfaces, trailing-slash → entry page (no redirect), and a guard that the `/admin` fallback does not shadow shared root-level assets. The unaffected-routes assertions (`/`, `/healthz`, `/_app/…`, root static files, bogus root path → 404, HEAD, non-GET → 404, build-absent) are kept.

## Why per-surface fallback (not `adapter-static`'s SPA `fallback` page)

We have two distinct surfaces that must fall back to *their own* entry page (`/admin` → `admin.html`, `/app` → `app.html`); a single shared fallback page can't distinguish them. Keeping `strict: true` + prerender also means the entry pages stay real prerendered HTML.

## Scope / deferred (tracked)

This lands the **server-side fallback + absolute asset base** — the enabling infrastructure. The `/admin` surface is still a single prerendered page with an in-page view switcher, so adopting actual URL-addressable deep routes inside the editors is the **#189** follow-up (its body already defers deep routes to "once #59 lands"); drag-to-order schedule authoring stays **#63**. No new issue needed — both are already tracked.

## License-boundary note

N/A — plain Fastify static file serving + a SvelteKit build-config flag. No GPL imports, no GPL binary added to the image, no subprocess/REST boundary, no Docker-image change. **No new dependency.**

## Test plan

- [x] `format:check`, `lint`, `typecheck` clean.
- [x] `npm test` — 943 unit tests pass; coverage 98.95% (gate 80%); `web/frontend.ts` at 100%.
- [x] `frontend.test.ts` — deep-route fallback (`/admin/settings`, `/app/time/today`), trailing-slash → entry page, asset non-shadowing, plus all the retained `/`/`/healthz`/`/_app`/static/404/HEAD/build-absent assertions.
- [x] `cd server/frontend && npm ci && npm run build` succeeds; emitted asset refs are root-absolute (`/_app/…`).

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012fQyns8AM45RXKstoBhw1S)_