### PR TITLE
feat(admin): schedules + exceptions policy editors (#189)

### DIFF
--- a/.claude/plans/issue-189-admin-schedules-exceptions-editor.md
+++ b/.claude/plans/issue-189-admin-schedules-exceptions-editor.md
@@ -1,0 +1,88 @@
+# Plan — Admin UI: Schedules / Exceptions editor (#189, follow-up of #53)
+
+## Context
+
+`#189` is the follow-up tracking the remaining `/admin` policy editors after the
+`#53` foundation slice. Already merged to `main`:
+
+- Foundation slice (#53): typed `/api` client, login/session, `/admin` shell,
+  Users editor.
+- Slice 1 (#189): Clients, Activities.
+- Slice 2 (#189, PR #244): Activity Groups (+ membership), Budgets, User↔Client
+  links.
+
+The **only** `/admin` editor still missing is **Schedules / Exceptions** — this
+slice. It closes out #189's CRUD scope.
+
+## Boundaries (explicit — do not cross)
+
+- **Recurring day-of-week + intra-day window authoring → #140.** This editor
+  creates the always-on degenerate schedule (all recurrence fields `null`) and
+  **renders** recurrence read-only so rules a future #140 editor authors still
+  display. No day-mask / time-window inputs here.
+- **Drag-to-order + first-match-wins (ordinal) → #63.** No reordering UI;
+  `ordinal` left at the column default on create.
+- **Group-targeted rules → #182 (PR #203, additive, separate tables/routes).**
+  This editor talks to the stable per-user `/api/schedules` + `/api/exceptions`
+  contract already on `main`; it is unaffected by #203.
+
+These match the carve-outs stated in #189's body and the slice-2 deferral note.
+
+## Contract (already on `main`, `server/src/api/policy/`)
+
+`/api/schedules` (+ `/:id`) and `/api/exceptions` (+ `/:id`) — full CRUD, guarded
+by `requireAdmin`, `?userId=` list filter. DTOs in `api/policy/dtos.ts`:
+
+- **Schedule**: `userId`, `targetKind` (`overall|activity|group`), `targetId`,
+  `action` (`allow|deny|extend`), recurrence fields (all nullable; created
+  `null`), `ordinal`.
+- **Exception**: `userId`, `targetKind`, `targetId`, `action`, `reason`
+  (nullable), `effectiveFrom` (nullable ISO), `expiresAt` (required ISO),
+  `createdAt`. Exception date bounds are **one-shot**, not recurrence — authoring
+  them is in scope.
+
+## Established frontend pattern (mirror exactly)
+
+- `src/lib/api/contract.ts` — `import type` re-exports of inferred zod DTO types.
+- `src/lib/api/<entity>.ts` — thin `apiFetch` wrappers (see `budgets.ts`).
+- `src/lib/views/<Entity>View.svelte` — list/create/inline-edit/delete (Svelte 5
+  runes, browser-only `onMount` load, inline error surface).
+- Nav wiring in `src/routes/admin/+page.svelte`.
+- `tests/api/<entity>.test.ts` — vitest, `fetch` spy asserting URL/method/body.
+
+## Work phases
+
+### Phase 1 — typed API layer + contract types + tests
+1. `contract.ts`: add `ScheduleResponse/CreateScheduleRequest/UpdateScheduleRequest`,
+   `ExceptionResponse/CreateExceptionRequest/UpdateExceptionRequest`, and the
+   `ScheduleAction` enum type to the re-exports.
+2. `src/lib/api/schedules.ts` + `src/lib/api/exceptions.ts` — `list(userId?)`,
+   `create`, `update(id)`, `delete(id)` (mirror `budgets.ts`, incl. `?userId=`).
+3. `tests/api/schedules.test.ts` + `tests/api/exceptions.test.ts`.
+
+### Phase 2 — views + nav wiring
+4. `SchedulesView.svelte`: create (user + scope + activity/group target + action;
+   recurrence created always-on), table with read-only recurrence summary
+   ("Always" when degenerate), inline edit of `action`, delete with confirm.
+5. `ExceptionsView.svelte`: create (user + scope + target + action + reason +
+   optional `effectiveFrom` + required `expiresAt` via `datetime-local`), table,
+   inline edit of `action` + `expiresAt` (+ `reason`), delete with confirm.
+6. Wire two nav items ("Schedules", "Exceptions") + imports + view switch in
+   `+page.svelte`.
+
+### Phase 3 — validate
+7. `npm run format`, `lint:fix`, `typecheck`, `npm test` (server gate, 80%).
+8. `cd server/frontend && npm ci && npm run check && npm run build` green.
+
+## Helpers / care points
+
+- `datetime-local` ⇄ ISO-8601 UTC: `new Date(local).toISOString()` to send;
+  ISO → local input value for edit prefill. `z.string().datetime()` requires a
+  trailing `Z`, which `toISOString()` produces.
+- Scope→target picker: clear `targetId` on scope change; `overall` sends `null`.
+- Errors surfaced inline via `ApiError.message` (same `messageOf` helper as the
+  other views).
+
+## Out of scope / deferred (note in PR, link issues)
+- Recurrence authoring → #140. Ordinal/drag-reorder → #63. Group targeting → #182.
+- Deep `/admin/*` routes + SPA fallback → #59.

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -39,6 +39,18 @@ export type {
   UpdateBudgetRequest,
   LinkResponse,
   UpsertLinkRequest,
+  ScheduleResponse,
+  CreateScheduleRequest,
+  UpdateScheduleRequest,
+  ExceptionResponse,
+  CreateExceptionRequest,
+  UpdateExceptionRequest,
 } from "../../../../src/api/policy/dtos.js";
-export type { ActivityKind, MatchType, Scope, BudgetWindow } from "../../../../src/policy/enums.js";
+export type {
+  ActivityKind,
+  MatchType,
+  Scope,
+  BudgetWindow,
+  ScheduleAction,
+} from "../../../../src/policy/enums.js";
 export type { ErrorEnvelope, ErrorDetail } from "../../../../src/api/errors.js";

--- a/server/frontend/src/lib/api/exceptions.ts
+++ b/server/frontend/src/lib/api/exceptions.ts
@@ -1,0 +1,46 @@
+/**
+ * CRUD calls for the `Exception` policy entity (#51 contract, #189 editor).
+ *
+ * Same proven shape as `$lib/api/budgets` (#53/#189): thin typed wrappers over
+ * {@link apiFetch}, with request/response types imported from the shared `/api`
+ * contract so the frontend never re-declares a DTO. An `Exception` is a
+ * one-shot, date-boxed override: it `allow`/`deny`/`extend`s a `targetKind`
+ * (`overall`, an `activity`, or an activity `group`) for a user over
+ * `[effectiveFrom ?? createdAt, expiresAt)`. Unlike a `Schedule` it does not
+ * recur — the date bounds are authored directly here.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type {
+  ExceptionResponse,
+  CreateExceptionRequest,
+  UpdateExceptionRequest,
+} from "./contract.js";
+
+/**
+ * List exceptions. With `userId` the server restricts to that user; without it,
+ * every exception is returned (the `?userId=` filter the route exposes).
+ */
+export function listExceptions(userId?: number): Promise<ExceptionResponse[]> {
+  const path = userId === undefined ? "/exceptions" : `/exceptions?userId=${userId}`;
+  return apiFetch<ExceptionResponse[]>(path);
+}
+
+/** Create an exception; the server validates target coherence and returns the row. */
+export function createException(input: CreateExceptionRequest): Promise<ExceptionResponse> {
+  return apiFetch<ExceptionResponse>("/exceptions", { method: "POST", body: input });
+}
+
+/** Patch an exception; `input` must carry at least one field (server enforces). */
+export function updateException(
+  id: number,
+  input: UpdateExceptionRequest,
+): Promise<ExceptionResponse> {
+  return apiFetch<ExceptionResponse>(`/exceptions/${id}`, { method: "PATCH", body: input });
+}
+
+/** Delete an exception. Resolves on the server's `204`. */
+export function deleteException(id: number): Promise<void> {
+  return apiFetch<void>(`/exceptions/${id}`, { method: "DELETE" });
+}

--- a/server/frontend/src/lib/api/schedules.ts
+++ b/server/frontend/src/lib/api/schedules.ts
@@ -1,0 +1,48 @@
+/**
+ * CRUD calls for the `Schedule` policy entity (#51 contract, #189 editor).
+ *
+ * Same proven shape as `$lib/api/budgets` (#53/#189): thin typed wrappers over
+ * {@link apiFetch}, with request/response types imported from the shared `/api`
+ * contract so the frontend never re-declares a DTO. A `Schedule` is a recurring
+ * rule that `allow`/`deny`/`extend`s a `targetKind` (`overall`, an `activity`,
+ * or an activity `group`) for a user. The recurrence + ordinal fields exist on
+ * the contract but are authored elsewhere: day-of-week / intra-day windows are
+ * #140 and drag-reorder is #63, so this editor creates the always-on degenerate
+ * rule and the wrappers stay a faithful pass-through of whatever the contract
+ * carries.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type {
+  ScheduleResponse,
+  CreateScheduleRequest,
+  UpdateScheduleRequest,
+} from "./contract.js";
+
+/**
+ * List schedules. With `userId` the server restricts to that user; without it,
+ * every schedule is returned (the `?userId=` filter the route exposes).
+ */
+export function listSchedules(userId?: number): Promise<ScheduleResponse[]> {
+  const path = userId === undefined ? "/schedules" : `/schedules?userId=${userId}`;
+  return apiFetch<ScheduleResponse[]>(path);
+}
+
+/** Create a schedule; the server validates target coherence and returns the row. */
+export function createSchedule(input: CreateScheduleRequest): Promise<ScheduleResponse> {
+  return apiFetch<ScheduleResponse>("/schedules", { method: "POST", body: input });
+}
+
+/** Patch a schedule; `input` must carry at least one field (server enforces). */
+export function updateSchedule(
+  id: number,
+  input: UpdateScheduleRequest,
+): Promise<ScheduleResponse> {
+  return apiFetch<ScheduleResponse>(`/schedules/${id}`, { method: "PATCH", body: input });
+}
+
+/** Delete a schedule. Resolves on the server's `204`. */
+export function deleteSchedule(id: number): Promise<void> {
+  return apiFetch<void>(`/schedules/${id}`, { method: "DELETE" });
+}

--- a/server/frontend/src/lib/views/ExceptionsView.svelte
+++ b/server/frontend/src/lib/views/ExceptionsView.svelte
@@ -1,0 +1,511 @@
+<!--
+  Exceptions editor (#189): repeats the Users/Activities/Budgets pattern (#53).
+  Loads `/api/exceptions` plus the users / activities / activity-groups it needs
+  to render targets and populate the create form, all on mount (browser only —
+  the page is prerendered to a static shell). Supports create, inline edit of
+  the `action`, `reason`, and `expiresAt`, and delete. All calls go through the
+  typed `$lib/api/exceptions` wrappers; errors surface inline.
+
+  An `Exception` is a one-shot, date-boxed override: it `allow`/`deny`/`extend`s
+  a `targetKind` (`overall`, a single `activity`, or an activity `group`) for a
+  user over `[effectiveFrom ?? createdAt, expiresAt)` (ADR 0005 §2). Unlike a
+  schedule it does not recur, so the date bounds are authored directly here via
+  `datetime-local` inputs. Scope and target are fixed at create time — changing
+  what an override applies to means deleting it and adding a new one.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ApiError } from "$lib/api/client.js";
+  import type {
+    ActivityGroupResponse,
+    ActivityResponse,
+    ExceptionResponse,
+    ScheduleAction,
+    Scope,
+    UserResponse,
+  } from "$lib/api/contract.js";
+  import {
+    listExceptions,
+    createException,
+    updateException,
+    deleteException,
+  } from "$lib/api/exceptions.js";
+  import { listUsers } from "$lib/api/users.js";
+  import { listActivities } from "$lib/api/activities.js";
+  import { listActivityGroups } from "$lib/api/activity-groups.js";
+
+  const SCOPE_OPTIONS: ReadonlyArray<{ value: Scope; label: string }> = [
+    { value: "overall", label: "Overall" },
+    { value: "activity", label: "Activity" },
+    { value: "group", label: "Activity group" },
+  ];
+
+  const ACTION_OPTIONS: ReadonlyArray<{ value: ScheduleAction; label: string }> = [
+    { value: "allow", label: "Allow" },
+    { value: "deny", label: "Deny" },
+    { value: "extend", label: "Extend" },
+  ];
+
+  let exceptions = $state<ExceptionResponse[]>([]);
+  let users = $state<UserResponse[]>([]);
+  let activities = $state<ActivityResponse[]>([]);
+  let groups = $state<ActivityGroupResponse[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // Create form.
+  let newUserId = $state<number | null>(null);
+  let newScope = $state<Scope>("overall");
+  let newTargetId = $state<number | null>(null);
+  let newAction = $state<ScheduleAction>("allow");
+  let newReason = $state("");
+  let newEffectiveFrom = $state("");
+  let newExpiresAt = $state("");
+  let creating = $state(false);
+
+  // Inline edit (action + reason + expiry).
+  let editingId = $state<number | null>(null);
+  let editAction = $state<ScheduleAction>("allow");
+  let editReason = $state("");
+  let editExpiresAt = $state("");
+  let saving = $state(false);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      [exceptions, users, activities, groups] = await Promise.all([
+        listExceptions(),
+        listUsers(),
+        listActivities(),
+        listActivityGroups(),
+      ]);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function userName(id: number): string {
+    return users.find((u) => u.id === id)?.displayName ?? `User ${id}`;
+  }
+
+  function scopeLabel(scope: Scope): string {
+    return SCOPE_OPTIONS.find((o) => o.value === scope)?.label ?? scope;
+  }
+
+  function actionLabel(action: ScheduleAction): string {
+    return ACTION_OPTIONS.find((o) => o.value === action)?.label ?? action;
+  }
+
+  /** Human label for an exception's target, given its scope + targetId. */
+  function targetLabel(exception: ExceptionResponse): string {
+    if (exception.targetKind === "overall" || exception.targetId === null) {
+      return "—";
+    }
+    if (exception.targetKind === "activity") {
+      return (
+        activities.find((a) => a.id === exception.targetId)?.matcher ??
+        `Activity ${exception.targetId}`
+      );
+    }
+    return groups.find((g) => g.id === exception.targetId)?.name ?? `Group ${exception.targetId}`;
+  }
+
+  /** ISO instant → readable local date+time for display. */
+  function formatInstant(iso: string | null): string {
+    return iso === null ? "—" : new Date(iso).toLocaleString();
+  }
+
+  /**
+   * A `datetime-local` value ("YYYY-MM-DDTHH:mm", local) → an ISO-8601 UTC
+   * instant, or `null` when the field is blank. `toISOString()` yields the
+   * trailing-`Z` form `z.string().datetime()` requires.
+   */
+  function localToIso(value: string): string | null {
+    if (value.trim() === "") {
+      return null;
+    }
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+
+  /** ISO instant → a `datetime-local` value in the browser's local zone for edit prefill. */
+  function isoToLocalInput(iso: string | null): string {
+    if (iso === null) {
+      return "";
+    }
+    const d = new Date(iso);
+    const pad = (n: number): string => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+
+  // The target picker only applies to the non-overall scopes; clear any stale
+  // selection when the scope changes so an `overall` override can't carry a target.
+  function onScopeChange(): void {
+    newTargetId = null;
+  }
+
+  let createDisabled = $derived(
+    creating ||
+      newUserId === null ||
+      newExpiresAt.trim() === "" ||
+      (newScope !== "overall" && newTargetId === null),
+  );
+
+  async function handleCreate(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    const expiresAt = localToIso(newExpiresAt);
+    if (newUserId === null || expiresAt === null) {
+      return;
+    }
+    creating = true;
+    error = null;
+    try {
+      const created = await createException({
+        userId: newUserId,
+        targetKind: newScope,
+        targetId: newScope === "overall" ? null : newTargetId,
+        action: newAction,
+        reason: newReason.trim() === "" ? null : newReason.trim(),
+        effectiveFrom: localToIso(newEffectiveFrom),
+        expiresAt,
+      });
+      exceptions = [...exceptions, created];
+      newScope = "overall";
+      newTargetId = null;
+      newAction = "allow";
+      newReason = "";
+      newEffectiveFrom = "";
+      newExpiresAt = "";
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      creating = false;
+    }
+  }
+
+  function startEdit(exception: ExceptionResponse): void {
+    editingId = exception.id;
+    editAction = exception.action;
+    editReason = exception.reason ?? "";
+    editExpiresAt = isoToLocalInput(exception.expiresAt);
+    error = null;
+  }
+
+  function cancelEdit(): void {
+    editingId = null;
+  }
+
+  async function saveEdit(id: number): Promise<void> {
+    const expiresAt = localToIso(editExpiresAt);
+    if (expiresAt === null) {
+      return;
+    }
+    saving = true;
+    error = null;
+    try {
+      const updated = await updateException(id, {
+        action: editAction,
+        reason: editReason.trim() === "" ? null : editReason.trim(),
+        expiresAt,
+      });
+      exceptions = exceptions.map((e) => (e.id === id ? updated : e));
+      editingId = null;
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleDelete(exception: ExceptionResponse): Promise<void> {
+    if (
+      !confirm(
+        `Delete this ${exception.action} ${exception.targetKind} exception? This cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+    error = null;
+    try {
+      await deleteException(exception.id);
+      exceptions = exceptions.filter((e) => e.id !== exception.id);
+    } catch (err) {
+      error = messageOf(err);
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>Exceptions</h1>
+    <p class="hint">
+      One-off overrides that allow, deny, or extend access for a fixed window —
+      e.g. "allow games until Sunday night". Each override needs an expiry; an
+      optional start defaults to now.
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  {#if !loading && users.length === 0}
+    <p class="muted">Add a user first — an exception always belongs to a user.</p>
+  {:else}
+    <form class="create" onsubmit={handleCreate}>
+      <select bind:value={newUserId} disabled={creating} aria-label="Exception user" required>
+        <option value={null} disabled selected>Choose a user…</option>
+        {#each users as user (user.id)}
+          <option value={user.id}>{user.displayName}</option>
+        {/each}
+      </select>
+      <select
+        bind:value={newScope}
+        onchange={onScopeChange}
+        disabled={creating}
+        aria-label="Exception scope"
+      >
+        {#each SCOPE_OPTIONS as option (option.value)}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </select>
+      {#if newScope === "activity"}
+        <select bind:value={newTargetId} disabled={creating} aria-label="Target activity" required>
+          <option value={null} disabled selected>Choose an activity…</option>
+          {#each activities as activity (activity.id)}
+            <option value={activity.id}>{activity.matcher} ({activity.kind})</option>
+          {/each}
+        </select>
+      {:else if newScope === "group"}
+        <select bind:value={newTargetId} disabled={creating} aria-label="Target group" required>
+          <option value={null} disabled selected>Choose a group…</option>
+          {#each groups as group (group.id)}
+            <option value={group.id}>{group.name}</option>
+          {/each}
+        </select>
+      {/if}
+      <select bind:value={newAction} disabled={creating} aria-label="Exception action">
+        {#each ACTION_OPTIONS as option (option.value)}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </select>
+      <input
+        type="text"
+        placeholder="Reason (optional)"
+        bind:value={newReason}
+        disabled={creating}
+        aria-label="Reason"
+      />
+      <label class="field">
+        <span>From</span>
+        <input
+          type="datetime-local"
+          bind:value={newEffectiveFrom}
+          disabled={creating}
+          aria-label="Effective from"
+        />
+      </label>
+      <label class="field">
+        <span>Expires</span>
+        <input
+          type="datetime-local"
+          bind:value={newExpiresAt}
+          disabled={creating}
+          required
+          aria-label="Expires at"
+        />
+      </label>
+      <button type="submit" disabled={createDisabled}>
+        {creating ? "Adding…" : "Add exception"}
+      </button>
+    </form>
+
+    {#if loading}
+      <p class="muted">Loading exceptions…</p>
+    {:else if exceptions.length === 0}
+      <p class="muted">No exceptions yet. Add one above.</p>
+    {:else}
+      <table>
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Scope</th>
+            <th>Target</th>
+            <th>Action</th>
+            <th>Reason</th>
+            <th>From</th>
+            <th>Expires</th>
+            <th class="actions-col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each exceptions as exception (exception.id)}
+            <tr>
+              <td>{userName(exception.userId)}</td>
+              <td>{scopeLabel(exception.targetKind)}</td>
+              <td class="muted">{targetLabel(exception)}</td>
+              {#if editingId === exception.id}
+                <td>
+                  <select bind:value={editAction} aria-label="Edit action">
+                    {#each ACTION_OPTIONS as option (option.value)}
+                      <option value={option.value}>{option.label}</option>
+                    {/each}
+                  </select>
+                </td>
+                <td>
+                  <input type="text" bind:value={editReason} aria-label="Edit reason" />
+                </td>
+                <td class="muted">{formatInstant(exception.effectiveFrom)}</td>
+                <td>
+                  <input
+                    type="datetime-local"
+                    bind:value={editExpiresAt}
+                    aria-label="Edit expiry"
+                  />
+                </td>
+                <td class="actions">
+                  <button
+                    onclick={() => saveEdit(exception.id)}
+                    disabled={saving || editExpiresAt.trim() === ""}
+                  >
+                    {saving ? "Saving…" : "Save"}
+                  </button>
+                  <button class="ghost" onclick={cancelEdit} disabled={saving}>Cancel</button>
+                </td>
+              {:else}
+                <td>{actionLabel(exception.action)}</td>
+                <td class="muted">{exception.reason ?? "—"}</td>
+                <td class="muted">{formatInstant(exception.effectiveFrom)}</td>
+                <td>{formatInstant(exception.expiresAt)}</td>
+                <td class="actions">
+                  <button class="ghost" onclick={() => startEdit(exception)}>Edit</button>
+                  <button class="danger" onclick={() => handleDelete(exception)}>Delete</button>
+                </td>
+              {/if}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+    max-width: 40rem;
+  }
+  .create {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+    align-items: end;
+  }
+  .create input[type="text"] {
+    flex: 0 1 12rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+  }
+  .create select,
+  .create input[type="datetime-local"] {
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    background: #fff;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    font-size: 0.75rem;
+    color: #6b7280;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+  }
+  th {
+    background: #f9fafb;
+    font-weight: 600;
+    color: #374151;
+  }
+  td input,
+  td select {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.3rem;
+    background: #fff;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .actions-col {
+    width: 1%;
+    white-space: nowrap;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  button.danger {
+    background: #dc2626;
+  }
+  .muted {
+    color: #6b7280;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/lib/views/ExceptionsView.svelte
+++ b/server/frontend/src/lib/views/ExceptionsView.svelte
@@ -149,10 +149,20 @@
     newTargetId = null;
   }
 
+  // A start after (or equal to) the expiry is rejected by the server's
+  // `effectiveFrom < expiresAt` refinement; mirror it client-side for fast
+  // feedback rather than waiting for the 400.
+  let datesInvalid = $derived.by(() => {
+    const from = localToIso(newEffectiveFrom);
+    const to = localToIso(newExpiresAt);
+    return from !== null && to !== null && Date.parse(from) >= Date.parse(to);
+  });
+
   let createDisabled = $derived(
     creating ||
       newUserId === null ||
       newExpiresAt.trim() === "" ||
+      datesInvalid ||
       (newScope !== "overall" && newTargetId === null),
   );
 
@@ -333,6 +343,10 @@
       </button>
     </form>
 
+    {#if datesInvalid}
+      <p class="warn" role="alert">Expiry must be after the start time.</p>
+    {/if}
+
     {#if loading}
       <p class="muted">Loading exceptions…</p>
     {:else if exceptions.length === 0}
@@ -507,5 +521,10 @@
     background: #fef2f2;
     color: #b91c1c;
     font-size: 0.85rem;
+  }
+  .warn {
+    margin: -0.5rem 0 1rem;
+    color: #b45309;
+    font-size: 0.8rem;
   }
 </style>

--- a/server/frontend/src/lib/views/SchedulesView.svelte
+++ b/server/frontend/src/lib/views/SchedulesView.svelte
@@ -1,0 +1,452 @@
+<!--
+  Schedules editor (#189): repeats the Users/Activities/Budgets pattern (#53).
+  Loads `/api/schedules` plus the users / activities / activity-groups it needs
+  to render targets and populate the create form, all on mount (browser only —
+  the page is prerendered to a static shell). Supports create, inline edit of
+  the `action`, and delete. All calls go through the typed `$lib/api/schedules`
+  wrappers; errors surface inline.
+
+  A `Schedule` is a recurring rule that `allow`/`deny`/`extend`s a `targetKind`
+  (`overall`, a single `activity`, or an activity `group`) for a user. Scope and
+  target are fixed at create time — changing what a rule applies to means
+  deleting it and adding a new one — so inline edit only exposes `action`.
+
+  Recurrence is rendered read-only here ("Always" for the degenerate always-on
+  rule). Authoring day-of-week + intra-day windows is #140, and drag-to-order of
+  the `ordinal` is #63; this editor creates the always-on rule and faithfully
+  displays any recurrence those editors set later.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ApiError } from "$lib/api/client.js";
+  import type {
+    ActivityGroupResponse,
+    ActivityResponse,
+    ScheduleAction,
+    ScheduleResponse,
+    Scope,
+    UserResponse,
+  } from "$lib/api/contract.js";
+  import {
+    listSchedules,
+    createSchedule,
+    updateSchedule,
+    deleteSchedule,
+  } from "$lib/api/schedules.js";
+  import { listUsers } from "$lib/api/users.js";
+  import { listActivities } from "$lib/api/activities.js";
+  import { listActivityGroups } from "$lib/api/activity-groups.js";
+
+  const SCOPE_OPTIONS: ReadonlyArray<{ value: Scope; label: string }> = [
+    { value: "overall", label: "Overall" },
+    { value: "activity", label: "Activity" },
+    { value: "group", label: "Activity group" },
+  ];
+
+  const ACTION_OPTIONS: ReadonlyArray<{ value: ScheduleAction; label: string }> = [
+    { value: "allow", label: "Allow" },
+    { value: "deny", label: "Deny" },
+    { value: "extend", label: "Extend" },
+  ];
+
+  // ISO weekday order, bit 0 = Monday … bit 6 = Sunday (ADR 0005 §1).
+  const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+  let schedules = $state<ScheduleResponse[]>([]);
+  let users = $state<UserResponse[]>([]);
+  let activities = $state<ActivityResponse[]>([]);
+  let groups = $state<ActivityGroupResponse[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // Create form.
+  let newUserId = $state<number | null>(null);
+  let newScope = $state<Scope>("overall");
+  let newTargetId = $state<number | null>(null);
+  let newAction = $state<ScheduleAction>("deny");
+  let creating = $state(false);
+
+  // Inline edit (action only).
+  let editingId = $state<number | null>(null);
+  let editAction = $state<ScheduleAction>("deny");
+  let saving = $state(false);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      [schedules, users, activities, groups] = await Promise.all([
+        listSchedules(),
+        listUsers(),
+        listActivities(),
+        listActivityGroups(),
+      ]);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function userName(id: number): string {
+    return users.find((u) => u.id === id)?.displayName ?? `User ${id}`;
+  }
+
+  function scopeLabel(scope: Scope): string {
+    return SCOPE_OPTIONS.find((o) => o.value === scope)?.label ?? scope;
+  }
+
+  function actionLabel(action: ScheduleAction): string {
+    return ACTION_OPTIONS.find((o) => o.value === action)?.label ?? action;
+  }
+
+  /** Human label for a schedule's target, given its scope + targetId. */
+  function targetLabel(schedule: ScheduleResponse): string {
+    if (schedule.targetKind === "overall" || schedule.targetId === null) {
+      return "—";
+    }
+    if (schedule.targetKind === "activity") {
+      return (
+        activities.find((a) => a.id === schedule.targetId)?.matcher ?? `Activity ${schedule.targetId}`
+      );
+    }
+    return groups.find((g) => g.id === schedule.targetId)?.name ?? `Group ${schedule.targetId}`;
+  }
+
+  /** Decode the 7-bit ISO-weekday mask (bit 0 = Monday) to a short label. */
+  function daysLabel(mask: number): string {
+    const days = WEEKDAYS.filter((_, i) => (mask & (1 << i)) !== 0);
+    return days.length === 7 ? "Every day" : days.join(", ");
+  }
+
+  /** Minutes-from-midnight → `HH:MM`. */
+  function clockLabel(minutes: number): string {
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+  }
+
+  /** ISO instant → a short local date (no time) for the effective-window scope. */
+  function dateLabel(iso: string): string {
+    return new Date(iso).toLocaleDateString();
+  }
+
+  /**
+   * Render a schedule's recurrence + date scope read-only. The degenerate row
+   * (no weekday, no intra-day window, no effective bounds) is the always-on
+   * rule. Authoring these fields is #140; this editor only displays them.
+   */
+  function recurrenceSummary(s: ScheduleResponse): string {
+    const parts: string[] = [];
+    if (s.recurrenceDays !== null) {
+      parts.push(daysLabel(s.recurrenceDays));
+    }
+    if (s.recurrenceStartMinute !== null && s.recurrenceEndMinute !== null) {
+      parts.push(`${clockLabel(s.recurrenceStartMinute)}–${clockLabel(s.recurrenceEndMinute)}`);
+    }
+    if (parts.length === 0) {
+      parts.push("Always");
+    }
+    if (s.effectiveFrom !== null || s.effectiveTo !== null) {
+      const from = s.effectiveFrom === null ? "…" : dateLabel(s.effectiveFrom);
+      const to = s.effectiveTo === null ? "…" : dateLabel(s.effectiveTo);
+      parts.push(`(${from} → ${to})`);
+    }
+    return parts.join(" ");
+  }
+
+  // The target picker only applies to the non-overall scopes; clear any stale
+  // selection when the scope changes so an `overall` rule can't carry a target.
+  function onScopeChange(): void {
+    newTargetId = null;
+  }
+
+  let createDisabled = $derived(
+    creating || newUserId === null || (newScope !== "overall" && newTargetId === null),
+  );
+
+  async function handleCreate(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    if (newUserId === null) {
+      return;
+    }
+    creating = true;
+    error = null;
+    try {
+      const created = await createSchedule({
+        userId: newUserId,
+        targetKind: newScope,
+        targetId: newScope === "overall" ? null : newTargetId,
+        action: newAction,
+        // Always-on degenerate rule; day/window authoring is #140.
+        recurrenceDays: null,
+        recurrenceStartMinute: null,
+        recurrenceEndMinute: null,
+        effectiveFrom: null,
+        effectiveTo: null,
+      });
+      schedules = [...schedules, created];
+      newScope = "overall";
+      newTargetId = null;
+      newAction = "deny";
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      creating = false;
+    }
+  }
+
+  function startEdit(schedule: ScheduleResponse): void {
+    editingId = schedule.id;
+    editAction = schedule.action;
+    error = null;
+  }
+
+  function cancelEdit(): void {
+    editingId = null;
+  }
+
+  async function saveEdit(id: number): Promise<void> {
+    saving = true;
+    error = null;
+    try {
+      const updated = await updateSchedule(id, { action: editAction });
+      schedules = schedules.map((s) => (s.id === id ? updated : s));
+      editingId = null;
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleDelete(schedule: ScheduleResponse): Promise<void> {
+    if (
+      !confirm(
+        `Delete this ${schedule.action} ${schedule.targetKind} schedule? This cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+    error = null;
+    try {
+      await deleteSchedule(schedule.id);
+      schedules = schedules.filter((s) => s.id !== schedule.id);
+    } catch (err) {
+      error = messageOf(err);
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>Schedules</h1>
+    <p class="hint">
+      Recurring rules that allow, deny, or extend access — overall or for a
+      specific activity or activity group. New rules apply at all times; setting
+      day-of-week and time-of-day windows comes later (#140).
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  {#if !loading && users.length === 0}
+    <p class="muted">Add a user first — a schedule always belongs to a user.</p>
+  {:else}
+    <form class="create" onsubmit={handleCreate}>
+      <select bind:value={newUserId} disabled={creating} aria-label="Schedule user" required>
+        <option value={null} disabled selected>Choose a user…</option>
+        {#each users as user (user.id)}
+          <option value={user.id}>{user.displayName}</option>
+        {/each}
+      </select>
+      <select
+        bind:value={newScope}
+        onchange={onScopeChange}
+        disabled={creating}
+        aria-label="Schedule scope"
+      >
+        {#each SCOPE_OPTIONS as option (option.value)}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </select>
+      {#if newScope === "activity"}
+        <select bind:value={newTargetId} disabled={creating} aria-label="Target activity" required>
+          <option value={null} disabled selected>Choose an activity…</option>
+          {#each activities as activity (activity.id)}
+            <option value={activity.id}>{activity.matcher} ({activity.kind})</option>
+          {/each}
+        </select>
+      {:else if newScope === "group"}
+        <select bind:value={newTargetId} disabled={creating} aria-label="Target group" required>
+          <option value={null} disabled selected>Choose a group…</option>
+          {#each groups as group (group.id)}
+            <option value={group.id}>{group.name}</option>
+          {/each}
+        </select>
+      {/if}
+      <select bind:value={newAction} disabled={creating} aria-label="Schedule action">
+        {#each ACTION_OPTIONS as option (option.value)}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </select>
+      <button type="submit" disabled={createDisabled}>
+        {creating ? "Adding…" : "Add schedule"}
+      </button>
+    </form>
+
+    {#if loading}
+      <p class="muted">Loading schedules…</p>
+    {:else if schedules.length === 0}
+      <p class="muted">No schedules yet. Add one above.</p>
+    {:else}
+      <table>
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Scope</th>
+            <th>Target</th>
+            <th>Action</th>
+            <th>When</th>
+            <th class="actions-col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each schedules as schedule (schedule.id)}
+            <tr>
+              <td>{userName(schedule.userId)}</td>
+              <td>{scopeLabel(schedule.targetKind)}</td>
+              <td class="muted">{targetLabel(schedule)}</td>
+              {#if editingId === schedule.id}
+                <td>
+                  <select bind:value={editAction} aria-label="Edit action">
+                    {#each ACTION_OPTIONS as option (option.value)}
+                      <option value={option.value}>{option.label}</option>
+                    {/each}
+                  </select>
+                </td>
+                <td class="muted">{recurrenceSummary(schedule)}</td>
+                <td class="actions">
+                  <button onclick={() => saveEdit(schedule.id)} disabled={saving}>
+                    {saving ? "Saving…" : "Save"}
+                  </button>
+                  <button class="ghost" onclick={cancelEdit} disabled={saving}>Cancel</button>
+                </td>
+              {:else}
+                <td>{actionLabel(schedule.action)}</td>
+                <td class="muted">{recurrenceSummary(schedule)}</td>
+                <td class="actions">
+                  <button class="ghost" onclick={() => startEdit(schedule)}>Edit</button>
+                  <button class="danger" onclick={() => handleDelete(schedule)}>Delete</button>
+                </td>
+              {/if}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+    max-width: 40rem;
+  }
+  .create {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+  }
+  .create select {
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    background: #fff;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+  }
+  th {
+    background: #f9fafb;
+    font-weight: 600;
+    color: #374151;
+  }
+  td select {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.3rem;
+    background: #fff;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .actions-col {
+    width: 1%;
+    white-space: nowrap;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  button.danger {
+    background: #dc2626;
+  }
+  .muted {
+    color: #6b7280;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/routes/admin/+page.svelte
+++ b/server/frontend/src/routes/admin/+page.svelte
@@ -26,6 +26,8 @@
   import ActivitiesView from "$lib/views/ActivitiesView.svelte";
   import ActivityGroupsView from "$lib/views/ActivityGroupsView.svelte";
   import BudgetsView from "$lib/views/BudgetsView.svelte";
+  import SchedulesView from "$lib/views/SchedulesView.svelte";
+  import ExceptionsView from "$lib/views/ExceptionsView.svelte";
   import LinksView from "$lib/views/LinksView.svelte";
 
   // `null` while the initial session probe is in flight.
@@ -43,6 +45,8 @@
     { id: "activities", label: "Activities" },
     { id: "activity-groups", label: "Activity Groups" },
     { id: "budgets", label: "Budgets" },
+    { id: "schedules", label: "Schedules" },
+    { id: "exceptions", label: "Exceptions" },
   ];
   let activeView = $state<string>("dashboard");
 
@@ -123,6 +127,10 @@
       <ActivityGroupsView />
     {:else if activeView === "budgets"}
       <BudgetsView />
+    {:else if activeView === "schedules"}
+      <SchedulesView />
+    {:else if activeView === "exceptions"}
+      <ExceptionsView />
     {:else}
       <DashboardView {username} onnavigate={(id) => (activeView = id)} />
     {/if}

--- a/server/frontend/tests/api/exceptions.test.ts
+++ b/server/frontend/tests/api/exceptions.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createException,
+  deleteException,
+  listExceptions,
+  updateException,
+} from "../../src/lib/api/exceptions.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("exceptions API", () => {
+  it("listExceptions GETs /api/exceptions without a filter", async () => {
+    const rows = [
+      {
+        id: 1,
+        userId: 1,
+        targetKind: "overall",
+        targetId: null,
+        action: "extend",
+        reason: "birthday",
+        effectiveFrom: null,
+        expiresAt: "2026-07-01T00:00:00.000Z",
+        createdAt: "2026-06-20T00:00:00.000Z",
+      },
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, rows));
+
+    const result = await listExceptions();
+
+    expect(result).toEqual(rows);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/exceptions");
+  });
+
+  it("listExceptions appends the ?userId= filter when given", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, []));
+
+    await listExceptions(42);
+
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/exceptions?userId=42");
+  });
+
+  it("createException POSTs the body to /api/exceptions", async () => {
+    const body = {
+      userId: 1,
+      targetKind: "activity" as const,
+      targetId: 9,
+      action: "deny" as const,
+      reason: "grounded",
+      effectiveFrom: null,
+      expiresAt: "2026-07-01T00:00:00.000Z",
+    };
+    const created = { id: 2, ...body, createdAt: "2026-06-20T00:00:00.000Z" };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(201, created));
+
+    const result = await createException(body);
+
+    expect(result).toEqual(created);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/exceptions");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBe(JSON.stringify(body));
+  });
+
+  it("updateException PATCHes /api/exceptions/:id", async () => {
+    const updated = {
+      id: 3,
+      userId: 1,
+      targetKind: "overall",
+      targetId: null,
+      action: "allow",
+      reason: null,
+      effectiveFrom: null,
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      createdAt: "2026-06-20T00:00:00.000Z",
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, updated));
+
+    const result = await updateException(3, { expiresAt: "2026-08-01T00:00:00.000Z" });
+
+    expect(result).toEqual(updated);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/exceptions/3");
+    expect((init as RequestInit).method).toBe("PATCH");
+    expect((init as RequestInit).body).toBe(
+      JSON.stringify({ expiresAt: "2026-08-01T00:00:00.000Z" }),
+    );
+  });
+
+  it("deleteException DELETEs /api/exceptions/:id and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(deleteException(4)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/exceptions/4");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+});

--- a/server/frontend/tests/api/schedules.test.ts
+++ b/server/frontend/tests/api/schedules.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createSchedule,
+  deleteSchedule,
+  listSchedules,
+  updateSchedule,
+} from "../../src/lib/api/schedules.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+const ALWAYS_ON = {
+  recurrenceDays: null,
+  recurrenceStartMinute: null,
+  recurrenceEndMinute: null,
+  effectiveFrom: null,
+  effectiveTo: null,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("schedules API", () => {
+  it("listSchedules GETs /api/schedules without a filter", async () => {
+    const rows = [
+      {
+        id: 1,
+        userId: 1,
+        targetKind: "overall",
+        targetId: null,
+        action: "deny",
+        ...ALWAYS_ON,
+        ordinal: 0,
+      },
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, rows));
+
+    const result = await listSchedules();
+
+    expect(result).toEqual(rows);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/schedules");
+  });
+
+  it("listSchedules appends the ?userId= filter when given", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, []));
+
+    await listSchedules(42);
+
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/schedules?userId=42");
+  });
+
+  it("createSchedule POSTs the body to /api/schedules", async () => {
+    const body = {
+      userId: 1,
+      targetKind: "activity" as const,
+      targetId: 9,
+      action: "deny" as const,
+      ...ALWAYS_ON,
+    };
+    const created = { id: 2, ...body, ordinal: 0 };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(201, created));
+
+    const result = await createSchedule(body);
+
+    expect(result).toEqual(created);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/schedules");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBe(JSON.stringify(body));
+  });
+
+  it("updateSchedule PATCHes /api/schedules/:id", async () => {
+    const updated = {
+      id: 3,
+      userId: 1,
+      targetKind: "overall",
+      targetId: null,
+      action: "allow",
+      ...ALWAYS_ON,
+      ordinal: 0,
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, updated));
+
+    const result = await updateSchedule(3, { action: "allow" });
+
+    expect(result).toEqual(updated);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/schedules/3");
+    expect((init as RequestInit).method).toBe("PATCH");
+    expect((init as RequestInit).body).toBe(JSON.stringify({ action: "allow" }));
+  });
+
+  it("deleteSchedule DELETEs /api/schedules/:id and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(deleteSchedule(4)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/schedules/4");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+});


### PR DESCRIPTION
## Summary

Lands the **last remaining `/admin` policy editor** and closes out the CRUD
scope tracked in #189 (the #53 capstone follow-up):

- **Schedules** editor — create / inline-edit / delete recurring
  `allow`/`deny`/`extend` rules against `/api/schedules`. Scope + target
  (`overall` / `activity` / `group`) chosen at create; inline edit toggles the
  `action`. Recurrence is rendered **read-only** ("Always" for the always-on
  degenerate rule); new rules are created always-on.
- **Exceptions** editor — create / inline-edit / delete one-shot, date-boxed
  overrides against `/api/exceptions`, with `datetime-local` authoring for the
  effective/expiry instants (converted to ISO-8601 UTC on the wire; ADR 0005 §2).
- Typed `$lib/api/{schedules,exceptions}` wrappers re-using the inferred zod DTO
  types (`ScheduleAction` added to the `contract.ts` re-exports) — **no
  hand-written DTOs**. Both views wired into the `/admin` shell nav.

All editors talk **only** to `/api/*` (the stable per-user contract already on
`main`); no privileged in-process shortcuts.

## Plan

Linked plan: `.claude/plans/issue-189-admin-schedules-exceptions-editor.md`
Roadmap: `docs/roadmap.md` → Phase 2.

## License-boundary note

N/A — frontend-only (Svelte 5 + type-only DTO re-exports). No transport,
packaging, or Docker-image change; no GPL surface. zod/drizzle are pulled in for
type resolution only and erased from the bundle.

## Deliberately deferred (boundaries unchanged)

- **Recurring day-of-week + intra-day window authoring → #140.** This editor
  reads/writes the always-on degenerate and faithfully renders any recurrence a
  future #140 editor sets; it does not author the day-mask / time-window UI.
- **Drag-to-order + first-match-wins** ordinal editing → #63.
- **Group-targeted** schedule/exception rules → #182 (PR #203 is additive,
  separate tables/routes; this editor is unaffected and uses the per-user
  contract).
- Deep `/admin/*` routes + SPA fallback → #59 (single prerendered page, in-page
  view switcher — unchanged from prior slices).

## Test plan

- [x] `server/frontend`: new `tests/api/{schedules,exceptions}.test.ts` assert
      URL/method/body for each wrapper (incl. the `?userId=` filter). `npm test`
      → 48 passing.
- [x] `npm run check` (`svelte-check`) → 0 errors / 0 warnings.
- [x] `npm run build` (`adapter-static`) → green.
- [x] Server gate unaffected: `eslint .` + `tsc --noEmit` clean (frontend is
      outside the server lint/prettier scope).

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TF8JBZ3bm4L4DMP7atKjsj)_