### PR TITLE
feat(admin): remaining policy editors — groups, budgets, user↔client links (#189)

### DIFF
--- a/.claude/plans/issue-189-admin-editors.md
+++ b/.claude/plans/issue-189-admin-editors.md
@@ -59,3 +59,57 @@ in-page `*View.svelte` with list/create/inline-edit/delete, wired into the
   + `npm run build` (svelte-kit sync && vite build) all green.
 - The server quality gate is unaffected (no `server/src` change) but re-run
   `format:check`/`lint`/`typecheck`/`test` from `server/` to be safe.
+
+---
+
+# Slice 2 — Activity Groups (+ membership), Budgets, User ↔ Client links
+
+The Clients + Activities slice above has landed on `main`. This slice picks up
+the next three editors, repeating the same proven pattern. Schedules /
+Exceptions are intentionally **still deferred** to avoid colliding with the
+in-flight schedule/exception work (#182 group-targeting, #140 recurring
+windows) and the #63 drag-to-order editor; they remain tracked on #189.
+
+## Scope of this PR
+
+1. **Activity Groups** — `/api/activity-groups` CRUD plus **membership**:
+   `GET /activity-groups/:groupId/activities`, `PUT|DELETE
+   /activity-groups/:groupId/activities/:activityId`. The view is master-detail:
+   a groups list (create/edit/delete name) with an expandable member panel that
+   adds activities from a dropdown and removes them.
+2. **Budgets** — `/api/budgets` CRUD. Create needs `userId`, `scope`
+   (overall/activity/group), `targetId` (null for overall, an `activity.id` for
+   `activity`, an `activity_group.id` for `group`), `window`
+   (daily/weekly/monthly), `secondsAllowed`. The view loads users + activities +
+   activity-groups for the target pickers and to render target names.
+3. **User ↔ Client links** — `/api/users/:userId/clients` (list per user),
+   `PUT|DELETE /users/:userId/clients/:clientId` (upsert/remove with
+   `linuxUsername` + `linuxUid`). The view loads users + clients for the
+   pickers and is scoped to the selected user.
+
+## Files
+
+- `server/frontend/src/lib/api/contract.ts` — add type-only re-exports:
+  `ActivityGroupResponse`, `Create/UpdateActivityGroupRequest`,
+  `BudgetResponse`, `Create/UpdateBudgetRequest`, `LinkResponse`,
+  `UpsertLinkRequest`, plus the `Scope` / `BudgetWindow` enums.
+- `server/frontend/src/lib/api/activity-groups.ts` — group CRUD +
+  `listGroupActivities` / `addActivityToGroup` / `removeActivityFromGroup`.
+- `server/frontend/src/lib/api/budgets.ts` — `listBudgets(userId?)` +
+  create/update/delete.
+- `server/frontend/src/lib/api/links.ts` — `listUserLinks` / `upsertLink` /
+  `deleteLink`.
+- `server/frontend/src/lib/views/ActivityGroupsView.svelte`,
+  `BudgetsView.svelte`, `LinksView.svelte`.
+- `server/frontend/src/routes/admin/+page.svelte` — add the three nav items +
+  render the views.
+- `server/frontend/tests/api/{activity-groups,budgets,links}.test.ts` — vitest
+  unit tests mirroring `tests/api/activities.test.ts`.
+
+## Still deferred — stays tracked on #189
+
+- Schedules / Exceptions editors (`/api/schedules`, `/api/exceptions`).
+- Deep `/admin/*` URL routes + SPA fallback — #59.
+
+Same constraints honoured as Slice 1 (only `/api/*`, browser-guarded calls,
+type-only DTO imports, no GPL surface).

--- a/server/frontend/src/lib/api/activity-groups.ts
+++ b/server/frontend/src/lib/api/activity-groups.ts
@@ -1,0 +1,65 @@
+/**
+ * CRUD + membership calls for the `ActivityGroup` policy entity (#51 contract,
+ * #189 editor).
+ *
+ * Same proven shape as `$lib/api/activities` (#53/#189): thin typed wrappers
+ * over {@link apiFetch}, with the request/response types imported from the
+ * shared `/api` contract so the frontend never re-declares a DTO. An
+ * `ActivityGroup` is a named bundle of {@link ActivityResponse} rows that a
+ * budget/schedule can target with scope `group`; the membership endpoints
+ * attach/detach individual activities.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type {
+  ActivityGroupResponse,
+  ActivityResponse,
+  CreateActivityGroupRequest,
+  UpdateActivityGroupRequest,
+} from "./contract.js";
+
+/** List all activity groups, in the order `/api` returns them. */
+export function listActivityGroups(): Promise<ActivityGroupResponse[]> {
+  return apiFetch<ActivityGroupResponse[]>("/activity-groups");
+}
+
+/** Create a group; the server validates `name` (unique) and returns the row. */
+export function createActivityGroup(
+  input: CreateActivityGroupRequest,
+): Promise<ActivityGroupResponse> {
+  return apiFetch<ActivityGroupResponse>("/activity-groups", { method: "POST", body: input });
+}
+
+/** Rename a group; `input` must carry at least one field (server enforces). */
+export function updateActivityGroup(
+  id: number,
+  input: UpdateActivityGroupRequest,
+): Promise<ActivityGroupResponse> {
+  return apiFetch<ActivityGroupResponse>(`/activity-groups/${id}`, { method: "PATCH", body: input });
+}
+
+/** Delete a group. Resolves on the server's `204`. */
+export function deleteActivityGroup(id: number): Promise<void> {
+  return apiFetch<void>(`/activity-groups/${id}`, { method: "DELETE" });
+}
+
+/** List the activities that are members of `groupId`. */
+export function listGroupActivities(groupId: number): Promise<ActivityResponse[]> {
+  return apiFetch<ActivityResponse[]>(`/activity-groups/${groupId}/activities`);
+}
+
+/**
+ * Add an activity to a group (idempotent `PUT`). Resolves on the server's
+ * `204`; a re-add of an existing member is a no-op server-side.
+ */
+export function addActivityToGroup(groupId: number, activityId: number): Promise<void> {
+  return apiFetch<void>(`/activity-groups/${groupId}/activities/${activityId}`, { method: "PUT" });
+}
+
+/** Remove an activity from a group. Resolves on the server's `204`. */
+export function removeActivityFromGroup(groupId: number, activityId: number): Promise<void> {
+  return apiFetch<void>(`/activity-groups/${groupId}/activities/${activityId}`, {
+    method: "DELETE",
+  });
+}

--- a/server/frontend/src/lib/api/budgets.ts
+++ b/server/frontend/src/lib/api/budgets.ts
@@ -1,0 +1,38 @@
+/**
+ * CRUD calls for the `Budget` policy entity (#51 contract, #189 editor).
+ *
+ * Same proven shape as `$lib/api/activities` (#53/#189): thin typed wrappers
+ * over {@link apiFetch}, with the request/response types imported from the
+ * shared `/api` contract so the frontend never re-declares a DTO. A `Budget`
+ * grants a user `secondsAllowed` of time per rollover `window` (daily / weekly
+ * / monthly) for a given `scope` (`overall`, a single `activity`, or an
+ * activity `group`); `targetId` is the referent for the non-`overall` scopes.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type { BudgetResponse, CreateBudgetRequest, UpdateBudgetRequest } from "./contract.js";
+
+/**
+ * List budgets. With `userId` the server restricts to that user; without it,
+ * every budget is returned (the `?userId=` filter the route exposes).
+ */
+export function listBudgets(userId?: number): Promise<BudgetResponse[]> {
+  const path = userId === undefined ? "/budgets" : `/budgets?userId=${userId}`;
+  return apiFetch<BudgetResponse[]>(path);
+}
+
+/** Create a budget; the server validates target coherence and returns the row. */
+export function createBudget(input: CreateBudgetRequest): Promise<BudgetResponse> {
+  return apiFetch<BudgetResponse>("/budgets", { method: "POST", body: input });
+}
+
+/** Patch a budget; `input` must carry at least one field (server enforces). */
+export function updateBudget(id: number, input: UpdateBudgetRequest): Promise<BudgetResponse> {
+  return apiFetch<BudgetResponse>(`/budgets/${id}`, { method: "PATCH", body: input });
+}
+
+/** Delete a budget. Resolves on the server's `204`. */
+export function deleteBudget(id: number): Promise<void> {
+  return apiFetch<void>(`/budgets/${id}`, { method: "DELETE" });
+}

--- a/server/frontend/src/lib/api/client.ts
+++ b/server/frontend/src/lib/api/client.ts
@@ -61,7 +61,7 @@ function isErrorEnvelope(value: unknown): value is ErrorEnvelope {
 
 /** Options for {@link apiFetch}. `body` is JSON-encoded when present. */
 export interface ApiFetchOptions {
-  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   /** Request body; serialized as JSON with the matching `Content-Type`. */
   body?: unknown;
   /** Optional override of the global `fetch` (used by tests). */

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -31,6 +31,14 @@ export type {
   ActivityResponse,
   CreateActivityRequest,
   UpdateActivityRequest,
+  ActivityGroupResponse,
+  CreateActivityGroupRequest,
+  UpdateActivityGroupRequest,
+  BudgetResponse,
+  CreateBudgetRequest,
+  UpdateBudgetRequest,
+  LinkResponse,
+  UpsertLinkRequest,
 } from "../../../../src/api/policy/dtos.js";
-export type { ActivityKind, MatchType } from "../../../../src/policy/enums.js";
+export type { ActivityKind, MatchType, Scope, BudgetWindow } from "../../../../src/policy/enums.js";
 export type { ErrorEnvelope, ErrorDetail } from "../../../../src/api/errors.js";

--- a/server/frontend/src/lib/api/links.ts
+++ b/server/frontend/src/lib/api/links.ts
@@ -1,0 +1,40 @@
+/**
+ * Calls for the `UserOnClient` link (#51 contract, #189 editor).
+ *
+ * Same proven shape as `$lib/api/activities` (#53/#189): thin typed wrappers
+ * over {@link apiFetch}, with the request/response types imported from the
+ * shared `/api` contract so the frontend never re-declares a DTO. A link maps
+ * a policy `User` to a Linux account (`linuxUsername` + `linuxUid`) on a given
+ * `Client`; the routes are nested under the user so the collection is scoped to
+ * one supervised user at a time.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type { LinkResponse, UpsertLinkRequest } from "./contract.js";
+
+/** List the client links for one user, in the order `/api` returns them. */
+export function listUserLinks(userId: number): Promise<LinkResponse[]> {
+  return apiFetch<LinkResponse[]>(`/users/${userId}/clients`);
+}
+
+/**
+ * Create-or-update the link between `userId` and `clientId` (idempotent `PUT`).
+ * The server enforces that the Linux UID is unique per client and returns the
+ * stored row.
+ */
+export function upsertLink(
+  userId: number,
+  clientId: number,
+  input: UpsertLinkRequest,
+): Promise<LinkResponse> {
+  return apiFetch<LinkResponse>(`/users/${userId}/clients/${clientId}`, {
+    method: "PUT",
+    body: input,
+  });
+}
+
+/** Remove the link between `userId` and `clientId`. Resolves on the `204`. */
+export function deleteLink(userId: number, clientId: number): Promise<void> {
+  return apiFetch<void>(`/users/${userId}/clients/${clientId}`, { method: "DELETE" });
+}

--- a/server/frontend/src/lib/views/ActivityGroupsView.svelte
+++ b/server/frontend/src/lib/views/ActivityGroupsView.svelte
@@ -1,0 +1,438 @@
+<!--
+  Activity Groups editor (#189): repeats the Users/Activities pattern (#53) with
+  an extra master-detail layer for membership. Loads `/api/activity-groups` and
+  `/api/activities` on mount (browser only — the page is prerendered to a static
+  shell), supports create / inline-rename / delete of groups, and — when a group
+  is expanded — add/remove of member activities. All calls go through the typed
+  `$lib/api/activity-groups` wrappers; errors are surfaced inline.
+
+  An `ActivityGroup` is a named bundle a budget/schedule can target with scope
+  `group`. Membership is loaded lazily when a group's panel is opened so the
+  initial render stays a single list query.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ApiError } from "$lib/api/client.js";
+  import type { ActivityGroupResponse, ActivityResponse } from "$lib/api/contract.js";
+  import { listActivities } from "$lib/api/activities.js";
+  import {
+    addActivityToGroup,
+    createActivityGroup,
+    deleteActivityGroup,
+    listActivityGroups,
+    listGroupActivities,
+    removeActivityFromGroup,
+    updateActivityGroup,
+  } from "$lib/api/activity-groups.js";
+
+  let groups = $state<ActivityGroupResponse[]>([]);
+  let activities = $state<ActivityResponse[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // Create form.
+  let newName = $state("");
+  let creating = $state(false);
+
+  // Inline rename.
+  let editingId = $state<number | null>(null);
+  let editName = $state("");
+  let saving = $state(false);
+
+  // Membership: the currently expanded group + its member rows, loaded lazily.
+  let openGroupId = $state<number | null>(null);
+  let members = $state<ActivityResponse[]>([]);
+  let membersLoading = $state(false);
+  let addActivityId = $state<number | null>(null);
+  let mutatingMembership = $state(false);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      [groups, activities] = await Promise.all([listActivityGroups(), listActivities()]);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  /** Activities matched by id, for rendering a member's kind/matcher. */
+  function activityById(id: number): ActivityResponse | undefined {
+    return activities.find((a) => a.id === id);
+  }
+
+  /** Activities not yet in the open group — the add-dropdown candidates. */
+  let candidates = $derived(
+    activities.filter((a) => !members.some((m) => m.id === a.id)),
+  );
+
+  async function handleCreate(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    creating = true;
+    error = null;
+    try {
+      const created = await createActivityGroup({ name: newName.trim() });
+      groups = [...groups, created];
+      newName = "";
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      creating = false;
+    }
+  }
+
+  function startEdit(group: ActivityGroupResponse): void {
+    editingId = group.id;
+    editName = group.name;
+    error = null;
+  }
+
+  function cancelEdit(): void {
+    editingId = null;
+  }
+
+  async function saveEdit(id: number): Promise<void> {
+    saving = true;
+    error = null;
+    try {
+      const updated = await updateActivityGroup(id, { name: editName.trim() });
+      groups = groups.map((g) => (g.id === id ? updated : g));
+      editingId = null;
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleDelete(group: ActivityGroupResponse): Promise<void> {
+    if (!confirm(`Delete activity group "${group.name}"? This cannot be undone.`)) {
+      return;
+    }
+    error = null;
+    try {
+      await deleteActivityGroup(group.id);
+      groups = groups.filter((g) => g.id !== group.id);
+      if (openGroupId === group.id) {
+        openGroupId = null;
+      }
+    } catch (err) {
+      error = messageOf(err);
+    }
+  }
+
+  async function toggleMembers(group: ActivityGroupResponse): Promise<void> {
+    if (openGroupId === group.id) {
+      openGroupId = null;
+      return;
+    }
+    openGroupId = group.id;
+    addActivityId = null;
+    membersLoading = true;
+    error = null;
+    try {
+      members = await listGroupActivities(group.id);
+    } catch (err) {
+      error = messageOf(err);
+      members = [];
+    } finally {
+      membersLoading = false;
+    }
+  }
+
+  async function handleAddMember(groupId: number): Promise<void> {
+    if (addActivityId === null) {
+      return;
+    }
+    mutatingMembership = true;
+    error = null;
+    try {
+      await addActivityToGroup(groupId, addActivityId);
+      const added = activityById(addActivityId);
+      if (added !== undefined) {
+        members = [...members, added];
+      }
+      addActivityId = null;
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      mutatingMembership = false;
+    }
+  }
+
+  async function handleRemoveMember(groupId: number, activityId: number): Promise<void> {
+    mutatingMembership = true;
+    error = null;
+    try {
+      await removeActivityFromGroup(groupId, activityId);
+      members = members.filter((m) => m.id !== activityId);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      mutatingMembership = false;
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>Activity Groups</h1>
+    <p class="hint">
+      Named bundles of activities. A budget or schedule can target a group so a
+      whole set of apps/domains shares one limit.
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  <form class="create" onsubmit={handleCreate}>
+    <input
+      type="text"
+      placeholder="Group name (e.g. Games)"
+      bind:value={newName}
+      disabled={creating}
+      required
+      aria-label="New group name"
+    />
+    <button type="submit" disabled={creating || newName.trim() === ""}>
+      {creating ? "Adding…" : "Add group"}
+    </button>
+  </form>
+
+  {#if loading}
+    <p class="muted">Loading activity groups…</p>
+  {:else if groups.length === 0}
+    <p class="muted">No activity groups yet. Add one above.</p>
+  {:else}
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th class="actions-col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each groups as group (group.id)}
+          <tr>
+            {#if editingId === group.id}
+              <td><input bind:value={editName} aria-label="Edit group name" /></td>
+              <td class="actions">
+                <button onclick={() => saveEdit(group.id)} disabled={saving || editName.trim() === ""}>
+                  {saving ? "Saving…" : "Save"}
+                </button>
+                <button class="ghost" onclick={cancelEdit} disabled={saving}>Cancel</button>
+              </td>
+            {:else}
+              <td>{group.name}</td>
+              <td class="actions">
+                <button class="ghost" onclick={() => toggleMembers(group)}>
+                  {openGroupId === group.id ? "Hide members" : "Members"}
+                </button>
+                <button class="ghost" onclick={() => startEdit(group)}>Rename</button>
+                <button class="danger" onclick={() => handleDelete(group)}>Delete</button>
+              </td>
+            {/if}
+          </tr>
+          {#if openGroupId === group.id}
+            <tr class="detail">
+              <td colspan="2">
+                {#if membersLoading}
+                  <p class="muted">Loading members…</p>
+                {:else}
+                  <div class="members">
+                    {#if members.length === 0}
+                      <p class="muted">No activities in this group yet.</p>
+                    {:else}
+                      <ul class="member-list">
+                        {#each members as member (member.id)}
+                          <li>
+                            <code>{member.matcher}</code>
+                            <span class="muted">({member.kind})</span>
+                            <button
+                              class="ghost small"
+                              disabled={mutatingMembership}
+                              onclick={() => handleRemoveMember(group.id, member.id)}
+                            >
+                              Remove
+                            </button>
+                          </li>
+                        {/each}
+                      </ul>
+                    {/if}
+                    {#if candidates.length === 0}
+                      <p class="muted">All activities are already in this group.</p>
+                    {:else}
+                      <div class="add-member">
+                        <select bind:value={addActivityId} aria-label="Activity to add">
+                          <option value={null} disabled selected>Choose an activity…</option>
+                          {#each candidates as activity (activity.id)}
+                            <option value={activity.id}>{activity.matcher} ({activity.kind})</option>
+                          {/each}
+                        </select>
+                        <button
+                          disabled={mutatingMembership || addActivityId === null}
+                          onclick={() => handleAddMember(group.id)}
+                        >
+                          {mutatingMembership ? "Adding…" : "Add to group"}
+                        </button>
+                      </div>
+                    {/if}
+                  </div>
+                {/if}
+              </td>
+            </tr>
+          {/if}
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+    max-width: 40rem;
+  }
+  .create {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+  }
+  .create input {
+    flex: 1 1 12rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+  }
+  th {
+    background: #f9fafb;
+    font-weight: 600;
+    color: #374151;
+  }
+  td input,
+  td select {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.3rem;
+    background: #fff;
+  }
+  tr.detail td {
+    background: #f9fafb;
+  }
+  .members {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .member-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .member-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .add-member {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .add-member select {
+    flex: 1 1 16rem;
+    padding: 0.4rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.3rem;
+    background: #fff;
+  }
+  code {
+    font-size: 0.85rem;
+    color: #111827;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .actions-col {
+    width: 1%;
+    white-space: nowrap;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  button.small {
+    padding: 0.2rem 0.5rem;
+    font-size: 0.8rem;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  button.danger {
+    background: #dc2626;
+  }
+  .muted {
+    color: #6b7280;
+    margin: 0;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/lib/views/BudgetsView.svelte
+++ b/server/frontend/src/lib/views/BudgetsView.svelte
@@ -1,0 +1,446 @@
+<!--
+  Budgets editor (#189): repeats the Users/Activities pattern (#53). Loads
+  `/api/budgets` plus the users / activities / activity-groups it needs to
+  render and pick targets, all on mount (browser only — the page is prerendered
+  to a static shell). Supports create, inline edit of the window + allowance,
+  and delete. All calls go through the typed `$lib/api/budgets` wrappers; errors
+  are surfaced inline.
+
+  A `Budget` grants a user `secondsAllowed` per rollover `window` for a `scope`:
+  `overall` (the user's whole screen time, no target), a single `activity`, or
+  an activity `group`. Scope/target are fixed at create time — changing what a
+  budget applies to means deleting it and adding a new one — so inline edit only
+  exposes the window + allowance, the values an admin actually tweaks.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ApiError } from "$lib/api/client.js";
+  import type {
+    ActivityGroupResponse,
+    ActivityResponse,
+    BudgetResponse,
+    BudgetWindow,
+    Scope,
+    UserResponse,
+  } from "$lib/api/contract.js";
+  import { listBudgets, createBudget, updateBudget, deleteBudget } from "$lib/api/budgets.js";
+  import { listUsers } from "$lib/api/users.js";
+  import { listActivities } from "$lib/api/activities.js";
+  import { listActivityGroups } from "$lib/api/activity-groups.js";
+
+  const SCOPE_OPTIONS: ReadonlyArray<{ value: Scope; label: string }> = [
+    { value: "overall", label: "Overall" },
+    { value: "activity", label: "Activity" },
+    { value: "group", label: "Activity group" },
+  ];
+
+  const WINDOW_OPTIONS: ReadonlyArray<{ value: BudgetWindow; label: string }> = [
+    { value: "daily", label: "Daily" },
+    { value: "weekly", label: "Weekly" },
+    { value: "monthly", label: "Monthly" },
+  ];
+
+  let budgets = $state<BudgetResponse[]>([]);
+  let users = $state<UserResponse[]>([]);
+  let activities = $state<ActivityResponse[]>([]);
+  let groups = $state<ActivityGroupResponse[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // Create form.
+  let newUserId = $state<number | null>(null);
+  let newScope = $state<Scope>("overall");
+  let newTargetId = $state<number | null>(null);
+  let newWindow = $state<BudgetWindow>("daily");
+  let newMinutes = $state("");
+  let creating = $state(false);
+
+  // Inline edit (window + allowance only).
+  let editingId = $state<number | null>(null);
+  let editWindow = $state<BudgetWindow>("daily");
+  let editMinutes = $state("");
+  let saving = $state(false);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      [budgets, users, activities, groups] = await Promise.all([
+        listBudgets(),
+        listUsers(),
+        listActivities(),
+        listActivityGroups(),
+      ]);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function userName(id: number): string {
+    return users.find((u) => u.id === id)?.displayName ?? `User ${id}`;
+  }
+
+  function scopeLabel(scope: Scope): string {
+    return SCOPE_OPTIONS.find((o) => o.value === scope)?.label ?? scope;
+  }
+
+  function windowLabel(window: BudgetWindow): string {
+    return WINDOW_OPTIONS.find((o) => o.value === window)?.label ?? window;
+  }
+
+  /** Human label for a budget's target, given its scope + targetId. */
+  function targetLabel(budget: BudgetResponse): string {
+    if (budget.scope === "overall" || budget.targetId === null) {
+      return "—";
+    }
+    if (budget.scope === "activity") {
+      return activities.find((a) => a.id === budget.targetId)?.matcher ?? `Activity ${budget.targetId}`;
+    }
+    return groups.find((g) => g.id === budget.targetId)?.name ?? `Group ${budget.targetId}`;
+  }
+
+  /** Render `secondsAllowed` as a compact `Xh Ym`. */
+  function formatAllowance(seconds: number): string {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.round((seconds % 3600) / 60);
+    if (hours === 0) {
+      return `${minutes}m`;
+    }
+    return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+  }
+
+  /** Parse a minutes field to whole seconds, or `null` if not a valid count. */
+  function minutesToSeconds(value: string): number | null {
+    const minutes = Number(value);
+    if (!Number.isInteger(minutes) || minutes < 0) {
+      return null;
+    }
+    return minutes * 60;
+  }
+
+  // The target picker only applies to the non-overall scopes; clear any stale
+  // selection when the scope changes so an `overall` budget can't carry a target.
+  function onScopeChange(): void {
+    newTargetId = null;
+  }
+
+  let createDisabled = $derived(
+    creating ||
+      newUserId === null ||
+      minutesToSeconds(newMinutes) === null ||
+      newMinutes.trim() === "" ||
+      (newScope !== "overall" && newTargetId === null),
+  );
+
+  async function handleCreate(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    const seconds = minutesToSeconds(newMinutes);
+    if (newUserId === null || seconds === null) {
+      return;
+    }
+    creating = true;
+    error = null;
+    try {
+      const created = await createBudget({
+        userId: newUserId,
+        scope: newScope,
+        targetId: newScope === "overall" ? null : newTargetId,
+        window: newWindow,
+        secondsAllowed: seconds,
+      });
+      budgets = [...budgets, created];
+      newScope = "overall";
+      newTargetId = null;
+      newWindow = "daily";
+      newMinutes = "";
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      creating = false;
+    }
+  }
+
+  function startEdit(budget: BudgetResponse): void {
+    editingId = budget.id;
+    editWindow = budget.window;
+    editMinutes = String(Math.round(budget.secondsAllowed / 60));
+    error = null;
+  }
+
+  function cancelEdit(): void {
+    editingId = null;
+  }
+
+  async function saveEdit(id: number): Promise<void> {
+    const seconds = minutesToSeconds(editMinutes);
+    if (seconds === null) {
+      return;
+    }
+    saving = true;
+    error = null;
+    try {
+      const updated = await updateBudget(id, { window: editWindow, secondsAllowed: seconds });
+      budgets = budgets.map((b) => (b.id === id ? updated : b));
+      editingId = null;
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleDelete(budget: BudgetResponse): Promise<void> {
+    if (!confirm(`Delete this ${budget.window} ${budget.scope} budget? This cannot be undone.`)) {
+      return;
+    }
+    error = null;
+    try {
+      await deleteBudget(budget.id);
+      budgets = budgets.filter((b) => b.id !== budget.id);
+    } catch (err) {
+      error = messageOf(err);
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>Budgets</h1>
+    <p class="hint">
+      How much time a user gets per day, week, or month — overall or for a
+      specific activity or activity group. Allowances are entered in minutes.
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  {#if !loading && users.length === 0}
+    <p class="muted">Add a user first — a budget always belongs to a user.</p>
+  {:else}
+    <form class="create" onsubmit={handleCreate}>
+      <select bind:value={newUserId} disabled={creating} aria-label="Budget user" required>
+        <option value={null} disabled selected>Choose a user…</option>
+        {#each users as user (user.id)}
+          <option value={user.id}>{user.displayName}</option>
+        {/each}
+      </select>
+      <select
+        bind:value={newScope}
+        onchange={onScopeChange}
+        disabled={creating}
+        aria-label="Budget scope"
+      >
+        {#each SCOPE_OPTIONS as option (option.value)}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </select>
+      {#if newScope === "activity"}
+        <select bind:value={newTargetId} disabled={creating} aria-label="Target activity" required>
+          <option value={null} disabled selected>Choose an activity…</option>
+          {#each activities as activity (activity.id)}
+            <option value={activity.id}>{activity.matcher} ({activity.kind})</option>
+          {/each}
+        </select>
+      {:else if newScope === "group"}
+        <select bind:value={newTargetId} disabled={creating} aria-label="Target group" required>
+          <option value={null} disabled selected>Choose a group…</option>
+          {#each groups as group (group.id)}
+            <option value={group.id}>{group.name}</option>
+          {/each}
+        </select>
+      {/if}
+      <select bind:value={newWindow} disabled={creating} aria-label="Budget window">
+        {#each WINDOW_OPTIONS as option (option.value)}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </select>
+      <input
+        type="number"
+        min="0"
+        step="1"
+        placeholder="Minutes"
+        bind:value={newMinutes}
+        disabled={creating}
+        required
+        aria-label="Allowance in minutes"
+      />
+      <button type="submit" disabled={createDisabled}>
+        {creating ? "Adding…" : "Add budget"}
+      </button>
+    </form>
+
+    {#if loading}
+      <p class="muted">Loading budgets…</p>
+    {:else if budgets.length === 0}
+      <p class="muted">No budgets yet. Add one above.</p>
+    {:else}
+      <table>
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Scope</th>
+            <th>Target</th>
+            <th>Window</th>
+            <th>Allowance</th>
+            <th class="actions-col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each budgets as budget (budget.id)}
+            <tr>
+              <td>{userName(budget.userId)}</td>
+              <td>{scopeLabel(budget.scope)}</td>
+              <td class="muted">{targetLabel(budget)}</td>
+              {#if editingId === budget.id}
+                <td>
+                  <select bind:value={editWindow} aria-label="Edit window">
+                    {#each WINDOW_OPTIONS as option (option.value)}
+                      <option value={option.value}>{option.label}</option>
+                    {/each}
+                  </select>
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    min="0"
+                    step="1"
+                    bind:value={editMinutes}
+                    aria-label="Edit allowance in minutes"
+                  />
+                </td>
+                <td class="actions">
+                  <button
+                    onclick={() => saveEdit(budget.id)}
+                    disabled={saving || minutesToSeconds(editMinutes) === null}
+                  >
+                    {saving ? "Saving…" : "Save"}
+                  </button>
+                  <button class="ghost" onclick={cancelEdit} disabled={saving}>Cancel</button>
+                </td>
+              {:else}
+                <td>{windowLabel(budget.window)}</td>
+                <td>{formatAllowance(budget.secondsAllowed)}</td>
+                <td class="actions">
+                  <button class="ghost" onclick={() => startEdit(budget)}>Edit</button>
+                  <button class="danger" onclick={() => handleDelete(budget)}>Delete</button>
+                </td>
+              {/if}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+    max-width: 40rem;
+  }
+  .create {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+  }
+  .create input {
+    flex: 0 1 8rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+  }
+  .create select {
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    background: #fff;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+  }
+  th {
+    background: #f9fafb;
+    font-weight: 600;
+    color: #374151;
+  }
+  td input,
+  td select {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.3rem;
+    background: #fff;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .actions-col {
+    width: 1%;
+    white-space: nowrap;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  button.danger {
+    background: #dc2626;
+  }
+  .muted {
+    color: #6b7280;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/lib/views/LinksView.svelte
+++ b/server/frontend/src/lib/views/LinksView.svelte
@@ -1,0 +1,370 @@
+<!--
+  User ↔ Client links editor (#189): repeats the Users/Activities pattern (#53)
+  but scoped to one user at a time, since the link routes are nested under the
+  user. Loads the users + clients lists on mount (browser only — the page is
+  prerendered to a static shell); picking a user loads that user's links. All
+  calls go through the typed `$lib/api/links` wrappers; errors are surfaced
+  inline.
+
+  A link maps a policy `User` to a Linux account (`linuxUsername` + `linuxUid`)
+  on a specific `Client` — the mapping enforcement needs to drive `timekpra`
+  and read ActivityWatch for the right OS account. The `PUT` is idempotent, so
+  the same form both creates and updates a link.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ApiError } from "$lib/api/client.js";
+  import type { ClientResponse, LinkResponse, UserResponse } from "$lib/api/contract.js";
+  import { listUsers } from "$lib/api/users.js";
+  import { listClients } from "$lib/api/clients.js";
+  import { listUserLinks, upsertLink, deleteLink } from "$lib/api/links.js";
+
+  let users = $state<UserResponse[]>([]);
+  let clients = $state<ClientResponse[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // The selected user whose links are shown.
+  let selectedUserId = $state<number | null>(null);
+  let links = $state<LinkResponse[]>([]);
+  let linksLoading = $state(false);
+
+  // Create/update form.
+  let formClientId = $state<number | null>(null);
+  let formUsername = $state("");
+  let formUid = $state("");
+  let submitting = $state(false);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      [users, clients] = await Promise.all([listUsers(), listClients()]);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function clientName(id: number): string {
+    return clients.find((c) => c.id === id)?.hostname ?? `Client ${id}`;
+  }
+
+  /** Clients the selected user is not yet linked to — the add-dropdown options. */
+  let candidateClients = $derived(
+    clients.filter((c) => !links.some((l) => l.clientId === c.id)),
+  );
+
+  /** Parse the UID field to a non-negative integer, or `null` if invalid. */
+  function parseUid(value: string): number | null {
+    const uid = Number(value);
+    return Number.isInteger(uid) && uid >= 0 ? uid : null;
+  }
+
+  async function onSelectUser(): Promise<void> {
+    resetForm();
+    if (selectedUserId === null) {
+      links = [];
+      return;
+    }
+    linksLoading = true;
+    error = null;
+    try {
+      links = await listUserLinks(selectedUserId);
+    } catch (err) {
+      error = messageOf(err);
+      links = [];
+    } finally {
+      linksLoading = false;
+    }
+  }
+
+  function resetForm(): void {
+    formClientId = null;
+    formUsername = "";
+    formUid = "";
+  }
+
+  let submitDisabled = $derived(
+    submitting ||
+      formClientId === null ||
+      formUsername.trim() === "" ||
+      parseUid(formUid) === null,
+  );
+
+  async function handleSubmit(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    const uid = parseUid(formUid);
+    if (selectedUserId === null || formClientId === null || uid === null) {
+      return;
+    }
+    submitting = true;
+    error = null;
+    try {
+      const saved = await upsertLink(selectedUserId, formClientId, {
+        linuxUsername: formUsername.trim(),
+        linuxUid: uid,
+      });
+      // `PUT` is upsert: replace an existing link to this client, else append.
+      const existing = links.some((l) => l.clientId === saved.clientId);
+      links = existing
+        ? links.map((l) => (l.clientId === saved.clientId ? saved : l))
+        : [...links, saved];
+      resetForm();
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      submitting = false;
+    }
+  }
+
+  /** Load a link's values into the form so the upsert updates it. */
+  function startEdit(link: LinkResponse): void {
+    formClientId = link.clientId;
+    formUsername = link.linuxUsername;
+    formUid = String(link.linuxUid);
+    error = null;
+  }
+
+  async function handleDelete(link: LinkResponse): Promise<void> {
+    if (selectedUserId === null) {
+      return;
+    }
+    if (!confirm(`Remove the link to ${clientName(link.clientId)}? This cannot be undone.`)) {
+      return;
+    }
+    error = null;
+    try {
+      await deleteLink(selectedUserId, link.clientId);
+      links = links.filter((l) => l.clientId !== link.clientId);
+    } catch (err) {
+      error = messageOf(err);
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>User ↔ Client links</h1>
+    <p class="hint">
+      Map a supervised user to their Linux account (username + UID) on each
+      client. Enforcement uses this mapping to target the right OS account.
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  {#if loading}
+    <p class="muted">Loading…</p>
+  {:else if users.length === 0}
+    <p class="muted">Add a user first — links are per user.</p>
+  {:else}
+    <div class="picker">
+      <label for="link-user">User</label>
+      <select id="link-user" bind:value={selectedUserId} onchange={onSelectUser}>
+        <option value={null} disabled selected>Choose a user…</option>
+        {#each users as user (user.id)}
+          <option value={user.id}>{user.displayName}</option>
+        {/each}
+      </select>
+    </div>
+
+    {#if selectedUserId !== null}
+      {#if clients.length === 0}
+        <p class="muted">Enrol a client first — there's nothing to link to yet.</p>
+      {:else}
+        <form class="create" onsubmit={handleSubmit}>
+          <select bind:value={formClientId} disabled={submitting} aria-label="Client" required>
+            <option value={null} disabled selected>Choose a client…</option>
+            {#each candidateClients as client (client.id)}
+              <option value={client.id}>{client.hostname}</option>
+            {/each}
+            <!-- Editing an existing link keeps its client selectable. -->
+            {#each links as link (link.clientId)}
+              {#if !candidateClients.some((c) => c.id === link.clientId)}
+                <option value={link.clientId}>{clientName(link.clientId)}</option>
+              {/if}
+            {/each}
+          </select>
+          <input
+            type="text"
+            placeholder="Linux username"
+            bind:value={formUsername}
+            disabled={submitting}
+            required
+            aria-label="Linux username"
+          />
+          <input
+            type="number"
+            min="0"
+            step="1"
+            placeholder="UID"
+            bind:value={formUid}
+            disabled={submitting}
+            required
+            aria-label="Linux UID"
+          />
+          <button type="submit" disabled={submitDisabled}>
+            {submitting ? "Saving…" : "Save link"}
+          </button>
+        </form>
+
+        {#if linksLoading}
+          <p class="muted">Loading links…</p>
+        {:else if links.length === 0}
+          <p class="muted">No links for this user yet. Add one above.</p>
+        {:else}
+          <table>
+            <thead>
+              <tr>
+                <th>Client</th>
+                <th>Linux username</th>
+                <th>UID</th>
+                <th class="actions-col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each links as link (link.clientId)}
+                <tr>
+                  <td>{clientName(link.clientId)}</td>
+                  <td><code>{link.linuxUsername}</code></td>
+                  <td class="muted">{link.linuxUid}</td>
+                  <td class="actions">
+                    <button class="ghost" onclick={() => startEdit(link)}>Edit</button>
+                    <button class="danger" onclick={() => handleDelete(link)}>Delete</button>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+      {/if}
+    {/if}
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+    max-width: 40rem;
+  }
+  .picker {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .picker label {
+    font-size: 0.9rem;
+    color: #374151;
+    font-weight: 600;
+  }
+  .picker select {
+    flex: 0 1 18rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    background: #fff;
+  }
+  .create {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+  }
+  .create input {
+    flex: 0 1 12rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+  }
+  .create select {
+    flex: 1 1 12rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    background: #fff;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+  }
+  th {
+    background: #f9fafb;
+    font-weight: 600;
+    color: #374151;
+  }
+  code {
+    font-size: 0.85rem;
+    color: #111827;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .actions-col {
+    width: 1%;
+    white-space: nowrap;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  button.danger {
+    background: #dc2626;
+  }
+  .muted {
+    color: #6b7280;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/routes/admin/+page.svelte
+++ b/server/frontend/src/routes/admin/+page.svelte
@@ -24,6 +24,9 @@
   import UsersView from "$lib/views/UsersView.svelte";
   import ClientsView from "$lib/views/ClientsView.svelte";
   import ActivitiesView from "$lib/views/ActivitiesView.svelte";
+  import ActivityGroupsView from "$lib/views/ActivityGroupsView.svelte";
+  import BudgetsView from "$lib/views/BudgetsView.svelte";
+  import LinksView from "$lib/views/LinksView.svelte";
 
   // `null` while the initial session probe is in flight.
   let session = $state<SessionResponse | null>(null);
@@ -36,7 +39,10 @@
     { id: "dashboard", label: "Dashboard" },
     { id: "users", label: "Users" },
     { id: "clients", label: "Clients" },
+    { id: "links", label: "User ↔ Client links" },
     { id: "activities", label: "Activities" },
+    { id: "activity-groups", label: "Activity Groups" },
+    { id: "budgets", label: "Budgets" },
   ];
   let activeView = $state<string>("dashboard");
 
@@ -109,8 +115,14 @@
       <UsersView />
     {:else if activeView === "clients"}
       <ClientsView />
+    {:else if activeView === "links"}
+      <LinksView />
     {:else if activeView === "activities"}
       <ActivitiesView />
+    {:else if activeView === "activity-groups"}
+      <ActivityGroupsView />
+    {:else if activeView === "budgets"}
+      <BudgetsView />
     {:else}
       <DashboardView {username} onnavigate={(id) => (activeView = id)} />
     {/if}

--- a/server/frontend/tests/api/activity-groups.test.ts
+++ b/server/frontend/tests/api/activity-groups.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  addActivityToGroup,
+  createActivityGroup,
+  deleteActivityGroup,
+  listActivityGroups,
+  listGroupActivities,
+  removeActivityFromGroup,
+  updateActivityGroup,
+} from "../../src/lib/api/activity-groups.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("activity-groups API", () => {
+  it("listActivityGroups GETs /api/activity-groups", async () => {
+    const rows = [{ id: 1, name: "Games" }];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, rows));
+
+    const result = await listActivityGroups();
+
+    expect(result).toEqual(rows);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/activity-groups");
+  });
+
+  it("createActivityGroup POSTs the body to /api/activity-groups", async () => {
+    const created = { id: 2, name: "Social" };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(201, created));
+
+    const result = await createActivityGroup({ name: "Social" });
+
+    expect(result).toEqual(created);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/activity-groups");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBe(JSON.stringify({ name: "Social" }));
+  });
+
+  it("updateActivityGroup PATCHes /api/activity-groups/:id", async () => {
+    const updated = { id: 3, name: "Streaming" };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, updated));
+
+    const result = await updateActivityGroup(3, { name: "Streaming" });
+
+    expect(result).toEqual(updated);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/activity-groups/3");
+    expect((init as RequestInit).method).toBe("PATCH");
+    expect((init as RequestInit).body).toBe(JSON.stringify({ name: "Streaming" }));
+  });
+
+  it("deleteActivityGroup DELETEs /api/activity-groups/:id and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(deleteActivityGroup(4)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/activity-groups/4");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+
+  it("listGroupActivities GETs the nested membership collection", async () => {
+    const rows = [{ id: 7, kind: "app", matcher: "steam", matchType: "exact" }];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, rows));
+
+    const result = await listGroupActivities(5);
+
+    expect(result).toEqual(rows);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/activity-groups/5/activities");
+  });
+
+  it("addActivityToGroup PUTs the membership and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(addActivityToGroup(5, 7)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/activity-groups/5/activities/7");
+    expect((init as RequestInit).method).toBe("PUT");
+  });
+
+  it("removeActivityFromGroup DELETEs the membership and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(removeActivityFromGroup(5, 7)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/activity-groups/5/activities/7");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+});

--- a/server/frontend/tests/api/budgets.test.ts
+++ b/server/frontend/tests/api/budgets.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createBudget,
+  deleteBudget,
+  listBudgets,
+  updateBudget,
+} from "../../src/lib/api/budgets.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("budgets API", () => {
+  it("listBudgets GETs /api/budgets without a filter", async () => {
+    const rows = [
+      { id: 1, userId: 1, scope: "overall", targetId: null, window: "daily", secondsAllowed: 7200 },
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, rows));
+
+    const result = await listBudgets();
+
+    expect(result).toEqual(rows);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/budgets");
+  });
+
+  it("listBudgets appends the ?userId= filter when given", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, []));
+
+    await listBudgets(42);
+
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/budgets?userId=42");
+  });
+
+  it("createBudget POSTs the body to /api/budgets", async () => {
+    const body = {
+      userId: 1,
+      scope: "activity" as const,
+      targetId: 9,
+      window: "daily" as const,
+      secondsAllowed: 3600,
+    };
+    const created = { id: 2, ...body };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(201, created));
+
+    const result = await createBudget(body);
+
+    expect(result).toEqual(created);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/budgets");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBe(JSON.stringify(body));
+  });
+
+  it("updateBudget PATCHes /api/budgets/:id", async () => {
+    const updated = {
+      id: 3,
+      userId: 1,
+      scope: "overall",
+      targetId: null,
+      window: "weekly",
+      secondsAllowed: 18000,
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, updated));
+
+    const result = await updateBudget(3, { secondsAllowed: 18000 });
+
+    expect(result).toEqual(updated);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/budgets/3");
+    expect((init as RequestInit).method).toBe("PATCH");
+    expect((init as RequestInit).body).toBe(JSON.stringify({ secondsAllowed: 18000 }));
+  });
+
+  it("deleteBudget DELETEs /api/budgets/:id and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(deleteBudget(4)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/budgets/4");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+});

--- a/server/frontend/tests/api/links.test.ts
+++ b/server/frontend/tests/api/links.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { deleteLink, listUserLinks, upsertLink } from "../../src/lib/api/links.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("links API", () => {
+  it("listUserLinks GETs the nested /api/users/:userId/clients collection", async () => {
+    const rows = [{ userId: 1, clientId: 2, linuxUsername: "alice", linuxUid: 1001 }];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, rows));
+
+    const result = await listUserLinks(1);
+
+    expect(result).toEqual(rows);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/users/1/clients");
+  });
+
+  it("upsertLink PUTs the body to /api/users/:userId/clients/:clientId", async () => {
+    const body = { linuxUsername: "alice", linuxUid: 1001 };
+    const created = { userId: 1, clientId: 2, ...body };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, created));
+
+    const result = await upsertLink(1, 2, body);
+
+    expect(result).toEqual(created);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/users/1/clients/2");
+    expect((init as RequestInit).method).toBe("PUT");
+    expect((init as RequestInit).body).toBe(JSON.stringify(body));
+  });
+
+  it("deleteLink DELETEs /api/users/:userId/clients/:clientId and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(deleteLink(1, 2)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/users/1/clients/2");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+});


### PR DESCRIPTION
## Summary

Next slice of #189 (the Clients + Activities editors already landed on `main`). Adds three more `/admin` editors, each repeating the established Users/Activities pattern (typed `apiFetch` wrappers over the shared inferred DTOs, an in-page `*View.svelte`, wired into the shell nav):

- **Activity Groups** (+ membership) — `/api/activity-groups` CRUD plus master-detail add/remove of member activities.
- **Budgets** — `/api/budgets` CRUD: scope-conditional target picker (overall / activity / group), window + minutes allowance, inline edit of window + allowance.
- **User ↔ Client links** — `/api/users/:userId/clients` upsert/remove (`linuxUsername`/UID), user-scoped; the idempotent `PUT` form doubles as create + edit.

## Plan

Linked plan: `.claude/plans/issue-189-admin-editors.md` (Slice 2 section)
Roadmap: `docs/roadmap.md` → Phase 2

## License-boundary note

N/A — frontend-only. Type-only DTO imports (erased at build), plain browser `fetch` over `/api/*`. No GPL surface, no transport/packaging change. (One non-DTO change: `ApiFetchOptions.method` gains `"PUT"` for the idempotent membership/link routes.)

## Test plan

- [x] `frontend` vitest unit tests for the new `activity-groups` / `budgets` / `links` wrappers (URL/method/body assertions, 204 on delete) — 38 tests green
- [x] `svelte-check` clean (0 errors)
- [x] `vite build` green with the new views (`adapter-static`)
- [x] server `format:check` / `lint` / `typecheck` clean (no `server/src` change)

Screenshots omitted: the editors only render for an authenticated admin against seeded policy data, so a static-shell capture would show only the login screen. No E2E/screenshot harness exists yet (out of scope per the implement-issue guidance).

## Deferred — stays tracked on #189

- **Schedules / Exceptions** editor — deferred to avoid colliding with in-flight #182 (group-targeting) / #140 (recurring windows) and the #63 drag-to-order editor.
- Deep `/admin/*` routes + SPA fallback — #59.
- Inline change of a budget's scope/target (delete + recreate for now) — minor follow-up if wanted.

Part of #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)