### PR TITLE
feat(client): Timekpr-nExT native warning UX for Alpha-1 (#268)

### DIFF
--- a/.claude/plans/issue-268-timekpr-native-warning-ux.md
+++ b/.claude/plans/issue-268-timekpr-native-warning-ux.md
@@ -1,0 +1,72 @@
+# Issue #268 — Enable + verify Timekpr-nExT native warning UX (Alpha-1)
+
+Roadmap: Phase 3 (client install). Alpha-1 epic #185; acceptance run #261.
+
+## Problem
+
+Alpha-1 ships **without** the `pct-client-agent` toast/cadence/grace UX (Phase
+8b: #103/#101/#106/#104/#105). So the *only* warning a supervised user gets
+before a Timekpr session cutoff is Timekpr-nExT's **own** client indicator. The
+Phase-3 installer installs the `timekpr-next` package but neither configures the
+client indicator's autostart nor verifies it runs — and gives no generous
+advance warning — so enforcement can land as a silent cold logout.
+
+## Upstream facts (verified)
+
+- Package ships the system-wide autostart entry
+  `/etc/xdg/autostart/timekpr-client.desktop`; client/indicator binary is
+  `/usr/bin/timekprc`.
+- `/etc/timekpr/timekpr.conf` keys (defaults):
+  - `TIMEKPR_FINAL_NOTIFICATION_TIME = 60` — single "time's almost up" heads-up,
+    N seconds before termination.
+  - `TIMEKPR_FINAL_WARNING_TIME = 10` — continuous final countdown duration.
+  - `TIMEKPR_TERMINATION_TIME = 15` — irreversible window (left untouched — it is
+    the technical termination-assignment lead, not a warning).
+
+## Design
+
+Generous Alpha-1 lead times (overridable via env, defaults chosen here):
+- `TIMEKPR_FINAL_NOTIFICATION_TIME = 300` (5-minute advance heads-up).
+- `TIMEKPR_FINAL_WARNING_TIME = 60` (final-minute countdown).
+
+Edit only those keys **in place**, preserving the rest of the file (session
+types, excluded users, polltime, …) — never overwrite the whole config.
+
+Autostart: copy the package's own `timekpr-client.desktop` into each supervised
+user's `~/.config/autostart/` (so the `Exec` stays correct across upgrades) and
+force it enabled (`Hidden=false`, `X-GNOME-Autostart-enabled=true`) to defend
+against a stale per-user `Hidden=true` override that would silently suppress the
+indicator on Cinnamon.
+
+## License / tamper posture
+
+Configures an upstream GPL tool by editing its config file + dropping a desktop
+entry — no in-process linkage, no GPL binary added to any image (same model as
+e2guardian). Tamper-resistance ceiling unchanged: this only *enables/verifies*
+an upstream tool's own UX and makes warnings **more** generous.
+
+## Phases
+
+1. **Lib helper + baseline install** (`client/lib/pct-common.sh`,
+   `client/install-baseline-tools.sh`):
+   - `pct_set_conf_key file key value` — idempotent in-place key set
+     (replace-or-append), dry-run aware.
+   - `pct_timekpr_write_user_autostart src dest` — copy + force-enable
+     (unit-testable without resolving a real user).
+   - Extend `pct_baseline_configure_timekpr` to tune the two warning keys.
+   - New per-user step `pct_baseline_configure_timekpr_client` wired after the
+     ActivityWatch step (so `~/.config` is already user-owned).
+   - bats: `pct-common.bats` (set-conf-key), `install-baseline-tools.bats`
+     (dry-run plan lines + real autostart write).
+2. **Self-test + docs** (`client/self-test.sh`, `client/tests/self-test.bats`,
+   `docs/client-install.md`):
+   - `pct_selftest_timekpr_client_autostart` — per supervised user, present &
+     not disabled; fail the enrol otherwise.
+   - Update self-test fixtures + add pass/fail cases.
+   - Document Timekpr's native client as the Alpha-1 warning UX (richer Phase-8b
+     UX is the Alpha-2 gate).
+
+## Tests / gate
+
+`shellcheck` clean across `client/**`; all bats green (no root/network/tools).
+No server/TypeScript changes. No new dependency.

--- a/client/install-baseline-tools.sh
+++ b/client/install-baseline-tools.sh
@@ -63,6 +63,25 @@ TIMEKPR_PPA="${TIMEKPR_PPA:-ppa:mjasnik/ppa}"
 # step idempotent; overridable so tests can point it at a fixture.
 TIMEKPR_PPA_LIST_GLOB="${TIMEKPR_PPA_LIST_GLOB:-/etc/apt/sources.list.d/*mjasnik*.list}"
 
+# Timekpr-nExT's own config + client-indicator autostart (#268). In Alpha-1 the
+# richer pct-client-agent cadence/grace UX (Phase 8b) is not shipped, so
+# Timekpr-nExT's native client indicator is the ONLY warning a supervised user
+# gets before a session cutoff. We tune its warning lead times to be generous
+# and ensure its indicator autostarts for each supervised user. All paths +
+# values are overridable on the established PCT_* pattern so the tests can
+# exercise this without root or the package installed.
+PCT_TIMEKPR_CONF="${PCT_TIMEKPR_CONF:-/etc/timekpr/timekpr.conf}"
+# Seconds before a cutoff for the single "time's almost up" heads-up
+# (upstream default 60). Generous Alpha-1 value: 5 minutes of warning.
+PCT_TIMEKPR_FINAL_NOTIFICATION_TIME="${PCT_TIMEKPR_FINAL_NOTIFICATION_TIME:-300}"
+# Seconds of continuous final countdown before a cutoff (upstream default 10).
+# Generous Alpha-1 value: the whole final minute counts down.
+PCT_TIMEKPR_FINAL_WARNING_TIME="${PCT_TIMEKPR_FINAL_WARNING_TIME:-60}"
+# The package's system-wide client-indicator autostart entry, and the per-user
+# filename we drop into ~/.config/autostart to guarantee + force-enable it.
+PCT_TIMEKPR_AUTOSTART_SRC="${PCT_TIMEKPR_AUTOSTART_SRC:-/etc/xdg/autostart/timekpr-client.desktop}"
+PCT_TIMEKPR_CLIENT_DESKTOP="${PCT_TIMEKPR_CLIENT_DESKTOP:-timekpr-client.desktop}"
+
 # Where the per-supervised-user e2guardian baseline skeletons live. A
 # pct-namespaced directory so we never disturb a household's existing
 # e2guardian config; Phase 6 Ansible reads these as the seed for the real
@@ -159,11 +178,21 @@ pct_baseline_install_activitywatch() {
 # --- step: Timekpr-nExT ----------------------------------------------------
 
 pct_baseline_configure_timekpr() {
-  pct_step "Configure Timekpr-nExT (baseline: enable daemon, empty policy)"
+  pct_step "Configure Timekpr-nExT (baseline: daemon + generous Alpha-1 warnings)"
   # Initial policy is intentionally empty — the dashboard pushes limits via
   # `timekpra` over SSH after enrolment. We only ensure the daemon is up and
   # the CLI the server drives is on PATH.
   pct_run systemctl enable --now timekpr.service
+
+  # Give supervised users plenty of advance warning before a session cutoff.
+  # Alpha-1 has no pct-client-agent cadence/grace UX (Phase 8b), so this is the
+  # only warning the user gets. Edit just these keys in place — the rest of the
+  # upstream config (session types, excluded users, polltime, …) is preserved.
+  pct_set_conf_key "$PCT_TIMEKPR_CONF" \
+    TIMEKPR_FINAL_NOTIFICATION_TIME "$PCT_TIMEKPR_FINAL_NOTIFICATION_TIME"
+  pct_set_conf_key "$PCT_TIMEKPR_CONF" \
+    TIMEKPR_FINAL_WARNING_TIME "$PCT_TIMEKPR_FINAL_WARNING_TIME"
+
   if pct_is_dry_run; then
     printf '%s %s\n' "$PCT_DRYRUN_PREFIX" "command -v timekpra" >&2
   elif command -v timekpra >/dev/null 2>&1; then
@@ -171,6 +200,50 @@ pct_baseline_configure_timekpr() {
   else
     pct_warn "timekpra not found on PATH; the dashboard's SSH transport needs it (check the timekpr-next install)"
   fi
+}
+
+# --- step: Timekpr-nExT client indicator autostart (per supervised user) ----
+
+# Copy the package's client-indicator autostart entry to `dest`, forcing it
+# enabled (stripping any Hidden / X-GNOME-Autostart-enabled lines and appending
+# the enabled forms). Factored out so it is unit-testable without resolving a
+# real user's home. Copying the package's own .desktop keeps its `Exec` correct
+# across upgrades; the force-enable defends against a stale per-user override.
+pct_timekpr_write_user_autostart() {
+  local src="$1" dest="$2"
+  mkdir -p "$(dirname "$dest")"
+  {
+    grep -viE '^[[:space:]]*(Hidden|X-GNOME-Autostart-enabled)[[:space:]]*=' "$src" || true
+    printf 'Hidden=false\nX-GNOME-Autostart-enabled=true\n'
+  } >"$dest"
+}
+
+pct_baseline_configure_timekpr_client() {
+  pct_step "Enable the Timekpr-nExT client indicator autostart (per supervised user)"
+  local user home dest
+  for user in "$@"; do
+    if ! pct_is_dry_run && ! getent passwd "$user" >/dev/null 2>&1; then
+      pct_warn "supervised user '${user}' does not exist; skipping client-indicator autostart"
+      continue
+    fi
+    home="$(getent passwd "$user" | cut -d: -f6 || true)"
+    [ -n "$home" ] || home="/home/${user}"
+    dest="${home}/.config/autostart/${PCT_TIMEKPR_CLIENT_DESKTOP}"
+    pct_log "Timekpr-nExT client indicator autostart for ${user}"
+
+    if pct_is_dry_run; then
+      printf '%s enable timekpr client indicator autostart for %s -> %s (from %s)\n' \
+        "$PCT_DRYRUN_PREFIX" "$user" "$dest" "$PCT_TIMEKPR_AUTOSTART_SRC" >&2
+      continue
+    fi
+
+    if [ ! -r "$PCT_TIMEKPR_AUTOSTART_SRC" ]; then
+      pct_warn "no system autostart entry ${PCT_TIMEKPR_AUTOSTART_SRC}; is timekpr-next installed? the time-left indicator may not appear for ${user}"
+      continue
+    fi
+    pct_timekpr_write_user_autostart "$PCT_TIMEKPR_AUTOSTART_SRC" "$dest"
+    pct_chown_user "$user" "${home}/.config/autostart"
+  done
 }
 
 # --- step: ActivityWatch per-user systemd --user units ---------------------
@@ -323,6 +396,7 @@ pct_install_baseline_tools() {
   pct_baseline_install_activitywatch
   pct_baseline_configure_timekpr
   pct_baseline_configure_activitywatch "$@"
+  pct_baseline_configure_timekpr_client "$@"
   pct_baseline_configure_e2guardian "$@"
   pct_ok "baseline tool install complete for: $*"
   if pct_is_dry_run; then

--- a/client/install-baseline-tools.sh
+++ b/client/install-baseline-tools.sh
@@ -73,6 +73,9 @@ TIMEKPR_PPA_LIST_GLOB="${TIMEKPR_PPA_LIST_GLOB:-/etc/apt/sources.list.d/*mjasnik
 PCT_TIMEKPR_CONF="${PCT_TIMEKPR_CONF:-/etc/timekpr/timekpr.conf}"
 # Seconds before a cutoff for the single "time's almost up" heads-up
 # (upstream default 60). Generous Alpha-1 value: 5 minutes of warning.
+# Invariant: keep this >= the final-warning countdown below — the heads-up
+# fires first, then the continuous countdown runs through to the cutoff. If you
+# override one, override the other so the ordering holds.
 PCT_TIMEKPR_FINAL_NOTIFICATION_TIME="${PCT_TIMEKPR_FINAL_NOTIFICATION_TIME:-300}"
 # Seconds of continuous final countdown before a cutoff (upstream default 10).
 # Generous Alpha-1 value: the whole final minute counts down.

--- a/client/lib/pct-common.sh
+++ b/client/lib/pct-common.sh
@@ -139,7 +139,9 @@ pct_chown_user() {
 # /etc/timekpr/timekpr.conf) without rewriting the whole file — so the package's
 # other settings survive. KEY must be a bare token (no regex metacharacters);
 # VALUE must not contain a newline. A leading `#` comment is never matched, so a
-# documentation comment for the same key is left alone.
+# documentation comment for the same key is left alone. Assumes at most one
+# uncommented assignment of KEY (the upstream config shape); if several exist
+# they are all rewritten to the same value rather than collapsed to one.
 # Usage: pct_set_conf_key /etc/timekpr/timekpr.conf TIMEKPR_FINAL_WARNING_TIME 60
 pct_set_conf_key() {
   local file="$1" key="$2" value="$3"

--- a/client/lib/pct-common.sh
+++ b/client/lib/pct-common.sh
@@ -131,3 +131,33 @@ pct_chown_user() {
   local user="$1" path="$2"
   pct_run chown -R "${user}:" "$path"
 }
+
+# Set `KEY = VALUE` in a simple `key = value` config file, replacing an existing
+# (uncommented) assignment in place or appending it, and leaving every other
+# line untouched. Dry-run aware. Used to tune specific keys in an upstream
+# tool's own config (e.g. Timekpr-nExT's warning lead times in
+# /etc/timekpr/timekpr.conf) without rewriting the whole file — so the package's
+# other settings survive. KEY must be a bare token (no regex metacharacters);
+# VALUE must not contain a newline. A leading `#` comment is never matched, so a
+# documentation comment for the same key is left alone.
+# Usage: pct_set_conf_key /etc/timekpr/timekpr.conf TIMEKPR_FINAL_WARNING_TIME 60
+pct_set_conf_key() {
+  local file="$1" key="$2" value="$3"
+  if pct_is_dry_run; then
+    printf '%s set %s = %s in %s\n' "$PCT_DRYRUN_PREFIX" "$key" "$value" "$file" >&2
+    return 0
+  fi
+  mkdir -p "$(dirname "$file")"
+  [ -f "$file" ] || : >"$file"
+  if grep -qE "^[[:space:]]*${key}[[:space:]]*=" "$file"; then
+    # Replace the existing assignment in place via a temp file, then copy the
+    # result back so the original file keeps its inode/permissions.
+    local tmp
+    tmp="$(mktemp)"
+    sed -E "s|^[[:space:]]*${key}[[:space:]]*=.*|${key} = ${value}|" "$file" >"$tmp"
+    cat "$tmp" >"$file"
+    rm -f "$tmp"
+  else
+    printf '%s = %s\n' "$key" "$value" >>"$file"
+  fi
+}

--- a/client/self-test.sh
+++ b/client/self-test.sh
@@ -16,9 +16,11 @@
 #   2. the dashboard SSH key is authorized for pct-agent (and sshd is up)
 #   3. the pct-agent sudoers drop-in is scoped to exactly `timekpra`
 #   4. the Timekpr-nExT daemon is up and `timekpra` answers for each user
-#   5. aw-server is reachable on loopback and returns buckets
-#   6. e2guardian is active
-#   7. the dashboard enrolment record is present
+#   5. the Timekpr-nExT client indicator autostarts for each supervised user
+#      (the Alpha-1 warning UX — see docs/client-install.md)
+#   6. aw-server is reachable on loopback and returns buckets
+#   7. e2guardian is active
+#   8. the dashboard enrolment record is present
 #
 # This is the client-side complement to the admin "Clients" health page (#81),
 # which shows the same component states from the server's perspective.
@@ -73,6 +75,10 @@ PCT_SUDOERS_DIR="${PCT_SUDOERS_DIR:-/etc/sudoers.d}"
 PCT_SSHD_SERVICE="${PCT_SSHD_SERVICE:-ssh.service}"
 PCT_TIMEKPR_SERVICE="${PCT_TIMEKPR_SERVICE:-timekpr.service}"
 PCT_E2GUARDIAN_SERVICE="${PCT_E2GUARDIAN_SERVICE:-e2guardian.service}"
+
+# The per-user Timekpr-nExT client-indicator autostart filename (under
+# ~/.config/autostart), kept in step with install-baseline-tools.sh (#268).
+PCT_TIMEKPR_CLIENT_DESKTOP="${PCT_TIMEKPR_CLIENT_DESKTOP:-timekpr-client.desktop}"
 
 # aw-server loopback bind (kept in step with install-baseline-tools.sh).
 AW_HOST="${AW_HOST:-127.0.0.1}"
@@ -226,6 +232,42 @@ pct_selftest_timekpra_users() {
   done
 }
 
+# A supervised user's home directory per the passwd database (first match only).
+pct_selftest_user_home() {
+  "$PCT_GETENT" passwd "$1" 2>/dev/null | head -n1 | cut -d: -f6
+}
+
+# 6b. The Timekpr-nExT client indicator autostarts for each supervised user.
+#
+# In Alpha-1 this is the ONLY pre-cutoff warning a supervised user gets — the
+# richer pct-client-agent cadence/grace/per-app UX is Phase 8b — so a missing
+# or disabled indicator must fail the enrol loudly here rather than surface
+# later as a silent cold logout. Read-only: we check that the per-user autostart
+# entry install-baseline-tools.sh (#268) drops is present and not disabled.
+pct_selftest_timekpr_client_autostart() {
+  local user
+  for user in "$@"; do
+    local desc="Timekpr-nExT client indicator autostarts for '${user}'"
+    if pct_selftest_preview "$desc"; then
+      continue
+    fi
+    local home dest
+    home="$(pct_selftest_user_home "$user")"
+    [ -n "$home" ] || home="/home/${user}"
+    dest="${home}/.config/autostart/${PCT_TIMEKPR_CLIENT_DESKTOP}"
+    if [ ! -f "$dest" ]; then
+      pct_selftest_fail "$desc" "no autostart entry ${dest} (the time-left indicator won't appear; re-run the installer)"
+      continue
+    fi
+    if grep -qiE '^[[:space:]]*Hidden[[:space:]]*=[[:space:]]*true' "$dest" ||
+      grep -qiE '^[[:space:]]*X-GNOME-Autostart-enabled[[:space:]]*=[[:space:]]*false' "$dest"; then
+      pct_selftest_fail "$desc" "${dest} is present but disabled (Hidden=true / autostart disabled)"
+      continue
+    fi
+    pct_selftest_pass "$desc"
+  done
+}
+
 # 7. aw-server is reachable on loopback and returns buckets.
 pct_selftest_aw_server() {
   local desc="aw-server reachable on ${AW_HOST}:${AW_PORT}"
@@ -323,6 +365,7 @@ pct_self_test() {
   pct_selftest_sudoers
   pct_selftest_timekpr_daemon
   pct_selftest_timekpra_users "$@"
+  pct_selftest_timekpr_client_autostart "$@"
   pct_selftest_aw_server
   pct_selftest_e2guardian
   pct_selftest_enrolment

--- a/client/tests/install-baseline-tools.bats
+++ b/client/tests/install-baseline-tools.bats
@@ -118,6 +118,47 @@ plan() { # run the script in dry-run with the given args, capture the plan
   [[ "$output" == *"systemctl enable --now e2guardian.service"* ]]
 }
 
+@test "tunes Timekpr-nExT warning lead times generously for Alpha-1" {
+  plan --supervised-user alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"set TIMEKPR_FINAL_NOTIFICATION_TIME = 300"* ]]
+  [[ "$output" == *"set TIMEKPR_FINAL_WARNING_TIME = 60"* ]]
+}
+
+@test "enables the timekpr client indicator autostart for each supervised user" {
+  plan --supervised-user alice --supervised-user bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"enable timekpr client indicator autostart for alice"* ]]
+  [[ "$output" == *"enable timekpr client indicator autostart for bob"* ]]
+  [[ "$output" == *"timekpr-client.desktop"* ]]
+}
+
+@test "client autostart copies the package entry and force-enables it (real write)" {
+  # A package autostart entry that is DISABLED by a stale Hidden=true; the copy
+  # must keep its Exec but flip it back on.
+  local src="${TMP}/timekpr-client.desktop"
+  cat >"$src" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=Timekpr-nExT Client
+Exec=timekprc --indicator
+Hidden=true
+X-GNOME-Autostart-enabled=false
+EOF
+  local dest="${TMP}/home/.config/autostart/timekpr-client.desktop"
+  run env -u PCT_DRY_RUN bash -c \
+    '. "$1"; pct_timekpr_write_user_autostart "$2" "$3"' _ "$SCRIPT" "$src" "$dest"
+  [ "$status" -eq 0 ]
+  [ -f "$dest" ]
+  # Exec is preserved from the package entry...
+  grep -qxF 'Exec=timekprc --indicator' "$dest"
+  # ...and the entry is forced enabled (no leftover disabling lines).
+  grep -qxF 'Hidden=false' "$dest"
+  grep -qxF 'X-GNOME-Autostart-enabled=true' "$dest"
+  ! grep -qiE '^[[:space:]]*Hidden[[:space:]]*=[[:space:]]*true' "$dest"
+  ! grep -qiE '^[[:space:]]*X-GNOME-Autostart-enabled[[:space:]]*=[[:space:]]*false' "$dest"
+}
+
 @test "does no iptables work (deferred to Phase 6 Ansible)" {
   plan --supervised-user alice
   # No iptables command should appear anywhere in the executed plan.

--- a/client/tests/pct-common.bats
+++ b/client/tests/pct-common.bats
@@ -109,3 +109,49 @@ EOF
   [ -f "$target" ]
   [ "$(cat "$target")" = "$(printf 'line one\nline two')" ]
 }
+
+@test "pct_set_conf_key reports intent (and writes nothing) under dry-run" {
+  local target="${TMP}/timekpr.conf"
+  PCT_DRY_RUN=1 run pct_set_conf_key "$target" TIMEKPR_FINAL_WARNING_TIME 60
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run] set TIMEKPR_FINAL_WARNING_TIME = 60 in ${target}"* ]]
+  [ ! -e "$target" ]
+}
+
+@test "pct_set_conf_key replaces an existing key in place, preserving other lines" {
+  local target="${TMP}/timekpr.conf"
+  cat >"$target" <<'EOF'
+[GENERAL]
+TIMEKPR_POLLTIME = 3
+TIMEKPR_FINAL_WARNING_TIME = 10
+TIMEKPR_TERMINATION_TIME = 15
+EOF
+  unset PCT_DRY_RUN
+  pct_set_conf_key "$target" TIMEKPR_FINAL_WARNING_TIME 60
+  grep -qxF 'TIMEKPR_FINAL_WARNING_TIME = 60' "$target"
+  # The old value is gone and the neighbouring keys are untouched.
+  ! grep -qxF 'TIMEKPR_FINAL_WARNING_TIME = 10' "$target"
+  grep -qxF 'TIMEKPR_POLLTIME = 3' "$target"
+  grep -qxF 'TIMEKPR_TERMINATION_TIME = 15' "$target"
+  # Exactly one assignment for the key (no duplicate appended).
+  [ "$(grep -cE '^[[:space:]]*TIMEKPR_FINAL_WARNING_TIME[[:space:]]*=' "$target")" -eq 1 ]
+}
+
+@test "pct_set_conf_key appends the key when it is absent" {
+  local target="${TMP}/timekpr.conf"
+  printf '[GENERAL]\nTIMEKPR_POLLTIME = 3\n' >"$target"
+  unset PCT_DRY_RUN
+  pct_set_conf_key "$target" TIMEKPR_FINAL_NOTIFICATION_TIME 300
+  grep -qxF 'TIMEKPR_FINAL_NOTIFICATION_TIME = 300' "$target"
+  grep -qxF 'TIMEKPR_POLLTIME = 3' "$target"
+}
+
+@test "pct_set_conf_key does not match a commented-out key (appends instead)" {
+  local target="${TMP}/timekpr.conf"
+  printf '# TIMEKPR_FINAL_WARNING_TIME = doc comment\n' >"$target"
+  unset PCT_DRY_RUN
+  pct_set_conf_key "$target" TIMEKPR_FINAL_WARNING_TIME 60
+  # The comment is preserved and a real assignment is appended.
+  grep -qF '# TIMEKPR_FINAL_WARNING_TIME = doc comment' "$target"
+  grep -qxF 'TIMEKPR_FINAL_WARNING_TIME = 60' "$target"
+}

--- a/client/tests/self-test.bats
+++ b/client/tests/self-test.bats
@@ -60,6 +60,19 @@ pct-agent ALL=(root) NOPASSWD: /usr/bin/timekpra
 EOF
   chmod 440 "${SUDOERS_DIR}/pct-agent"
 
+  # Timekpr-nExT client-indicator autostart entry (#268). The getent stub
+  # resolves every supervised user's home to STUB_AGENT_HOME, so the per-user
+  # autostart check finds it here.
+  mkdir -p "${STUB_AGENT_HOME}/.config/autostart"
+  cat >"${STUB_AGENT_HOME}/.config/autostart/timekpr-client.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=Timekpr-nExT Client
+Exec=timekprc --indicator
+Hidden=false
+X-GNOME-Autostart-enabled=true
+EOF
+
   STATE_DIR="${TMP}/state"
   mkdir -p "$STATE_DIR"
   cat >"${STATE_DIR}/pct-client.env" <<'EOF'
@@ -105,6 +118,7 @@ run_selftest() { run env bash "$SCRIPT" "$@"; }
   [[ "$output" == *"[ok] pct-agent service account exists"* ]]
   [[ "$output" == *"[ok] dashboard SSH key authorized for pct-agent"* ]]
   [[ "$output" == *"[ok] timekpra reports status for 'alice'"* ]]
+  [[ "$output" == *"[ok] Timekpr-nExT client indicator autostarts for 'alice'"* ]]
   [[ "$output" == *"[ok] aw-server reachable on 127.0.0.1:5600"* ]]
   [[ "$output" == *"[ok] client enrolled with the dashboard"* ]]
 }
@@ -190,6 +204,23 @@ run_selftest() { run env bash "$SCRIPT" "$@"; }
   STUB_TIMEKPRA_FAIL=1 run_selftest --supervised-user alice
   [ "$status" -eq 1 ]
   [[ "$output" == *"[error] timekpra reports status for 'alice'"* ]]
+}
+
+@test "missing timekpr client indicator autostart -> failure" {
+  rm -f "${STUB_AGENT_HOME}/.config/autostart/timekpr-client.desktop"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[error] Timekpr-nExT client indicator autostarts for 'alice'"* ]]
+  [[ "$output" == *"the time-left indicator won't appear"* ]]
+}
+
+@test "disabled (Hidden=true) timekpr client indicator autostart -> failure" {
+  printf '[Desktop Entry]\nExec=timekprc --indicator\nHidden=true\n' \
+    >"${STUB_AGENT_HOME}/.config/autostart/timekpr-client.desktop"
+  run_selftest --supervised-user alice
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"[error] Timekpr-nExT client indicator autostarts for 'alice'"* ]]
+  [[ "$output" == *"present but disabled"* ]]
 }
 
 @test "aw-server unreachable -> failure" {

--- a/docs/client-install.md
+++ b/docs/client-install.md
@@ -61,6 +61,29 @@ dashboard, has a short TTL, and is single-use.
 4. **Configure Timekpr-nExT**
    - Enable the daemon. Initial policy is empty; the server will push
      policy via `timekpra` after enrolment completes.
+   - **Tune the native warning lead times** in `/etc/timekpr/timekpr.conf`
+     (only these keys are edited in place; the rest of the upstream config
+     is preserved): `TIMEKPR_FINAL_NOTIFICATION_TIME = 300` (a single
+     "time's almost up" heads-up five minutes before a cutoff) and
+     `TIMEKPR_FINAL_WARNING_TIME = 60` (a final-minute countdown). Both are
+     overridable via `PCT_TIMEKPR_FINAL_NOTIFICATION_TIME` /
+     `PCT_TIMEKPR_FINAL_WARNING_TIME`.
+   - **Autostart the client indicator** for each supervised user: copy the
+     package's `/etc/xdg/autostart/timekpr-client.desktop` into the user's
+     `~/.config/autostart/` and force it enabled (`Hidden=false`,
+     `X-GNOME-Autostart-enabled=true`), so the tray icon and time-left
+     notifications appear on Cinnamon login even if a stale per-user override
+     had disabled it.
+
+   > **Alpha-1 warning UX.** Timekpr-nExT's *own* client indicator is the
+   > warning mechanism for Alpha-1 — it is the only pre-cutoff warning a
+   > supervised user gets while the richer `pct-client-agent` experience
+   > (escalating time-remaining cadence, grace-period countdown, per-app
+   > force-close toasts and sounds — see
+   > [`client-notifications.md`](client-notifications.md)) is still Phase 8b /
+   > the Alpha-2 gate. That is why the warning lead times above are
+   > deliberately generous and the self-test (step 9) fails the enrol if the
+   > indicator is not set to autostart.
 5. **Configure ActivityWatch**
    - Install `aw-server`, `aw-watcher-window`, `aw-watcher-afk` as
      systemd `--user` units enabled for each supervised user.
@@ -113,7 +136,10 @@ dashboard, has a short TTL, and is single-use.
      round-trip itself needs the dashboard's private key, so it is verified
      server-side); the `pct-agent` sudoers drop-in is scoped to exactly
      `timekpra`; the Timekpr-nExT daemon is active and `timekpra --userinfo
-     <user>` answers for each supervised user; `aw-server` is reachable on
+     <user>` answers for each supervised user; the Timekpr-nExT client
+     indicator is set to autostart for each supervised user (the Alpha-1
+     warning UX — a missing/disabled indicator fails the enrol rather than
+     producing a silent cold cutoff); `aw-server` is reachable on
      `localhost:5600` and returns buckets; e2guardian is active; and the
      dashboard enrolment record (`/etc/pct/pct-client.env`) is present and
      `0600`.


### PR DESCRIPTION
## Summary

Alpha-1 ships **without** the `pct-client-agent` toast/cadence/grace UX (Phase 8b: #103/#101/#106/#104/#105), so Timekpr-nExT's **own** client indicator is the only warning a supervised user gets before a session cutoff. The Phase-3 installer installed the `timekpr-next` package but never configured the indicator's autostart or gave generous advance warning — enforcement could land as a silent cold logout. This makes Timekpr's native client the reliable, verified Alpha-1 warning mechanism.

- **Tune** (`install-baseline-tools.sh`): set `TIMEKPR_FINAL_NOTIFICATION_TIME = 300` (5-minute heads-up) and `TIMEKPR_FINAL_WARNING_TIME = 60` (final-minute countdown) in `/etc/timekpr/timekpr.conf`, editing only those keys **in place** so the rest of the upstream config survives. New `pct_set_conf_key` helper in `pct-common.sh` (idempotent replace-or-append, dry-run aware).
- **Install**: new per-user step copies the package's `/etc/xdg/autostart/timekpr-client.desktop` into each supervised user's `~/.config/autostart/` (keeping `Exec` correct across upgrades) and force-enables it (`Hidden=false`, `X-GNOME-Autostart-enabled=true`) to defend against a stale per-user disable.
- **Verify** (`self-test.sh`): new read-only per-user check that the indicator autostart is present and not disabled; fails the enrol loudly otherwise (same non-punitive style as the existing checks).
- **Docs** (`docs/client-install.md`): note that Timekpr's native client is the Alpha-1 warning UX and the richer `pct-client-agent` cadence/grace/per-app toasts are Phase 8b / the Alpha-2 gate.

All paths/values are overridable on the established `PCT_*` pattern.

## Plan

Linked plan: `.claude/plans/issue-268-timekpr-native-warning-ux.md`
Roadmap: `docs/roadmap.md` → Phase 3 (client install). Alpha-1 epic #185; acceptance run #261.

## License-boundary note

N/A to the GPL boundary — configures an upstream GPL tool (Timekpr-nExT) by editing its own config file and dropping a desktop entry, no in-process linkage, no GPL binary added to any image (same model as e2guardian). No transport/packaging/Docker change; `license-guard` unaffected. **Tamper-resistance ceiling unchanged** — this only enables/verifies an upstream tool's own UX and makes warnings *more* generous. No new dependency.

## Test plan

- [x] `shellcheck` clean across `client/**` + `scripts/**`.
- [x] `pct-common.bats` — `pct_set_conf_key`: dry-run preview, in-place replace (preserving neighbours, no duplicate), append-when-absent, commented-key not matched.
- [x] `install-baseline-tools.bats` — dry-run plan tunes both warning keys; per-user autostart enable line; real-write copy preserves `Exec` and force-enables a `Hidden=true` package entry.
- [x] `self-test.bats` — green path asserts the new indicator check; missing entry and disabled (`Hidden=true`) entry both fail the enrol.
- [x] Full client bats suite green (no root/network/tools); no server/TypeScript changes.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYH9uZX62rCcA6QdrH656M)_