### PR TITLE
feat(admin): integration tokens management page (#250)

### DIFF
--- a/.claude/plans/issue-250-integration-tokens-admin-ui.md
+++ b/.claude/plans/issue-250-integration-tokens-admin-ui.md
@@ -1,0 +1,72 @@
+# Issue #250 — Admin UI: integration tokens management page
+
+Phase 10. The **frontend half of #114** (backend merged to `main`). Pure
+frontend work mirroring the established `$lib/api` + `*View.svelte` patterns;
+no server code, no new license surface (`CLAUDE.md` → "Read + mint + revoke
+only").
+
+## Backend it consumes (already on `main`, #114)
+
+- `POST /api/integrations/tokens` — mint (admin-guarded), returns plaintext
+  `secret` **once** (`integrationTokenCreatedSchema`).
+- `GET /api/integrations/tokens` — list summaries (`integrationTokenSummarySchema`,
+  never the secret).
+- `POST /api/integrations/tokens/:id/revoke` — revoke (idempotent), returns the
+  updated summary.
+- DTOs in `server/src/api/integrations/dtos.ts`; scope vocabulary
+  `INTEGRATION_SCOPES = ["grants:write", "policy:read"]` in
+  `server/src/integrations/scopes.ts`.
+
+## Scope (frontend only)
+
+1. **Contract surface** — extend `server/frontend/src/lib/api/contract.ts` with
+   type-only re-exports of the four integration-token DTO types plus the
+   `IntegrationScope` type (the scopes-checkbox UI needs the type to keep its
+   runtime option list drift-checked, exactly as `BudgetsView` types
+   `WINDOW_OPTIONS` against `BudgetWindow`).
+2. **API wrapper** — `server/frontend/src/lib/api/integration-tokens.ts`: thin
+   `apiFetch` wrappers `listIntegrationTokens`, `createIntegrationToken`,
+   `revokeIntegrationToken`, mirroring `clients.ts`.
+3. **View** — `server/frontend/src/lib/views/IntegrationTokensView.svelte`:
+   - List tokens: name, scope chips, created / last-used / revoked timestamps,
+     and an active/revoked state badge.
+   - "Create token" flow: name input + scope checkboxes
+     (`grants:write`, `policy:read`, ≥1 required); on success render the
+     plaintext `secret` **once** in a highlighted panel with a copy button
+     (mirroring `ClientHealthView`'s `navigator.clipboard` + `copied` flag) and
+     a clear "you won't see this again" warning. Append the new token (as a
+     summary) to the table.
+   - Revoke action with `confirm()`; on success swap the row for the returned
+     summary (now carrying `revokedAt`) and disable revoke for already-revoked
+     tokens. Errors surfaced inline via the shared `role="alert"` pattern.
+4. **Wire into the admin shell** — add `{ id: "integrations", label: "Integrations" }`
+   to `navItems` and an `{:else if activeView === "integrations"}` branch in
+   `routes/admin/+page.svelte`.
+
+### Product decision: the "Rate" column in the mock
+
+`design/admin/integrations.html` shows a per-token rate column. Rate limiting is
+**#115** (separate Phase-10 issue) and the summary DTO carries no rate data, so
+this slice omits that column. Noted in the PR; tracked by #115.
+
+## Tests
+
+- `tests/api/integration-tokens.test.ts` — mirrors `tests/api/clients.test.ts`:
+  list GETs the path, create POSTs the body, revoke POSTs `/…/:id/revoke`.
+- `tests/components/integration-tokens-view-crud.test.ts` — mirrors
+  `clients-view-crud.test.ts`: renders rows, empty state, create shows the
+  secret once + appends the row, revoke after confirm shows the revoked badge,
+  revoke declined is a no-op, list error → alert, create error stays inline.
+
+## Gates
+
+From `server/frontend`: `npm run check && npm test && npm run build` (the CI
+`frontend-build` job). Pre-commit excludes `server/frontend/` from
+prettier/eslint/tsc; match existing formatting by hand. No server code touched,
+so the server coverage gate is unaffected.
+
+## Deferred / follow-ups
+
+- Per-token rate display + limiting — **#115**.
+- DNS/AdGuard and Notification-defaults cards in the same mock — their own
+  phases (7 and 8b); out of scope here.

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -48,6 +48,13 @@ export type {
 } from "../../../../src/api/policy/dtos.js";
 export type { AuditEntryResponse, AuditListResponse } from "../../../../src/api/audit/dtos.js";
 export type {
+  CreateIntegrationTokenRequest,
+  IntegrationTokenCreatedResponse,
+  IntegrationTokenSummaryResponse,
+  IntegrationTokenListResponse,
+} from "../../../../src/api/integrations/dtos.js";
+export type { IntegrationScope } from "../../../../src/integrations/scopes.js";
+export type {
   MintEnrolmentTokenRequest,
   EnrolmentTokenResponse,
 } from "../../../../src/api/clients/dtos.js";

--- a/server/frontend/src/lib/api/integration-tokens.ts
+++ b/server/frontend/src/lib/api/integration-tokens.ts
@@ -1,0 +1,44 @@
+/**
+ * Calls for the per-integration API tokens (#114 contract, #250 admin UI).
+ *
+ * The same proven shape as `$lib/api/clients`: thin typed wrappers over
+ * {@link apiFetch}, with the request/response types imported from the shared
+ * `/api` contract so the frontend never re-declares a DTO. An integration token
+ * is a scoped, revocable machine credential an external system (e.g. the family
+ * calendar) uses on the inbound `/api/integrations/*` endpoints.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type {
+  CreateIntegrationTokenRequest,
+  IntegrationTokenCreatedResponse,
+  IntegrationTokenListResponse,
+  IntegrationTokenSummaryResponse,
+} from "./contract.js";
+
+/** List all integration tokens as summaries — never includes a secret. */
+export function listIntegrationTokens(): Promise<IntegrationTokenListResponse> {
+  return apiFetch<IntegrationTokenListResponse>("/integrations/tokens");
+}
+
+/**
+ * Mint an integration token. The response carries the plaintext `secret`
+ * **once** — only its hash is stored server-side — so the caller must show it
+ * immediately and never re-fetch it.
+ */
+export function createIntegrationToken(
+  input: CreateIntegrationTokenRequest,
+): Promise<IntegrationTokenCreatedResponse> {
+  return apiFetch<IntegrationTokenCreatedResponse>("/integrations/tokens", {
+    method: "POST",
+    body: input,
+  });
+}
+
+/** Revoke a token (idempotent); resolves to the updated summary. */
+export function revokeIntegrationToken(id: number): Promise<IntegrationTokenSummaryResponse> {
+  return apiFetch<IntegrationTokenSummaryResponse>(`/integrations/tokens/${id}/revoke`, {
+    method: "POST",
+  });
+}

--- a/server/frontend/src/lib/views/IntegrationTokensView.svelte
+++ b/server/frontend/src/lib/views/IntegrationTokensView.svelte
@@ -1,0 +1,455 @@
+<!--
+  Integration tokens editor (#250): the admin surface for the per-integration
+  API tokens whose backend landed in #114. Loads `/api/integrations/tokens` on
+  mount (browser only — the page is prerendered to a static shell), supports
+  minting a scoped token and revoking one. All calls go through the typed
+  `$lib/api/integration-tokens` wrappers; errors are surfaced inline.
+
+  A token is a scoped, revocable machine credential an external system (e.g. the
+  family calendar) uses on the inbound `/api/integrations/*` endpoints. The
+  plaintext secret is returned by the mint call **once** — only its hash is
+  stored — so this view reveals it a single time with a copy affordance and a
+  clear "you won't see it again" warning, mirroring the enrol-a-client flow.
+
+  Per-token rate display/limiting is #115 and the summary DTO carries no rate
+  data, so the rate column in the mock (`design/admin/integrations.html`) is
+  deliberately omitted from this slice.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { browser } from "$app/environment";
+  import { ApiError } from "$lib/api/client.js";
+  import type {
+    IntegrationScope,
+    IntegrationTokenCreatedResponse,
+    IntegrationTokenSummaryResponse,
+  } from "$lib/api/contract.js";
+  import {
+    createIntegrationToken,
+    listIntegrationTokens,
+    revokeIntegrationToken,
+  } from "$lib/api/integration-tokens.js";
+
+  // Runtime scope vocabulary for the create form, typed against the contract's
+  // `IntegrationScope` so it can never drift from the set the server accepts
+  // (the same drift-checked pattern `BudgetsView` uses for `WINDOW_OPTIONS`).
+  const SCOPE_OPTIONS: ReadonlyArray<{
+    value: IntegrationScope;
+    description: string;
+  }> = [
+    { value: "grants:write", description: "Create grants — award screen time" },
+    { value: "policy:read", description: "Read effective policy and status" },
+  ];
+
+  let tokens = $state<IntegrationTokenSummaryResponse[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // Create form.
+  let newName = $state("");
+  let selectedScopes = $state<IntegrationScope[]>([]);
+  let creating = $state(false);
+
+  // The just-minted token whose plaintext secret is shown exactly once.
+  let minted = $state<IntegrationTokenCreatedResponse | null>(null);
+  let copied = $state(false);
+
+  // Revoke in flight, by token id (so only that row's button shows progress).
+  let revokingId = $state<number | null>(null);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      tokens = await listIntegrationTokens();
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function toggleScope(scope: IntegrationScope, checked: boolean): void {
+    selectedScopes = checked
+      ? [...selectedScopes.filter((s) => s !== scope), scope]
+      : selectedScopes.filter((s) => s !== scope);
+  }
+
+  async function handleCreate(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    creating = true;
+    error = null;
+    copied = false;
+    try {
+      const created = await createIntegrationToken({
+        name: newName.trim(),
+        scopes: selectedScopes,
+      });
+      minted = created;
+      tokens = [
+        ...tokens,
+        {
+          id: created.id,
+          name: created.name,
+          scopes: created.scopes,
+          createdAt: created.createdAt,
+          lastUsedAt: null,
+          revokedAt: null,
+        },
+      ];
+      newName = "";
+      selectedScopes = [];
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      creating = false;
+    }
+  }
+
+  function dismissSecret(): void {
+    minted = null;
+    copied = false;
+  }
+
+  async function copySecret(): Promise<void> {
+    if (minted === null || !browser || !navigator.clipboard) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(minted.secret);
+      copied = true;
+    } catch {
+      copied = false;
+    }
+  }
+
+  async function handleRevoke(token: IntegrationTokenSummaryResponse): Promise<void> {
+    if (!confirm(`Revoke token "${token.name}"? Integrations using it stop working immediately.`)) {
+      return;
+    }
+    revokingId = token.id;
+    error = null;
+    try {
+      const updated = await revokeIntegrationToken(token.id);
+      tokens = tokens.map((t) => (t.id === token.id ? updated : t));
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      revokingId = null;
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+
+  /** Format an ISO-8601 UTC timestamp as a short local date-time, or a dash. */
+  function formatDate(iso: string | null): string {
+    if (iso === null) {
+      return "—";
+    }
+    const date = new Date(iso);
+    return Number.isNaN(date.getTime()) ? iso : date.toLocaleString();
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>Integrations</h1>
+    <p class="hint">
+      Scoped, revocable API tokens for external systems. All inbound traffic goes through
+      <code>/api/integrations/*</code> and authenticates with one of these tokens.
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  <form class="create" onsubmit={handleCreate}>
+    <input
+      type="text"
+      placeholder="Integration name (e.g. calendar)"
+      bind:value={newName}
+      disabled={creating}
+      required
+      aria-label="New token name"
+    />
+    <fieldset class="scopes" disabled={creating}>
+      <legend>Scopes</legend>
+      {#each SCOPE_OPTIONS as option (option.value)}
+        <label class="scope-opt">
+          <input
+            type="checkbox"
+            checked={selectedScopes.includes(option.value)}
+            onchange={(e) => toggleScope(option.value, e.currentTarget.checked)}
+            aria-label={`Scope ${option.value}`}
+          />
+          <span class="scope-name">{option.value}</span>
+          <span class="scope-desc">{option.description}</span>
+        </label>
+      {/each}
+    </fieldset>
+    <button type="submit" disabled={creating || newName.trim() === "" || selectedScopes.length === 0}>
+      {creating ? "Minting…" : "Mint token"}
+    </button>
+  </form>
+
+  {#if minted}
+    <div class="secret" role="status">
+      <div class="secret-head">
+        <strong>Token “{minted.name}” minted.</strong>
+        <button class="ghost" onclick={dismissSecret}>Dismiss</button>
+      </div>
+      <p class="warn">
+        Copy the secret now — it is shown <strong>once</strong> and cannot be retrieved again.
+      </p>
+      <div class="secret-row">
+        <code class="secret-value">{minted.secret}</code>
+        <button onclick={copySecret}>{copied ? "Copied!" : "Copy secret"}</button>
+      </div>
+    </div>
+  {/if}
+
+  {#if loading}
+    <p class="muted">Loading tokens…</p>
+  {:else if tokens.length === 0}
+    <p class="muted">No integration tokens yet. Mint one above.</p>
+  {:else}
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Scopes</th>
+          <th>Created</th>
+          <th>Last used</th>
+          <th>State</th>
+          <th class="actions-col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each tokens as token (token.id)}
+          <tr class:revoked={token.revokedAt !== null}>
+            <td>{token.name}</td>
+            <td class="chips">
+              {#each token.scopes as scope (scope)}
+                <span class="chip">{scope}</span>
+              {/each}
+            </td>
+            <td class="muted">{formatDate(token.createdAt)}</td>
+            <td class="muted">{formatDate(token.lastUsedAt)}</td>
+            <td>
+              {#if token.revokedAt === null}
+                <span class="badge active">active</span>
+              {:else}
+                <span class="badge revoked" title={`Revoked ${formatDate(token.revokedAt)}`}>
+                  revoked
+                </span>
+              {/if}
+            </td>
+            <td class="actions">
+              {#if token.revokedAt === null}
+                <button
+                  class="danger"
+                  onclick={() => handleRevoke(token)}
+                  disabled={revokingId === token.id}
+                >
+                  {revokingId === token.id ? "Revoking…" : "Revoke"}
+                </button>
+              {:else}
+                <span class="muted">—</span>
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+  }
+  code {
+    background: #f3f4f6;
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.25rem;
+    font-size: 0.85em;
+  }
+  .create {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+    flex-wrap: wrap;
+    align-items: flex-end;
+  }
+  .create input[type="text"] {
+    flex: 1 1 14rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+  }
+  .scopes {
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    padding: 0.4rem 0.75rem 0.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .scopes legend {
+    font-size: 0.8rem;
+    color: #374151;
+    font-weight: 600;
+    padding: 0 0.3rem;
+  }
+  .scope-opt {
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+    gap: 0.4rem;
+    align-items: baseline;
+    font-size: 0.85rem;
+  }
+  .scope-name {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-weight: 600;
+  }
+  .scope-desc {
+    color: #6b7280;
+  }
+  .secret {
+    margin-bottom: 1.25rem;
+    padding: 0.75rem 0.9rem;
+    border: 1px solid #fcd34d;
+    background: #fffbeb;
+    border-radius: 0.5rem;
+  }
+  .secret-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .warn {
+    margin: 0.4rem 0;
+    color: #92400e;
+    font-size: 0.85rem;
+  }
+  .secret-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .secret-value {
+    flex: 1 1 16rem;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    padding: 0.45rem 0.55rem;
+    word-break: break-all;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+    vertical-align: top;
+  }
+  th {
+    background: #f9fafb;
+    font-weight: 600;
+    color: #374151;
+  }
+  tr.revoked td {
+    opacity: 0.6;
+  }
+  .chips {
+    display: flex;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+  }
+  .chip {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.7rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.3rem;
+    background: #eef2ff;
+    color: #3730a3;
+    font-weight: 600;
+  }
+  .badge {
+    font-size: 0.72rem;
+    padding: 0.15rem 0.45rem;
+    border-radius: 0.3rem;
+    font-weight: 600;
+  }
+  .badge.active {
+    background: #dcfce7;
+    color: #166534;
+  }
+  .badge.revoked {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .actions-col {
+    width: 1%;
+    white-space: nowrap;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  button.danger {
+    background: #dc2626;
+  }
+  .muted {
+    color: #6b7280;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/routes/admin/+page.svelte
+++ b/server/frontend/src/routes/admin/+page.svelte
@@ -30,6 +30,7 @@
   import SchedulesView from "$lib/views/SchedulesView.svelte";
   import ExceptionsView from "$lib/views/ExceptionsView.svelte";
   import LinksView from "$lib/views/LinksView.svelte";
+  import IntegrationTokensView from "$lib/views/IntegrationTokensView.svelte";
   import AuditLogView from "$lib/views/AuditLogView.svelte";
 
   // `null` while the initial session probe is in flight.
@@ -50,6 +51,7 @@
     { id: "budgets", label: "Budgets" },
     { id: "schedules", label: "Schedules" },
     { id: "exceptions", label: "Exceptions" },
+    { id: "integrations", label: "Integrations" },
     { id: "audit", label: "Audit log" },
   ];
   let activeView = $state<string>("dashboard");
@@ -137,6 +139,8 @@
       <SchedulesView />
     {:else if activeView === "exceptions"}
       <ExceptionsView />
+    {:else if activeView === "integrations"}
+      <IntegrationTokensView />
     {:else if activeView === "audit"}
       <AuditLogView />
     {:else}

--- a/server/frontend/tests/api/integration-tokens.test.ts
+++ b/server/frontend/tests/api/integration-tokens.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createIntegrationToken,
+  listIntegrationTokens,
+  revokeIntegrationToken,
+} from "../../src/lib/api/integration-tokens.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("integration tokens API", () => {
+  it("listIntegrationTokens GETs /api/integrations/tokens", async () => {
+    const rows = [
+      {
+        id: 1,
+        name: "calendar",
+        scopes: ["grants:write", "policy:read"],
+        createdAt: "2026-06-01T00:00:00.000Z",
+        lastUsedAt: null,
+        revokedAt: null,
+      },
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, rows));
+
+    const result = await listIntegrationTokens();
+
+    expect(result).toEqual(rows);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/integrations/tokens");
+  });
+
+  it("createIntegrationToken POSTs the body and returns the once-only secret", async () => {
+    const created = {
+      id: 2,
+      name: "calendar",
+      scopes: ["grants:write"],
+      secret: "PCT-secret-9f2a",
+      createdAt: "2026-06-02T00:00:00.000Z",
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(201, created));
+
+    const request = { name: "calendar", scopes: ["grants:write" as const] };
+    const result = await createIntegrationToken(request);
+
+    expect(result).toEqual(created);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/integrations/tokens");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBe(JSON.stringify(request));
+  });
+
+  it("revokeIntegrationToken POSTs /api/integrations/tokens/:id/revoke", async () => {
+    const revoked = {
+      id: 3,
+      name: "home-assistant",
+      scopes: ["policy:read"],
+      createdAt: "2026-05-20T00:00:00.000Z",
+      lastUsedAt: "2026-06-01T00:00:00.000Z",
+      revokedAt: "2026-06-03T00:00:00.000Z",
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, revoked));
+
+    const result = await revokeIntegrationToken(3);
+
+    expect(result).toEqual(revoked);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/integrations/tokens/3/revoke");
+    expect((init as RequestInit).method).toBe("POST");
+  });
+});

--- a/server/frontend/tests/components/integration-tokens-view-crud.test.ts
+++ b/server/frontend/tests/components/integration-tokens-view-crud.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Flow test for `IntegrationTokensView` (#250).
+ *
+ * Mirrors `clients-view-crud.test.ts`: renders the real component against a
+ * mocked `$lib/api/integration-tokens` (no live backend) and exercises the
+ * highest-value flows — list, empty state, mint-with-once-only-secret, revoke
+ * (confirmed + declined), and the inline error surfaces.
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  IntegrationTokenCreatedResponse,
+  IntegrationTokenSummaryResponse,
+} from "../../src/lib/api/contract.js";
+
+const listIntegrationTokens = vi.fn<() => Promise<IntegrationTokenSummaryResponse[]>>();
+const createIntegrationToken =
+  vi.fn<(input: unknown) => Promise<IntegrationTokenCreatedResponse>>();
+const revokeIntegrationToken =
+  vi.fn<(id: number) => Promise<IntegrationTokenSummaryResponse>>();
+
+vi.mock("$lib/api/integration-tokens", () => ({
+  listIntegrationTokens: () => listIntegrationTokens(),
+  createIntegrationToken: (input: unknown) => createIntegrationToken(input),
+  revokeIntegrationToken: (id: number) => revokeIntegrationToken(id),
+}));
+
+const { default: IntegrationTokensView } = await import(
+  "../../src/lib/views/IntegrationTokensView.svelte"
+);
+
+function summary(
+  overrides: Partial<IntegrationTokenSummaryResponse> = {},
+): IntegrationTokenSummaryResponse {
+  return {
+    id: 1,
+    name: "calendar",
+    scopes: ["grants:write"],
+    createdAt: "2026-06-01T00:00:00.000Z",
+    lastUsedAt: null,
+    revokedAt: null,
+    ...overrides,
+  } as IntegrationTokenSummaryResponse;
+}
+
+beforeEach(() => {
+  listIntegrationTokens.mockReset();
+  createIntegrationToken.mockReset();
+  revokeIntegrationToken.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("IntegrationTokensView", () => {
+  it("renders the tokens returned by the API", async () => {
+    listIntegrationTokens.mockResolvedValue([summary({ id: 1, name: "calendar" })]);
+
+    render(IntegrationTokensView);
+
+    expect(await screen.findByText("calendar")).toBeInTheDocument();
+    expect(listIntegrationTokens).toHaveBeenCalledOnce();
+  });
+
+  it("shows the empty state when there are no tokens", async () => {
+    listIntegrationTokens.mockResolvedValue([]);
+
+    render(IntegrationTokensView);
+
+    expect(
+      await screen.findByText("No integration tokens yet. Mint one above."),
+    ).toBeInTheDocument();
+  });
+
+  it("mints a token, reveals the secret once, and appends the row", async () => {
+    listIntegrationTokens.mockResolvedValue([]);
+    createIntegrationToken.mockResolvedValue({
+      id: 7,
+      name: "home-assistant",
+      scopes: ["policy:read"],
+      secret: "PCT-secret-abcdef",
+      createdAt: "2026-06-02T00:00:00.000Z",
+    });
+
+    render(IntegrationTokensView);
+    await screen.findByText("No integration tokens yet. Mint one above.");
+
+    await fireEvent.input(screen.getByLabelText("New token name"), {
+      target: { value: "home-assistant" },
+    });
+    await fireEvent.click(screen.getByLabelText("Scope policy:read"));
+    await fireEvent.click(screen.getByRole("button", { name: "Mint token" }));
+
+    // The plaintext secret is shown once, with the "shown once" warning.
+    expect(await screen.findByText("PCT-secret-abcdef")).toBeInTheDocument();
+    expect(screen.getByText(/shown/i)).toBeInTheDocument();
+    expect(createIntegrationToken).toHaveBeenCalledWith({
+      name: "home-assistant",
+      scopes: ["policy:read"],
+    });
+    // The new token also appears as a row.
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("home-assistant")).toBeInTheDocument();
+  });
+
+  it("revokes a token after confirmation and shows the revoked badge", async () => {
+    listIntegrationTokens.mockResolvedValue([summary({ id: 1, name: "calendar" })]);
+    revokeIntegrationToken.mockResolvedValue(
+      summary({ id: 1, name: "calendar", revokedAt: "2026-06-03T00:00:00.000Z" }),
+    );
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(IntegrationTokensView);
+    await screen.findByText("calendar");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+
+    expect(await screen.findByText("revoked")).toBeInTheDocument();
+    expect(revokeIntegrationToken).toHaveBeenCalledWith(1);
+    // The revoke action is gone once revoked.
+    expect(screen.queryByRole("button", { name: "Revoke" })).not.toBeInTheDocument();
+  });
+
+  it("does not revoke when the confirmation is declined", async () => {
+    listIntegrationTokens.mockResolvedValue([summary({ id: 1, name: "calendar" })]);
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(IntegrationTokensView);
+    await screen.findByText("calendar");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+
+    expect(revokeIntegrationToken).not.toHaveBeenCalled();
+    expect(screen.getByText("calendar")).toBeInTheDocument();
+  });
+
+  it("surfaces an ApiError from the list load in the inline alert", async () => {
+    const { ApiError } = await import("../../src/lib/api/client.js");
+    listIntegrationTokens.mockRejectedValue(new ApiError(500, "internal", "The server exploded."));
+
+    render(IntegrationTokensView);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("The server exploded.");
+  });
+
+  it("keeps a mint error inline without losing the existing rows", async () => {
+    const { ApiError } = await import("../../src/lib/api/client.js");
+    listIntegrationTokens.mockResolvedValue([summary({ id: 1, name: "calendar" })]);
+    createIntegrationToken.mockRejectedValue(new ApiError(409, "conflict", "That name is taken."));
+
+    render(IntegrationTokensView);
+    await screen.findByText("calendar");
+
+    await fireEvent.input(screen.getByLabelText("New token name"), {
+      target: { value: "calendar" },
+    });
+    await fireEvent.click(screen.getByLabelText("Scope grants:write"));
+    await fireEvent.click(screen.getByRole("button", { name: "Mint token" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("That name is taken.");
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("calendar")).toBeInTheDocument();
+  });
+});

--- a/server/frontend/tests/components/integration-tokens-view-crud.test.ts
+++ b/server/frontend/tests/components/integration-tokens-view-crud.test.ts
@@ -6,7 +6,7 @@
  * highest-value flows — list, empty state, mint-with-once-only-secret, revoke
  * (confirmed + declined), and the inline error surfaces.
  */
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
+import { fireEvent, render, screen, within } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
@@ -103,6 +103,41 @@ describe("IntegrationTokensView", () => {
     // The new token also appears as a row.
     const table = screen.getByRole("table");
     expect(within(table).getByText("home-assistant")).toBeInTheDocument();
+    // Shown exactly once: the appended row must not leak the secret, and the
+    // view never re-fetches the list to try to recover it.
+    expect(within(table).queryByText("PCT-secret-abcdef")).not.toBeInTheDocument();
+    expect(listIntegrationTokens).toHaveBeenCalledOnce();
+  });
+
+  it("copies the minted secret to the clipboard and clears it on dismiss", async () => {
+    listIntegrationTokens.mockResolvedValue([]);
+    createIntegrationToken.mockResolvedValue({
+      id: 8,
+      name: "calendar",
+      scopes: ["grants:write"],
+      secret: "PCT-secret-xyz",
+      createdAt: "2026-06-02T00:00:00.000Z",
+    });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(IntegrationTokensView);
+    await screen.findByText("No integration tokens yet. Mint one above.");
+
+    await fireEvent.input(screen.getByLabelText("New token name"), {
+      target: { value: "calendar" },
+    });
+    await fireEvent.click(screen.getByLabelText("Scope grants:write"));
+    await fireEvent.click(screen.getByRole("button", { name: "Mint token" }));
+    await screen.findByText("PCT-secret-xyz");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Copy secret" }));
+    expect(writeText).toHaveBeenCalledWith("PCT-secret-xyz");
+    expect(await screen.findByRole("button", { name: "Copied!" })).toBeInTheDocument();
+
+    // Dismissing the one-time reveal removes the secret from the DOM for good.
+    await fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByText("PCT-secret-xyz")).not.toBeInTheDocument();
   });
 
   it("revokes a token after confirmation and shows the revoked badge", async () => {


### PR DESCRIPTION
## Summary

- Adds the `/admin` **Integrations** page for the per-integration API tokens whose backend landed in #114: list tokens (scopes, created / last-used / state), mint a scoped token, and revoke one.
- Minting reveals the plaintext `secret` **exactly once** (the API only returns it on create) with a copy affordance and a clear "you won't see this again" warning; the new token is appended to the table as a summary.
- Pure frontend work mirroring the established `$lib/api` + `*View.svelte` patterns — no server code changed, no new enforcement or license surface (`CLAUDE.md` → "Read + mint + revoke only").

## Plan

Linked plan: `.claude/plans/issue-250-integration-tokens-admin-ui.md`
Roadmap: docs/roadmap.md → Phase 10

## Product decision

The mock (`design/admin/integrations.html`) shows a per-token **rate** column. Rate limiting is **#115** (separate Phase-10 issue) and the summary DTO carries no rate data, so this slice omits that column — deferred to #115.

## License-boundary note

N/A — no transport or packaging changes. Frontend-only: a typed `apiFetch` wrapper over the existing JSON API, type-only DTO re-exports through `contract.ts` (erased at build time, no runtime coupling across the process boundary), and a Svelte view. No GPL surface touched.

## Test plan

- [x] `npm run check` (svelte-check) — 0 errors.
- [x] `npm test` — 91 passed (10 new): API wrapper tests (`tests/api/integration-tokens.test.ts`) and component flow tests (`tests/components/integration-tokens-view-crud.test.ts`) covering list, empty state, mint-with-once-only-secret, revoke (confirmed + declined), and inline error surfaces.
- [x] `npm run build` — succeeds; no build artifacts committed.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdy9hffP7AgwBxqX2SBkw)_