### PR TITLE
feat(transport): admin "Add time today" same-day timekpra adjustment (#257)

### DIFF
--- a/.claude/plans/issue-257-add-time-today.md
+++ b/.claude/plans/issue-257-add-time-today.md
@@ -1,0 +1,104 @@
+# Issue #257 — Admin "Add time today" (same-day `timekpra` adjustment)
+
+Roadmap: `docs/roadmap.md` → **Phase 4** (SSH + `timekpra` transport).
+Epic: #185 (Alpha-1 readiness), folded-in decision #2 — the pre-Grant-ledger
+"give Alice 30 more minutes right now" lever.
+
+## Goal
+
+A manual admin action — `/api` route + `timekpra` transport op + an admin-UI
+button — that adjusts a supervised user's **remaining time for _today_** on the
+client(s) they're linked to, **without** changing the standing daily `Budget`.
+
+## Key design decision — online-only, NOT offline-queued
+
+The issue text says "routed through … the offline queue (#161)". I am
+**deliberately diverging** and applying online-only, because:
+
+- The offline queue (#84) is **at-least-once with coalescing**, and its
+  `drainer.ts` contract explicitly requires **idempotent** executors. The
+  standing policy push is idempotent (re-resolve effective policy → set
+  _absolute_ limits). An additive `--settimeleft +N` is **not** idempotent:
+  a crash-then-replay would double-apply, and coalescing two queued `+15`s
+  (latest-wins) would silently drop one. Both are correctness bugs.
+- This lever is an **ephemeral same-day** nudge that "does not persist past the
+  daily rollover" (issue text) — a change queued against an offline client is
+  likely moot by the time the client reconnects.
+
+So: apply **synchronously** to each reachable linked client; report a per-client
+`unreachable` outcome for offline ones (no enqueue). The transport command is
+still **audited** (#85) on every path. Documented in `docs/architecture.md`;
+divergence flagged on the issue + PR. A queue-safe (absolute-target) variant can
+be a later follow-up if wanted.
+
+Also distinct from the existing push: this is an **awaitable** operation that
+returns a result to the admin, not the fire-and-forget `PolicyPushStub.push`.
+
+## Timekpr grammar
+
+`timekpra --settimeleft USER OPERATION SECONDS`, `OPERATION ∈ {+,-,=}`
+(verified against upstream `timekpra` admin CLI docs; ISO/seconds conventions as
+the other builders use). `+`/`-` adjust today's remaining time; `=` sets it.
+
+## Phases
+
+### Phase 1 — Transport (pure + client method)
+- `transport/timekpr/commands.ts`: `TimeLeftOperation` type (`"+"|"-"|"="`),
+  `buildSetTimeLeft(username, op, seconds)` → `["--settimeleft", username, op,
+  String(seconds)]`, with `assertUsername` + `assertSeconds` + op validation.
+- `transport/timekpr/client.ts`: `setTimeLeft(op, seconds)` via `#exec`.
+- Re-export `TimeLeftOperation` / `buildSetTimeLeft` from `timekpr/index.ts`.
+- Tests: `tests/transport/timekpr/commands.test.ts` (new cases),
+  `tests/transport/timekpr/client.test.ts` (new case).
+
+### Phase 2 — Adjustment service + live wiring
+- `transport/time-today/adjust.ts`:
+  - `TimeTodayClient` (structural: `setTimeLeft`), `TimeTodayClientFactory`.
+  - `TimeTodayAdjustment` (`userId`, `operation`, `seconds`, optional `clientId`).
+  - `ClientAdjustmentResult` (`clientId`, `osUsername`, `status:
+    applied|unreachable|failed`, optional `error`).
+  - `adjustTimeToday(db, buildClient, adjustment)` — resolves the user's links
+    (optionally filtered to `clientId`), runs `setTimeLeft` per client, maps the
+    SSH taxonomy via `isRetriable` → `unreachable` vs `failed`. Pure of HTTP.
+- `transport/policy-push/bootstrap.ts`: in **live** mode add
+  `adjustTimeToday` to the returned `PolicyPushTransport`, built from the same
+  audited SSH `TimekprClient` factory (context `actor:"admin"`,
+  `reason:"time.adjusted"`). In **fallback** mode (no SSH key) leave it
+  `undefined` (mirrors how `policyPush` is optional) so the route returns 503.
+- `transport/policy-push/index.ts`: export the new types.
+- Tests: `tests/transport/time-today/adjust.test.ts`; extend
+  `tests/transport/policy-push/bootstrap.test.ts` for live-vs-fallback presence.
+
+### Phase 3 — API route
+- `api/policy/dtos.ts`: `adjustTimeTodaySchema` (refine: exactly one of
+  `deltaSeconds` (int, non-zero, bounded ±86400) / `setSeconds` (int 0..86400);
+  optional `clientId` positive int) + `timeTodayResponseSchema` +
+  `toTimeTodayResponse`. Re-export from `api/policy/index.ts` and the `api/`
+  barrel.
+- `api/policy/time-today.ts`: `registerTimeTodayRoutes(scope, adjuster?)` —
+  `POST /users/:userId/time-today`, admin-guarded; 404 unknown user; 404 when a
+  given `clientId` isn't linked; 409 `no_linked_clients` when the user has no
+  links; 503 `transport_unavailable` when `adjuster` is absent. Maps delta sign
+  → `+`/`-`, `setSeconds` → `=`.
+- `api/plugin.ts` + `web/app.ts`: thread `policyPush.adjustTimeToday` through.
+- Tests: `tests/api/time-today.test.ts` (app.inject: 401/404/409/503/200 +
+  per-client result shape + delta/set mapping + validation).
+
+### Phase 4 — Admin UI
+- `frontend/src/lib/api/time-today.ts`: `adjustTimeToday(userId, body)` wrapper.
+- `frontend/src/lib/api/contract.ts`: re-export the two DTO types.
+- `LinksView.svelte`: per-user "Add time today" control (`+15` / `+30` / custom
+  minutes, optional per-client) with the **not-a-Grant** caveat, surfacing the
+  per-client applied/unreachable/failed result. Online-only is honest in copy.
+- Test: `frontend/tests/components/links-view-time-today.test.ts`.
+
+## License boundary
+
+None touched — still exec-over-SSH of `timekpra` (GPL) as a subprocess via the
+existing facade; no in-process linkage, no GPL binary in the image, no new
+dependency, no transport/REST boundary collapsed. UI `/api` stays type-only.
+
+## Out of scope (tracked elsewhere)
+- Grant ledger / additive auditable overlay + integrator grants — Phase 10.
+- `lockout.cleared` event / "you can log back in" toast — Phase 8b/8c.
+- Queue-safe (absolute-target) offline variant — follow-up issue if wanted.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -266,6 +266,36 @@ works (the change is logged, not dispatched). The file-level Ansible push
 (step 4) is still Phase 6, and PlayTime / per-activity limits are Phase 8 — both
 plug into the same call sites without reshaping them.
 
+#### "Add time today" — the same-day adjustment lever (#257)
+
+`POST /api/users/:userId/time-today` is a manual admin action that adjusts a
+supervised user's **remaining time for today** (`timekpra --settimeleft USER
+(+|-|=) SECONDS`) on their linked client(s) — the pre-Grant-ledger bonus / unlock
+affordance (#185). It does **not** change the standing daily `Budget`; it is a
+same-day, ephemeral nudge that Timekpr forgets at the daily rollover. The durable,
+auditable, idempotent path is the **Grant ledger** (Phase 10), which supersedes
+this lever.
+
+Two ways it deliberately differs from the standing policy push above:
+
+- **Awaitable, not fire-and-forget.** The admin clicked "give Alice 30 more
+  minutes" and wants to know it took, so the route awaits the transport and
+  returns a per-client `applied | unreachable | failed` result.
+- **Online-only — _not_ routed through the offline queue.** The queue (#84) is
+  at-least-once with coalescing and therefore requires **idempotent** executors;
+  the standing push satisfies that by setting *absolute* limits. An additive
+  `--settimeleft +N` is **not** idempotent — a crash-then-replay would
+  double-apply and coalescing two queued adjustments would drop one. So an
+  adjustment to an unreachable client is reported as `unreachable` rather than
+  queued. (A queue-safe absolute-target variant could be added later if a
+  same-day adjustment to an offline client is ever wanted; tracked as a
+  follow-up.)
+
+Both paths are still recorded in the **audit log** (#85) — the `--settimeleft`
+command is attributed to `actor: "admin"`, `reason: "time.adjusted"`. When the
+live transport isn't wired (no SSH key yet), the route returns `503
+transport_unavailable` rather than silently no-op'ing.
+
 ### Inbound (client → server) — telemetry pull
 
 1. Periodic job on the server (croner inside the dashboard process)

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -45,6 +45,9 @@ export type {
   ExceptionResponse,
   CreateExceptionRequest,
   UpdateExceptionRequest,
+  AdjustTimeTodayRequest,
+  TimeTodayResponse,
+  ClientAdjustmentResultDto,
 } from "../../../../src/api/policy/dtos.js";
 export type { AuditEntryResponse, AuditListResponse } from "../../../../src/api/audit/dtos.js";
 export type {

--- a/server/frontend/src/lib/api/time-today.ts
+++ b/server/frontend/src/lib/api/time-today.ts
@@ -1,0 +1,31 @@
+/**
+ * Call for the "Add time today" same-day adjustment lever (#257).
+ *
+ * Same proven shape as the other `$lib/api/*` wrappers: a thin typed wrapper
+ * over {@link apiFetch}, with the request/response types imported from the
+ * shared `/api` contract so the frontend never re-declares a DTO. This adjusts a
+ * user's *remaining time for today* on their linked client(s) via the server's
+ * `timekpra --settimeleft` transport, without changing the standing daily
+ * `Budget`. It is an online-only nudge: the response reports a per-client
+ * `applied | unreachable | failed` outcome (offline clients are not queued).
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type { AdjustTimeTodayRequest, TimeTodayResponse } from "./contract.js";
+
+/**
+ * Adjust `userId`'s remaining time for today. The body carries exactly one of
+ * `deltaSeconds` (signed, non-zero — `+1800` = "+30 min") or `setSeconds`
+ * (absolute — `0` = lock out now), plus an optional `clientId` to restrict the
+ * adjustment to one linked client. Returns the resolved op + per-client results.
+ */
+export function adjustTimeToday(
+  userId: number,
+  input: AdjustTimeTodayRequest,
+): Promise<TimeTodayResponse> {
+  return apiFetch<TimeTodayResponse>(`/users/${userId}/time-today`, {
+    method: "POST",
+    body: input,
+  });
+}

--- a/server/frontend/src/lib/views/LinksView.svelte
+++ b/server/frontend/src/lib/views/LinksView.svelte
@@ -16,9 +16,11 @@
   import { onMount } from "svelte";
   import { ApiError } from "$lib/api/client.js";
   import type { ClientResponse, LinkResponse, UserResponse } from "$lib/api/contract.js";
+  import type { TimeTodayResponse } from "$lib/api/contract.js";
   import { listUsers } from "$lib/api/users.js";
   import { listClients } from "$lib/api/clients.js";
   import { listUserLinks, upsertLink, deleteLink } from "$lib/api/links.js";
+  import { adjustTimeToday } from "$lib/api/time-today.js";
 
   let users = $state<UserResponse[]>([]);
   let clients = $state<ClientResponse[]>([]);
@@ -35,6 +37,13 @@
   let formOsUsername = $state("");
   let formOsUserRef = $state("");
   let submitting = $state(false);
+
+  // "Add time today" lever (#257): a same-day remaining-time nudge applied to
+  // every client this user is linked to. Not a Grant — see the caveat in the UI.
+  let adjusting = $state(false);
+  let adjustError = $state<string | null>(null);
+  let adjustResult = $state<TimeTodayResponse | null>(null);
+  let customMinutes = $state("");
 
   onMount(load);
 
@@ -72,6 +81,9 @@
 
   async function onSelectUser(): Promise<void> {
     resetForm();
+    adjustResult = null;
+    adjustError = null;
+    customMinutes = "";
     if (selectedUserId === null) {
       links = [];
       return;
@@ -148,6 +160,41 @@
     } catch (err) {
       error = messageOf(err);
     }
+  }
+
+  /**
+   * Apply a same-day time adjustment (in minutes) to every client this user is
+   * linked to. A positive value adds time, a negative value takes it back; the
+   * server records the `--settimeleft` command in the audit log. Online-only —
+   * the result lists each client's applied/unreachable/failed outcome.
+   */
+  async function addTimeToday(minutes: number): Promise<void> {
+    if (selectedUserId === null || minutes === 0 || !Number.isFinite(minutes)) {
+      return;
+    }
+    adjusting = true;
+    adjustError = null;
+    adjustResult = null;
+    try {
+      adjustResult = await adjustTimeToday(selectedUserId, {
+        deltaSeconds: Math.round(minutes * 60),
+      });
+    } catch (err) {
+      adjustError = messageOf(err);
+    } finally {
+      adjusting = false;
+    }
+  }
+
+  /** Apply the custom-minutes field, then clear it. */
+  async function addCustomMinutes(): Promise<void> {
+    const minutes = Number(customMinutes);
+    if (!Number.isFinite(minutes) || minutes === 0) {
+      adjustError = "Enter a non-zero number of minutes";
+      return;
+    }
+    await addTimeToday(minutes);
+    customMinutes = "";
   }
 
   /** Render any thrown value as a UI-safe message. */
@@ -255,6 +302,66 @@
               {/each}
             </tbody>
           </table>
+
+          <section class="add-time" aria-label="Add time today">
+            <h2>Add time today</h2>
+            <p class="caveat">
+              A one-off adjustment to this user's <strong>remaining time
+              today</strong> on every linked client — it does not change their
+              standing daily limit and is forgotten at the next daily rollover.
+              This is <strong>not</strong> a logged reward grant (that's coming
+              later); the change takes effect on the client when it's online.
+            </p>
+            <div class="add-time-controls">
+              <button
+                class="grant"
+                disabled={adjusting}
+                onclick={() => addTimeToday(15)}
+              >
+                +15 min
+              </button>
+              <button
+                class="grant"
+                disabled={adjusting}
+                onclick={() => addTimeToday(30)}
+              >
+                +30 min
+              </button>
+              <span class="custom">
+                <input
+                  type="number"
+                  inputmode="numeric"
+                  step="1"
+                  placeholder="minutes (± )"
+                  bind:value={customMinutes}
+                  disabled={adjusting}
+                  aria-label="Custom minutes (negative to remove time)"
+                />
+                <button class="ghost" disabled={adjusting} onclick={addCustomMinutes}>
+                  {adjusting ? "Applying…" : "Apply"}
+                </button>
+              </span>
+            </div>
+
+            {#if adjustError}
+              <p class="error" role="alert">{adjustError}</p>
+            {/if}
+
+            {#if adjustResult}
+              <ul class="results" aria-label="Adjustment results">
+                {#each adjustResult.results as r (r.clientId)}
+                  <li class={`result result-${r.status}`}>
+                    <span class="result-client">{clientName(r.clientId)}</span>
+                    <span class="result-status">{r.status}</span>
+                    {#if r.error}<span class="result-error">{r.error}</span>{/if}
+                  </li>
+                {/each}
+                {#if adjustResult.results.length === 0}
+                  <li class="muted">No linked clients were affected.</li>
+                {/if}
+              </ul>
+            {/if}
+          </section>
         {/if}
       {/if}
     {/if}
@@ -362,6 +469,73 @@
     background: #dc2626;
   }
   .muted {
+    color: #6b7280;
+  }
+  .add-time {
+    margin-top: 1.5rem;
+    padding: 1rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background: #f9fafb;
+  }
+  .add-time h2 {
+    margin: 0 0 0.4rem;
+    font-size: 1rem;
+  }
+  .caveat {
+    margin: 0 0 0.75rem;
+    color: #6b7280;
+    font-size: 0.85rem;
+    max-width: 40rem;
+  }
+  .add-time-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .custom {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .custom input {
+    width: 9rem;
+    padding: 0.4rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+  }
+  button.grant {
+    background: #047857;
+  }
+  .results {
+    list-style: none;
+    margin: 0.75rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .result {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+  }
+  .result-status {
+    font-weight: 600;
+    text-transform: capitalize;
+  }
+  .result-applied .result-status {
+    color: #047857;
+  }
+  .result-unreachable .result-status {
+    color: #b45309;
+  }
+  .result-failed .result-status {
+    color: #b91c1c;
+  }
+  .result-error {
     color: #6b7280;
   }
   .error {

--- a/server/frontend/tests/components/links-view-time-today.test.ts
+++ b/server/frontend/tests/components/links-view-time-today.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Component test for the "Add time today" control on `LinksView` (#257).
+ *
+ * Exercises the logic this view adds beyond the link CRUD skeleton: picking a
+ * user, the quick +15/+30 and custom-minutes adjustments (minutes → seconds),
+ * and rendering the per-client applied/unreachable result. Drives the real
+ * component against a mocked `$lib/api` (no live backend), following the
+ * established `tests/components/*` pattern.
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ClientResponse,
+  LinkResponse,
+  TimeTodayResponse,
+  UserResponse,
+} from "../../src/lib/api/contract.js";
+
+const listUsers = vi.fn<() => Promise<UserResponse[]>>();
+const listClients = vi.fn<() => Promise<ClientResponse[]>>();
+const listUserLinks = vi.fn<(userId: number) => Promise<LinkResponse[]>>();
+const adjustTimeToday = vi.fn<(userId: number, input: unknown) => Promise<TimeTodayResponse>>();
+
+vi.mock("$lib/api/users", () => ({ listUsers: () => listUsers() }));
+vi.mock("$lib/api/clients", () => ({ listClients: () => listClients() }));
+vi.mock("$lib/api/links", () => ({
+  listUserLinks: (userId: number) => listUserLinks(userId),
+  upsertLink: vi.fn(),
+  deleteLink: vi.fn(),
+}));
+vi.mock("$lib/api/time-today", () => ({
+  adjustTimeToday: (userId: number, input: unknown) => adjustTimeToday(userId, input),
+}));
+
+const { default: LinksView } = await import("../../src/lib/views/LinksView.svelte");
+
+function user(overrides: Partial<UserResponse> = {}): UserResponse {
+  return {
+    id: 1,
+    displayName: "Alice",
+    tz: "UTC",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as UserResponse;
+}
+
+function client(overrides: Partial<ClientResponse> = {}): ClientResponse {
+  return { id: 7, hostname: "mint-01", ...overrides } as ClientResponse;
+}
+
+function link(overrides: Partial<LinkResponse> = {}): LinkResponse {
+  return { userId: 1, clientId: 7, osUsername: "alice", osUserRef: "1001" } as LinkResponse;
+}
+
+/** Pick "Alice" in the user dropdown and wait for her links to load. */
+async function selectAlice(): Promise<void> {
+  await screen.findByRole("option", { name: "Alice" });
+  await fireEvent.change(screen.getByLabelText("User"), { target: { value: "1" } });
+  await screen.findByText("Add time today");
+}
+
+beforeEach(() => {
+  listUsers.mockReset().mockResolvedValue([user()]);
+  listClients.mockReset().mockResolvedValue([client()]);
+  listUserLinks.mockReset().mockResolvedValue([link()]);
+  adjustTimeToday.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("LinksView — Add time today (#257)", () => {
+  it("sends +30 minutes as a 1800-second delta and renders the per-client result", async () => {
+    adjustTimeToday.mockResolvedValue({
+      userId: 1,
+      operation: "+",
+      seconds: 1800,
+      results: [{ clientId: 7, osUsername: "alice", status: "applied" }],
+    });
+
+    render(LinksView);
+    await selectAlice();
+
+    await fireEvent.click(screen.getByRole("button", { name: "+30 min" }));
+
+    await waitFor(() => expect(adjustTimeToday).toHaveBeenCalledWith(1, { deltaSeconds: 1800 }));
+
+    const results = await screen.findByLabelText("Adjustment results");
+    expect(within(results).getByText("mint-01")).toBeInTheDocument();
+    expect(within(results).getByText("applied")).toBeInTheDocument();
+  });
+
+  it("sends a custom minute amount (negative removes time)", async () => {
+    adjustTimeToday.mockResolvedValue({
+      userId: 1,
+      operation: "-",
+      seconds: 600,
+      results: [{ clientId: 7, osUsername: "alice", status: "applied" }],
+    });
+
+    render(LinksView);
+    await selectAlice();
+
+    await fireEvent.input(screen.getByLabelText("Custom minutes (negative to remove time)"), {
+      target: { value: "-10" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => expect(adjustTimeToday).toHaveBeenCalledWith(1, { deltaSeconds: -600 }));
+  });
+
+  it("does not call the API for a zero / empty custom amount", async () => {
+    render(LinksView);
+    await selectAlice();
+
+    await fireEvent.input(screen.getByLabelText("Custom minutes (negative to remove time)"), {
+      target: { value: "0" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(adjustTimeToday).not.toHaveBeenCalled();
+    expect(await screen.findByRole("alert")).toHaveTextContent("non-zero");
+  });
+
+  it("surfaces an unreachable client outcome", async () => {
+    adjustTimeToday.mockResolvedValue({
+      userId: 1,
+      operation: "+",
+      seconds: 900,
+      results: [{ clientId: 7, osUsername: "alice", status: "unreachable", error: "offline" }],
+    });
+
+    render(LinksView);
+    await selectAlice();
+
+    await fireEvent.click(screen.getByRole("button", { name: "+15 min" }));
+
+    const results = await screen.findByLabelText("Adjustment results");
+    expect(within(results).getByText("unreachable")).toBeInTheDocument();
+    expect(within(results).getByText("offline")).toBeInTheDocument();
+  });
+
+  it("shows an error when the adjustment request fails", async () => {
+    adjustTimeToday.mockRejectedValue(new Error("transport unavailable"));
+
+    render(LinksView);
+    await selectAlice();
+
+    await fireEvent.click(screen.getByRole("button", { name: "+15 min" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("transport unavailable");
+  });
+});

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -102,6 +102,15 @@ export {
   groupExceptionResponseSchema,
   type CreateGroupExceptionRequest,
   type GroupExceptionResponse,
+  // "Add time today" same-day adjustment (#257)
+  adjustTimeTodaySchema,
+  timeTodayResponseSchema,
+  clientAdjustmentResultSchema,
+  toTimeLeftCommand,
+  TIME_TODAY_MAX_SECONDS,
+  type AdjustTimeTodayRequest,
+  type TimeTodayResponse,
+  type ClientAdjustmentResultDto,
 } from "./policy/index.js";
 
 // Client-enrolment DTOs (#77): the admin token-mint + install-script enrol

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -11,13 +11,18 @@ import type { FastifyInstance, FastifyPluginAsync } from "fastify";
 import { registerAuth } from "../auth/index.js";
 import type { Settings } from "../config.js";
 import { registerEventStream, type EventHub } from "../events/index.js";
+import type { TimeTodayAdjuster } from "../transport/policy-push/index.js";
 import type { PolicyPushStub } from "../transport/stub.js";
 import { registerAuditRoutes } from "./audit/index.js";
 import { registerClientEnrolmentRoutes, registerClientHealthRoutes } from "./clients/index.js";
 import { registerDnsRoutes } from "./dns/index.js";
 import { registerIntegrationRoutes } from "./integrations/index.js";
 import { registerMetaRoute } from "./meta.js";
-import { registerEffectiveRoutes, registerPolicyRoutes } from "./policy/index.js";
+import {
+  registerEffectiveRoutes,
+  registerPolicyRoutes,
+  registerTimeTodayRoutes,
+} from "./policy/index.js";
 import { registerSystemRoutes } from "./system/index.js";
 import { installApiConventions } from "./validation.js";
 
@@ -37,6 +42,13 @@ export interface ApiPluginOptions {
    * back to the logging stub (#54).
    */
   policyPush?: PolicyPushStub;
+  /**
+   * The awaitable "Add time today" adjuster (#257), present only when the live
+   * transport is wired (SSH key exists). Absent in tests / before the SSH-key
+   * bootstrap (#39), where `POST /users/:userId/time-today` returns a
+   * `503 transport_unavailable`.
+   */
+  timeToday?: TimeTodayAdjuster;
 }
 
 /**
@@ -53,6 +65,10 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   // The live SSH dispatcher (#201) is injected from buildApp; absent it, the
   // routes log the intended push (the Phase-2 stub) instead of dispatching.
   registerPolicyRoutes(scope, opts.policyPush);
+  // "Add time today" same-day lever (#257): POST /users/:userId/time-today.
+  // The live `timekpra`-over-SSH adjuster is injected from buildApp; absent it,
+  // the route reports the transport as unavailable (503).
+  registerTimeTodayRoutes(scope, opts.timeToday);
   // Effective-policy preview (#143): GET /users/:userId/effective. Needs
   // `settings` for the server-default timezone of users with no `tz`.
   registerEffectiveRoutes(scope, opts.settings);
@@ -91,6 +107,7 @@ export function registerApi(
   settings: Settings,
   eventHub: EventHub,
   policyPush?: PolicyPushStub,
+  timeToday?: TimeTodayAdjuster,
 ): void {
   app.register(apiPlugin, {
     prefix: "/api",
@@ -99,5 +116,6 @@ export function registerApi(
     // Spread only when present: under exactOptionalPropertyTypes an explicit
     // `undefined` is not assignable to the optional `policyPush?` field.
     ...(policyPush !== undefined ? { policyPush } : {}),
+    ...(timeToday !== undefined ? { timeToday } : {}),
   });
 }

--- a/server/src/api/policy/dtos.ts
+++ b/server/src/api/policy/dtos.ts
@@ -638,3 +638,82 @@ export function toGroupExceptionResponse(row: GroupExceptionRow): GroupException
     createdAt: row.createdAt.toISOString(),
   };
 }
+
+// --- "Add time today" same-day adjustment (#257) ---------------------------
+
+/**
+ * The most a single adjustment may add, subtract, or set — one day in seconds.
+ * `timekpra` tracks today's remaining time, so anything beyond a day is a
+ * fat-finger rather than a real intent; the bound keeps the lever sane.
+ */
+export const TIME_TODAY_MAX_SECONDS = 86_400;
+
+/**
+ * Body of `POST /users/:userId/time-today`: adjust the user's **remaining time
+ * for today** on their linked client(s), without touching the standing daily
+ * `Budget` (#257). Exactly one of:
+ *
+ * - `deltaSeconds` — a signed, non-zero adjustment (`+1800` = "+30 min",
+ *   `-600` = "take back 10 min"), or
+ * - `setSeconds` — set today's remaining time outright (`0` = lock out now).
+ *
+ * `clientId`, when given, restricts the adjustment to that one linked client;
+ * omitted, it applies to every client the user is linked to.
+ */
+export const adjustTimeTodaySchema = z
+  .object({
+    deltaSeconds: z
+      .number()
+      .int()
+      .min(-TIME_TODAY_MAX_SECONDS)
+      .max(TIME_TODAY_MAX_SECONDS)
+      .refine((n) => n !== 0, { message: "deltaSeconds must be non-zero" })
+      .optional(),
+    setSeconds: z.number().int().min(0).max(TIME_TODAY_MAX_SECONDS).optional(),
+    clientId: z.number().int().positive().optional(),
+  })
+  .refine((b) => (b.deltaSeconds === undefined) !== (b.setSeconds === undefined), {
+    message: "Provide exactly one of deltaSeconds or setSeconds",
+  });
+
+/** The `timekpra --settimeleft` operation: `+`/`-` delta, or `=` set. */
+export const timeLeftOperationSchema = z.enum(["+", "-", "="]);
+
+/** Per-client outcome of an adjustment (mirrors the transport service result). */
+export const clientAdjustmentResultSchema = z.object({
+  clientId: z.number().int(),
+  osUsername: z.string(),
+  status: z.enum(["applied", "unreachable", "failed"]),
+  error: z.string().optional(),
+});
+
+/** Response of `POST /users/:userId/time-today`: the resolved op + per-client results. */
+export const timeTodayResponseSchema = z.object({
+  userId: z.number().int(),
+  operation: timeLeftOperationSchema,
+  seconds: z.number().int(),
+  results: z.array(clientAdjustmentResultSchema),
+});
+
+export type AdjustTimeTodayRequest = z.infer<typeof adjustTimeTodaySchema>;
+export type ClientAdjustmentResultDto = z.infer<typeof clientAdjustmentResultSchema>;
+export type TimeTodayResponse = z.infer<typeof timeTodayResponseSchema>;
+
+/**
+ * Resolve the request body to the `timekpra --settimeleft` operation + a
+ * non-negative second count. A positive delta adds (`+`), a negative delta
+ * subtracts (`-`) its magnitude, and `setSeconds` sets outright (`=`). The DTO's
+ * `refine` guarantees exactly one branch applies.
+ */
+export function toTimeLeftCommand(body: AdjustTimeTodayRequest): {
+  operation: z.infer<typeof timeLeftOperationSchema>;
+  seconds: number;
+} {
+  if (body.deltaSeconds !== undefined) {
+    return body.deltaSeconds >= 0
+      ? { operation: "+", seconds: body.deltaSeconds }
+      : { operation: "-", seconds: -body.deltaSeconds };
+  }
+  // The refine guarantees setSeconds is present when deltaSeconds is not.
+  return { operation: "=", seconds: body.setSeconds ?? 0 };
+}

--- a/server/src/api/policy/dtos.ts
+++ b/server/src/api/policy/dtos.ts
@@ -691,7 +691,9 @@ export const clientAdjustmentResultSchema = z.object({
 export const timeTodayResponseSchema = z.object({
   userId: z.number().int(),
   operation: timeLeftOperationSchema,
-  seconds: z.number().int(),
+  // The applied magnitude in seconds — always the non-negative count passed to
+  // `--settimeleft`, bounded like the request (one day max).
+  seconds: z.number().int().min(0).max(TIME_TODAY_MAX_SECONDS),
   results: z.array(clientAdjustmentResultSchema),
 });
 

--- a/server/src/api/policy/index.ts
+++ b/server/src/api/policy/index.ts
@@ -4,6 +4,7 @@
  * top-level `api/` barrel so the contract is imported from one place.
  */
 export { registerPolicyRoutes } from "./routes.js";
+export { registerTimeTodayRoutes } from "./time-today.js";
 export {
   registerEffectiveRoutes,
   activeRuleResponseSchema,
@@ -89,4 +90,13 @@ export {
   groupExceptionResponseSchema,
   type CreateGroupExceptionRequest,
   type GroupExceptionResponse,
+  // "Add time today" same-day adjustment (#257)
+  adjustTimeTodaySchema,
+  timeTodayResponseSchema,
+  clientAdjustmentResultSchema,
+  toTimeLeftCommand,
+  TIME_TODAY_MAX_SECONDS,
+  type AdjustTimeTodayRequest,
+  type TimeTodayResponse,
+  type ClientAdjustmentResultDto,
 } from "./dtos.js";

--- a/server/src/api/policy/time-today.ts
+++ b/server/src/api/policy/time-today.ts
@@ -1,0 +1,91 @@
+/**
+ * The "Add time today" admin route (#257):
+ * `POST /api/users/:userId/time-today`.
+ *
+ * The pre-Grant-ledger bonus / unlock lever (#185): adjust a supervised user's
+ * **remaining time for today** on their linked client(s) via `timekpra
+ * --settimeleft`, without touching the standing daily `Budget`. Unlike the CRUD
+ * routes' fire-and-forget policy push, this **awaits** the transport so the
+ * admin gets a per-client applied/unreachable/failed result back.
+ *
+ * The live adjustment is the injected {@link TimeTodayAdjuster} (the audited
+ * `timekpra`-over-SSH service from the policy-push bootstrap). When it is absent
+ * — dev / CI / before first-run SSH keygen (#39) — the route reports the
+ * transport as unavailable (503) rather than silently doing nothing, mirroring
+ * how the CRUD routes degrade to the logging push stub.
+ *
+ * License boundary: none touched — plain TypeScript + zod over the injected
+ * transport, which execs `timekpra` over the SSH subprocess facade.
+ */
+import type { FastifyInstance } from "fastify";
+
+import * as repo from "../../policy/repository.js";
+import type { TimeTodayAdjuster } from "../../transport/policy-push/index.js";
+import { TimeTodayTargetError } from "../../transport/time-today/index.js";
+import { ApiError } from "../errors.js";
+import type { ZodTypeProvider } from "../validation.js";
+import {
+  adjustTimeTodaySchema,
+  toTimeLeftCommand,
+  userIdParamsSchema,
+  type TimeTodayResponse,
+} from "./dtos.js";
+
+/**
+ * Register `POST /api/users/:userId/time-today` on an already-`/api`-prefixed
+ * scope. Call after {@link registerAuth} so `scope.requireAdmin` exists.
+ * `adjustTimeToday` is the live transport adjuster; omitted, the route returns
+ * `503 transport_unavailable`.
+ */
+export function registerTimeTodayRoutes(
+  scope: FastifyInstance,
+  adjustTimeToday?: TimeTodayAdjuster,
+): void {
+  const typed = scope.withTypeProvider<ZodTypeProvider>();
+  const guard = { preHandler: scope.requireAdmin };
+
+  typed.post(
+    "/users/:userId/time-today",
+    { ...guard, schema: { params: userIdParamsSchema, body: adjustTimeTodaySchema } },
+    async (request): Promise<TimeTodayResponse> => {
+      const { userId } = request.params;
+
+      // A non-existent user is a 404 — distinct from "exists but has no links"
+      // (a 409 below), which the transport's targeting error reports.
+      if (repo.getUser(scope.db, userId) === undefined) {
+        throw new ApiError(404, "not_found", `User ${userId} not found`);
+      }
+
+      if (adjustTimeToday === undefined) {
+        throw new ApiError(
+          503,
+          "transport_unavailable",
+          "Policy push transport is not configured; run first-run SSH keygen (#39) to enable same-day time adjustments",
+        );
+      }
+
+      const { clientId } = request.body;
+      const { operation, seconds } = toTimeLeftCommand(request.body);
+
+      try {
+        const { results } = await adjustTimeToday({
+          userId,
+          operation,
+          seconds,
+          ...(clientId !== undefined ? { clientId } : {}),
+        });
+        return { userId, operation, seconds, results };
+      } catch (err) {
+        if (err instanceof TimeTodayTargetError) {
+          // A given-but-unlinked client is a 404 (the addressed target doesn't
+          // exist for this user); a user with no links at all is a 409 (the
+          // request is well-formed but there's nothing to act on).
+          throw clientId !== undefined
+            ? new ApiError(404, "not_found", err.message)
+            : new ApiError(409, "no_linked_clients", err.message);
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/server/src/transport/policy-push/bootstrap.ts
+++ b/server/src/transport/policy-push/bootstrap.ts
@@ -36,6 +36,11 @@ import {
 } from "../ssh/index.js";
 import { createPolicyPushStub } from "../stub.js";
 import type { PolicyPushStub } from "../stub.js";
+import {
+  adjustTimeToday,
+  type TimeTodayAdjustment,
+  type TimeTodayResult,
+} from "../time-today/index.js";
 import { TimekprClient } from "../timekpr/index.js";
 import { createPolicyPushDispatcher } from "./dispatcher.js";
 import { createPolicyPushExecutor } from "./executor.js";
@@ -50,10 +55,23 @@ export interface BootstrapSshTransport extends AuditableTransport {
   disposeAll(): void;
 }
 
+/**
+ * Applies a same-day "Add time today" adjustment (#257) over the live transport.
+ * Awaitable (unlike the fire-and-forget dispatcher) so the admin route can
+ * return a per-client result.
+ */
+export type TimeTodayAdjuster = (adjustment: TimeTodayAdjustment) => Promise<TimeTodayResult>;
+
 /** A live policy-push transport: the dispatcher plus its teardown. */
 export interface PolicyPushTransport {
   /** The dispatcher the policy routes push through. */
   readonly dispatcher: PolicyPushStub;
+  /**
+   * The "Add time today" adjuster (#257), present only when the live transport
+   * is wired (SSH key exists). Absent in the logging fallback — the admin route
+   * then reports the transport as unavailable rather than silently no-op'ing.
+   */
+  readonly adjustTimeToday?: TimeTodayAdjuster;
   /** Stop the drainer and close pooled SSH connections (on `app.close()`). */
   dispose(): void;
 }
@@ -141,8 +159,29 @@ export function createPolicyPushTransport(
   const probe = sshReachabilityProbe(db, ssh, credentials);
   const drainer = startOfflineQueueDrainer({ db, probe, executor, log });
 
+  // The same-day "Add time today" lever (#257): a synchronous, audited
+  // `--settimeleft` over the same audited SSH `timekpra` client, attributed to
+  // the admin. Online-only (see `time-today/adjust.ts` for why it is not queued).
+  const timeTodayAdjuster: TimeTodayAdjuster = (adjustment) =>
+    adjustTimeToday(
+      db,
+      ({ client, username, userId }) =>
+        new TimekprClient(
+          auditing.withContext({
+            clientId: client.id,
+            userId,
+            actor: "admin",
+            reason: "time.adjusted",
+          }),
+          targetFromClient(client, credentials),
+          username,
+        ),
+      adjustment,
+    );
+
   return {
     dispatcher,
+    adjustTimeToday: timeTodayAdjuster,
     dispose: (): void => {
       drainer.stop();
       ssh.disposeAll();

--- a/server/src/transport/policy-push/index.ts
+++ b/server/src/transport/policy-push/index.ts
@@ -36,4 +36,5 @@ export {
   type BootstrapSshTransport,
   type CreatePolicyPushTransportOptions,
   type PolicyPushTransport,
+  type TimeTodayAdjuster,
 } from "./bootstrap.js";

--- a/server/src/transport/time-today/adjust.ts
+++ b/server/src/transport/time-today/adjust.ts
@@ -1,0 +1,168 @@
+/**
+ * The "Add time today" adjustment service (#257, Phase 4 transport).
+ *
+ * A manual admin lever that adjusts a supervised user's **remaining time for
+ * today** on the client(s) they're linked to — `timekpra --settimeleft` — with
+ * no change to the standing daily `Budget`. It is the pre-Grant-ledger bonus /
+ * unlock affordance (#185); the durable, auditable, idempotent Grant model is
+ * Phase 10.
+ *
+ * **Online-only, by design — not routed through the offline queue (#84).** The
+ * queue is at-least-once with coalescing and therefore requires *idempotent*
+ * executors (see `queue/drainer.ts`); the standing policy push satisfies that by
+ * setting *absolute* limits. An additive `--settimeleft +N` is **not**
+ * idempotent — a crash-then-replay would double-apply and coalescing two queued
+ * adjustments would drop one. This lever is also an *ephemeral same-day* nudge
+ * (it does not persist past the daily rollover), so an adjustment queued against
+ * an offline client is likely moot by the time it reconnects. So this applies
+ * synchronously to each reachable client and reports a per-client `unreachable`
+ * outcome for the rest, rather than enqueuing. Every attempt is still recorded
+ * in the audit log (#85) because the injected client runs over the
+ * `AuditingTransport`.
+ *
+ * Unlike the fire-and-forget `PolicyPushStub.push`, this is **awaitable**: the
+ * admin gets a per-client result back so the UI can say what actually happened.
+ *
+ * License boundary: none touched — orchestration over Drizzle + an injected
+ * `timekpra` client that execs over the existing SSH subprocess facade. No GPL
+ * code is linked in-process (`CLAUDE.md` → "License boundaries").
+ */
+import type { PolicyDb } from "../../policy/db.js";
+import { getClient, listUserLinks, type ClientRow } from "../../policy/repository.js";
+import { isRetriable } from "../queue/types.js";
+import type { TimeLeftOperation } from "../timekpr/commands.js";
+
+/**
+ * The slice of {@link import("../timekpr/client.js").TimekprClient} the service
+ * drives. Declared structurally so the real client satisfies it and a test can
+ * pass a recording fake without an `as` cast — the same pattern as
+ * `PolicyPushClient`.
+ */
+export interface TimeTodayClient {
+  setTimeLeft(operation: TimeLeftOperation, seconds: number): Promise<unknown>;
+}
+
+/** Addressing for the {@link TimeTodayClientFactory}. */
+export interface TimeTodayClientTarget {
+  /** The enrolled client the command is dispatched to. */
+  readonly client: ClientRow;
+  /** The supervised Linux account `timekpra` acts on (from the user↔client link). */
+  readonly username: string;
+  /** The affected supervised user's id (audit attribution). */
+  readonly userId: number;
+}
+
+/**
+ * Builds the {@link TimeTodayClient} for one (client, user) adjustment.
+ * Production returns a `TimekprClient` over the audited SSH transport bound to
+ * the client's `SshTarget`; tests return a recording fake.
+ */
+export type TimeTodayClientFactory = (target: TimeTodayClientTarget) => TimeTodayClient;
+
+/** A single same-day remaining-time adjustment request. */
+export interface TimeTodayAdjustment {
+  /** The supervised user whose remaining time is adjusted. */
+  readonly userId: number;
+  /** `+`/`-` for an additive delta, `=` to set today's remaining time outright. */
+  readonly operation: TimeLeftOperation;
+  /** A non-negative number of seconds (the magnitude of the delta, or the target). */
+  readonly seconds: number;
+  /**
+   * Restrict the adjustment to one client the user is linked to; when omitted it
+   * applies to **every** client the user is linked to.
+   */
+  readonly clientId?: number;
+}
+
+/** Per-client outcome of an adjustment attempt. */
+export type ClientAdjustmentStatus = "applied" | "unreachable" | "failed";
+
+/** What happened on one client for an adjustment. */
+export interface ClientAdjustmentResult {
+  /** The client the adjustment targeted. */
+  readonly clientId: number;
+  /** The supervised Linux account on that client. */
+  readonly osUsername: string;
+  /** Whether the command applied, the host was unreachable, or it failed. */
+  readonly status: ClientAdjustmentStatus;
+  /** A secret-free error summary for a non-`applied` outcome. */
+  readonly error?: string;
+}
+
+/** The outcome of an adjustment across all targeted clients. */
+export interface TimeTodayResult {
+  readonly results: ClientAdjustmentResult[];
+}
+
+/** Distinguishes "no such link" (a caller error) from a per-client push failure. */
+export class TimeTodayTargetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeTodayTargetError";
+  }
+}
+
+/** Render a thrown value as a secret-free message for the per-client result. */
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Apply a same-day time adjustment to each of the user's linked clients (or the
+ * single `clientId` requested), online-only.
+ *
+ * Resolution + targeting errors throw {@link TimeTodayTargetError} (the caller
+ * maps these to a 4xx): the user has no links, or the requested `clientId` is
+ * not one of them. A per-client *push* failure never throws — it is captured in
+ * that client's {@link ClientAdjustmentResult} (`unreachable` for the retriable
+ * SSH taxonomy, `failed` otherwise) so a partial fan-out still returns a full
+ * report.
+ */
+export async function adjustTimeToday(
+  db: PolicyDb,
+  buildClient: TimeTodayClientFactory,
+  adjustment: TimeTodayAdjustment,
+): Promise<TimeTodayResult> {
+  const { userId, operation, seconds, clientId } = adjustment;
+
+  const links = listUserLinks(db, userId);
+  const targets = clientId === undefined ? links : links.filter((l) => l.clientId === clientId);
+
+  if (clientId !== undefined && targets.length === 0) {
+    throw new TimeTodayTargetError(`User ${userId} is not linked to client ${clientId}`);
+  }
+  if (targets.length === 0) {
+    throw new TimeTodayTargetError(`User ${userId} is not linked to any client; nothing to adjust`);
+  }
+
+  const results: ClientAdjustmentResult[] = [];
+  for (const link of targets) {
+    // The client could have been deleted between the link read and here; skip
+    // a dangling link rather than failing the whole fan-out.
+    const client = getClient(db, link.clientId);
+    if (client === undefined) {
+      results.push({
+        clientId: link.clientId,
+        osUsername: link.osUsername,
+        status: "failed",
+        error: `Client ${link.clientId} no longer exists`,
+      });
+      continue;
+    }
+
+    const timekpr = buildClient({ client, username: link.osUsername, userId });
+    try {
+      await timekpr.setTimeLeft(operation, seconds);
+      results.push({ clientId: link.clientId, osUsername: link.osUsername, status: "applied" });
+    } catch (error) {
+      results.push({
+        clientId: link.clientId,
+        osUsername: link.osUsername,
+        status: isRetriable(error) ? "unreachable" : "failed",
+        error: errorMessage(error),
+      });
+    }
+  }
+
+  return { results };
+}

--- a/server/src/transport/time-today/index.ts
+++ b/server/src/transport/time-today/index.ts
@@ -1,0 +1,22 @@
+/**
+ * "Add time today" transport (#257): an awaitable, online-only admin lever that
+ * adjusts a supervised user's remaining time for today via `timekpra
+ * --settimeleft`, independent of the standing daily limit. See `./adjust.ts` for
+ * the design rationale (why it is not routed through the offline queue).
+ *
+ * License boundary: none touched — execs `timekpra` over the SSH subprocess
+ * facade; no GPL code linked in-process.
+ */
+export const moduleName = "transport/time-today";
+
+export {
+  adjustTimeToday,
+  TimeTodayTargetError,
+  type ClientAdjustmentResult,
+  type ClientAdjustmentStatus,
+  type TimeTodayAdjustment,
+  type TimeTodayClient,
+  type TimeTodayClientFactory,
+  type TimeTodayClientTarget,
+  type TimeTodayResult,
+} from "./adjust.js";

--- a/server/src/transport/timekpr/client.ts
+++ b/server/src/transport/timekpr/client.ts
@@ -30,6 +30,7 @@ import {
   buildSetPlayTimeLimitOverride,
   buildSetPlayTimeLimits,
   buildSetPlayTimeUnaccountedIntervalsEnabled,
+  buildSetTimeLeft,
   buildSetTimeLimits,
   buildSetTimeLimitMonth,
   buildSetTimeLimitWeek,
@@ -38,6 +39,7 @@ import {
   type AllowedHoursDay,
   type IsoWeekday,
   type PlayTimeActivity,
+  type TimeLeftOperation,
 } from "./commands.js";
 import { TimekprArgumentError } from "./errors.js";
 import { timekprUserInfoSchema, type TimekprUserInfo } from "./userinfo.js";
@@ -169,6 +171,16 @@ export class TimekprClient {
   /** Set the rolling monthly session-time limit in seconds (`--settimelimitmonth`). */
   setTimeLimitMonth(seconds: number): Promise<ExecResult> {
     return this.#exec(() => buildSetTimeLimitMonth(this.#username, seconds));
+  }
+
+  /**
+   * Adjust or set the user's **remaining time for today** (`--settimeleft`) —
+   * the same-day "add 30 minutes" / "set time left" lever (#257), independent of
+   * the standing daily limit. `operation` is `"+"`/`"-"` for an additive delta
+   * or `"="` to set outright; `seconds` is a non-negative count.
+   */
+  setTimeLeft(operation: TimeLeftOperation, seconds: number): Promise<ExecResult> {
+    return this.#exec(() => buildSetTimeLeft(this.#username, operation, seconds));
   }
 
   /** Enable or disable PlayTime (app-group time) for the user (`--setplaytimeenabled`). */

--- a/server/src/transport/timekpr/commands.ts
+++ b/server/src/transport/timekpr/commands.ts
@@ -17,6 +17,7 @@
  * - `--setallowedhours USER (DAY|ALL) 'H;H[mm-mm];!H;…'`
  * - `--settimelimits USER 's;s;…'`  (per allowed weekday)
  * - `--settimelimitweek USER s` / `--settimelimitmonth USER s`
+ * - `--settimeleft USER (+|-|=) s`  (adjust/set today's remaining time)
  * - `--setplaytimeenabled USER (true|false)`
  * - `--setplaytimelimitoverride USER (true|false)`
  * - `--setplaytimeunaccountedintervalsenabled USER (true|false)`
@@ -39,6 +40,20 @@ import { TimekprArgumentError } from "./errors.js";
 
 /** An ISO-8601 weekday number: `1` = Monday … `7` = Sunday. */
 export type IsoWeekday = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+/**
+ * The operation of a `timekpra --settimeleft` command:
+ * - `"+"` add seconds to today's remaining time,
+ * - `"-"` subtract seconds from today's remaining time,
+ * - `"="` set today's remaining time to exactly the given seconds.
+ *
+ * Verified against the upstream `timekpra` admin CLI
+ * (`--settimeleft USER (+|-|=) SECONDS`).
+ */
+export type TimeLeftOperation = "+" | "-" | "=";
+
+/** The accepted {@link TimeLeftOperation} literals, for validation/iteration. */
+export const TIME_LEFT_OPERATIONS: readonly TimeLeftOperation[] = ["+", "-", "="];
 
 /** Sentinel for "every day" in {@link buildSetAllowedHours}'s day position. */
 export const ALL_DAYS = "ALL";
@@ -270,6 +285,30 @@ export function buildSetTimeLimitMonth(username: string, seconds: number): strin
   assertUsername(username);
   assertSeconds(seconds, "monthly time limit");
   return ["--settimelimitmonth", username, String(seconds)];
+}
+
+/**
+ * `--settimeleft USER (+|-|=) s` — adjust or set the user's **remaining time
+ * for today**, without touching the standing daily limit (`--settimelimits`).
+ *
+ * Unlike the limit setters this is a same-day, ephemeral nudge: `+`/`-` are an
+ * additive delta against the day's accounting and `=` sets it outright. The
+ * caller maps a signed request (e.g. "+30 minutes") to a non-negative second
+ * count plus an operation, so `seconds` is always a non-negative integer here.
+ */
+export function buildSetTimeLeft(
+  username: string,
+  operation: TimeLeftOperation,
+  seconds: number,
+): string[] {
+  assertUsername(username);
+  if (!TIME_LEFT_OPERATIONS.includes(operation)) {
+    throw new TimekprArgumentError(
+      `timekpra: settimeleft operation must be one of '+', '-', '=', got ${JSON.stringify(operation)}`,
+    );
+  }
+  assertSeconds(seconds, "time-left adjustment");
+  return ["--settimeleft", username, operation, String(seconds)];
 }
 
 /** `--setplaytimeenabled USER (true|false)` — master PlayTime switch. */

--- a/server/src/transport/timekpr/index.ts
+++ b/server/src/transport/timekpr/index.ts
@@ -21,15 +21,18 @@ export {
   buildSetPlayTimeLimitOverride,
   buildSetPlayTimeUnaccountedIntervalsEnabled,
   buildSetPlayTimeLimits,
+  buildSetTimeLeft,
   buildSetTimeLimits,
   buildSetTimeLimitMonth,
   buildSetTimeLimitWeek,
   buildUserInfo,
   assertUsername,
+  TIME_LEFT_OPERATIONS,
   type AllowedHour,
   type AllowedHoursDay,
   type IsoWeekday,
   type PlayTimeActivity,
+  type TimeLeftOperation,
 } from "./commands.js";
 export {
   DEFAULT_TIMEKPRA_BINARY,

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -18,7 +18,10 @@ import { EventHub } from "../events/index.js";
 import { createDb, type PolicyDb } from "../policy/db.js";
 import { createAnsibleVenvSupervisor, type AnsibleVenvSupervisor } from "../setup/ansible-venv.js";
 import { createAdGuardService, type AdGuardService } from "../transport/adguard/index.js";
-import { createPolicyPushTransport } from "../transport/policy-push/index.js";
+import {
+  createPolicyPushTransport,
+  type PolicyPushTransport,
+} from "../transport/policy-push/index.js";
 import { registerFrontend } from "./frontend.js";
 import { REQUEST_ID_HEADER, buildLoggerOptions, genRequestId, type LogStream } from "./logger.js";
 
@@ -78,6 +81,14 @@ export interface BuildAppOptions {
    * constructing the app.
    */
   ansibleVenv?: AnsibleVenvSupervisor;
+  /**
+   * Inject the outbound {@link PolicyPushTransport} (#201/#257). When omitted,
+   * {@link buildApp} builds the live `timekpra`-over-SSH transport from settings
+   * (or the logging fallback when no SSH key exists yet). Tests inject one with
+   * a fake `adjustTimeToday` to exercise `POST /users/:userId/time-today`
+   * without SSH. An injected transport is left for its provider to dispose.
+   */
+  policyPush?: PolicyPushTransport;
 }
 
 /**
@@ -109,10 +120,14 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   // Outbound policy-push transport (#201): the live `timekpra`-over-SSH
   // dispatcher when the SSH key exists (#39), else the logging stub. It also
   // owns the offline-queue drainer + pooled SSH connections, torn down on close
-  // — before the db it reads from (when buildApp owns that db).
-  const policyPush = createPolicyPushTransport({ settings, db, log: app.log });
+  // — before the db it reads from (when buildApp owns that db). A test may
+  // inject one (e.g. with a fake `adjustTimeToday`); only the handle buildApp
+  // creates is disposed here, mirroring the `db` seam.
+  const policyPush =
+    options.policyPush ?? createPolicyPushTransport({ settings, db, log: app.log });
+  const ownsPolicyPush = options.policyPush === undefined;
   app.addHook("onClose", async () => {
-    policyPush.dispose();
+    if (ownsPolicyPush) policyPush.dispose();
     if (ownsDb) db.$client.close();
   });
 
@@ -160,7 +175,7 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   // within this prefix, leaving /, /healthz, /admin and /app untouched. Auth
   // (#52) is wired inside this scope and needs the settings (PCT_SECRET_KEY,
   // first-admin bootstrap) threaded through.
-  registerApi(app, settings, eventHub, policyPush.dispatcher);
+  registerApi(app, settings, eventHub, policyPush.dispatcher, policyPush.adjustTimeToday);
 
   // Serve the prerendered SvelteKit build at /admin and /app (#40). Skipped
   // (with a warning) when the build directory is absent, so /, /healthz, and

--- a/server/tests/api/time-today.test.ts
+++ b/server/tests/api/time-today.test.ts
@@ -1,0 +1,292 @@
+/**
+ * HTTP tests for the "Add time today" route (#257):
+ * `POST /api/users/:userId/time-today`.
+ *
+ * Driven through the real app via `app.inject()` with a genuine admin cookie.
+ * A fake {@link PolicyPushTransport} is injected so the route's 200 path runs
+ * without SSH; a separate app built without one exercises the 503 fallback.
+ */
+import type { InjectOptions } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SESSION_COOKIE } from "../../src/auth/session.js";
+import { loadSettings } from "../../src/config.js";
+import { createClient, createUser, upsertLink } from "../../src/policy/repository.js";
+import type { PolicyPushTransport } from "../../src/transport/policy-push/index.js";
+import {
+  TimeTodayTargetError,
+  type TimeTodayAdjustment,
+  type TimeTodayResult,
+} from "../../src/transport/time-today/index.js";
+import { buildTestApp, type TestApp } from "../helpers/app.js";
+
+function configuredSettings() {
+  return loadSettings({
+    PCT_LOG_LEVEL: "silent",
+    PCT_SECRET_KEY: "time-today-secret",
+    PCT_ADMIN_USERNAME: "ben",
+    PCT_ADMIN_PASSWORD: "hunter2",
+  });
+}
+
+function sessionCookie(res: { headers: Record<string, unknown> }): string {
+  const raw = res.headers["set-cookie"];
+  const headers = Array.isArray(raw) ? (raw as string[]) : [String(raw ?? "")];
+  const match = headers.find((h) => h.startsWith(`${SESSION_COOKIE}=`));
+  if (match === undefined) throw new Error("no session cookie set");
+  return match.split(";")[0] ?? "";
+}
+
+/** A recording fake transport: the dispatcher is inert, the adjuster is provided. */
+function fakeTransport(adjust: (a: TimeTodayAdjustment) => Promise<TimeTodayResult>): {
+  transport: PolicyPushTransport;
+  calls: TimeTodayAdjustment[];
+} {
+  const calls: TimeTodayAdjustment[] = [];
+  return {
+    calls,
+    transport: {
+      dispatcher: { push: () => undefined },
+      adjustTimeToday: (a) => {
+        calls.push(a);
+        return adjust(a);
+      },
+      dispose: () => undefined,
+    },
+  };
+}
+
+describe("POST /api/users/:userId/time-today", () => {
+  let harness: TestApp;
+  let cookie: string;
+  let calls: TimeTodayAdjustment[];
+
+  async function setup(
+    adjust: (a: TimeTodayAdjustment) => Promise<TimeTodayResult>,
+  ): Promise<void> {
+    const fake = fakeTransport(adjust);
+    calls = fake.calls;
+    harness = buildTestApp({
+      appOptions: { settings: configuredSettings(), policyPush: fake.transport },
+    });
+    await harness.app.ready();
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    cookie = sessionCookie(login);
+  }
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  function auth(opts: InjectOptions) {
+    return harness.app.inject({ ...opts, headers: { ...opts.headers, cookie } });
+  }
+
+  function seedLinkedUser(): number {
+    const userId = createUser(harness.db, { displayName: "Alice", tz: "UTC" }).id;
+    const clientId = createClient(harness.db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+    upsertLink(harness.db, userId, clientId, { osUsername: "alice", osUserRef: "1001" });
+    return userId;
+  }
+
+  it("rejects anonymous access with a 401", async () => {
+    await setup(async () => ({ results: [] }));
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/users/1/time-today",
+      payload: { deltaSeconds: 1800 },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("applies a positive delta as a `+` op and returns the per-client results", async () => {
+    await setup(async () => ({
+      results: [{ clientId: 7, osUsername: "alice", status: "applied" }],
+    }));
+    const userId = seedLinkedUser();
+
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { deltaSeconds: 1800 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      userId,
+      operation: "+",
+      seconds: 1800,
+      results: [{ clientId: 7, osUsername: "alice", status: "applied" }],
+    });
+    expect(calls).toEqual([{ userId, operation: "+", seconds: 1800 }]);
+  });
+
+  it("maps a negative delta to a `-` op with the magnitude", async () => {
+    await setup(async () => ({ results: [] }));
+    const userId = seedLinkedUser();
+
+    await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { deltaSeconds: -600 },
+    });
+
+    expect(calls[0]).toMatchObject({ operation: "-", seconds: 600 });
+  });
+
+  it("maps setSeconds to a `=` op and forwards clientId", async () => {
+    await setup(async () => ({ results: [] }));
+    const userId = seedLinkedUser();
+
+    await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { setSeconds: 0, clientId: 42 },
+    });
+
+    expect(calls[0]).toMatchObject({ operation: "=", seconds: 0, clientId: 42 });
+  });
+
+  it("404s for a non-existent user (before touching the transport)", async () => {
+    await setup(async () => ({ results: [] }));
+    const res = await auth({
+      method: "POST",
+      url: "/api/users/9999/time-today",
+      payload: { deltaSeconds: 1800 },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("409 no_linked_clients when the user has no links", async () => {
+    await setup(async () => {
+      throw new TimeTodayTargetError("User has no links");
+    });
+    const userId = createUser(harness.db, { displayName: "Bob", tz: "UTC" }).id;
+
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { deltaSeconds: 1800 },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.code).toBe("no_linked_clients");
+  });
+
+  it("404 when a given clientId isn't linked to the user", async () => {
+    await setup(async () => {
+      throw new TimeTodayTargetError("not linked to client 42");
+    });
+    const userId = seedLinkedUser();
+
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { deltaSeconds: 1800, clientId: 42 },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+  });
+
+  it("surfaces a per-client unreachable outcome with a 200 (not queued)", async () => {
+    await setup(async () => ({
+      results: [{ clientId: 7, osUsername: "alice", status: "unreachable", error: "offline" }],
+    }));
+    const userId = seedLinkedUser();
+
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { deltaSeconds: 900 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().results[0]).toEqual({
+      clientId: 7,
+      osUsername: "alice",
+      status: "unreachable",
+      error: "offline",
+    });
+  });
+
+  it("rejects a body with neither delta nor set (400)", async () => {
+    await setup(async () => ({ results: [] }));
+    const userId = seedLinkedUser();
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a body with both delta and set (400)", async () => {
+    await setup(async () => ({ results: [] }));
+    const userId = seedLinkedUser();
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { deltaSeconds: 1800, setSeconds: 3600 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a zero delta (400)", async () => {
+    await setup(async () => ({ results: [] }));
+    const userId = seedLinkedUser();
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { deltaSeconds: 0 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects a delta beyond one day (400)", async () => {
+    await setup(async () => ({ results: [] }));
+    const userId = seedLinkedUser();
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { deltaSeconds: 86_401 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("POST /api/users/:userId/time-today without a live transport", () => {
+  let harness: TestApp;
+  let cookie: string;
+
+  beforeEach(async () => {
+    // No `policyPush` injected and no SSH key → the fallback transport has no
+    // adjuster, so the route reports the transport as unavailable.
+    harness = buildTestApp({ appOptions: { settings: configuredSettings() } });
+    await harness.app.ready();
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    cookie = sessionCookie(login);
+  });
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  it("503 transport_unavailable when no adjuster is wired", async () => {
+    const userId = createUser(harness.db, { displayName: "Alice", tz: "UTC" }).id;
+    const res = await harness.app.inject({
+      method: "POST",
+      url: `/api/users/${userId}/time-today`,
+      payload: { deltaSeconds: 1800 },
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json().error.code).toBe("transport_unavailable");
+  });
+});

--- a/server/tests/transport/policy-push/bootstrap.test.ts
+++ b/server/tests/transport/policy-push/bootstrap.test.ts
@@ -85,6 +85,9 @@ describe("createPolicyPushTransport", () => {
       lines.find((l) => l.msg?.toString().includes("SSH private key not found")),
     ).toBeDefined();
     expect(lines.find((l) => l.msg === PUSH_STUB_MESSAGE)).toBeDefined();
+    // The "Add time today" adjuster (#257) is absent in the fallback, so the
+    // admin route can report the transport as unavailable rather than no-op.
+    expect(transport.adjustTimeToday).toBeUndefined();
     // dispose is callable and harmless on the fallback.
     expect(() => transport.dispose()).not.toThrow();
   });
@@ -122,6 +125,41 @@ describe("createPolicyPushTransport", () => {
 
     transport.dispose();
     expect(ssh.disposed).toBe(1);
+  });
+
+  it("exposes an audited 'Add time today' adjuster in live mode (#257)", async () => {
+    const userId = createUser(db, { displayName: "Alice", tz: "UTC" }).id;
+    const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+    upsertLink(db, userId, clientId, { osUsername: "alice", osUserRef: "1001" });
+
+    const ssh = fakeSsh();
+    const transport = createPolicyPushTransport({
+      settings,
+      db,
+      log,
+      loadCredentials: () => ({ privateKey: "FAKE-KEY" }),
+      sshTransport: ssh,
+    });
+
+    const adjust = transport.adjustTimeToday;
+    expect(adjust).toBeDefined();
+    if (adjust === undefined) throw new Error("expected a live adjuster");
+    const result = await adjust({ userId, operation: "+", seconds: 1800 });
+
+    expect(result.results).toEqual([{ clientId, osUsername: "alice", status: "applied" }]);
+    // The adjustment reaches the fake SSH transport as real `--settimeleft` argv.
+    expect(
+      ssh.checked.some(
+        (argv) => argv.includes("--settimeleft") && argv.includes("+") && argv.includes("1800"),
+      ),
+    ).toBe(true);
+    // ...and it is audited with admin attribution + the time.adjusted reason.
+    const entries = listAuditEntries(db, { limit: 50 });
+    expect(
+      entries.some((e) => e.clientId === clientId && e.userId === userId && e.actor === "admin"),
+    ).toBe(true);
+
+    transport.dispose();
   });
 });
 

--- a/server/tests/transport/policy-push/bootstrap.test.ts
+++ b/server/tests/transport/policy-push/bootstrap.test.ts
@@ -156,7 +156,13 @@ describe("createPolicyPushTransport", () => {
     // ...and it is audited with admin attribution + the time.adjusted reason.
     const entries = listAuditEntries(db, { limit: 50 });
     expect(
-      entries.some((e) => e.clientId === clientId && e.userId === userId && e.actor === "admin"),
+      entries.some(
+        (e) =>
+          e.clientId === clientId &&
+          e.userId === userId &&
+          e.actor === "admin" &&
+          e.reason === "time.adjusted",
+      ),
     ).toBe(true);
 
     transport.dispose();

--- a/server/tests/transport/time-today/adjust-dangling-link.test.ts
+++ b/server/tests/transport/time-today/adjust-dangling-link.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Covers the defensive "dangling link" branch in {@link adjustTimeToday}: a link
+ * row still resolves but its client has vanished between the read and the
+ * dispatch (a TOCTOU race the FK cascade normally prevents). The repository is
+ * mocked so `listUserLinks` returns a link whose `getClient` is `undefined`,
+ * which can't be constructed against a real FK-enforced DB.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/policy/repository.js", () => ({
+  listUserLinks: () => [{ userId: 1, clientId: 7, osUsername: "alice", osUserRef: "1001" }],
+  getClient: () => undefined,
+}));
+
+const { adjustTimeToday } = await import("../../../src/transport/time-today/adjust.js");
+const { testDb } = await import("../../helpers/db.js");
+
+describe("adjustTimeToday — dangling link", () => {
+  it("marks the client failed and never builds a client when getClient returns undefined", async () => {
+    const db = testDb();
+    let built = 0;
+    const result = await adjustTimeToday(
+      db,
+      () => {
+        built += 1;
+        return { setTimeLeft: async () => undefined };
+      },
+      { userId: 1, operation: "+", seconds: 1800 },
+    );
+
+    expect(built).toBe(0);
+    expect(result.results).toEqual([
+      {
+        clientId: 7,
+        osUsername: "alice",
+        status: "failed",
+        error: "Client 7 no longer exists",
+      },
+    ]);
+    db.$client.close();
+  });
+});

--- a/server/tests/transport/time-today/adjust.test.ts
+++ b/server/tests/transport/time-today/adjust.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for the "Add time today" adjustment service (#257): fanning a
+ * `--settimeleft` op out to a user's linked clients, the per-client
+ * applied/unreachable/failed outcomes, and the targeting errors (no links / a
+ * client the user isn't linked to). No SSH — the `timekpra` client is a fake.
+ */
+import { describe, expect, it } from "vitest";
+
+import { createClient, createUser, upsertLink } from "../../../src/policy/repository.js";
+import { SshCommandError, SshUnreachableError } from "../../../src/transport/ssh/errors.js";
+import {
+  adjustTimeToday,
+  TimeTodayTargetError,
+  type TimeTodayClient,
+  type TimeTodayClientTarget,
+} from "../../../src/transport/time-today/adjust.js";
+import { testDb, type TestDb } from "../../helpers/db.js";
+
+const sshTarget = { host: "mint-01", port: 22, username: "pct-agent" } as const;
+
+/** A recording `TimeTodayClient`; optionally rejects to exercise the outcomes. */
+function recordingClient(behaviour?: { rejectWith?: Error }): {
+  readonly client: TimeTodayClient;
+  readonly calls: string[];
+} {
+  const calls: string[] = [];
+  return {
+    calls,
+    client: {
+      async setTimeLeft(operation, seconds) {
+        calls.push(`${operation}${seconds}`);
+        if (behaviour?.rejectWith) throw behaviour.rejectWith;
+      },
+    },
+  };
+}
+
+function unreachable(): SshUnreachableError {
+  return new SshUnreachableError(sshTarget, { cause: new Error("ECONNREFUSED") });
+}
+
+function commandFailed(): SshCommandError {
+  return new SshCommandError(sshTarget, ["sudo", "timekpra"], {
+    code: 1,
+    signal: null,
+    stdout: "",
+    stderr: "no such user",
+  });
+}
+
+describe("adjustTimeToday", () => {
+  let db: TestDb;
+
+  function seedUser(): number {
+    db = testDb();
+    return createUser(db, { displayName: "Alice", tz: "UTC" }).id;
+  }
+
+  function link(userId: number, hostname: string, osUsername: string): number {
+    const clientId = createClient(db, { hostname, sshUser: "pct-agent" }).id;
+    upsertLink(db, userId, clientId, { osUsername, osUserRef: "1001" });
+    return clientId;
+  }
+
+  it("applies the adjustment to every linked client and reports the calls", async () => {
+    const userId = seedUser();
+    const c1 = link(userId, "mint-01", "alice");
+    const c2 = link(userId, "mint-02", "alice2");
+
+    const rec = recordingClient();
+    const built: TimeTodayClientTarget[] = [];
+    const result = await adjustTimeToday(
+      db,
+      (t) => {
+        built.push(t);
+        return rec.client;
+      },
+      { userId, operation: "+", seconds: 1800 },
+    );
+
+    expect(result.results).toEqual([
+      { clientId: c1, osUsername: "alice", status: "applied" },
+      { clientId: c2, osUsername: "alice2", status: "applied" },
+    ]);
+    // One `--settimeleft +1800` per linked client, attributed to the user.
+    expect(rec.calls).toEqual(["+1800", "+1800"]);
+    expect(built.map((t) => ({ id: t.client.id, username: t.username, userId: t.userId }))).toEqual(
+      [
+        { id: c1, username: "alice", userId },
+        { id: c2, username: "alice2", userId },
+      ],
+    );
+  });
+
+  it("restricts to a single client when clientId is given", async () => {
+    const userId = seedUser();
+    link(userId, "mint-01", "alice");
+    const c2 = link(userId, "mint-02", "alice2");
+
+    const rec = recordingClient();
+    const result = await adjustTimeToday(db, () => rec.client, {
+      userId,
+      operation: "=",
+      seconds: 3600,
+      clientId: c2,
+    });
+
+    expect(result.results).toEqual([{ clientId: c2, osUsername: "alice2", status: "applied" }]);
+    expect(rec.calls).toEqual(["=3600"]);
+  });
+
+  it("marks a client unreachable on the retriable SSH taxonomy (not queued)", async () => {
+    const userId = seedUser();
+    const c1 = link(userId, "mint-01", "alice");
+
+    const rec = recordingClient({ rejectWith: unreachable() });
+    const result = await adjustTimeToday(db, () => rec.client, {
+      userId,
+      operation: "+",
+      seconds: 900,
+    });
+
+    expect(result.results[0]?.status).toBe("unreachable");
+    expect(result.results[0]?.error).toMatch(/unreachable/i);
+    expect(result.results[0]?.clientId).toBe(c1);
+  });
+
+  it("marks a client failed on a non-retriable command error", async () => {
+    const userId = seedUser();
+    link(userId, "mint-01", "alice");
+
+    const rec = recordingClient({ rejectWith: commandFailed() });
+    const result = await adjustTimeToday(db, () => rec.client, {
+      userId,
+      operation: "-",
+      seconds: 60,
+    });
+
+    expect(result.results[0]?.status).toBe("failed");
+    expect(result.results[0]?.error).toMatch(/Remote command failed/i);
+  });
+
+  it("reports a partial fan-out (one applied, one unreachable)", async () => {
+    const userId = seedUser();
+    const c1 = link(userId, "mint-01", "alice");
+    const c2 = link(userId, "mint-02", "alice2");
+
+    const ok = recordingClient();
+    const down = recordingClient({ rejectWith: unreachable() });
+    const result = await adjustTimeToday(
+      db,
+      (t) => (t.client.id === c1 ? ok.client : down.client),
+      { userId, operation: "+", seconds: 1800 },
+    );
+
+    expect(result.results).toEqual([
+      { clientId: c1, osUsername: "alice", status: "applied" },
+      expect.objectContaining({ clientId: c2, osUsername: "alice2", status: "unreachable" }),
+    ]);
+  });
+
+  it("throws TimeTodayTargetError when the user has no links", async () => {
+    const userId = seedUser();
+    await expect(
+      adjustTimeToday(db, () => recordingClient().client, {
+        userId,
+        operation: "+",
+        seconds: 1800,
+      }),
+    ).rejects.toBeInstanceOf(TimeTodayTargetError);
+  });
+
+  it("throws TimeTodayTargetError when the requested client isn't linked", async () => {
+    const userId = seedUser();
+    link(userId, "mint-01", "alice");
+    await expect(
+      adjustTimeToday(db, () => recordingClient().client, {
+        userId,
+        operation: "+",
+        seconds: 1800,
+        clientId: 9999,
+      }),
+    ).rejects.toBeInstanceOf(TimeTodayTargetError);
+  });
+});

--- a/server/tests/transport/timekpr/client.test.ts
+++ b/server/tests/transport/timekpr/client.test.ts
@@ -127,6 +127,19 @@ describe("TimekprClient setters", () => {
     ]);
   });
 
+  it("routes a same-day time-left adjustment through execChecked (#257)", async () => {
+    const client = clientFor();
+    await client.setTimeLeft("+", 1800);
+    expect(transport.checked).toHaveLength(1);
+    expect(transport.checked[0]?.argv).toEqual([
+      ...DEFAULT_TIMEKPRA_BINARY,
+      "--settimeleft",
+      "alice",
+      "+",
+      "1800",
+    ]);
+  });
+
   it("honours a binary override and forwarded exec options", async () => {
     const client = new TimekprClient(transport, TARGET, "alice", {
       binary: ["/usr/bin/timekpra"],

--- a/server/tests/transport/timekpr/commands.test.ts
+++ b/server/tests/transport/timekpr/commands.test.ts
@@ -18,6 +18,7 @@ import {
   buildSetPlayTimeLimitOverride,
   buildSetPlayTimeUnaccountedIntervalsEnabled,
   buildSetPlayTimeLimits,
+  buildSetTimeLeft,
   buildSetTimeLimits,
   buildSetTimeLimitMonth,
   buildSetTimeLimitWeek,
@@ -165,6 +166,37 @@ describe("session-limit builders", () => {
   ])("rejects a %s second value", (_label, seconds) => {
     expect(() => buildSetTimeLimitWeek(USER, seconds)).toThrow(/non-negative integer/);
     expect(() => buildSetTimeLimits(USER, [seconds])).toThrow(/non-negative integer/);
+  });
+});
+
+describe("buildSetTimeLeft", () => {
+  it("builds an additive (+) adjustment for today", () => {
+    expect(buildSetTimeLeft(USER, "+", 1800)).toEqual(["--settimeleft", "alice", "+", "1800"]);
+  });
+
+  it("builds a subtractive (-) adjustment for today", () => {
+    expect(buildSetTimeLeft(USER, "-", 600)).toEqual(["--settimeleft", "alice", "-", "600"]);
+  });
+
+  it("builds an absolute (=) set for today", () => {
+    expect(buildSetTimeLeft(USER, "=", 0)).toEqual(["--settimeleft", "alice", "=", "0"]);
+  });
+
+  it("rejects an unknown operation", () => {
+    // @ts-expect-error — exercising the runtime guard against an off-grammar op
+    expect(() => buildSetTimeLeft(USER, "*", 60)).toThrow(/operation must be one of/);
+  });
+
+  it.each([
+    ["negative", -1],
+    ["fractional", 1.5],
+    ["NaN", Number.NaN],
+  ])("rejects a %s second value", (_label, seconds) => {
+    expect(() => buildSetTimeLeft(USER, "+", seconds)).toThrow(/non-negative integer/);
+  });
+
+  it("rejects an invalid username before formatting", () => {
+    expect(() => buildSetTimeLeft("a b", "+", 60)).toThrow(TimekprArgumentError);
   });
 });
 


### PR DESCRIPTION
## Summary

The Alpha-1 unlock/bonus lever (#185, decision #2): a manual admin action that adjusts a supervised user's **remaining time for _today_** on the client(s) they're linked to — `timekpra --settimeleft USER (+|-|=) SECONDS` — **without** changing the standing daily `Budget`. Fills the gap until the auditable Grant ledger lands in Phase 10.

Delivered end-to-end across four phases:

- **Transport** — `buildSetTimeLeft` argv builder + `TimekprClient.setTimeLeft` (exec over the existing SSH facade).
- **Service** — `transport/time-today`: an **awaitable, online-only** per-user adjustment that fans out to the user's linked clients over the audited SSH `timekpra` client, returning a per-client `applied | unreachable | failed` result. Wired into the policy-push bootstrap as `PolicyPushTransport.adjustTimeToday` (live mode only), attributed to `actor:"admin"`, `reason:"time.adjusted"`.
- **API** — `POST /api/users/:userId/time-today` (zod DTO: exactly one of `deltaSeconds` / `setSeconds`, optional `clientId`, bounded to one day), admin-guarded, audited. 404 unknown user · 404 unlinked `clientId` · 409 `no_linked_clients` · 503 `transport_unavailable` · 200 with per-client results.
- **Admin UI** — an "Add time today" panel on the Links view: `+15` / `+30` / custom ± minutes, the **not-a-Grant / forgotten-at-rollover** caveat, and a per-client result list.

## Plan

Linked plan: `.claude/plans/issue-257-add-time-today.md`
Roadmap: `docs/roadmap.md` → Phase 4 (SSH + `timekpra` transport).

## Design note — online-only, NOT offline-queued (deliberate divergence)

The issue says "route through the offline queue (#161)". I'm diverging, because the offline queue is **at-least-once with coalescing** and therefore requires **idempotent** executors (the standing policy push satisfies this by setting _absolute_ limits). An additive `--settimeleft +N` is **not** idempotent — a crash-then-replay double-applies and coalescing two queued `+15`s drops one. Combined with this being an *ephemeral same-day* nudge (moot after the daily rollover), the correct behaviour is **online-only**: apply synchronously when the client is reachable, return a clear per-client `unreachable` outcome otherwise. The command is still **audited** on every path. Documented in `docs/architecture.md` → "Add time today". A queue-safe (absolute-target) variant is tracked as a follow-up — **#274**.

It is also **awaitable** (unlike the fire-and-forget policy-push dispatcher) so the admin gets a per-client result back — hence a distinct transport surface rather than reusing `PolicyPushStub.push`.

## License-boundary note

N/A — still exec-over-SSH of `timekpra` (GPL) as a subprocess via the existing facade; no in-process linkage, no GPL binary added to the image, **no new dependency**, no transport/REST boundary collapsed. The frontend `/api` boundary stays type-only (DTO types re-exported through `contract.ts`).

## First-pass review

A subagent review found **no blockers**. Addressed follow-ups in `0b9f06c`: a focused test for the defensive dangling-link branch, a tightened audit-`reason` assertion, and a bounded response `seconds`.

## Deferred (tracked)

- **Queue-safe (absolute-target) offline variant** — **#274** (the portion of #257's "route through the offline queue" note this PR deliberately does not implement; see the design note above).
- Grant ledger / additive auditable overlay + integrator grants — Phase 10.
- `lockout.cleared` event / "you can log back in" toast — Phase 8b/8c.

## Test plan

- [x] `commands.test.ts` / `client.test.ts` — `buildSetTimeLeft` `+`/`-`/`=`, bad op, bad seconds/username; `setTimeLeft` argv.
- [x] `time-today/adjust.test.ts` (+ `adjust-dangling-link.test.ts`) — fan-out, single-client, unreachable, failed, partial, targeting errors, dangling link.
- [x] `policy-push/bootstrap.test.ts` — live adjuster present + audited (`actor:"admin"`, `reason:"time.adjusted"`); absent in fallback.
- [x] `api/time-today.test.ts` — 401 / 404 / 409 / 503 / 200, delta/set/clientId mapping, all validation rejections.
- [x] `links-view-time-today.test.ts` — +15/+30/custom → seconds, result render, unreachable, error.
- [x] Backend gate green: `format:check` / `lint` / `typecheck` / `test` (**1263 tests**, coverage ≥ 80%). Frontend `check` (0 errors) / `test` (86) / `build`.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)