### PR TITLE
feat(setup): Ansible venv bootstrap on first run (#39)

### DIFF
--- a/.claude/plans/issue-39-ansible-venv-bootstrap.md
+++ b/.claude/plans/issue-39-ansible-venv-bootstrap.md
@@ -62,9 +62,9 @@ ships `python3-venv` solely for this).
    exists; a missing source is a logged no-op (does not fail the venv). The
    image does not yet COPY the playbooks (build context is `server/`; playbooks
    live in `client/ansible/playbooks/`, outside it) — so today the sync no-ops
-   on the real image. That packaging gap is **out of scope here** and gets its
-   own follow-up issue linked from the PR; the sync code is complete and
-   correct the moment the playbooks ship.
+   on the real image. That packaging gap is **out of scope here** and tracked
+   in the follow-up **#260** (Dockerfile/build-context work); the sync code is
+   complete and correct the moment the playbooks ship.
 
 ## Injectable seams (so tests never spawn `python3`)
 

--- a/.claude/plans/issue-39-ansible-venv-bootstrap.md
+++ b/.claude/plans/issue-39-ansible-venv-bootstrap.md
@@ -1,0 +1,98 @@
+# Issue #39 — Ansible venv bootstrap (Phase-6 step)
+
+Issue #39 is a **cross-phase tracker** for the deferred container first-run
+steps. Its slices land with their phases:
+
+| Step | Phase | Status |
+| --- | --- | --- |
+| Schema migration | 2 | ✅ in-process on boot (#49) |
+| SSH key bootstrap | 4 | ✅ in-process on boot (#205) |
+| **Ansible venv bootstrap** | **6** | **this slice** |
+| AdGuard Home fetch/supervise | 7 | deferred — AdGuard REST client/config not landed yet |
+
+Phase 6 is reachable: the `transport/ansible` runner (#130), the re-apply
+scheduler (#93), and the ActivityWatch playbook (#91) are all merged. The
+runner resolves `ansible-playbook` at `<ansibleDir>/venv/bin/ansible-playbook`
+and **throws `AnsibleUnavailableError` until the venv exists** — this slice is
+the missing piece that creates it.
+
+## Goal
+
+On boot, idempotently ensure the isolated Ansible venv exists in the data
+volume with `ansible-core` installed, sync the in-image playbooks into
+`<ansibleDir>/playbooks/`, and surface the result so the admin UI can show
+"Ansible unavailable" with a reason when a network-less first run can't pip
+install. No GPL code is linked in-process — `python3`/`pip`/`ansible-playbook`
+are all subprocesses (`CLAUDE.md` → License boundaries; the image already
+ships `python3-venv` solely for this).
+
+## Design decisions
+
+1. **In-process at boot, mirroring migration (#49) and SSH keygen (#205).**
+   The doc framed the Ansible step as an entrypoint step, but in-process gives
+   us: Vitest tests (the entrypoint is shell), status surfaced to the admin UI,
+   and no extra tooling in the image. Node spawns `python3 -m venv` / `pip` /
+   `ansible-playbook` as **subprocesses** — the license boundary is identical
+   to a shell entrypoint, so nothing is collapsed. Update the entrypoint comment
+   and `docs/server-deployment.md` step 2 accordingly.
+
+2. **Supervisor object holding a status snapshot, mirroring `AdGuardService`.**
+   `AnsibleVenvSupervisor` exposes an immutable `.status` (read by a new
+   read-only `GET /api/system/ansible` route behind `requireAdmin`, mirroring
+   `GET /api/dns`) and an idempotent `async bootstrap(logger?)` that never
+   throws — every failure is caught, classified, logged loudly, and surfaced.
+
+3. **Non-blocking kickoff in `main.ts`, not `app.ts`.** `pip install
+   ansible-core` is slow; we must not delay `listen`. The supervisor is built
+   and decorated in `app.ts` (default state `idle`, no spawn — so unit tests
+   that build the app make no subprocess calls, exactly like AdGuard `disabled`
+   mode is inert). `main.ts` fires `void app.ansibleVenv.bootstrap(app.log)`
+   after `listen`, like it already fires the SSH keygen. State transitions
+   `idle → bootstrapping → ready | unavailable`.
+
+4. **Version reconciliation via a sentinel.** Write the installed `ansible-core`
+   version to `<venv>/.pct-ansible-core-version`. On boot: binary missing →
+   create + install; binary present but sentinel ≠ configured version (or
+   missing) → reinstall (upgrade reconcile, satisfying the doc's "upgrades
+   reconcile it per release"); binary present and sentinel matches → no-op
+   `ready`. Keeps idempotency *and* the upgrade path honest and testable.
+
+5. **Playbook sync is best-effort + gated on packaging.** Sync from
+   `ansiblePlaybookSourceDir` into `<ansibleDir>/playbooks/` when the source
+   exists; a missing source is a logged no-op (does not fail the venv). The
+   image does not yet COPY the playbooks (build context is `server/`; playbooks
+   live in `client/ansible/playbooks/`, outside it) — so today the sync no-ops
+   on the real image. That packaging gap is **out of scope here** and gets its
+   own follow-up issue linked from the PR; the sync code is complete and
+   correct the moment the playbooks ship.
+
+## Injectable seams (so tests never spawn `python3`)
+
+`AnsibleVenvSupervisorDeps`: `runCommand(file, args)` (default
+`promisify(execFile)`), `fileExists`, `readSentinel`/`writeSentinel`,
+`syncPlaybooks` (default fs recursive copy), `now`.
+
+## Phases
+
+1. **Config + supervisor + tests.** Add `ansibleCoreVersion`
+   (`PCT_ANSIBLE_CORE_VERSION`, pinned default) and `ansiblePlaybookSourceDir`
+   (`PCT_ANSIBLE_PLAYBOOK_SRC`, default in-image path) to `config.ts`. Write
+   `setup/ansible-venv.ts`. Unit-test the branch matrix (no-op when present +
+   sentinel match; create+install when absent; reinstall on version drift;
+   pip/venv failure → `unavailable`, never throws; playbook sync present/absent).
+2. **Wire + API + tests.** Decorate `app.ansibleVenv` in `app.ts` (no auto-run),
+   fire bootstrap in `main.ts`. Add `GET /api/system/ansible` DTO + route +
+   barrel export; HTTP test (anon 401 + serialized snapshot). Config test for
+   the new settings.
+3. **Docs + finalize.** Update `docs/server-deployment.md` first-run step 2 and
+   the `docker-entrypoint.sh` comment (Ansible venv is now an in-process boot
+   step). File the playbook-packaging follow-up issue and link it.
+
+## Acceptance criteria mapping (#39)
+
+- Idempotent, guarded so a missing download (no network) leaves the dashboard
+  starting with Ansible disabled + an error surfaced → `bootstrap()` catches
+  all, sets `unavailable` + detail, `GET /api/system/ansible` surfaces it.
+- No GPL binary added to the image → venv lives in `/data`; only subprocesses;
+  `license-guard` untouched.
+- Tests for the idempotency/branching logic → Phase 1 unit matrix.

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -87,14 +87,24 @@ idempotently:
    entrypoint itself runs no migration step, and the runtime and migrations
    always open the same `DATABASE_URL` file with no double-migration hazard
    (issues #49, #39).
-2. **Ansible bootstrap** — if `/data/ansible/venv` is missing, create it
-   and `pip install ansible-core` (downloaded from PyPI at runtime, not
-   from the image). Sync `playbooks/` from the image. The directory root is
+2. **Ansible bootstrap** — the Node server ensures the venv **in-process on
+   boot** (issue #39), mirroring the in-process migrator and SSH keygen above:
+   if `<PCT_ANSIBLE_DIR>/venv/bin/ansible-playbook` is missing it creates the
+   venv and `pip install ansible-core==<PCT_ANSIBLE_CORE_VERSION>` (downloaded
+   from PyPI at runtime, not bundled in the image), then records the version in
+   a sentinel inside the venv so an image upgrade that bumps the pin reconciles
+   it (see "Upgrade path"). It also syncs `playbooks/` from the image's
+   read-only copy (`PCT_ANSIBLE_PLAYBOOK_SRC`) — a missing source is a logged
+   no-op. `python3`/`pip`/`ansible-playbook` are all driven **as subprocesses**,
+   never linked in-process (`docs/licensing-analysis.md`); the image ships only
+   a stock `python3-venv` for this, no Ansible binary. The directory root is
    `PCT_ANSIBLE_DIR` (default `/data/ansible`); the Phase-6 runner
-   (`transport/ansible`) execs `ansible-playbook` from
-   `<PCT_ANSIBLE_DIR>/venv/bin/` against playbooks in
-   `<PCT_ANSIBLE_DIR>/playbooks/` — always as a subprocess, never linked
-   in-process (`docs/licensing-analysis.md`).
+   (`transport/ansible`) execs `ansible-playbook` from `<PCT_ANSIBLE_DIR>/venv/
+   bin/` against playbooks in `<PCT_ANSIBLE_DIR>/playbooks/`. The bootstrap runs
+   in the background after the HTTP listener is up (a slow `pip install` does not
+   delay startup) and never crashes the process: a network-less first run leaves
+   Ansible disabled with the reason surfaced at `GET /api/system/ansible` for the
+   admin UI.
 3. **AdGuard Home bootstrap** — driven by `PCT_ADGUARD_MODE` (see
    "AdGuard Home deployment modes" below). In `managed` mode, the
    first-time fetch downloads the latest stable release from

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -8,17 +8,19 @@
 # In scope today: ensure the documented /data volume layout exists, then
 # exec the compiled Node server.
 #
-# Two first-run steps are deliberately NOT entrypoint steps: the Node server
+# Several first-run steps are deliberately NOT entrypoint steps: the Node server
 # does them in-process on boot, so the runtime image ships no extra tooling:
 #   - Schema migration via drizzle-orm's better-sqlite3 migrator (#49), so the
 #     image never ships drizzle-kit and migrator/runtime can't double-migrate.
 #   - SSH key bootstrap (generate id_ed25519 if absent) via node:crypto (#39),
 #     so the image never ships an ssh-keygen binary.
-# See docs/server-deployment.md -> "First-run setup" steps 1 and 4.
+#   - Ansible venv bootstrap (#39): the server spawns `python3 -m venv` +
+#     `pip install ansible-core` as subprocesses in the background after listen,
+#     so the image ships no Ansible binary (only a stock python3-venv) and a slow
+#     pip install never blocks startup. Status is surfaced at GET /api/system/ansible.
+# See docs/server-deployment.md -> "First-run setup" steps 1, 2, and 4.
 #
-# The remaining heavier first-run steps each land with their roadmap phase and
-# are tracked in #39:
-#   - Ansible venv bootstrap (pip install ansible-core)           [Phase 6]
+# The remaining heavier first-run step lands with its roadmap phase, tracked in #39:
 #   - AdGuard Home fetch / supervise (managed mode)               [Phase 7]
 set -eu
 

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -151,6 +151,14 @@ export {
   type DnsStatusResponse,
 } from "./dns/index.js";
 
+// System-status DTO (#39): the read-only contract surfacing first-run subsystem
+// health (the Ansible venv bootstrap). Schema lives in `./system/dtos.ts`.
+export {
+  ansibleVenvStateSchema,
+  ansibleVenvStatusResponseSchema,
+  type AnsibleVenvStatusResponse,
+} from "./system/index.js";
+
 // Auth DTOs (#52). Re-exported here so the frontend imports the auth contract
 // from the same `/api` surface as every other DTO; the schemas themselves live
 // in `../auth/dtos.ts` next to the routes that use them.

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -17,6 +17,7 @@ import { registerClientEnrolmentRoutes, registerClientHealthRoutes } from "./cli
 import { registerDnsRoutes } from "./dns/index.js";
 import { registerMetaRoute } from "./meta.js";
 import { registerEffectiveRoutes, registerPolicyRoutes } from "./policy/index.js";
+import { registerSystemRoutes } from "./system/index.js";
 import { installApiConventions } from "./validation.js";
 
 /** Options the `/api` plugin needs from its host app. */
@@ -74,6 +75,9 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   registerAuditRoutes(scope);
   // DNS status (#95): admin-only read of the active AdGuard mode + health.
   registerDnsRoutes(scope);
+  // System status (#39): admin-only read of first-run subsystem health (the
+  // Ansible venv bootstrap, so the admin sees when/why Ansible is unavailable).
+  registerSystemRoutes(scope);
 };
 
 /** Mount the JSON API under `/api` on the given app. */

--- a/server/src/api/system/dtos.ts
+++ b/server/src/api/system/dtos.ts
@@ -1,0 +1,41 @@
+/**
+ * zod DTO for the system-status read API (#39), shared with the frontend (the
+ * single `/api/*` contract). Read-only — these are runtime facts, not a
+ * request-mutable resource — so there is no write DTO.
+ *
+ * The Ansible block mirrors {@link AnsibleVenvStatus} from `setup/ansible-venv`;
+ * the mapper {@link toAnsibleVenvStatusResponse} is the single conversion point,
+ * and its return type makes the transport-side `AnsibleVenvState` enum and the
+ * schema here a compile-time drift guard — they cannot diverge silently.
+ */
+import { z } from "zod";
+
+import type { AnsibleVenvStatus } from "../../setup/ansible-venv.js";
+
+/** Lifecycle state of the first-run Ansible venv bootstrap. */
+export const ansibleVenvStateSchema = z.enum(["idle", "bootstrapping", "ready", "unavailable"]);
+
+/** Response shape of `GET /api/system/ansible`. */
+export const ansibleVenvStatusResponseSchema = z.object({
+  state: ansibleVenvStateSchema,
+  binaryPath: z.string(),
+  playbooksDir: z.string(),
+  coreVersion: z.string(),
+  checkedAt: z.string().nullable(),
+  detail: z.string().nullable(),
+});
+
+/** The inferred `GET /api/system/ansible` response type, shared with the frontend. */
+export type AnsibleVenvStatusResponse = z.infer<typeof ansibleVenvStatusResponseSchema>;
+
+/** Map the setup-layer {@link AnsibleVenvStatus} snapshot onto the wire contract. */
+export function toAnsibleVenvStatusResponse(status: AnsibleVenvStatus): AnsibleVenvStatusResponse {
+  return {
+    state: status.state,
+    binaryPath: status.binaryPath,
+    playbooksDir: status.playbooksDir,
+    coreVersion: status.coreVersion,
+    checkedAt: status.checkedAt,
+    detail: status.detail,
+  };
+}

--- a/server/src/api/system/index.ts
+++ b/server/src/api/system/index.ts
@@ -1,0 +1,10 @@
+/** System-status API (#39): read-only first-run subsystem health. */
+export const moduleName = "api/system";
+
+export {
+  ansibleVenvStateSchema,
+  ansibleVenvStatusResponseSchema,
+  toAnsibleVenvStatusResponse,
+  type AnsibleVenvStatusResponse,
+} from "./dtos.js";
+export { registerSystemRoutes } from "./routes.js";

--- a/server/src/api/system/routes.ts
+++ b/server/src/api/system/routes.ts
@@ -1,0 +1,36 @@
+/**
+ * Read-only system-status routes (#39): `GET /api/system/ansible`.
+ *
+ * Registered inside the `/api` plugin scope (after `registerAuth`) so it
+ * inherits the zod validator + shared error envelope and sits behind
+ * `requireAdmin` — first-run subsystem health is admin information. The handler
+ * is thin: read the {@link AnsibleVenvStatus} snapshot off the `app.ansibleVenv`
+ * supervisor decorated in `buildApp` and serialise it.
+ *
+ * This is the contract the admin UI consumes to surface whether Ansible is
+ * ready (and, on a network-less first run, *why* it isn't) — the
+ * "feature disabled + error surfaced" behaviour `docs/server-deployment.md` →
+ * "First-run setup" requires.
+ *
+ * License boundary: none touched — plain TypeScript + zod + Fastify.
+ */
+import type { FastifyInstance } from "fastify";
+
+import type { ZodTypeProvider } from "../validation.js";
+import { toAnsibleVenvStatusResponse, type AnsibleVenvStatusResponse } from "./dtos.js";
+
+/**
+ * Register the system-status read routes on an already-`/api`-prefixed scope.
+ * Call after {@link registerAuth} so `scope.requireAdmin` is decorated; reads
+ * the `ansibleVenv` supervisor decorated onto the app in `buildApp`.
+ */
+export function registerSystemRoutes(scope: FastifyInstance): void {
+  const typed = scope.withTypeProvider<ZodTypeProvider>();
+
+  typed.get(
+    "/system/ansible",
+    { preHandler: scope.requireAdmin },
+    async (): Promise<AnsibleVenvStatusResponse> =>
+      toAnsibleVenvStatusResponse(scope.ansibleVenv.status),
+  );
+}

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -144,6 +144,28 @@ const settingsSchema = z
      */
     ansibleDir: z.string().min(1).default("/data/ansible"),
     /**
+     * Pinned `ansible-core` version installed into the first-run venv
+     * (`PCT_ANSIBLE_CORE_VERSION`). The boot-time bootstrap (#39) runs
+     * `pip install ansible-core==<version>` and records it in a sentinel under
+     * the venv so an image upgrade that bumps this default reconciles the venv
+     * (`docs/server-deployment.md` → "Upgrade path"). A bare version string so
+     * the install is reproducible; validated here so a typo fails fast.
+     */
+    ansibleCoreVersion: z
+      .string()
+      .regex(/^[0-9][0-9A-Za-z.-]*$/, {
+        message: "must be a bare version like 2.18.1",
+      })
+      .default("2.18.1"),
+    /**
+     * Read-only, in-image source directory the first-run bootstrap (#39) syncs
+     * playbooks from into `<ansibleDir>/playbooks/` (`PCT_ANSIBLE_PLAYBOOK_SRC`).
+     * Defaults to the path the image is expected to ship them at. A missing
+     * source is a logged no-op (the venv still bootstraps), so the dashboard
+     * starts cleanly before the playbooks are packaged into the image.
+     */
+    ansiblePlaybookSourceDir: z.string().min(1).default("/app/ansible/playbooks"),
+    /**
      * Path to the dashboard's SSH **public** key (`PCT_SSH_PUBLIC_KEY_PATH`).
      * The client-enrolment response (#77) returns this so the client can
      * authorize the dashboard in `pct-agent`'s `authorized_keys`. The key pair
@@ -295,6 +317,8 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
     adminUsername: env.PCT_ADMIN_USERNAME,
     adminPassword: env.PCT_ADMIN_PASSWORD,
     ansibleDir: env.PCT_ANSIBLE_DIR,
+    ansibleCoreVersion: env.PCT_ANSIBLE_CORE_VERSION,
+    ansiblePlaybookSourceDir: env.PCT_ANSIBLE_PLAYBOOK_SRC,
     sshPublicKeyPath: env.PCT_SSH_PUBLIC_KEY_PATH,
     sshPrivateKeyPath: env.PCT_SSH_PRIVATE_KEY_PATH,
     telemetry: {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -59,6 +59,13 @@ async function main(): Promise<void> {
     app.log.error(err);
     process.exit(1);
   }
+
+  // Bootstrap the first-run Ansible venv (#39, Phase-6 step) in the background,
+  // after listen so a slow `pip install ansible-core` never delays the dashboard
+  // becoming reachable. `bootstrap()` never throws — a network-less first run
+  // records `unavailable` and the reason is surfaced at GET /api/system/ansible
+  // (docs/server-deployment.md → "First-run setup") — so a bare `void` is safe.
+  void app.ansibleVenv.bootstrap(app.log);
 }
 
 void main();

--- a/server/src/setup/ansible-venv.ts
+++ b/server/src/setup/ansible-venv.ts
@@ -1,0 +1,292 @@
+/**
+ * Ansible venv bootstrap (the Phase-6 first-run step of #39).
+ *
+ * The `transport/ansible` runner (#130) execs `ansible-playbook` from an
+ * isolated venv in the data volume (`<ansibleDir>/venv/bin/ansible-playbook`)
+ * and throws `AnsibleUnavailableError` until that venv exists. Something has to
+ * *create* it on first run — this module does, and it runs **in-process at
+ * boot** (`main.ts`), mirroring the migrate-on-boot (#49) and SSH-keygen (#205)
+ * precedents so the runtime image needs no Ansible binary baked in (the image
+ * ships only a stock `python3-venv`, used solely here).
+ *
+ * It spawns `python3 -m venv` and `pip install ansible-core==<pinned>` as
+ * **subprocesses** (`node:child_process`) and copies playbook *files* — it never
+ * imports or links Ansible in-process (`CLAUDE.md` → "License boundaries"). That
+ * boundary is identical whether this runs from the shell entrypoint or from
+ * Node; running it from Node buys testability and a status the admin UI can
+ * surface, without collapsing anything.
+ *
+ * `bootstrap()` never throws: a network-less first run (no PyPI) leaves the
+ * dashboard starting with Ansible `unavailable` and the reason surfaced via
+ * `GET /api/system/ansible` (`docs/server-deployment.md` → "First-run setup"),
+ * rather than crashing the process.
+ */
+import { execFile } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Lifecycle state of the venv bootstrap.
+ *
+ * - `idle` — built but not yet run (the state a freshly constructed supervisor
+ *   reports, so building the app spawns nothing — tests and the boot path that
+ *   hasn't fired `bootstrap()` yet both see this).
+ * - `bootstrapping` — a `bootstrap()` call is in flight.
+ * - `ready` — `ansible-playbook` is present at the expected path with the
+ *   pinned `ansible-core` installed; the runner can exec it.
+ * - `unavailable` — the venv could not be created/installed (e.g. no network);
+ *   the runner stays disabled and `detail` says why.
+ */
+export type AnsibleVenvState = "idle" | "bootstrapping" | "ready" | "unavailable";
+
+/** An immutable snapshot of the venv bootstrap's last-observed state. */
+export interface AnsibleVenvStatus {
+  /** Lifecycle state (see {@link AnsibleVenvState}). */
+  readonly state: AnsibleVenvState;
+  /** The `ansible-playbook` path the runner will exec. */
+  readonly binaryPath: string;
+  /** Directory the runner resolves playbooks from. */
+  readonly playbooksDir: string;
+  /** The pinned `ansible-core` version targeted. */
+  readonly coreVersion: string;
+  /** ISO-8601 timestamp of the last `bootstrap()`, or `null` if never run. */
+  readonly checkedAt: string | null;
+  /** Human-readable reason when not `ready`, else `null`. */
+  readonly detail: string | null;
+}
+
+/**
+ * Minimal structural logger {@link AnsibleVenvSupervisor.bootstrap} uses. Fastify's
+ * `app.log` (pino) satisfies it without a cast; a test can pass a recording fake.
+ */
+export interface AnsibleVenvLogger {
+  info(obj: object, msg?: string): void;
+  error(obj: object, msg?: string): void;
+}
+
+/** Result of running a subprocess. */
+export interface RunCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+/** Spawns a subprocess and resolves with its captured output (rejects on failure). */
+export type RunCommand = (file: string, args: string[]) => Promise<RunCommandResult>;
+
+/** Injectable seams so tests never spawn `python3`/`pip` or read real PyPI. */
+export interface AnsibleVenvSupervisorDeps {
+  /** Subprocess runner; defaults to a promisified `execFile`. */
+  runCommand?: RunCommand;
+  /** Existence check; defaults to `node:fs` `existsSync`. */
+  fileExists?: (path: string) => boolean;
+  /** Read the recorded `ansible-core` version, or `null` if absent/unreadable. */
+  readSentinel?: (path: string) => string | null;
+  /** Record the installed `ansible-core` version. */
+  writeSentinel?: (path: string, value: string) => void;
+  /** Recursively create a directory (and parents). */
+  makeDir?: (path: string) => void;
+  /**
+   * Copy `sourceDir` into `destDir`; returns `true` if a copy happened, `false`
+   * if the source did not exist (a no-op). Defaults to a recursive `cpSync`.
+   */
+  syncPlaybooks?: (sourceDir: string, destDir: string) => boolean;
+  /** Clock for `checkedAt`; defaults to `() => new Date()`. */
+  now?: () => Date;
+}
+
+/** Configuration the supervisor needs (a slice of {@link Settings}). */
+export interface AnsibleVenvSupervisorConfig {
+  /** Root of the data-volume Ansible directory (`<root>/venv`, `<root>/playbooks`). */
+  ansibleDir: string;
+  /** Pinned `ansible-core` version to install. */
+  coreVersion: string;
+  /** Read-only, in-image directory playbooks are synced from. */
+  playbookSourceDir: string;
+  /** `python3` interpreter to create the venv with. Defaults to `"python3"`. */
+  pythonBin?: string;
+}
+
+/** Filename of the version sentinel written inside the venv. */
+const VERSION_SENTINEL = ".pct-ansible-core-version";
+
+/** Default recursive copy: copies `sourceDir`→`destDir`, or no-ops if absent. */
+function defaultSyncPlaybooks(sourceDir: string, destDir: string): boolean {
+  if (!existsSync(sourceDir)) return false;
+  cpSync(sourceDir, destDir, { recursive: true });
+  return true;
+}
+
+/** Default sentinel read: the trimmed file contents, or `null` if unreadable. */
+function defaultReadSentinel(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Creates the Ansible venv on first run and holds the last-observed
+ * {@link AnsibleVenvStatus}. Construct via {@link createAnsibleVenvSupervisor};
+ * build once per app and decorate it onto Fastify so the status route reads the
+ * same instance.
+ */
+export class AnsibleVenvSupervisor {
+  readonly #config: Required<AnsibleVenvSupervisorConfig>;
+  readonly #deps: Required<AnsibleVenvSupervisorDeps>;
+  readonly #venvDir: string;
+  readonly #binaryPath: string;
+  readonly #pythonInVenv: string;
+  readonly #sentinelPath: string;
+  readonly #playbooksDir: string;
+  #status: AnsibleVenvStatus;
+
+  constructor(config: AnsibleVenvSupervisorConfig, deps: AnsibleVenvSupervisorDeps = {}) {
+    this.#config = { pythonBin: "python3", ...config };
+    this.#deps = {
+      runCommand: deps.runCommand ?? ((file, args) => execFileAsync(file, args)),
+      fileExists: deps.fileExists ?? existsSync,
+      readSentinel: deps.readSentinel ?? defaultReadSentinel,
+      writeSentinel: deps.writeSentinel ?? ((path, value) => writeFileSync(path, `${value}\n`)),
+      makeDir: deps.makeDir ?? ((path) => void mkdirSync(path, { recursive: true })),
+      syncPlaybooks: deps.syncPlaybooks ?? defaultSyncPlaybooks,
+      now: deps.now ?? (() => new Date()),
+    };
+
+    this.#venvDir = join(this.#config.ansibleDir, "venv");
+    this.#binaryPath = join(this.#venvDir, "bin", "ansible-playbook");
+    this.#pythonInVenv = join(this.#venvDir, "bin", "python");
+    this.#sentinelPath = join(this.#venvDir, VERSION_SENTINEL);
+    this.#playbooksDir = join(this.#config.ansibleDir, "playbooks");
+
+    this.#status = {
+      state: "idle",
+      binaryPath: this.#binaryPath,
+      playbooksDir: this.#playbooksDir,
+      coreVersion: this.#config.coreVersion,
+      checkedAt: null,
+      detail: null,
+    };
+  }
+
+  /** An immutable snapshot of the current status. */
+  get status(): AnsibleVenvStatus {
+    return { ...this.#status };
+  }
+
+  /**
+   * Ensure the venv exists with the pinned `ansible-core`, syncing playbooks.
+   *
+   * Idempotent and safe to call unconditionally on every boot:
+   * - playbooks are synced from the in-image source (a missing source is a
+   *   logged no-op, so a not-yet-packaged image still bootstraps);
+   * - the venv is created + `pip install`ed only when its `ansible-playbook` is
+   *   absent, or reinstalled when the recorded version differs from the pinned
+   *   one (so an image upgrade that bumps the pin reconciles the venv);
+   * - when the binary is present and the version matches, it is a fast no-op.
+   *
+   * Never throws — every failure is caught, recorded as `unavailable` with a
+   * `detail`, and logged at `error` level so startup is not blocked.
+   */
+  async bootstrap(logger?: AnsibleVenvLogger): Promise<AnsibleVenvStatus> {
+    const at = this.#deps.now().toISOString();
+    this.#status = { ...this.#status, state: "bootstrapping" };
+
+    // Playbook sync is independent of the venv: a failure here must not stop the
+    // venv work, and a missing source dir is expected before the playbooks are
+    // packaged into the image (#39 follow-up).
+    this.#syncPlaybooks(logger);
+
+    try {
+      const reason = this.#installNeeded();
+      if (reason === null) {
+        return this.#settle("ready", at, null, logger, "Ansible venv already present");
+      }
+
+      this.#deps.makeDir(this.#config.ansibleDir);
+      if (reason === "missing") {
+        await this.#deps.runCommand(this.#config.pythonBin, ["-m", "venv", this.#venvDir]);
+      }
+      await this.#deps.runCommand(this.#pythonInVenv, [
+        "-m",
+        "pip",
+        "install",
+        "--no-input",
+        "--disable-pip-version-check",
+        `ansible-core==${this.#config.coreVersion}`,
+      ]);
+      this.#deps.writeSentinel(this.#sentinelPath, this.#config.coreVersion);
+
+      const msg =
+        reason === "missing"
+          ? "created Ansible venv and installed ansible-core (first run)"
+          : "reconciled Ansible venv to the pinned ansible-core version";
+      return this.#settle("ready", at, null, logger, msg);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      this.#status = { ...this.#status, state: "unavailable", checkedAt: at, detail };
+      logger?.error(
+        { event: "ansible_venv_bootstrap", state: "unavailable", err },
+        `Ansible venv bootstrap failed; Ansible disabled: ${detail}`,
+      );
+      return this.status;
+    }
+  }
+
+  /**
+   * Whether (and why) `pip install` must run: `"missing"` when there is no
+   * venv binary, `"drift"` when it exists but the recorded version differs from
+   * the pin, or `null` when the venv is already at the pinned version.
+   */
+  #installNeeded(): "missing" | "drift" | null {
+    if (!this.#deps.fileExists(this.#binaryPath)) return "missing";
+    const recorded = this.#deps.readSentinel(this.#sentinelPath);
+    return recorded === this.#config.coreVersion ? null : "drift";
+  }
+
+  #syncPlaybooks(logger?: AnsibleVenvLogger): void {
+    try {
+      const copied = this.#deps.syncPlaybooks(this.#config.playbookSourceDir, this.#playbooksDir);
+      if (copied) {
+        logger?.info(
+          { event: "ansible_playbook_sync", source: this.#config.playbookSourceDir },
+          "synced Ansible playbooks from the image",
+        );
+      } else {
+        logger?.info(
+          { event: "ansible_playbook_sync", source: this.#config.playbookSourceDir },
+          "no in-image Ansible playbooks to sync (source absent)",
+        );
+      }
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      logger?.error(
+        { event: "ansible_playbook_sync", err },
+        `Ansible playbook sync failed (continuing): ${detail}`,
+      );
+    }
+  }
+
+  #settle(
+    state: AnsibleVenvState,
+    at: string,
+    detail: string | null,
+    logger: AnsibleVenvLogger | undefined,
+    msg: string,
+  ): AnsibleVenvStatus {
+    this.#status = { ...this.#status, state, checkedAt: at, detail };
+    logger?.info({ event: "ansible_venv_bootstrap", state }, msg);
+    return this.status;
+  }
+}
+
+/** Build an {@link AnsibleVenvSupervisor} from the relevant settings. */
+export function createAnsibleVenvSupervisor(
+  config: AnsibleVenvSupervisorConfig,
+  deps: AnsibleVenvSupervisorDeps = {},
+): AnsibleVenvSupervisor {
+  return new AnsibleVenvSupervisor(config, deps);
+}

--- a/server/src/setup/ansible-venv.ts
+++ b/server/src/setup/ansible-venv.ts
@@ -192,7 +192,6 @@ export class AnsibleVenvSupervisor {
    * `detail`, and logged at `error` level so startup is not blocked.
    */
   async bootstrap(logger?: AnsibleVenvLogger): Promise<AnsibleVenvStatus> {
-    const at = this.#deps.now().toISOString();
     this.#status = { ...this.#status, state: "bootstrapping" };
 
     // Playbook sync is independent of the venv: a failure here must not stop the
@@ -203,7 +202,7 @@ export class AnsibleVenvSupervisor {
     try {
       const reason = this.#installNeeded();
       if (reason === null) {
-        return this.#settle("ready", at, null, logger, "Ansible venv already present");
+        return this.#settle("ready", null, logger, "Ansible venv already present");
       }
 
       this.#deps.makeDir(this.#config.ansibleDir);
@@ -224,10 +223,17 @@ export class AnsibleVenvSupervisor {
         reason === "missing"
           ? "created Ansible venv and installed ansible-core (first run)"
           : "reconciled Ansible venv to the pinned ansible-core version";
-      return this.#settle("ready", at, null, logger, msg);
+      return this.#settle("ready", null, logger, msg);
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
-      this.#status = { ...this.#status, state: "unavailable", checkedAt: at, detail };
+      // Timestamp captured at completion (here, after the potentially
+      // multi-minute pip install), so `checkedAt` means "last settled".
+      this.#status = {
+        ...this.#status,
+        state: "unavailable",
+        checkedAt: this.#deps.now().toISOString(),
+        detail,
+      };
       logger?.error(
         { event: "ansible_venv_bootstrap", state: "unavailable", err },
         `Ansible venv bootstrap failed; Ansible disabled: ${detail}`,
@@ -272,12 +278,13 @@ export class AnsibleVenvSupervisor {
 
   #settle(
     state: AnsibleVenvState,
-    at: string,
     detail: string | null,
     logger: AnsibleVenvLogger | undefined,
     msg: string,
   ): AnsibleVenvStatus {
-    this.#status = { ...this.#status, state, checkedAt: at, detail };
+    // Timestamp captured at completion so `checkedAt` reflects when the
+    // bootstrap settled, not when it began (pip install can take minutes).
+    this.#status = { ...this.#status, state, checkedAt: this.#deps.now().toISOString(), detail };
     logger?.info({ event: "ansible_venv_bootstrap", state }, msg);
     return this.status;
   }

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -16,6 +16,7 @@ import { registerApi } from "../api/index.js";
 import { loadSettings, type Settings } from "../config.js";
 import { EventHub } from "../events/index.js";
 import { createDb, type PolicyDb } from "../policy/db.js";
+import { createAnsibleVenvSupervisor, type AnsibleVenvSupervisor } from "../setup/ansible-venv.js";
 import { createAdGuardService, type AdGuardService } from "../transport/adguard/index.js";
 import { createPolicyPushTransport } from "../transport/policy-push/index.js";
 import { registerFrontend } from "./frontend.js";
@@ -35,6 +36,14 @@ declare module "fastify" {
      * `settings.adguard` unless injected via {@link BuildAppOptions.adguard}.
      */
     adguard: AdGuardService;
+    /**
+     * The first-run Ansible venv bootstrap supervisor (#39). `GET
+     * /api/system/ansible` reads its `status` snapshot. Built from settings
+     * here but **not** run by `buildApp`: `main.ts` fires `bootstrap()` after
+     * `listen` (a slow `pip install` must not block startup), so building the
+     * app — including in tests — spawns nothing.
+     */
+    ansibleVenv: AnsibleVenvSupervisor;
   }
 }
 
@@ -62,6 +71,13 @@ export interface BuildAppOptions {
    * existing tests make no AdGuard calls.
    */
   adguard?: AdGuardService;
+  /**
+   * Inject an {@link AnsibleVenvSupervisor} (tests pass one with a fake runner).
+   * When omitted, {@link buildApp} builds one from settings. Either way
+   * `buildApp` never calls `bootstrap()`, so no subprocess is spawned by
+   * constructing the app.
+   */
+  ansibleVenv?: AnsibleVenvSupervisor;
 }
 
 /**
@@ -115,6 +131,20 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   app.addHook("onReady", async () => {
     await adguard.runPreflight(app.log);
   });
+
+  // The first-run Ansible venv bootstrap supervisor (#39), read by
+  // GET /api/system/ansible. Built (or injected) here so the route has a status
+  // to serialise, but NOT run here: `main.ts` fires `bootstrap()` after `listen`
+  // so a slow `pip install` never delays startup, and constructing the app —
+  // including every test that builds it — spawns no subprocess.
+  const ansibleVenv =
+    options.ansibleVenv ??
+    createAnsibleVenvSupervisor({
+      ansibleDir: settings.ansibleDir,
+      coreVersion: settings.ansibleCoreVersion,
+      playbookSourceDir: settings.ansiblePlaybookSourceDir,
+    });
+  app.decorate("ansibleVenv", ansibleVenv);
 
   app.get("/", async (_request, reply) => {
     return reply.type("text/plain").send("hello, no policy yet");

--- a/server/tests/api/system.test.ts
+++ b/server/tests/api/system.test.ts
@@ -1,0 +1,162 @@
+/**
+ * HTTP tests for the system-status read route `GET /api/system/ansible` (#39),
+ * driven through the real app via `app.inject()` with a genuine admin session
+ * cookie — per docs/testing.md → "HTTP routes". Covers the anonymous-401 guard
+ * and the serialised snapshot for the ready and unavailable cases, with an
+ * injected {@link AnsibleVenvSupervisor} (fake runner) so no test spawns Python.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SESSION_COOKIE } from "../../src/auth/session.js";
+import { loadSettings } from "../../src/config.js";
+import {
+  createAnsibleVenvSupervisor,
+  type AnsibleVenvSupervisor,
+  type RunCommand,
+} from "../../src/setup/ansible-venv.js";
+import { buildTestApp, type TestApp } from "../helpers/app.js";
+
+const CORE_VERSION = "2.18.1";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pct-system-route-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function configuredSettings() {
+  return loadSettings({
+    PCT_LOG_LEVEL: "silent",
+    PCT_SECRET_KEY: "system-test-secret",
+    PCT_ADMIN_USERNAME: "ben",
+    PCT_ADMIN_PASSWORD: "hunter2",
+    PCT_ANSIBLE_DIR: dir,
+    PCT_ANSIBLE_CORE_VERSION: CORE_VERSION,
+  });
+}
+
+function sessionCookie(res: { headers: Record<string, unknown> }): string {
+  const raw = res.headers["set-cookie"];
+  const headers = Array.isArray(raw) ? (raw as string[]) : [String(raw ?? "")];
+  const match = headers.find((h) => h.startsWith(`${SESSION_COOKIE}=`));
+  if (match === undefined) throw new Error("no session cookie set");
+  return match.split(";")[0] ?? "";
+}
+
+/** A runner that simulates Python creating the venv on `-m venv`. */
+const okRunner: RunCommand = async (_file, args) => {
+  if (args.includes("venv")) {
+    const venvDir = args[args.length - 1] as string;
+    mkdirSync(join(venvDir, "bin"), { recursive: true });
+    writeFileSync(join(venvDir, "bin", "ansible-playbook"), "#!/bin/sh\n");
+  }
+  return { stdout: "", stderr: "" };
+};
+
+const failingRunner: RunCommand = async () => {
+  throw new Error("no network to PyPI");
+};
+
+/** Build the test app around an injected supervisor and log in as admin. */
+async function harnessWith(
+  ansibleVenv: AnsibleVenvSupervisor,
+): Promise<{ harness: TestApp; cookie: string }> {
+  const harness = buildTestApp({ appOptions: { settings: configuredSettings(), ansibleVenv } });
+  await harness.app.ready();
+  const login = await harness.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username: "ben", password: "hunter2" },
+  });
+  return { harness, cookie: sessionCookie(login) };
+}
+
+describe("GET /api/system/ansible", () => {
+  it("rejects an anonymous request with 401", async () => {
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: okRunner },
+    );
+    const { harness } = await harnessWith(supervisor);
+    try {
+      const res = await harness.app.inject({ method: "GET", url: "/api/system/ansible" });
+      expect(res.statusCode).toBe(401);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("serialises a ready snapshot for an admin", async () => {
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: okRunner },
+    );
+    await supervisor.bootstrap();
+    const { harness, cookie } = await harnessWith(supervisor);
+    try {
+      const res = await harness.app.inject({
+        method: "GET",
+        url: "/api/system/ansible",
+        headers: { cookie },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.state).toBe("ready");
+      expect(body.coreVersion).toBe(CORE_VERSION);
+      expect(body.binaryPath).toBe(join(dir, "venv", "bin", "ansible-playbook"));
+      expect(body.playbooksDir).toBe(join(dir, "playbooks"));
+      expect(body.detail).toBeNull();
+      expect(typeof body.checkedAt).toBe("string");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("surfaces an unavailable snapshot with the failure reason", async () => {
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: failingRunner },
+    );
+    await supervisor.bootstrap();
+    const { harness, cookie } = await harnessWith(supervisor);
+    try {
+      const res = await harness.app.inject({
+        method: "GET",
+        url: "/api/system/ansible",
+        headers: { cookie },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.state).toBe("unavailable");
+      expect(body.detail).toContain("no network to PyPI");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("reports idle before bootstrap has run", async () => {
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: okRunner },
+    );
+    const { harness, cookie } = await harnessWith(supervisor);
+    try {
+      const res = await harness.app.inject({
+        method: "GET",
+        url: "/api/system/ansible",
+        headers: { cookie },
+      });
+      expect(res.json().state).toBe("idle");
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -16,6 +16,8 @@ describe("loadSettings", () => {
     expect(settings.logLevel).toBe("info");
     expect(settings.secretKey).toBeUndefined();
     expect(settings.ansibleDir).toBe("/data/ansible");
+    expect(settings.ansibleCoreVersion).toBe("2.18.1");
+    expect(settings.ansiblePlaybookSourceDir).toBe("/app/ansible/playbooks");
     expect(settings.sshPublicKeyPath).toBe("/data/secrets/ssh/id_ed25519.pub");
     expect(settings.sshPrivateKeyPath).toBe("/data/secrets/ssh/id_ed25519");
     expect(settings.adguard).toEqual({ mode: "disabled" });
@@ -26,6 +28,21 @@ describe("loadSettings", () => {
 
   it("honours an explicit PCT_ANSIBLE_DIR", () => {
     expect(loadSettings({ PCT_ANSIBLE_DIR: "/srv/ansible" }).ansibleDir).toBe("/srv/ansible");
+  });
+
+  it("honours explicit Ansible venv bootstrap settings", () => {
+    const settings = loadSettings({
+      PCT_ANSIBLE_CORE_VERSION: "2.17.6",
+      PCT_ANSIBLE_PLAYBOOK_SRC: "/opt/playbooks",
+    });
+    expect(settings.ansibleCoreVersion).toBe("2.17.6");
+    expect(settings.ansiblePlaybookSourceDir).toBe("/opt/playbooks");
+  });
+
+  it("rejects a non-version PCT_ANSIBLE_CORE_VERSION", () => {
+    expect(() => loadSettings({ PCT_ANSIBLE_CORE_VERSION: "latest; rm -rf /" })).toThrow(
+      /bare version/,
+    );
   });
 
   it("honours explicit SSH key paths", () => {

--- a/server/tests/setup/ansible-venv.test.ts
+++ b/server/tests/setup/ansible-venv.test.ts
@@ -216,6 +216,9 @@ describe("AnsibleVenvSupervisor.bootstrap — failure handling", () => {
 
     expect(status.state).toBe("unavailable");
     expect(status.detail).toContain("simulated pip failure");
+    // The sentinel must not be written when the install fails, so the next boot
+    // re-detects "drift" and retries rather than trusting a half-done install.
+    expect(existsSync(sentinel(dir))).toBe(false);
   });
 });
 

--- a/server/tests/setup/ansible-venv.test.ts
+++ b/server/tests/setup/ansible-venv.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the Ansible venv bootstrap (#39, Phase-6 first-run step).
+ *
+ * The subprocess runner (`python3 -m venv` / `pip install`) is injected so no
+ * test spawns Python or touches PyPI; the filesystem work (dir creation,
+ * version sentinel, playbook sync) runs for real against a temp `ansibleDir`,
+ * and the fake runner simulates Python creating the venv binary so the
+ * default-deps paths (sentinel read/write) are exercised end to end.
+ */
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAnsibleVenvSupervisor, type RunCommand } from "../../src/setup/ansible-venv.js";
+
+const CORE_VERSION = "2.18.1";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pct-ansible-venv-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const venvBinary = (ansibleDir: string): string =>
+  join(ansibleDir, "venv", "bin", "ansible-playbook");
+const sentinel = (ansibleDir: string): string =>
+  join(ansibleDir, "venv", ".pct-ansible-core-version");
+const playbooksDest = (ansibleDir: string): string => join(ansibleDir, "playbooks");
+
+interface Recorder {
+  calls: { file: string; args: string[] }[];
+  run: RunCommand;
+}
+
+/**
+ * A runner that records every call and, on a `python -m venv <dir>` call,
+ * simulates the interpreter by creating the venv's `bin/ansible-playbook` — so
+ * the real default sentinel writer (which writes inside the venv) succeeds.
+ */
+function recordingRunner(opts: { failOn?: "venv" | "pip" } = {}): Recorder {
+  const calls: { file: string; args: string[] }[] = [];
+  const run: RunCommand = async (file, args) => {
+    calls.push({ file, args });
+    const isVenv = args.includes("venv");
+    const isPip = args.includes("pip");
+    if ((opts.failOn === "venv" && isVenv) || (opts.failOn === "pip" && isPip)) {
+      throw new Error(`simulated ${opts.failOn} failure`);
+    }
+    if (isVenv) {
+      const venvDir = args[args.length - 1] as string;
+      mkdirSync(join(venvDir, "bin"), { recursive: true });
+      writeFileSync(join(venvDir, "bin", "ansible-playbook"), "#!/bin/sh\n");
+    }
+    return { stdout: "", stderr: "" };
+  };
+  return { calls, run };
+}
+
+function fakeLogger() {
+  return { info: vi.fn(), error: vi.fn() };
+}
+
+describe("AnsibleVenvSupervisor construction", () => {
+  it("reports idle, spawns nothing, and exposes the resolved paths", () => {
+    const runCommand = vi.fn();
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand },
+    );
+    const status = supervisor.status;
+    expect(status.state).toBe("idle");
+    expect(status.checkedAt).toBeNull();
+    expect(status.binaryPath).toBe(venvBinary(dir));
+    expect(status.playbooksDir).toBe(playbooksDest(dir));
+    expect(status.coreVersion).toBe(CORE_VERSION);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns a copy from status (snapshot is immutable from outside)", () => {
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: vi.fn() },
+    );
+    expect(supervisor.status).not.toBe(supervisor.status);
+  });
+});
+
+describe("AnsibleVenvSupervisor.bootstrap — venv creation", () => {
+  it("creates the venv and pip-installs the pinned ansible-core when absent", async () => {
+    const recorder = recordingRunner();
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: recorder.run },
+    );
+
+    const status = await supervisor.bootstrap();
+
+    expect(status.state).toBe("ready");
+    expect(status.checkedAt).not.toBeNull();
+    expect(status.detail).toBeNull();
+    // python -m venv <venvDir>, then <venv>/bin/python -m pip install …==<version>.
+    expect(recorder.calls).toHaveLength(2);
+    expect(recorder.calls[0]?.file).toBe("python3");
+    expect(recorder.calls[0]?.args).toEqual(["-m", "venv", join(dir, "venv")]);
+    expect(recorder.calls[1]?.file).toBe(join(dir, "venv", "bin", "python"));
+    expect(recorder.calls[1]?.args).toContain(`ansible-core==${CORE_VERSION}`);
+    // The version sentinel is recorded for later drift detection.
+    expect(readFileSync(sentinel(dir), "utf8").trim()).toBe(CORE_VERSION);
+  });
+
+  it("honours a configured python interpreter", async () => {
+    const recorder = recordingRunner();
+    const supervisor = createAnsibleVenvSupervisor(
+      {
+        ansibleDir: dir,
+        coreVersion: CORE_VERSION,
+        playbookSourceDir: join(dir, "src"),
+        pythonBin: "python3.11",
+      },
+      { runCommand: recorder.run },
+    );
+    await supervisor.bootstrap();
+    expect(recorder.calls[0]?.file).toBe("python3.11");
+  });
+});
+
+describe("AnsibleVenvSupervisor.bootstrap — idempotency & reconciliation", () => {
+  function seedVenv(version: string): void {
+    mkdirSync(join(dir, "venv", "bin"), { recursive: true });
+    writeFileSync(venvBinary(dir), "#!/bin/sh\n");
+    writeFileSync(sentinel(dir), `${version}\n`);
+  }
+
+  it("is a no-op when the binary is present and the version matches", async () => {
+    seedVenv(CORE_VERSION);
+    const recorder = recordingRunner();
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: recorder.run },
+    );
+
+    const status = await supervisor.bootstrap();
+
+    expect(status.state).toBe("ready");
+    expect(recorder.calls).toHaveLength(0); // no venv create, no pip install
+  });
+
+  it("reinstalls (no venv recreate) when the recorded version drifts from the pin", async () => {
+    seedVenv("2.17.0");
+    const recorder = recordingRunner();
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: recorder.run },
+    );
+
+    const status = await supervisor.bootstrap();
+
+    expect(status.state).toBe("ready");
+    // Exactly one call — the pip reinstall — and not a `venv` recreate.
+    expect(recorder.calls).toHaveLength(1);
+    expect(recorder.calls[0]?.args).toContain("pip");
+    expect(recorder.calls[0]?.args).toContain(`ansible-core==${CORE_VERSION}`);
+    expect(recorder.calls[0]?.args).not.toContain("venv");
+    expect(readFileSync(sentinel(dir), "utf8").trim()).toBe(CORE_VERSION);
+  });
+
+  it("reinstalls when the binary is present but the sentinel is missing", async () => {
+    mkdirSync(join(dir, "venv", "bin"), { recursive: true });
+    writeFileSync(venvBinary(dir), "#!/bin/sh\n");
+    const recorder = recordingRunner();
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: recorder.run },
+    );
+
+    const status = await supervisor.bootstrap();
+
+    expect(status.state).toBe("ready");
+    expect(recorder.calls).toHaveLength(1);
+    expect(recorder.calls[0]?.args).toContain("pip");
+  });
+});
+
+describe("AnsibleVenvSupervisor.bootstrap — failure handling", () => {
+  it("records unavailable with a reason and never throws when venv creation fails", async () => {
+    const recorder = recordingRunner({ failOn: "venv" });
+    const log = fakeLogger();
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: recorder.run },
+    );
+
+    const status = await supervisor.bootstrap(log);
+
+    expect(status.state).toBe("unavailable");
+    expect(status.detail).toContain("simulated venv failure");
+    expect(status.checkedAt).not.toBeNull();
+    expect(log.error).toHaveBeenCalled();
+    expect(existsSync(sentinel(dir))).toBe(false);
+  });
+
+  it("records unavailable when the pip install fails (e.g. no network)", async () => {
+    const recorder = recordingRunner({ failOn: "pip" });
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      { runCommand: recorder.run },
+    );
+
+    const status = await supervisor.bootstrap();
+
+    expect(status.state).toBe("unavailable");
+    expect(status.detail).toContain("simulated pip failure");
+  });
+});
+
+describe("AnsibleVenvSupervisor.bootstrap — playbook sync", () => {
+  it("copies playbooks from the in-image source into <ansibleDir>/playbooks", async () => {
+    const source = join(dir, "image-playbooks");
+    mkdirSync(source, { recursive: true });
+    writeFileSync(join(source, "activitywatch.yml"), "---\n");
+    const log = fakeLogger();
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: source },
+      { runCommand: recordingRunner().run },
+    );
+
+    await supervisor.bootstrap(log);
+
+    expect(existsSync(join(playbooksDest(dir), "activitywatch.yml"))).toBe(true);
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "ansible_playbook_sync" }),
+      expect.stringContaining("synced"),
+    );
+  });
+
+  it("no-ops the sync (and still bootstraps the venv) when the source is absent", async () => {
+    const recorder = recordingRunner();
+    const log = fakeLogger();
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "missing") },
+      { runCommand: recorder.run },
+    );
+
+    const status = await supervisor.bootstrap(log);
+
+    expect(status.state).toBe("ready");
+    expect(existsSync(playbooksDest(dir))).toBe(false);
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "ansible_playbook_sync" }),
+      expect.stringContaining("no in-image"),
+    );
+  });
+
+  it("continues to bootstrap the venv when the playbook sync throws", async () => {
+    const recorder = recordingRunner();
+    const log = fakeLogger();
+    const supervisor = createAnsibleVenvSupervisor(
+      { ansibleDir: dir, coreVersion: CORE_VERSION, playbookSourceDir: join(dir, "src") },
+      {
+        runCommand: recorder.run,
+        syncPlaybooks: () => {
+          throw new Error("disk full");
+        },
+      },
+    );
+
+    const status = await supervisor.bootstrap(log);
+
+    expect(status.state).toBe("ready");
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "ansible_playbook_sync" }),
+      expect.stringContaining("disk full"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The **Ansible venv bootstrap** first-run step of #39 (its Phase-6 step). The `transport/ansible` runner (#130) execs `ansible-playbook` from `<ansibleDir>/venv/bin/` and throws `AnsibleUnavailableError` until that venv exists — this PR creates it.

- New `setup/ansible-venv.ts`: an `AnsibleVenvSupervisor` modelled on `AdGuardService` — an immutable `.status` snapshot plus an idempotent, **never-throwing** `bootstrap()` that spawns `python3 -m venv` + `pip install ansible-core==<pinned>` as **subprocesses** and syncs the in-image playbooks into `<ansibleDir>/playbooks/`.
- **In-process at boot**, mirroring the migrate-on-boot (#49) and SSH-keygen (#205) precedents, so the runtime image still ships no Ansible — only the stock `python3-venv` it already carries for exactly this.
- **Idempotent + upgrade-reconciling** via a version sentinel (`<venv>/.pct-ansible-core-version`): create+install when the binary is absent, reinstall when the recorded version drifts from the pin (so an image upgrade reconciles the venv), fast no-op when it matches.
- **Non-blocking:** `app.ts` builds + decorates the supervisor but never runs it; `main.ts` fires `bootstrap()` *after* `listen`, so a slow `pip install` never delays startup. A network-less first run records `unavailable` + a reason instead of crashing.
- **Admin surface:** read-only `GET /api/system/ansible` serialises the status (mirroring `GET /api/dns`) — the "feature disabled + error surfaced in the admin UI" behaviour the deployment doc requires.
- New settings: `ansibleCoreVersion` (`PCT_ANSIBLE_CORE_VERSION`, pinned default `2.18.1`) and `ansiblePlaybookSourceDir` (`PCT_ANSIBLE_PLAYBOOK_SRC`).
- Docs: `server-deployment.md` → "First-run setup" step 2 + the `docker-entrypoint.sh` comment updated (the venv bootstrap is now an in-process boot step).

## Plan

Linked plan: `.claude/plans/issue-39-ansible-venv-bootstrap.md`
Roadmap: `docs/roadmap.md` → Phase 6 (Ansible config push).

## License-boundary note

None crossed. `python3`/`pip`/`ansible-playbook` are all driven as **subprocesses** (`node:child_process`); no Ansible (GPL) is imported or linked in-process, and **no GPL binary is added to the image** — the venv lives in the `/data` volume, created at runtime (`CLAUDE.md` → "License boundaries"; `docs/licensing-analysis.md`). `license-guard` unaffected. **No new dependency.**

## Scope — deferred (tracked in #260)

The dashboard image does not yet COPY the Phase-6 playbooks (build context is `server/`; the playbooks live in `client/ansible/playbooks/`, **outside** it), so the playbook *sync* no-ops on the real image until that packaging gap is closed. The sync code here is complete and correct the moment the playbooks ship. Tracked in **#260** (Dockerfile/build-context work).

#39 is a **cross-phase tracker** and stays open after this slice; the AdGuard Home fetch step → **Phase 7** remains deferred (no AdGuard REST client/config has landed yet).

## Test plan

- [x] `format:check`, `lint`, `typecheck` clean.
- [x] Full unit suite green (1135 tests), coverage 98.87% (gate 80%); `setup/ansible-venv.ts` + `api/system` at 100% statements.
- [x] Supervisor unit matrix: create+install when absent; no-op when present+version match; reinstall on version drift / missing sentinel; `unavailable` (never throws) on venv/pip failure; playbook sync present/absent/throwing — all with an injected runner so no test spawns Python.
- [x] `GET /api/system/ansible`: anon 401 + ready/unavailable/idle serialisation.
- [x] `config`: new settings' defaults + overrides + version validation.

Closes #39 partially — part of the #39 cross-phase tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)