### PR TITLE
feat(admin): Client Health view + enrol-a-client flow (#194)

### DIFF
--- a/.claude/plans/194-admin-clients-health-page.md
+++ b/.claude/plans/194-admin-clients-health-page.md
@@ -1,0 +1,108 @@
+# Plan — #194 Admin UI: Clients health/status page + enrol-a-client flow
+
+**Roadmap:** Phase 3 (client install). Frontend half of #81 (backend landed),
+split the same way #183 was split from #85.
+
+## Context (verified on `main`)
+
+Backend is fully in place; this is a pure-frontend slice on the existing
+`/admin` SvelteKit shell (#53).
+
+- `GET /api/clients/health` → `ClientHealthResponse[]`,
+  `GET /api/clients/:id/health` → `ClientHealthResponse`. Registered in
+  `server/src/api/plugin.ts` via `registerClientHealthRoutes`, behind
+  `requireAdmin`. Source: `server/src/api/clients/health-routes.ts`,
+  `health-service.ts`, `health-dtos.ts`.
+- `POST /api/clients/enrolment-tokens` (admin-guarded). Request
+  `mintEnrolmentTokenSchema` (`{ supervisedUsers: [{userId, linuxUsername}],
+  ttlSeconds?, hostname? }`), response `enrolmentTokenResponseSchema`
+  (`{ id, token, expiresAt }`). Source: `server/src/api/clients/dtos.ts`,
+  `routes.ts`.
+- DTO shapes (`health-dtos.ts`):
+  - `clientHealthSchema`: `clientId, hostname, reachability
+    (online|offline|unknown), lastSeen (ISO|null), enrolledAt (ISO),
+    probedAt (ISO|null), components[], queue`.
+  - `componentHealthSchema`: `component (timekpr-next|activitywatch|
+    e2guardian|pct-client-bridge|pct-client-agent), status (ok|unhealthy|
+    unknown), detail`.
+  - `clientQueueSchema`: `pending (int), failed (int), actions[]`.
+  - `queuedActionSummarySchema`: `id, kind, coalesceKey, status, attempts,
+    lastError (null), enqueuedAt, updatedAt`.
+- The DTO does **not** carry supervised-users / IP / distro (those appear in
+  the design mock but not the real contract). Render only what the contract
+  provides — no invented fields.
+- Frontend shell: single prerendered `/admin/+page.svelte` switching views via
+  client-side state; `AppShell` nav `items`; typed wrappers in `$lib/api/*`;
+  DTO types re-exported type-only through `$lib/api/contract.ts`. Frontend
+  has a vitest toolchain (`npm run test`) with API-wrapper tests under
+  `server/frontend/tests/api/`.
+- Mock: `design/admin/clients.html` — per-client cards with a reachability
+  pill, component rows, queued-change callout, and an enrol panel showing the
+  `curl … | sudo bash -s -- --enrolment-token … --supervised-user …`
+  one-liner (documented in `docs/client-install.md`).
+
+## Design decisions
+
+- **New nav item "Client Health"** → new `ClientHealthView.svelte`, leaving the
+  existing `ClientsView` (CRUD editor from #189) untouched. The two surfaces
+  are distinct concerns; consolidation is a possible follow-up, noted in the
+  PR. The health view owns the read-only status + the token-mint enrol flow.
+- **Component labels** mapped client-side (`timekpr-next` → "Timekpr-nExT",
+  etc.); status/reachability → badge classes (ok=green, unhealthy=red/amber,
+  unknown/offline=grey/amber). All five components render in catalogue order
+  from the per-client `components[]` the API returns.
+- **Degraded state:** when `probedAt === null` (no SSH prober yet, #39 plumbs it
+  later) reachability/components come back `unknown`; the view shows a small
+  "not yet probed" note while still rendering real enrol/queue state.
+- **Enrol one-liner** built from `window.location.origin` +
+  `/install-client.sh` + the minted token + the supervised usernames, matching
+  `docs/client-install.md`. Token shown once with a copy button.
+- **Contract types:** add type-only re-exports for the four health DTO types
+  and the two enrolment types to `contract.ts`; no DTO is re-declared
+  (CLAUDE.md). Component/status/reachability unions are taken from the DTO
+  field types, not separately imported.
+
+## Phases
+
+### Phase A — typed API wrappers + contract types (+ tests)
+- `contract.ts`: re-export `ClientHealthResponse`, `ComponentHealthDto`,
+  `ClientQueueDto`, `QueuedActionSummary` (from `health-dtos.js`) and
+  `MintEnrolmentTokenRequest`, `EnrolmentTokenResponse` (from `dtos.js`).
+- New `$lib/api/client-health.ts`: `listClientHealth()`,
+  `getClientHealth(id)`.
+- `$lib/api/clients.ts`: add `mintEnrolmentToken(input)`.
+- Tests: `tests/api/client-health.test.ts` and extend
+  `tests/api/clients.test.ts` for the mint call — mirror existing style
+  (mock `fetch`, assert URL/method/body).
+
+### Phase B — ClientHealthView + nav wiring
+- `ClientHealthView.svelte`: load list on mount (browser-guarded), per-client
+  card with reachability pill, `lastSeen`/`probedAt`/`enrolledAt`, five
+  component badges with detail, queue summary (pending/failed counts +
+  expandable per-action rows showing `kind`/`status`/`attempts`/`lastError`),
+  empty + error + degraded states, a "Refresh" action.
+- Wire nav item `client-health` + view switch in `+page.svelte`.
+
+### Phase C — enrol-a-client flow
+- An "Enrol a new client" panel in the health view: pick an existing user
+  (from `listUsers()`), enter the Linux username, optional hostname, mint the
+  token, render the install one-liner + expiry, copy button, and a "mint
+  another" reset. Support ≥1 supervised-user rows (schema requires distinct
+  usernames; min 1).
+
+## Quality gate (run from `server/` after each phase)
+`npm run format` · `npm run lint:fix` · `npm run typecheck` · `npm test`
+(coverage ≥80%). Frontend: `cd server/frontend && npm ci && npm run build`
+and `npm run test` for the API-wrapper tests.
+
+## License boundary
+N/A — JSON-API-only frontend code; no GPL imports, no transport/packaging
+changes, no Docker image change. Read-only health + token-mint; no new
+enforcement, no tamper-resistance surface.
+
+## Deferred (note in PR; file issues if not already tracked)
+- Live reachability/component data depends on the SSH prober wiring (#39 — SSH
+  key bootstrap merged; prober injection lands with the live transport).
+- "Probe now" / "Re-apply config" action buttons from the mock are write
+  actions outside #194's read-only scope — not implemented here.
+- Consolidating the CRUD `ClientsView` and the health view into one page.

--- a/server/frontend/src/lib/api/client-health.ts
+++ b/server/frontend/src/lib/api/client-health.ts
@@ -1,0 +1,25 @@
+/**
+ * Read-only calls for the client health/status surface (#194, frontend half of
+ * #81). The admin "Client Health" view renders, per enrolled client, its
+ * reachability, per-component health, and offline + queued-change state.
+ *
+ * Same proven shape as the CRUD wrappers (`$lib/api/clients`, #53): thin typed
+ * wrappers over {@link apiFetch}, with the response types imported from the
+ * shared `/api` contract so the frontend never re-declares a DTO. These are
+ * reads only — they never mutate client state.
+ *
+ * License boundary: none — JSON API only. The remote SSH probing that produces
+ * this data happens server-side behind the transport facade.
+ */
+import { apiFetch } from "./client.js";
+import type { ClientHealthResponse } from "./contract.js";
+
+/** List health/status for every enrolled client, in the order `/api` returns. */
+export function listClientHealth(): Promise<ClientHealthResponse[]> {
+  return apiFetch<ClientHealthResponse[]>("/clients/health");
+}
+
+/** Fetch health/status for a single client; rejects with a `404` if unknown. */
+export function getClientHealth(id: number): Promise<ClientHealthResponse> {
+  return apiFetch<ClientHealthResponse>(`/clients/${id}/health`);
+}

--- a/server/frontend/src/lib/api/clients.ts
+++ b/server/frontend/src/lib/api/clients.ts
@@ -9,7 +9,13 @@
  * License boundary: none — JSON API only.
  */
 import { apiFetch } from "./client.js";
-import type { ClientResponse, CreateClientRequest, UpdateClientRequest } from "./contract.js";
+import type {
+  ClientResponse,
+  CreateClientRequest,
+  EnrolmentTokenResponse,
+  MintEnrolmentTokenRequest,
+  UpdateClientRequest,
+} from "./contract.js";
 
 /** List all enrolled clients, in the order `/api` returns them. */
 export function listClients(): Promise<ClientResponse[]> {
@@ -29,4 +35,19 @@ export function updateClient(id: number, input: UpdateClientRequest): Promise<Cl
 /** Delete a client. Resolves on the server's `204`. */
 export function deleteClient(id: number): Promise<void> {
   return apiFetch<void>(`/clients/${id}`, { method: "DELETE" });
+}
+
+/**
+ * Mint a single-use, short-lived enrolment token scoped to the supervised
+ * user(s) the new client will carry (#77, surfaced by the enrol-a-client flow
+ * in #194). The plaintext `token` is returned **once** — only its hash is
+ * stored — so the caller must show it immediately.
+ */
+export function mintEnrolmentToken(
+  input: MintEnrolmentTokenRequest,
+): Promise<EnrolmentTokenResponse> {
+  return apiFetch<EnrolmentTokenResponse>("/clients/enrolment-tokens", {
+    method: "POST",
+    body: input,
+  });
 }

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -40,5 +40,15 @@ export type {
   LinkResponse,
   UpsertLinkRequest,
 } from "../../../../src/api/policy/dtos.js";
+export type {
+  MintEnrolmentTokenRequest,
+  EnrolmentTokenResponse,
+} from "../../../../src/api/clients/dtos.js";
+export type {
+  ClientHealthResponse,
+  ComponentHealthDto,
+  ClientQueueDto,
+  QueuedActionSummary,
+} from "../../../../src/api/clients/health-dtos.js";
 export type { ActivityKind, MatchType, Scope, BudgetWindow } from "../../../../src/policy/enums.js";
 export type { ErrorEnvelope, ErrorDetail } from "../../../../src/api/errors.js";

--- a/server/frontend/src/lib/views/ClientHealthView.svelte
+++ b/server/frontend/src/lib/views/ClientHealthView.svelte
@@ -117,10 +117,15 @@
     minted = null;
     copied = false;
     try {
-      const supervisedUsers = enrolRows.map((r) => ({
-        userId: r.userId as number,
-        linuxUsername: r.linuxUsername.trim(),
-      }));
+      // `enrolReady` already guarantees every row has a non-null userId; this
+      // loop narrows the type without an `as` cast (CLAUDE.md → no casts).
+      const supervisedUsers: { userId: number; linuxUsername: string }[] = [];
+      for (const r of enrolRows) {
+        if (r.userId === null) {
+          return;
+        }
+        supervisedUsers.push({ userId: r.userId, linuxUsername: r.linuxUsername.trim() });
+      }
       const hostname = enrolHostname.trim();
       minted = await mintEnrolmentToken({
         supervisedUsers,
@@ -144,7 +149,13 @@
     enrolRows = [{ userId: null, linuxUsername: "" }];
   }
 
-  /** The install one-liner shown to the admin, per `docs/client-install.md`. */
+  /**
+   * The install one-liner shown to the admin, per `docs/client-install.md` →
+   * "Usage" (non-interactive form). The dashboard's own origin is the server
+   * URL the client enrols against, so `--server-url` is filled from it — the
+   * piped (`bash -s --`) form is non-interactive and the script can't prompt
+   * for it over the consumed stdin.
+   */
   let installCommand = $derived.by(() => {
     if (minted === null) {
       return "";
@@ -154,6 +165,7 @@
     return (
       `curl -fsSL ${origin}/install-client.sh \\\n` +
       `  | sudo bash -s -- \\\n` +
+      `    --server-url ${origin} \\\n` +
       `    --enrolment-token ${minted.token} \\\n` +
       userFlags
     );

--- a/server/frontend/src/lib/views/ClientHealthView.svelte
+++ b/server/frontend/src/lib/views/ClientHealthView.svelte
@@ -1,0 +1,618 @@
+<!--
+  Client health/status + enrol flow (#194, frontend half of #81).
+
+  Read-only operational view over `GET /api/clients/health`: per enrolled
+  client it shows reachability, the health of the five supervised components,
+  and the offline + queued-change state, plus an "enrol a new client" panel
+  that mints a scoped, single-use token (`POST /api/clients/enrolment-tokens`)
+  and renders the documented install one-liner.
+
+  Reachability/component health is reported `unknown` until the live SSH prober
+  is wired (#39 plumbs the credentials; the prober injection lands with the
+  live transport). This view renders that degraded state gracefully — real
+  enrolment + queue data still shows. All calls go through the typed
+  `$lib/api/*` wrappers; nothing here mutates client policy.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { browser } from "$app/environment";
+  import { ApiError } from "$lib/api/client.js";
+  import type {
+    ClientHealthResponse,
+    ComponentHealthDto,
+    EnrolmentTokenResponse,
+    UserResponse,
+  } from "$lib/api/contract.js";
+  import { listClientHealth } from "$lib/api/client-health.js";
+  import { mintEnrolmentToken } from "$lib/api/clients.js";
+  import { listUsers } from "$lib/api/users.js";
+
+  let clients = $state<ClientHealthResponse[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // Per-client queue-detail expand/collapse, keyed by clientId.
+  let expanded = $state<Record<number, boolean>>({});
+
+  // Enrol flow.
+  let users = $state<UserResponse[]>([]);
+  let enrolHostname = $state("");
+  let enrolRows = $state<{ userId: number | null; linuxUsername: string }[]>([
+    { userId: null, linuxUsername: "" },
+  ]);
+  let minting = $state(false);
+  let minted = $state<EnrolmentTokenResponse | null>(null);
+  let mintedUsernames = $state<string[]>([]);
+  let enrolError = $state<string | null>(null);
+  let copied = $state(false);
+
+  /** Friendly labels for the wire component identifiers. */
+  const COMPONENT_LABELS: Record<ComponentHealthDto["component"], string> = {
+    "timekpr-next": "Timekpr-nExT",
+    activitywatch: "ActivityWatch",
+    e2guardian: "e2guardian",
+    "pct-client-bridge": "pct-client-bridge",
+    "pct-client-agent": "pct-client-agent",
+  };
+
+  onMount(() => {
+    void load();
+    void loadUsers();
+  });
+
+  async function load(): Promise<void> {
+    if (!browser) {
+      return;
+    }
+    loading = true;
+    error = null;
+    try {
+      clients = await listClientHealth();
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadUsers(): Promise<void> {
+    if (!browser) {
+      return;
+    }
+    try {
+      users = await listUsers();
+    } catch {
+      // The enrol form degrades to "no users yet"; the health list above still
+      // renders, so a users-fetch failure must not blank the whole page.
+      users = [];
+    }
+  }
+
+  function toggleQueue(clientId: number): void {
+    expanded = { ...expanded, [clientId]: !expanded[clientId] };
+  }
+
+  function addEnrolRow(): void {
+    enrolRows = [...enrolRows, { userId: null, linuxUsername: "" }];
+  }
+
+  function removeEnrolRow(index: number): void {
+    enrolRows = enrolRows.filter((_, i) => i !== index);
+  }
+
+  /** True when every row names a user + a Linux username and rows are distinct. */
+  let enrolReady = $derived(
+    enrolRows.length > 0 &&
+      enrolRows.every((r) => r.userId !== null && r.linuxUsername.trim() !== "") &&
+      new Set(enrolRows.map((r) => r.linuxUsername.trim())).size === enrolRows.length,
+  );
+
+  async function handleMint(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    if (!enrolReady) {
+      return;
+    }
+    minting = true;
+    enrolError = null;
+    minted = null;
+    copied = false;
+    try {
+      const supervisedUsers = enrolRows.map((r) => ({
+        userId: r.userId as number,
+        linuxUsername: r.linuxUsername.trim(),
+      }));
+      const hostname = enrolHostname.trim();
+      minted = await mintEnrolmentToken({
+        supervisedUsers,
+        ttlSeconds: 3600,
+        ...(hostname === "" ? {} : { hostname }),
+      });
+      mintedUsernames = supervisedUsers.map((u) => u.linuxUsername);
+    } catch (err) {
+      enrolError = messageOf(err);
+    } finally {
+      minting = false;
+    }
+  }
+
+  function resetEnrol(): void {
+    minted = null;
+    mintedUsernames = [];
+    enrolError = null;
+    copied = false;
+    enrolHostname = "";
+    enrolRows = [{ userId: null, linuxUsername: "" }];
+  }
+
+  /** The install one-liner shown to the admin, per `docs/client-install.md`. */
+  let installCommand = $derived.by(() => {
+    if (minted === null) {
+      return "";
+    }
+    const origin = browser ? window.location.origin : "https://<server>";
+    const userFlags = mintedUsernames.map((u) => `    --supervised-user ${u}`).join(" \\\n");
+    return (
+      `curl -fsSL ${origin}/install-client.sh \\\n` +
+      `  | sudo bash -s -- \\\n` +
+      `    --enrolment-token ${minted.token} \\\n` +
+      userFlags
+    );
+  });
+
+  async function copyCommand(): Promise<void> {
+    if (installCommand === "" || !browser || !navigator.clipboard) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(installCommand);
+      copied = true;
+    } catch {
+      copied = false;
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+
+  /** Format an ISO-8601 UTC timestamp as a short local date-time, or a dash. */
+  function formatDateTime(iso: string | null): string {
+    if (iso === null) {
+      return "—";
+    }
+    const date = new Date(iso);
+    return Number.isNaN(date.getTime()) ? iso : date.toLocaleString();
+  }
+
+  function reachabilityClass(reachability: ClientHealthResponse["reachability"]): string {
+    if (reachability === "online") {
+      return "ok";
+    }
+    return reachability === "offline" ? "warn" : "unknown";
+  }
+
+  function componentClass(status: ComponentHealthDto["status"]): string {
+    if (status === "ok") {
+      return "ok";
+    }
+    return status === "unhealthy" ? "bad" : "unknown";
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>Client Health</h1>
+    <p class="hint">
+      Reachability and per-component health for every enrolled machine, plus
+      what's queued for any client that's offline.
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  <div class="toolbar">
+    <button class="ghost" onclick={() => load()} disabled={loading}>
+      {loading ? "Refreshing…" : "Refresh"}
+    </button>
+  </div>
+
+  {#if loading}
+    <p class="muted">Loading client health…</p>
+  {:else if clients.length === 0}
+    <p class="muted">No clients enrolled yet. Enrol one below.</p>
+  {:else}
+    <div class="grid">
+      {#each clients as client (client.clientId)}
+        <article class="card">
+          <div class="card-top">
+            <div>
+              <div class="hostname">{client.hostname}</div>
+              <div class="muted small">
+                enrolled {formatDateTime(client.enrolledAt)}
+              </div>
+            </div>
+            <span class="pill {reachabilityClass(client.reachability)}">
+              {client.reachability}
+            </span>
+          </div>
+
+          <dl class="kv">
+            <div><dt>Last seen</dt><dd>{formatDateTime(client.lastSeen)}</dd></div>
+            <div>
+              <dt>Last probe</dt>
+              <dd>
+                {#if client.probedAt === null}
+                  <span class="muted">not yet probed</span>
+                {:else}
+                  {formatDateTime(client.probedAt)}
+                {/if}
+              </dd>
+            </div>
+          </dl>
+
+          <div class="components">
+            <div class="section-title">Components</div>
+            {#each client.components as comp (comp.component)}
+              <div class="comp">
+                <span class="dot {componentClass(comp.status)}" aria-hidden="true"></span>
+                <span class="comp-name">{COMPONENT_LABELS[comp.component] ?? comp.component}</span>
+                <span class="muted small">{comp.detail}</span>
+              </div>
+            {/each}
+          </div>
+
+          <div class="queue">
+            <div class="queue-head">
+              <span class="section-title">Queued changes</span>
+              <span class="counts">
+                <span class="pill {client.queue.pending > 0 ? 'warn' : 'ok'}">
+                  {client.queue.pending} pending
+                </span>
+                {#if client.queue.failed > 0}
+                  <span class="pill bad">{client.queue.failed} failed</span>
+                {/if}
+              </span>
+            </div>
+            {#if client.queue.actions.length > 0}
+              <button class="link" onclick={() => toggleQueue(client.clientId)}>
+                {expanded[client.clientId] ? "Hide" : "Show"} queued actions
+                ({client.queue.actions.length})
+              </button>
+              {#if expanded[client.clientId]}
+                <ul class="actions">
+                  {#each client.queue.actions as action (action.id)}
+                    <li>
+                      <span class="mono">{action.kind}</span>
+                      <span class="pill {action.status === 'failed' ? 'bad' : 'warn'}">
+                        {action.status}
+                      </span>
+                      <span class="muted small">
+                        ×{action.attempts}{action.lastError ? ` · ${action.lastError}` : ""}
+                      </span>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            {:else}
+              <p class="muted small">Nothing queued.</p>
+            {/if}
+          </div>
+        </article>
+      {/each}
+    </div>
+  {/if}
+
+  <section class="enrol">
+    <header class="head">
+      <h2>Enrol a new client</h2>
+      <p class="hint">
+        Mint a one-time, short-lived token scoped to the supervised user(s) this
+        machine will carry, then run the printed command on the fresh Mint box.
+      </p>
+    </header>
+
+    {#if enrolError}
+      <p class="error" role="alert">{enrolError}</p>
+    {/if}
+
+    {#if minted === null}
+      <form onsubmit={handleMint}>
+        {#each enrolRows as row, index (index)}
+          <div class="enrol-row">
+            <select bind:value={row.userId} aria-label="Supervised user">
+              <option value={null} disabled>Select a user…</option>
+              {#each users as user (user.id)}
+                <option value={user.id}>{user.displayName}</option>
+              {/each}
+            </select>
+            <input
+              type="text"
+              placeholder="Linux username (e.g. chloe)"
+              bind:value={row.linuxUsername}
+              aria-label="Linux username"
+            />
+            {#if enrolRows.length > 1}
+              <button type="button" class="ghost" onclick={() => removeEnrolRow(index)}>
+                Remove
+              </button>
+            {/if}
+          </div>
+        {/each}
+
+        <button type="button" class="link" onclick={addEnrolRow}>+ Add another user</button>
+
+        <input
+          type="text"
+          class="hostname-input"
+          placeholder="Expected hostname (optional)"
+          bind:value={enrolHostname}
+          aria-label="Expected hostname"
+        />
+
+        {#if users.length === 0}
+          <p class="muted small">Add a user first — the token must be scoped to one.</p>
+        {/if}
+
+        <button type="submit" disabled={minting || !enrolReady}>
+          {minting ? "Minting…" : "Generate enrolment token"}
+        </button>
+      </form>
+    {:else}
+      <div class="minted">
+        <p class="muted small">
+          Run this on the client — the token expires {formatDateTime(minted.expiresAt)} and works
+          once:
+        </p>
+        <pre class="command">{installCommand}</pre>
+        <div class="minted-actions">
+          <button onclick={() => copyCommand()}>{copied ? "Copied!" : "Copy command"}</button>
+          <button class="ghost" onclick={resetEnrol}>Mint another</button>
+        </div>
+      </div>
+    {/if}
+  </section>
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  h2 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+  }
+  .toolbar {
+    margin-bottom: 1rem;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    gap: 1rem;
+  }
+  .card {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.6rem;
+    padding: 1rem;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .card-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+  .hostname {
+    font-weight: 650;
+  }
+  .kv {
+    margin: 0;
+    display: grid;
+    gap: 0.2rem;
+  }
+  .kv div {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    border-bottom: 1px dashed #f3f4f6;
+    padding: 0.2rem 0;
+  }
+  .kv dt {
+    color: #6b7280;
+  }
+  .kv dd {
+    margin: 0;
+  }
+  .section-title {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #9ca3af;
+    font-weight: 600;
+  }
+  .components {
+    border-top: 1px solid #f3f4f6;
+    padding-top: 0.5rem;
+  }
+  .comp {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+    font-size: 0.85rem;
+  }
+  .comp-name {
+    font-weight: 500;
+  }
+  .dot {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    flex: none;
+    background: #9ca3af;
+  }
+  .dot.ok {
+    background: #16a34a;
+  }
+  .dot.bad {
+    background: #dc2626;
+  }
+  .dot.unknown {
+    background: #9ca3af;
+  }
+  .queue {
+    border-top: 1px solid #f3f4f6;
+    padding-top: 0.5rem;
+  }
+  .queue-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .counts {
+    display: flex;
+    gap: 0.35rem;
+  }
+  .actions {
+    list-style: none;
+    margin: 0.5rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 0.35rem;
+  }
+  .actions li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+  }
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: #e5e7eb;
+    color: #374151;
+  }
+  .pill.ok {
+    background: #dcfce7;
+    color: #166534;
+  }
+  .pill.warn {
+    background: #fef3c7;
+    color: #92400e;
+  }
+  .pill.bad {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+  .pill.unknown {
+    background: #e5e7eb;
+    color: #4b5563;
+  }
+  .enrol {
+    margin-top: 2rem;
+    border-top: 1px solid #e5e7eb;
+    padding-top: 1.5rem;
+  }
+  .enrol form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    max-width: 40rem;
+  }
+  .enrol-row {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .enrol-row select,
+  .enrol-row input {
+    flex: 1 1 12rem;
+  }
+  select,
+  input {
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    font-size: 0.9rem;
+  }
+  .hostname-input {
+    max-width: 40rem;
+  }
+  .command {
+    background: #0f1222;
+    color: #9be7b6;
+    padding: 0.75rem 0.9rem;
+    border-radius: 0.5rem;
+    font-size: 0.8rem;
+    overflow-x: auto;
+    white-space: pre;
+    margin: 0.5rem 0;
+  }
+  .minted-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+  .small {
+    font-size: 0.8rem;
+  }
+  .mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.8rem;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+    align-self: flex-start;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  button.link {
+    background: none;
+    color: #2563eb;
+    padding: 0;
+    font-size: 0.85rem;
+    align-self: flex-start;
+  }
+  .muted {
+    color: #6b7280;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/routes/admin/+page.svelte
+++ b/server/frontend/src/routes/admin/+page.svelte
@@ -23,6 +23,7 @@
   import DashboardView from "$lib/views/DashboardView.svelte";
   import UsersView from "$lib/views/UsersView.svelte";
   import ClientsView from "$lib/views/ClientsView.svelte";
+  import ClientHealthView from "$lib/views/ClientHealthView.svelte";
   import ActivitiesView from "$lib/views/ActivitiesView.svelte";
   import ActivityGroupsView from "$lib/views/ActivityGroupsView.svelte";
   import BudgetsView from "$lib/views/BudgetsView.svelte";
@@ -39,6 +40,7 @@
     { id: "dashboard", label: "Dashboard" },
     { id: "users", label: "Users" },
     { id: "clients", label: "Clients" },
+    { id: "client-health", label: "Client Health" },
     { id: "links", label: "User ↔ Client links" },
     { id: "activities", label: "Activities" },
     { id: "activity-groups", label: "Activity Groups" },
@@ -115,6 +117,8 @@
       <UsersView />
     {:else if activeView === "clients"}
       <ClientsView />
+    {:else if activeView === "client-health"}
+      <ClientHealthView />
     {:else if activeView === "links"}
       <LinksView />
     {:else if activeView === "activities"}

--- a/server/frontend/tests/api/client-health.test.ts
+++ b/server/frontend/tests/api/client-health.test.ts
@@ -45,5 +45,6 @@ describe("client-health API", () => {
 
     expect(result).toEqual(health);
     expect(fetchMock.mock.calls[0]![0]).toBe("/api/clients/1/health");
+    expect((fetchMock.mock.calls[0]![1] as RequestInit).method).toBe("GET");
   });
 });

--- a/server/frontend/tests/api/client-health.test.ts
+++ b/server/frontend/tests/api/client-health.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getClientHealth, listClientHealth } from "../../src/lib/api/client-health.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("client-health API", () => {
+  const health = {
+    clientId: 1,
+    hostname: "mint-01",
+    reachability: "unknown",
+    lastSeen: null,
+    enrolledAt: "2026-01-01T00:00:00.000Z",
+    probedAt: null,
+    components: [{ component: "timekpr-next", status: "unknown", detail: "not probed" }],
+    queue: { pending: 0, failed: 0, actions: [] },
+  };
+
+  it("listClientHealth GETs /api/clients/health", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, [health]));
+
+    const result = await listClientHealth();
+
+    expect(result).toEqual([health]);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/clients/health");
+    expect((fetchMock.mock.calls[0]![1] as RequestInit).method).toBe("GET");
+  });
+
+  it("getClientHealth GETs /api/clients/:id/health", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, health));
+
+    const result = await getClientHealth(1);
+
+    expect(result).toEqual(health);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/clients/1/health");
+  });
+});

--- a/server/frontend/tests/api/clients.test.ts
+++ b/server/frontend/tests/api/clients.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createClient, deleteClient, listClients, updateClient } from "../../src/lib/api/clients.js";
+import {
+  createClient,
+  deleteClient,
+  listClients,
+  mintEnrolmentToken,
+  updateClient,
+} from "../../src/lib/api/clients.js";
 
 function jsonResponse(status: number, body: unknown): Response {
   return {
@@ -80,5 +86,23 @@ describe("clients API", () => {
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(url).toBe("/api/clients/4");
     expect((init as RequestInit).method).toBe("DELETE");
+  });
+
+  it("mintEnrolmentToken POSTs the scoped request to /api/clients/enrolment-tokens", async () => {
+    const minted = { id: 5, token: "PCT-9f2a-7c1e-d40b", expiresAt: "2026-01-01T01:00:00.000Z" };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(201, minted));
+
+    const request = {
+      supervisedUsers: [{ userId: 1, linuxUsername: "chloe" }],
+      ttlSeconds: 3600,
+      hostname: "chloe-laptop",
+    };
+    const result = await mintEnrolmentToken(request);
+
+    expect(result).toEqual(minted);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/clients/enrolment-tokens");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBe(JSON.stringify(request));
   });
 });


### PR DESCRIPTION
## Summary

- Adds the read-only **"Client Health"** admin surface (the frontend half of #81) on the existing `/admin` SvelteKit shell: per-client reachability + five-component health badges, last-seen / last-probe, and offline + queued-change indicators (pending/failed counts with an expandable per-action list).
- Adds the **enrol-a-client flow**: mint a scoped, single-use token (`POST /api/clients/enrolment-tokens`) and render the documented `install-client.sh` one-liner with a copy button.
- Typed `$lib/api` wrappers (`client-health.ts`; `mintEnrolmentToken` on `clients.ts`); health + enrolment DTO types re-exported **type-only** through `contract.ts` — no DTO re-declared. Frontend vitest coverage for the new wrappers.

The backend it consumes already landed on `main` (`registerClientHealthRoutes` in `api/plugin.ts`, the `clientHealthSchema`/`componentHealthSchema`/`queuedActionSummarySchema` DTOs, and the enrolment-token mint route), so this is a pure-frontend slice.

Degrades gracefully to "not yet probed" when the SSH prober reports no probe — reachability/components come back `unknown` until the prober is wired (#39 merged the SSH key bootstrap; prober injection lands with the live transport). Real enrol + queue state still renders.

## Plan

Linked plan: `.claude/plans/194-admin-clients-health-page.md`
Roadmap: `docs/roadmap.md` → Phase 3

## License-boundary note

N/A — JSON-API-only frontend code. No GPL imports, no transport/packaging changes, no Docker image change. Read-only health + token-mint only; no new enforcement, no tamper-resistance surface (`CLAUDE.md`).

## Test plan

- [x] `cd server/frontend && npm run check` — svelte-check, 0 errors
- [x] `npm run test` — 41 frontend tests pass (incl. new `client-health.test.ts` + `mintEnrolmentToken`)
- [x] `npm run build` — adapter-static build succeeds
- [x] prettier-clean (server toolchain) on the new/modified `.ts` files
- [ ] Manual: log in to `/admin`, open **Client Health**, confirm degraded `unknown` rendering with no live prober, and mint a token to see the install one-liner

## Deferred (out of #194's read-only scope)

- "Probe now" / "Re-apply config" write actions from the mock — not implemented (read-only view).
- Live reachability/component data depends on the SSH prober injection landing with the live transport (#39 / Phase 4).
- Possible follow-up: consolidating the CRUD `ClientsView` and this health view into one page.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014aJML88wWR7jegkKeKjXdD)_