### PR TITLE
feat(usage): admin burndown + per-activity timeline views (#62)

### DIFF
--- a/.claude/plans/usage-views-api.md
+++ b/.claude/plans/usage-views-api.md
@@ -1,0 +1,68 @@
+# Plan — #62 Admin burndown + per-activity timeline (Phase 5)
+
+Roadmap: `docs/roadmap.md` → Phase 5 (ActivityWatch telemetry → derived views).
+Architecture: `docs/architecture.md` → "Key derived views" (per-user budget
+burndown; per-activity timeline). ADR 0001/0003 (effective-TZ window rollover).
+
+## Problem
+
+`policy/usage.ts` (#88) already computes the rollups the two views need
+(`usageByActivityInWindow`, `groupSecondsInWindow`, `activityTimeline`) and
+`policy/budget-window.ts` resolves the effective-TZ window. But there is **no
+`/api` surface** exposing them and **no `$lib/api/usage`** wrapper, so the
+"rendering half" (#62) has nothing to consume. This slice closes that gap and
+ships the two reusable components.
+
+## Scope (this PR)
+
+### Phase A — backend usage API (`server/src/api/usage/`)
+Mirrors `GET /api/users/:userId/effective` (#143, `api/policy/effective.ts`):
+thin DB seam over the pure rollups, admin-guarded, single `/api` zod contract.
+
+- `GET /api/users/:userId/usage/burndown?window=daily|weekly|monthly`
+  → `{ userId, window, tz, windowStart, windowEnd, now, budgets: [{ scope,
+  targetId, allowedSeconds, consumedSeconds }] }`. One row per budget the user
+  has in that window; `consumedSeconds` from the matching rollup (overall = Σ
+  all samples in window; activity = `usageByActivityInWindow`; group =
+  `groupSecondsInWindow`). `allowedSeconds` = the budget row's `secondsAllowed`
+  (baseline; grant overlay deferred — see below).
+- `GET /api/users/:userId/usage/timeline?from&to`
+  → `{ userId, tz, from, to, activities: [{ id, kind, matcher }], samples:
+  [{ activityId, startedAt, endedAt }] }`. Raw intervals from `activityTimeline`
+  plus the distinct activities they reference, for lane labels. Defaults to the
+  user's `daily` window (today) when `from`/`to` omitted.
+- DTOs in `api/usage/dtos.ts`; routes in `api/usage/routes.ts`; barrel
+  `api/usage/index.ts`; wired in `api/plugin.ts` after auth (needs `settings`
+  for the server-default TZ). Re-export DTO types from `api/index.ts`.
+- Tests: `server/tests/api/usage/routes.test.ts` — 401 guard, 404 unknown user,
+  400 bad window/dates, happy paths (overall + per-activity + group consumed),
+  default-window, effective-TZ. Time-bomb-safe fixtures (samples relative to
+  `Date.now()`, per #254).
+
+### Phase B — frontend burndown
+- `server/frontend/src/lib/api/usage.ts` typed wrapper (`getBurndown`,
+  `getTimeline`); contract re-exports in `lib/api/contract.ts`.
+- `server/frontend/src/lib/components/charts/BudgetBurndown.svelte` (Svelte 5,
+  hand-rolled SVG, **no new dep**): remaining-vs-budget curve derived from the
+  budget total + timeline samples, ideal-pace reference line, "now" marker,
+  Today/Week/Month toggle. Reads the API itself (window toggle re-fetches).
+- Component test `tests/components/budget-burndown.test.ts` (mock `$lib/api/usage`).
+
+### Phase C — frontend timeline
+- `server/frontend/src/lib/components/charts/ActivityTimeline.svelte`:
+  per-activity horizontal lanes across `[from,to)`.
+- Component test `tests/components/activity-timeline.test.ts`.
+
+## Deferred (tracked via a follow-up issue linked from the PR)
+- **Discrete grant-bump markers** on the burndown — needs the Phase-10 Grant
+  ledger / grant endpoints (#113…), not built yet. `effectivePolicy` folds
+  grant *totals* into the daily budget, but per-event markers need ledger
+  timestamps. Baseline budget is what's meaningful today.
+- Wiring the components into a concrete `/admin` user-detail route (composes
+  with #53 shell).
+- Playwright/real-browser E2E (guide warns against standing one up here).
+
+## License boundary
+Plain TypeScript + zod + Drizzle over the policy model; type-only frontend
+imports of the contract (erased at build). No GPL linkage, no Docker image
+change.

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -58,6 +58,13 @@ export type {
   QueuedActionSummary,
 } from "../../../../src/api/clients/health-dtos.js";
 export type {
+  BurndownResponse,
+  BudgetBurndownRow,
+  TimelineResponse,
+  TimelineActivity,
+  TimelineSample,
+} from "../../../../src/api/usage/dtos.js";
+export type {
   ActivityKind,
   MatchType,
   Scope,

--- a/server/frontend/src/lib/api/usage.ts
+++ b/server/frontend/src/lib/api/usage.ts
@@ -1,0 +1,55 @@
+/**
+ * Read calls for the usage views (#62 backend, #62 components).
+ *
+ * Usage is **read-only** over HTTP — it is derived from telemetry, never from a
+ * request — so this exposes two queries that mirror the other `$lib/api/*`
+ * wrappers (#53): thin typed wrappers over {@link apiFetch}, with the request
+ * shape and response type taken from the shared `/api` contract so the frontend
+ * never re-declares a DTO.
+ *
+ * - `getBurndown` → `GET /api/users/:id/usage/burndown` (per-budget consumed vs
+ *   allowed for the chosen rollover window).
+ * - `getTimeline` → `GET /api/users/:id/usage/timeline` (raw per-activity
+ *   intervals + their activity labels over a range).
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type { BudgetWindow, BurndownResponse, TimelineResponse } from "./contract.js";
+
+/**
+ * Fetch the per-budget burndown for one user over `window` (defaults to
+ * `daily`). The window is resolved in the user's effective timezone server-side.
+ */
+export function getBurndown(
+  userId: number,
+  window: BudgetWindow = "daily",
+): Promise<BurndownResponse> {
+  return apiFetch<BurndownResponse>(`/users/${userId}/usage/burndown?window=${window}`);
+}
+
+/** Optional `[from, to)` range for {@link getTimeline}; ISO-8601 UTC instants. */
+export interface TimelineRange {
+  /** Inclusive start; omitted ⇒ the user's daily window start (today). */
+  from?: string;
+  /** Exclusive end; omitted ⇒ the user's daily window end. */
+  to?: string;
+}
+
+/**
+ * Fetch the per-activity timeline for one user. Omitting both bounds defaults
+ * to the user's `daily` window (today) in their effective timezone.
+ */
+export function getTimeline(userId: number, range: TimelineRange = {}): Promise<TimelineResponse> {
+  const query = new URLSearchParams();
+  if (range.from !== undefined) {
+    query.set("from", range.from);
+  }
+  if (range.to !== undefined) {
+    query.set("to", range.to);
+  }
+  const qs = query.toString();
+  return apiFetch<TimelineResponse>(
+    `/users/${userId}/usage/timeline${qs.length > 0 ? `?${qs}` : ""}`,
+  );
+}

--- a/server/frontend/src/lib/charts/burndown.ts
+++ b/server/frontend/src/lib/charts/burndown.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure geometry helpers for the overall-budget burndown chart (#62).
+ *
+ * Kept free of Svelte/DOM so the consumption maths is unit-tested directly: the
+ * component imports these to place the actual-remaining curve, the ideal-pace
+ * reference line, and the "now" marker. All instants are ISO-8601 UTC strings
+ * (the `/api` contract); the window is half-open `[windowStart, windowEnd)`.
+ */
+import type { TimelineSample } from "$lib/api/contract.js";
+
+/** A point on the remaining-budget curve: epoch ms `t`, seconds `remaining`. */
+export interface RemainingPoint {
+  t: number;
+  remaining: number;
+}
+
+function ms(iso: string): number {
+  return new Date(iso).getTime();
+}
+
+/** Clamped overlap of `[start, end)` with `[from, to)`, in seconds (never < 0). */
+function overlapSeconds(start: number, end: number, from: number, to: number): number {
+  return Math.max(0, Math.min(end, to) - Math.max(start, from)) / 1000;
+}
+
+/** Total seconds consumed across `samples` within `[windowStart, windowEnd)`. */
+export function consumedSeconds(
+  samples: readonly TimelineSample[],
+  windowStart: string,
+  windowEnd: string,
+): number {
+  const from = ms(windowStart);
+  const to = ms(windowEnd);
+  return samples.reduce(
+    (sum, s) => sum + overlapSeconds(ms(s.startedAt), ms(s.endedAt), from, to),
+    0,
+  );
+}
+
+/**
+ * The remaining-budget series: starts at `budgetSeconds` at the window open and
+ * steps down by each sample's in-window consumption, in chronological order.
+ * Remaining is floored at zero (an over-budget day flatlines on the axis). The
+ * first point is always the window start; samples with no overlap are skipped.
+ */
+export function remainingSeries(
+  budgetSeconds: number,
+  samples: readonly TimelineSample[],
+  windowStart: string,
+  windowEnd: string,
+): RemainingPoint[] {
+  const from = ms(windowStart);
+  const to = ms(windowEnd);
+  const points: RemainingPoint[] = [{ t: from, remaining: budgetSeconds }];
+  let remaining = budgetSeconds;
+  const sorted = [...samples].sort((a, b) => ms(a.startedAt) - ms(b.startedAt));
+  for (const sample of sorted) {
+    const start = ms(sample.startedAt);
+    const end = ms(sample.endedAt);
+    const secs = overlapSeconds(start, end, from, to);
+    if (secs <= 0) {
+      continue;
+    }
+    remaining = Math.max(0, remaining - secs);
+    points.push({ t: Math.min(end, to), remaining });
+  }
+  return points;
+}
+
+/**
+ * The ideal-pace remaining at instant `at`: a straight burn from `budgetSeconds`
+ * at the window open to zero at the window close. Clamps outside the window.
+ */
+export function idealRemaining(
+  budgetSeconds: number,
+  windowStart: string,
+  windowEnd: string,
+  at: string,
+): number {
+  const from = ms(windowStart);
+  const to = ms(windowEnd);
+  const now = ms(at);
+  if (now <= from) {
+    return budgetSeconds;
+  }
+  if (now >= to || to <= from) {
+    return 0;
+  }
+  return budgetSeconds * (1 - (now - from) / (to - from));
+}

--- a/server/frontend/src/lib/charts/timeline.ts
+++ b/server/frontend/src/lib/charts/timeline.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure geometry helpers for the per-activity timeline (#62).
+ *
+ * Kept free of Svelte/DOM so the placement maths is unit-tested directly. Each
+ * sample becomes a lane segment positioned as a percentage of the `[from, to)`
+ * window, which the component renders as a horizontal bar in its activity lane.
+ */
+import type { TimelineSample } from "$lib/api/contract.js";
+
+/** A sample's placement within the timeline window, in percent of its width. */
+export interface LaneSegment {
+  activityId: number;
+  /** Left edge as a percentage `[0, 100)` of the window. */
+  leftPct: number;
+  /** Width as a percentage `(0, 100]` of the window. */
+  widthPct: number;
+}
+
+function ms(iso: string): number {
+  return new Date(iso).getTime();
+}
+
+/**
+ * Project each sample onto the `[from, to)` window as a percentage segment,
+ * clamping to the window edges and dropping samples that fall entirely outside
+ * it (zero width). Returns `[]` for a non-positive window.
+ */
+export function laneSegments(
+  samples: readonly TimelineSample[],
+  from: string,
+  to: string,
+): LaneSegment[] {
+  const start = ms(from);
+  const end = ms(to);
+  const span = end - start;
+  if (span <= 0) {
+    return [];
+  }
+  const segments: LaneSegment[] = [];
+  for (const sample of samples) {
+    const clampedStart = Math.max(ms(sample.startedAt), start);
+    const clampedEnd = Math.min(ms(sample.endedAt), end);
+    const widthPct = (Math.max(0, clampedEnd - clampedStart) / span) * 100;
+    if (widthPct <= 0) {
+      continue;
+    }
+    segments.push({
+      activityId: sample.activityId,
+      leftPct: ((clampedStart - start) / span) * 100,
+      widthPct,
+    });
+  }
+  return segments;
+}

--- a/server/frontend/src/lib/components/charts/ActivityTimeline.svelte
+++ b/server/frontend/src/lib/components/charts/ActivityTimeline.svelte
@@ -1,0 +1,129 @@
+<!--
+  Per-activity usage timeline (#62): horizontal lanes, one per activity, showing
+  when each activity was active across the window — the second of the Phase-5
+  "Key derived views" (docs/architecture.md). Reads
+  `GET /api/users/:id/usage/timeline` through the typed `$lib/api/usage` wrapper;
+  omitting `from`/`to` defaults to the user's daily window (today).
+
+  Browser-only and read-only — usage is derived from telemetry, never written
+  from the UI. Lane labels use the activity matcher until friendlier names exist.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  import { ApiError } from "$lib/api/client.js";
+  import type { TimelineActivity, TimelineResponse } from "$lib/api/contract.js";
+  import { getTimeline, type TimelineRange } from "$lib/api/usage.js";
+  import { laneSegments } from "$lib/charts/timeline.js";
+
+  interface Props {
+    /** The supervised user whose timeline to render. */
+    userId: number;
+    /** Optional window start (ISO-8601 UTC); defaults to today. */
+    from?: string;
+    /** Optional window end (ISO-8601 UTC); defaults to today. */
+    to?: string;
+  }
+  let { userId, from, to }: Props = $props();
+
+  let data = $state<TimelineResponse | null>(null);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // One lane per activity, with its samples projected onto the window.
+  let lanes = $derived.by(() => {
+    const current = data;
+    if (current === null) {
+      return [];
+    }
+    return current.activities.map((activity) => ({
+      activity,
+      segments: laneSegments(
+        current.samples.filter((s) => s.activityId === activity.id),
+        current.from,
+        current.to,
+      ),
+    }));
+  });
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const range: TimelineRange = {
+        ...(from !== undefined ? { from } : {}),
+        ...(to !== undefined ? { to } : {}),
+      };
+      data = await getTimeline(userId, range);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+
+  function activityLabel(activity: TimelineActivity): string {
+    return activity.matcher;
+  }
+</script>
+
+<section class="timeline" aria-label="Per-activity timeline">
+  {#if loading}
+    <p class="status">Loading timeline…</p>
+  {:else if error !== null}
+    <p class="status" role="alert">{error}</p>
+  {:else if data !== null}
+    {#if lanes.length === 0}
+      <p class="empty">No activity recorded for this period.</p>
+    {:else}
+      <ul class="lanes">
+        {#each lanes as lane (lane.activity.id)}
+          <li class="lane">
+            <span class="label">{activityLabel(lane.activity)}</span>
+            <span class="track" aria-hidden="true">
+              {#each lane.segments as seg, i (i)}
+                <span class="segment" style="left: {seg.leftPct}%; width: {seg.widthPct}%"></span>
+              {/each}
+            </span>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .lanes {
+    list-style: none;
+    padding: 0;
+  }
+  .lane {
+    display: grid;
+    grid-template-columns: 8rem 1fr;
+    gap: 0.5rem;
+    align-items: center;
+  }
+  .track {
+    position: relative;
+    display: block;
+    height: 0.75rem;
+    background: #f3f4f6;
+    border-radius: 0.25rem;
+  }
+  .segment {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    background: #2563eb;
+    border-radius: 0.25rem;
+  }
+</style>

--- a/server/frontend/src/lib/components/charts/BudgetBurndown.svelte
+++ b/server/frontend/src/lib/components/charts/BudgetBurndown.svelte
@@ -1,0 +1,235 @@
+<!--
+  Overall-budget burndown chart (#62), the rendering half of the Phase-5
+  "Key derived views" (docs/architecture.md). Reads
+  `GET /api/users/:id/usage/burndown` + `…/usage/timeline` through the typed
+  `$lib/api/usage` wrapper and draws remaining budget over the window with an
+  ideal-pace reference line and a "now" marker, plus a per-budget consumed/allowed
+  list. Today / Week / Month re-fetch the corresponding rollover window.
+
+  The SVG is decorative (`aria-hidden`); the textual summary + per-budget list
+  are the accessible surface and what the component tests assert on. Browser-only
+  and read-only — usage is derived from telemetry, never written from the UI.
+
+  Deferred (tracked): discrete grant-bump markers need the Phase-10 grant ledger.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  import { ApiError } from "$lib/api/client.js";
+  import type {
+    BudgetBurndownRow,
+    BudgetWindow,
+    BurndownResponse,
+    TimelineResponse,
+  } from "$lib/api/contract.js";
+  import { getBurndown, getTimeline } from "$lib/api/usage.js";
+  import { remainingSeries } from "$lib/charts/burndown.js";
+  import { formatDuration } from "$lib/format/duration.js";
+
+  interface Props {
+    /** The supervised user whose usage to chart. */
+    userId: number;
+  }
+  let { userId }: Props = $props();
+
+  // `satisfies` keeps every value a valid `BudgetWindow`, so a renamed enum
+  // member fails the build here rather than shipping a dead toggle option.
+  const WINDOW_OPTIONS = [
+    { value: "daily", label: "Today" },
+    { value: "weekly", label: "Week" },
+    { value: "monthly", label: "Month" },
+  ] as const satisfies ReadonlyArray<{ value: BudgetWindow; label: string }>;
+
+  let period = $state<BudgetWindow>("daily");
+  let burndown = $state<BurndownResponse | null>(null);
+  let timeline = $state<TimelineResponse | null>(null);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  let overall = $derived(burndown?.budgets.find((b) => b.scope === "overall") ?? null);
+
+  const VIEW_W = 100;
+  const VIEW_H = 40;
+
+  // The remaining-budget polyline + "now" marker, in the SVG's viewBox units.
+  // `null` when there is no overall budget to burn down.
+  let curve = $derived.by(() => {
+    const data = burndown;
+    const samples = timeline?.samples ?? [];
+    if (data === null || overall === null || overall.allowedSeconds <= 0) {
+      return null;
+    }
+    const windowStartMs = new Date(data.windowStart).getTime();
+    const span = new Date(data.windowEnd).getTime() - windowStartMs;
+    if (span <= 0) {
+      return null;
+    }
+    const budget = overall.allowedSeconds;
+    const points = remainingSeries(budget, samples, data.windowStart, data.windowEnd)
+      .map((p) => {
+        const x = ((p.t - windowStartMs) / span) * VIEW_W;
+        const y = VIEW_H * (1 - p.remaining / budget);
+        return `${x.toFixed(2)},${y.toFixed(2)}`;
+      })
+      .join(" ");
+    const nowX = Math.max(
+      0,
+      Math.min(VIEW_W, ((new Date(data.now).getTime() - windowStartMs) / span) * VIEW_W),
+    );
+    return { points, nowX };
+  });
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const data = await getBurndown(userId, period);
+      burndown = data;
+      // The timeline over the same window feeds the actual-remaining curve.
+      timeline = await getTimeline(userId, { from: data.windowStart, to: data.windowEnd });
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function selectWindow(value: BudgetWindow): void {
+    if (value === period) {
+      return;
+    }
+    period = value;
+    void load();
+  }
+
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+
+  /** A human label for a budget row (ids until activity names are surfaced). */
+  function budgetLabel(b: BudgetBurndownRow): string {
+    if (b.scope === "overall") {
+      return "Overall";
+    }
+    const noun = b.scope === "group" ? "Group" : "Activity";
+    return `${noun} #${b.targetId ?? "?"}`;
+  }
+
+  /** Consumed fraction of a budget as a clamped percentage. */
+  function consumedPct(b: BudgetBurndownRow): number {
+    return b.allowedSeconds <= 0 ? 0 : Math.min(100, (b.consumedSeconds / b.allowedSeconds) * 100);
+  }
+</script>
+
+<section class="burndown" aria-label="Budget burndown">
+  <div class="toggle" role="group" aria-label="Window">
+    {#each WINDOW_OPTIONS as opt (opt.value)}
+      <button type="button" aria-pressed={period === opt.value} onclick={() => selectWindow(opt.value)}>
+        {opt.label}
+      </button>
+    {/each}
+  </div>
+
+  {#if loading}
+    <p class="status">Loading usage…</p>
+  {:else if error !== null}
+    <p class="status" role="alert">{error}</p>
+  {:else if burndown !== null}
+    {#if overall !== null}
+      <p class="summary">
+        {formatDuration(overall.consumedSeconds)} of {formatDuration(overall.allowedSeconds)} used ·
+        {formatDuration(Math.max(0, overall.allowedSeconds - overall.consumedSeconds))} remaining
+      </p>
+      {#if curve !== null}
+        <svg
+          class="chart"
+          viewBox="0 0 {VIEW_W} {VIEW_H}"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <line class="ideal" x1="0" y1="0" x2={VIEW_W} y2={VIEW_H} />
+          <polyline class="actual" points={curve.points} fill="none" />
+          <line class="now" x1={curve.nowX} y1="0" x2={curve.nowX} y2={VIEW_H} />
+        </svg>
+      {/if}
+    {:else}
+      <p class="empty">No overall budget set for this window.</p>
+    {/if}
+
+    {#if burndown.budgets.length > 0}
+      <ul class="budgets">
+        {#each burndown.budgets as b (b.scope + ":" + (b.targetId ?? "null"))}
+          <li>
+            <span class="label">{budgetLabel(b)}</span>
+            <span class="bar"><span class="fill" style="width: {consumedPct(b)}%"></span></span>
+            <span class="value">
+              {formatDuration(b.consumedSeconds)} / {formatDuration(b.allowedSeconds)}
+            </span>
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <p class="empty">No budgets defined for this window.</p>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .toggle {
+    display: inline-flex;
+    gap: 0.25rem;
+  }
+  .toggle button[aria-pressed="true"] {
+    font-weight: 600;
+    text-decoration: underline;
+  }
+  .chart {
+    display: block;
+    width: 100%;
+    height: 8rem;
+  }
+  .ideal {
+    stroke: #9ca3af;
+    stroke-width: 0.4;
+    stroke-dasharray: 1.5 1.5;
+  }
+  .actual {
+    stroke: #2563eb;
+    stroke-width: 0.8;
+  }
+  .now {
+    stroke: #dc2626;
+    stroke-width: 0.4;
+  }
+  .budgets {
+    list-style: none;
+    padding: 0;
+  }
+  .budgets li {
+    display: grid;
+    grid-template-columns: 8rem 1fr 8rem;
+    gap: 0.5rem;
+    align-items: center;
+  }
+  .bar {
+    display: block;
+    height: 0.5rem;
+    background: #e5e7eb;
+    border-radius: 0.25rem;
+    overflow: hidden;
+  }
+  .fill {
+    display: block;
+    height: 100%;
+    background: #2563eb;
+  }
+  .value {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/server/frontend/src/lib/components/charts/BudgetBurndown.svelte
+++ b/server/frontend/src/lib/components/charts/BudgetBurndown.svelte
@@ -52,7 +52,11 @@
   const VIEW_H = 40;
 
   // The remaining-budget polyline + "now" marker, in the SVG's viewBox units.
-  // `null` when there is no overall budget to burn down.
+  // `null` when there is no overall budget to burn down. The curve is built from
+  // the raw timeline intervals (not the API's scalar `consumedSeconds`) because
+  // it needs the *step shape* over the window — when time was burned, not just
+  // the total. The scalar still drives the textual summary, and the two agree by
+  // construction (identical half-open clamp, same window).
   let curve = $derived.by(() => {
     const data = burndown;
     const samples = timeline?.samples ?? [];

--- a/server/frontend/src/lib/format/duration.ts
+++ b/server/frontend/src/lib/format/duration.ts
@@ -1,0 +1,24 @@
+/**
+ * Compact human duration formatting, shared by the usage views (#62).
+ *
+ * Renders a seconds count as `Xh Ym` (dropping a zero hours or zero minutes
+ * component), e.g. `5400 → "1h 30m"`, `1800 → "30m"`, `7200 → "2h"`. Negative
+ * inputs clamp to zero so a rounding artefact never prints a negative duration.
+ */
+
+/** Render `seconds` as a compact `Xh Ym` (or `Ym` / `Xh`). */
+export function formatDuration(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds));
+  let hours = Math.floor(total / 3600);
+  let minutes = Math.round((total - hours * 3600) / 60);
+  // A value like 3599s rounds its minutes to 60; carry it into the hours so we
+  // never print "0h 60m".
+  if (minutes === 60) {
+    hours += 1;
+    minutes = 0;
+  }
+  if (hours === 0) {
+    return `${minutes}m`;
+  }
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+}

--- a/server/frontend/tests/api/charts.test.ts
+++ b/server/frontend/tests/api/charts.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { TimelineSample } from "../../src/lib/api/contract.js";
+import { consumedSeconds, idealRemaining, remainingSeries } from "../../src/lib/charts/burndown.js";
+import { laneSegments } from "../../src/lib/charts/timeline.js";
+import { formatDuration } from "../../src/lib/format/duration.js";
+
+const WINDOW_START = "2026-06-20T00:00:00.000Z";
+const WINDOW_END = "2026-06-21T00:00:00.000Z";
+
+function sample(activityId: number, startedAt: string, endedAt: string): TimelineSample {
+  return { activityId, startedAt, endedAt };
+}
+
+describe("formatDuration", () => {
+  it("renders hours and minutes", () => {
+    expect(formatDuration(5400)).toBe("1h 30m");
+  });
+  it("drops a zero hours component", () => {
+    expect(formatDuration(1800)).toBe("30m");
+  });
+  it("drops a zero minutes component", () => {
+    expect(formatDuration(7200)).toBe("2h");
+  });
+  it("carries a 60-minute rounding artefact into the hours", () => {
+    expect(formatDuration(3599)).toBe("1h");
+  });
+  it("clamps a negative value to zero", () => {
+    expect(formatDuration(-10)).toBe("0m");
+  });
+});
+
+describe("burndown geometry", () => {
+  it("sums the clamped overlap of every sample in the window", () => {
+    const samples = [
+      sample(1, "2026-06-20T01:00:00.000Z", "2026-06-20T01:30:00.000Z"), // 1800
+      // Straddles the window end → only the in-window half counts.
+      sample(2, "2026-06-20T23:30:00.000Z", "2026-06-21T00:30:00.000Z"), // 1800
+      // Entirely outside → ignored.
+      sample(3, "2026-06-22T00:00:00.000Z", "2026-06-22T01:00:00.000Z"),
+    ];
+    expect(consumedSeconds(samples, WINDOW_START, WINDOW_END)).toBe(3600);
+  });
+
+  it("steps the remaining series down by each sample's consumption", () => {
+    const samples = [
+      sample(1, "2026-06-20T02:00:00.000Z", "2026-06-20T02:30:00.000Z"), // 1800
+      sample(1, "2026-06-20T01:00:00.000Z", "2026-06-20T01:10:00.000Z"), // 600
+    ];
+    const series = remainingSeries(7200, samples, WINDOW_START, WINDOW_END);
+    // Sorted chronologically: start, then the 01:00 sample, then the 02:00 one.
+    expect(series.map((p) => p.remaining)).toEqual([7200, 6600, 4800]);
+  });
+
+  it("floors remaining at zero for an over-budget day", () => {
+    const samples = [sample(1, "2026-06-20T01:00:00.000Z", "2026-06-20T03:00:00.000Z")]; // 7200
+    const series = remainingSeries(3600, samples, WINDOW_START, WINDOW_END);
+    expect(series.at(-1)?.remaining).toBe(0);
+  });
+
+  it("computes ideal pace linearly, clamped to the window", () => {
+    expect(idealRemaining(7200, WINDOW_START, WINDOW_END, WINDOW_START)).toBe(7200);
+    expect(idealRemaining(7200, WINDOW_START, WINDOW_END, WINDOW_END)).toBe(0);
+    expect(idealRemaining(7200, WINDOW_START, WINDOW_END, "2026-06-20T12:00:00.000Z")).toBe(3600);
+    // Before / after the window clamp to the endpoints.
+    expect(idealRemaining(7200, WINDOW_START, WINDOW_END, "2026-06-19T00:00:00.000Z")).toBe(7200);
+  });
+});
+
+describe("timeline geometry", () => {
+  it("projects each sample onto the window as a percentage segment", () => {
+    const samples = [sample(1, "2026-06-20T06:00:00.000Z", "2026-06-20T12:00:00.000Z")];
+    const [seg] = laneSegments(samples, WINDOW_START, WINDOW_END);
+    expect(seg).toEqual({ activityId: 1, leftPct: 25, widthPct: 25 });
+  });
+
+  it("clamps a sample that straddles the window edges", () => {
+    const samples = [sample(1, "2026-06-19T18:00:00.000Z", "2026-06-20T06:00:00.000Z")];
+    const [seg] = laneSegments(samples, WINDOW_START, WINDOW_END);
+    expect(seg).toEqual({ activityId: 1, leftPct: 0, widthPct: 25 });
+  });
+
+  it("drops samples with no in-window overlap", () => {
+    const samples = [sample(1, "2026-06-22T00:00:00.000Z", "2026-06-22T01:00:00.000Z")];
+    expect(laneSegments(samples, WINDOW_START, WINDOW_END)).toEqual([]);
+  });
+
+  it("returns no segments for a non-positive window", () => {
+    const samples = [sample(1, WINDOW_START, WINDOW_END)];
+    expect(laneSegments(samples, WINDOW_END, WINDOW_START)).toEqual([]);
+  });
+});

--- a/server/frontend/tests/api/usage.test.ts
+++ b/server/frontend/tests/api/usage.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getBurndown, getTimeline } from "../../src/lib/api/usage.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("usage API", () => {
+  it("getBurndown GETs the daily window by default", async () => {
+    const body = { userId: 1, window: "daily", tz: "UTC", budgets: [] };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, body));
+
+    const result = await getBurndown(1);
+
+    expect(result).toEqual(body);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/users/1/usage/burndown?window=daily");
+  });
+
+  it("getBurndown passes the chosen window", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, { budgets: [] }));
+
+    await getBurndown(7, "monthly");
+
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/users/7/usage/burndown?window=monthly");
+  });
+
+  it("getTimeline omits the querystring when no range is given", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, { samples: [], activities: [] }));
+
+    await getTimeline(3);
+
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/users/3/usage/timeline");
+  });
+
+  it("getTimeline encodes the from/to range", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, { samples: [], activities: [] }));
+
+    await getTimeline(3, { from: "2026-06-20T00:00:00.000Z", to: "2026-06-21T00:00:00.000Z" });
+
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toContain("/api/users/3/usage/timeline?");
+    expect(url).toContain("from=2026-06-20T00%3A00%3A00.000Z");
+    expect(url).toContain("to=2026-06-21T00%3A00%3A00.000Z");
+  });
+});

--- a/server/frontend/tests/components/activity-timeline.test.ts
+++ b/server/frontend/tests/components/activity-timeline.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Component smoke test for the per-activity timeline (#62).
+ *
+ * Renders `ActivityTimeline` against a mocked `$lib/api/usage` (no live backend)
+ * and asserts the lane labels render per activity, the empty state, and the
+ * inline error surface.
+ */
+import { render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineResponse } from "../../src/lib/api/contract.js";
+
+const getTimeline = vi.fn<() => Promise<TimelineResponse>>();
+
+vi.mock("$lib/api/usage", () => ({
+  getTimeline: () => getTimeline(),
+}));
+
+const { default: ActivityTimeline } = await import(
+  "../../src/lib/components/charts/ActivityTimeline.svelte"
+);
+
+function timeline(overrides: Partial<TimelineResponse> = {}): TimelineResponse {
+  return {
+    userId: 1,
+    tz: "UTC",
+    from: "2026-06-20T00:00:00.000Z",
+    to: "2026-06-21T00:00:00.000Z",
+    activities: [
+      { id: 1, kind: "app", matcher: "steam" },
+      { id: 2, kind: "app", matcher: "discord" },
+    ],
+    samples: [
+      { activityId: 1, startedAt: "2026-06-20T06:00:00.000Z", endedAt: "2026-06-20T12:00:00.000Z" },
+      { activityId: 2, startedAt: "2026-06-20T13:00:00.000Z", endedAt: "2026-06-20T13:30:00.000Z" },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  getTimeline.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ActivityTimeline", () => {
+  it("renders one labelled lane per activity", async () => {
+    getTimeline.mockResolvedValue(timeline());
+
+    render(ActivityTimeline, { userId: 1 });
+
+    expect(await screen.findByText("steam")).toBeInTheDocument();
+    expect(screen.getByText("discord")).toBeInTheDocument();
+    expect(getTimeline).toHaveBeenCalledOnce();
+  });
+
+  it("shows the empty state when nothing was recorded", async () => {
+    getTimeline.mockResolvedValue(timeline({ activities: [], samples: [] }));
+
+    render(ActivityTimeline, { userId: 1 });
+
+    expect(await screen.findByText("No activity recorded for this period.")).toBeInTheDocument();
+  });
+
+  it("surfaces an API error inline", async () => {
+    getTimeline.mockRejectedValue(new Error("nope"));
+
+    render(ActivityTimeline, { userId: 1 });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("nope");
+  });
+});

--- a/server/frontend/tests/components/budget-burndown.test.ts
+++ b/server/frontend/tests/components/budget-burndown.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Component smoke test for the overall-budget burndown chart (#62).
+ *
+ * Renders `BudgetBurndown` against a mocked `$lib/api/usage` (no live backend)
+ * and drives the logic the typed API-wrapper tests can't reach: the load →
+ * summary render, the Today/Week/Month toggle re-fetching the right window, the
+ * no-overall-budget empty state, and the inline error surface.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BurndownResponse, TimelineResponse } from "../../src/lib/api/contract.js";
+
+const getBurndown = vi.fn<(userId: number, window?: string) => Promise<BurndownResponse>>();
+const getTimeline = vi.fn<() => Promise<TimelineResponse>>();
+
+vi.mock("$lib/api/usage", () => ({
+  getBurndown: (userId: number, window?: string) => getBurndown(userId, window),
+  getTimeline: () => getTimeline(),
+}));
+
+const { default: BudgetBurndown } = await import(
+  "../../src/lib/components/charts/BudgetBurndown.svelte"
+);
+
+function burndown(overrides: Partial<BurndownResponse> = {}): BurndownResponse {
+  return {
+    userId: 1,
+    window: "daily",
+    tz: "UTC",
+    windowStart: "2026-06-20T00:00:00.000Z",
+    windowEnd: "2026-06-21T00:00:00.000Z",
+    now: "2026-06-20T12:00:00.000Z",
+    budgets: [{ scope: "overall", targetId: null, allowedSeconds: 7200, consumedSeconds: 1800 }],
+    ...overrides,
+  };
+}
+
+function timeline(): TimelineResponse {
+  return {
+    userId: 1,
+    tz: "UTC",
+    from: "2026-06-20T00:00:00.000Z",
+    to: "2026-06-21T00:00:00.000Z",
+    activities: [{ id: 1, kind: "app", matcher: "steam" }],
+    samples: [
+      { activityId: 1, startedAt: "2026-06-20T01:00:00.000Z", endedAt: "2026-06-20T01:30:00.000Z" },
+    ],
+  };
+}
+
+beforeEach(() => {
+  getBurndown.mockReset();
+  getTimeline.mockReset();
+  getTimeline.mockResolvedValue(timeline());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("BudgetBurndown", () => {
+  it("renders the overall consumed/remaining summary", async () => {
+    getBurndown.mockResolvedValue(burndown());
+
+    render(BudgetBurndown, { userId: 1 });
+
+    expect(await screen.findByText(/30m of 2h used/)).toBeInTheDocument();
+    expect(screen.getByText(/1h 30m remaining/)).toBeInTheDocument();
+    expect(getBurndown).toHaveBeenCalledWith(1, "daily");
+  });
+
+  it("re-fetches the weekly window when the Week toggle is clicked", async () => {
+    getBurndown.mockResolvedValue(burndown());
+
+    render(BudgetBurndown, { userId: 1 });
+    await screen.findByText(/30m of 2h used/);
+
+    getBurndown.mockResolvedValue(burndown({ window: "weekly" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Week" }));
+
+    await waitFor(() => expect(getBurndown).toHaveBeenLastCalledWith(1, "weekly"));
+    expect(screen.getByRole("button", { name: "Week" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows the empty state when there is no overall budget", async () => {
+    getBurndown.mockResolvedValue(burndown({ budgets: [] }));
+
+    render(BudgetBurndown, { userId: 1 });
+
+    expect(await screen.findByText("No overall budget set for this window.")).toBeInTheDocument();
+    expect(screen.getByText("No budgets defined for this window.")).toBeInTheDocument();
+  });
+
+  it("surfaces an API error inline", async () => {
+    getBurndown.mockRejectedValue(new Error("boom"));
+
+    render(BudgetBurndown, { userId: 1 });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("boom");
+  });
+});

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -142,6 +142,26 @@ export {
   type ListAuditQuery,
 } from "./audit/index.js";
 
+// Usage-views DTOs (#62): the read-only contract for the admin burndown chart
+// and per-activity timeline. Schemas live in `./usage/dtos.ts` next to the route.
+export {
+  budgetBurndownRowSchema,
+  burndownQuerySchema,
+  burndownResponseSchema,
+  timelineActivitySchema,
+  timelineQuerySchema,
+  timelineResponseSchema,
+  timelineSampleSchema,
+  usageParamsSchema,
+  type BudgetBurndownRow,
+  type BurndownQuery,
+  type BurndownResponse,
+  type TimelineActivity,
+  type TimelineQuery,
+  type TimelineResponse,
+  type TimelineSample,
+} from "./usage/index.js";
+
 // DNS-status DTO (#95): the read-only contract surfacing the active AdGuard mode
 // and its health. Schema lives in `./dns/dtos.ts` next to the route.
 export {

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -19,6 +19,7 @@ import { registerIntegrationRoutes } from "./integrations/index.js";
 import { registerMetaRoute } from "./meta.js";
 import { registerEffectiveRoutes, registerPolicyRoutes } from "./policy/index.js";
 import { registerSystemRoutes } from "./system/index.js";
+import { registerUsageRoutes } from "./usage/index.js";
 import { installApiConventions } from "./validation.js";
 
 /** Options the `/api` plugin needs from its host app. */
@@ -56,6 +57,10 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   // Effective-policy preview (#143): GET /users/:userId/effective. Needs
   // `settings` for the server-default timezone of users with no `tz`.
   registerEffectiveRoutes(scope, opts.settings);
+  // Usage views (#62): admin-only read of per-budget burndown + the
+  // per-activity timeline, the data source for the Phase-5 chart components.
+  // Needs `settings` for the server-default timezone of users with no `tz`.
+  registerUsageRoutes(scope, opts.settings);
   // Client enrolment (#77): admin-minted token + the install script's enrol
   // exchange. `settings` carries the SSH-public-key path the enrol response returns.
   registerClientEnrolmentRoutes(scope, opts.settings);

--- a/server/src/api/usage/dtos.ts
+++ b/server/src/api/usage/dtos.ts
@@ -1,0 +1,125 @@
+/**
+ * zod DTOs for the usage-views read API (#62), shared with the frontend (the
+ * single `/api/*` contract). Two read-only views, both sourced from the
+ * `policy/usage.ts` rollups (#88) resolved over the user's effective-timezone
+ * budget window (ADR 0001/0003):
+ *
+ * - **burndown** — per-budget `allowedSeconds` (baseline) vs `consumedSeconds`
+ *   for `daily` / `weekly` / `monthly` ("today / week / month").
+ * - **timeline** — the raw per-activity intervals over `[from, to)`, plus the
+ *   distinct activities they reference, for the per-activity lane labels.
+ *
+ * There is no write DTO: usage is derived from telemetry, never from a request.
+ * All instants serialise as ISO-8601 UTC strings (storage stays UTC epoch
+ * seconds); seconds are whole numbers (sample boundaries are second-aligned).
+ */
+import { z } from "zod";
+
+import { activityKindSchema, budgetWindowSchema, scopeSchema } from "../../policy/enums.js";
+
+/** `:userId` path param shared by both usage routes. */
+export const usageParamsSchema = z.object({ userId: z.coerce.number().int().positive() });
+
+/** The inferred, validated `:userId` params. */
+export type UsageParams = z.infer<typeof usageParamsSchema>;
+
+/**
+ * Querystring for `GET …/usage/burndown`. `window` selects the rollover period
+ * to roll up over, defaulting to `daily` ("today").
+ */
+export const burndownQuerySchema = z.object({
+  window: budgetWindowSchema.default("daily"),
+});
+
+/** The inferred, validated burndown query. */
+export type BurndownQuery = z.infer<typeof burndownQuerySchema>;
+
+/**
+ * One budget's burndown: its baseline allowance and how much has been consumed
+ * in the window. `targetId` is `null` for the `overall` budget, the activity id
+ * for an `activity` budget, and the group id for a `group` budget.
+ */
+export const budgetBurndownRowSchema = z.object({
+  scope: scopeSchema,
+  targetId: z.number().int().nullable(),
+  /** Baseline budget for the window, in seconds (grant overlay is deferred). */
+  allowedSeconds: z.number().int(),
+  /** Seconds consumed in the window, clamped to the window's overlap. */
+  consumedSeconds: z.number().int(),
+});
+
+/** The inferred shape of one budget burndown row. */
+export type BudgetBurndownRow = z.infer<typeof budgetBurndownRowSchema>;
+
+/**
+ * The burndown response: the effective window bounds (so the renderer can place
+ * the "now" marker and ideal-pace line) plus one row per budget the user has in
+ * that window.
+ */
+export const burndownResponseSchema = z.object({
+  userId: z.number().int(),
+  window: budgetWindowSchema,
+  tz: z.string(),
+  /** Inclusive window start, ISO-8601 UTC. */
+  windowStart: z.string(),
+  /** Exclusive window end, ISO-8601 UTC. */
+  windowEnd: z.string(),
+  /** The reference instant the window was resolved around, ISO-8601 UTC. */
+  now: z.string(),
+  budgets: z.array(budgetBurndownRowSchema),
+});
+
+/** The inferred shape of the burndown response. */
+export type BurndownResponse = z.infer<typeof burndownResponseSchema>;
+
+/**
+ * Querystring for `GET …/usage/timeline`. Both bounds are optional ISO-8601
+ * datetimes; when omitted the handler defaults to the user's `daily` window
+ * (today) in their effective timezone. `from` must precede `to` (enforced in
+ * the handler, where the defaults are resolved).
+ */
+export const timelineQuerySchema = z.object({
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+});
+
+/** The inferred, validated timeline query. */
+export type TimelineQuery = z.infer<typeof timelineQuerySchema>;
+
+/** An activity referenced by the timeline, for the lane label. */
+export const timelineActivitySchema = z.object({
+  id: z.number().int(),
+  kind: activityKindSchema,
+  matcher: z.string(),
+});
+
+/** The inferred shape of one timeline activity label. */
+export type TimelineActivity = z.infer<typeof timelineActivitySchema>;
+
+/** One usage interval on the timeline. */
+export const timelineSampleSchema = z.object({
+  activityId: z.number().int(),
+  /** Interval start, ISO-8601 UTC. */
+  startedAt: z.string(),
+  /** Interval end (exclusive), ISO-8601 UTC. */
+  endedAt: z.string(),
+});
+
+/** The inferred shape of one timeline sample. */
+export type TimelineSample = z.infer<typeof timelineSampleSchema>;
+
+/**
+ * The timeline response: the resolved `[from, to)` window plus the intervals
+ * (ascending by start) and the distinct activities they reference.
+ */
+export const timelineResponseSchema = z.object({
+  userId: z.number().int(),
+  tz: z.string(),
+  from: z.string(),
+  to: z.string(),
+  activities: z.array(timelineActivitySchema),
+  samples: z.array(timelineSampleSchema),
+});
+
+/** The inferred shape of the timeline response. */
+export type TimelineResponse = z.infer<typeof timelineResponseSchema>;

--- a/server/src/api/usage/index.ts
+++ b/server/src/api/usage/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Usage-views API surface (#62): the route registrar plus the zod DTOs and
+ * inferred types the frontend consumes. Re-exported from the top-level `api/`
+ * barrel so the contract is imported from one place.
+ */
+export { registerUsageRoutes } from "./routes.js";
+export {
+  budgetBurndownRowSchema,
+  burndownQuerySchema,
+  burndownResponseSchema,
+  timelineActivitySchema,
+  timelineQuerySchema,
+  timelineResponseSchema,
+  timelineSampleSchema,
+  usageParamsSchema,
+  type BudgetBurndownRow,
+  type BurndownQuery,
+  type BurndownResponse,
+  type TimelineActivity,
+  type TimelineQuery,
+  type TimelineResponse,
+  type TimelineSample,
+} from "./dtos.js";

--- a/server/src/api/usage/routes.ts
+++ b/server/src/api/usage/routes.ts
@@ -1,0 +1,155 @@
+/**
+ * The usage-views read API (#62):
+ *
+ * - `GET /api/users/:userId/usage/burndown?window=daily|weekly|monthly`
+ * - `GET /api/users/:userId/usage/timeline?from&to`
+ *
+ * These are the contract the admin burndown chart and per-activity timeline
+ * (`docs/architecture.md` → "Key derived views") consume. Like the
+ * effective-policy preview (#143, `api/policy/effective.ts`) the handlers stay
+ * thin: resolve the user's effective timezone, roll up over the effective-TZ
+ * window via the pure `policy/usage.ts` helpers, and serialise. The Svelte
+ * components live in the frontend; the API never renders.
+ *
+ * License boundary: none touched — plain TypeScript + zod + Drizzle.
+ */
+import { and, eq, inArray } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+
+import type { Settings } from "../../config.js";
+import { effectiveWindow, resolveEffectiveTz } from "../../policy/budget-window.js";
+import * as repo from "../../policy/repository.js";
+import { activities, budgets } from "../../policy/schema.js";
+import {
+  activityTimeline,
+  groupSecondsInWindow,
+  usageByActivityInWindow,
+} from "../../policy/usage.js";
+import { ApiError } from "../errors.js";
+import type { ZodTypeProvider } from "../validation.js";
+import {
+  burndownQuerySchema,
+  timelineQuerySchema,
+  usageParamsSchema,
+  type BudgetBurndownRow,
+  type BurndownResponse,
+  type TimelineResponse,
+} from "./dtos.js";
+
+/**
+ * Register the usage read routes on an already-`/api`-prefixed scope. Call
+ * after {@link registerAuth} so `scope.requireAdmin` exists; `settings`
+ * supplies the server-default timezone for users with no `tz`.
+ */
+export function registerUsageRoutes(scope: FastifyInstance, settings: Settings): void {
+  const typed = scope.withTypeProvider<ZodTypeProvider>();
+  const guard = { preHandler: scope.requireAdmin };
+
+  typed.get(
+    "/users/:userId/usage/burndown",
+    { ...guard, schema: { params: usageParamsSchema, querystring: burndownQuerySchema } },
+    async (request): Promise<BurndownResponse> => {
+      const { userId } = request.params;
+      const user = repo.getUser(scope.db, userId);
+      if (user === undefined) {
+        throw new ApiError(404, "not_found", `User ${userId} not found`);
+      }
+
+      const tz = resolveEffectiveTz(user.tz, settings.defaultTz);
+      const { window } = request.query;
+      const now = new Date();
+      const bounds = effectiveWindow(window, now, tz);
+
+      // One pass of per-activity consumption serves both the overall total
+      // (Σ over every activity) and each per-activity budget row.
+      const byActivity = usageByActivityInWindow(scope.db, { userId, window, now, tz });
+      const overallConsumed = [...byActivity.values()].reduce((sum, secs) => sum + secs, 0);
+
+      const budgetRows = scope.db
+        .select()
+        .from(budgets)
+        .where(and(eq(budgets.userId, userId), eq(budgets.window, window)))
+        .all();
+
+      const rows: BudgetBurndownRow[] = budgetRows.map((row) => {
+        let consumed: number;
+        if (row.scope === "activity" && row.targetId !== null) {
+          consumed = byActivity.get(row.targetId) ?? 0;
+        } else if (row.scope === "group" && row.targetId !== null) {
+          consumed = groupSecondsInWindow(scope.db, {
+            userId,
+            window,
+            now,
+            tz,
+            groupId: row.targetId,
+          });
+        } else {
+          // `overall` (target_id null by the schema CHECK) — total screen time.
+          consumed = overallConsumed;
+        }
+        return {
+          scope: row.scope,
+          targetId: row.targetId,
+          allowedSeconds: row.secondsAllowed,
+          consumedSeconds: Math.round(consumed),
+        };
+      });
+
+      return {
+        userId,
+        window,
+        tz,
+        windowStart: bounds.start.toISOString(),
+        windowEnd: bounds.end.toISOString(),
+        now: now.toISOString(),
+        budgets: rows,
+      };
+    },
+  );
+
+  typed.get(
+    "/users/:userId/usage/timeline",
+    { ...guard, schema: { params: usageParamsSchema, querystring: timelineQuerySchema } },
+    async (request): Promise<TimelineResponse> => {
+      const { userId } = request.params;
+      const user = repo.getUser(scope.db, userId);
+      if (user === undefined) {
+        throw new ApiError(404, "not_found", `User ${userId} not found`);
+      }
+
+      const tz = resolveEffectiveTz(user.tz, settings.defaultTz);
+      // Default the window to "today" in the user's effective zone; either
+      // bound can be overridden independently.
+      const defaults = effectiveWindow("daily", new Date(), tz);
+      const from = request.query.from !== undefined ? new Date(request.query.from) : defaults.start;
+      const to = request.query.to !== undefined ? new Date(request.query.to) : defaults.end;
+      if (from.getTime() >= to.getTime()) {
+        throw new ApiError(400, "validation_error", "`from` must be before `to`");
+      }
+
+      const samples = activityTimeline(scope.db, { userId, from, to });
+      const activityIds = [...new Set(samples.map((sample) => sample.activityId))];
+      const activityRows =
+        activityIds.length > 0
+          ? scope.db.select().from(activities).where(inArray(activities.id, activityIds)).all()
+          : [];
+
+      return {
+        userId,
+        tz,
+        from: from.toISOString(),
+        to: to.toISOString(),
+        activities: activityRows.map((activity) => ({
+          id: activity.id,
+          kind: activity.kind,
+          matcher: activity.matcher,
+        })),
+        samples: samples.map((sample) => ({
+          activityId: sample.activityId,
+          startedAt: sample.startedAt.toISOString(),
+          endedAt: sample.endedAt.toISOString(),
+        })),
+      };
+    },
+  );
+}

--- a/server/tests/api/usage/routes.test.ts
+++ b/server/tests/api/usage/routes.test.ts
@@ -1,0 +1,303 @@
+/**
+ * HTTP tests for the usage-views read API (#62):
+ * `GET /api/users/:userId/usage/burndown` and `…/usage/timeline`, driven
+ * through the real app via `app.inject()` with a genuine admin session cookie.
+ *
+ * Covers the anonymous-401 guard, 404 for an unknown user, the validation
+ * failures (bad window / inverted range), the composed burndown happy path
+ * (overall + per-activity + group consumption against baseline budgets), the
+ * default window, the timeline happy path with lane labels, and the
+ * effective-timezone window resolution.
+ *
+ * Fixtures anchor usage samples to **today's UTC midnight** rather than the
+ * wall clock, so the assertions are deterministic regardless of the time of
+ * day the suite runs and never mature into a time-bomb (#254).
+ */
+import type { InjectOptions } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SESSION_COOKIE } from "../../../src/auth/session.js";
+import { loadSettings } from "../../../src/config.js";
+import {
+  activities,
+  activitiesToGroups,
+  activityGroups,
+  budgets,
+  clients,
+  usageSamples,
+} from "../../../src/policy/schema.js";
+import { buildTestApp, type TestApp } from "../../helpers/app.js";
+
+function configuredSettings() {
+  return loadSettings({
+    PCT_LOG_LEVEL: "silent",
+    PCT_SECRET_KEY: "usage-test-secret",
+    PCT_ADMIN_USERNAME: "ben",
+    PCT_ADMIN_PASSWORD: "hunter2",
+  });
+}
+
+function sessionCookie(res: { headers: Record<string, unknown> }): string {
+  const raw = res.headers["set-cookie"];
+  const headers = Array.isArray(raw) ? (raw as string[]) : [String(raw ?? "")];
+  const match = headers.find((h) => h.startsWith(`${SESSION_COOKIE}=`));
+  if (match === undefined) throw new Error("no session cookie set");
+  return match.split(";")[0] ?? "";
+}
+
+/** Today's UTC midnight — the start of the `daily` window for a UTC user. */
+function utcMidnight(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+/** A Date `offsetMinutes` after today's UTC midnight (always within today). */
+function todayAt(offsetMinutes: number): Date {
+  return new Date(utcMidnight().getTime() + offsetMinutes * 60_000);
+}
+
+describe("usage views API", () => {
+  let harness: TestApp;
+  let cookie: string;
+
+  beforeEach(async () => {
+    harness = buildTestApp({ appOptions: { settings: configuredSettings() } });
+    await harness.app.ready();
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    cookie = sessionCookie(login);
+  });
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  function auth(opts: InjectOptions) {
+    return harness.app.inject({ ...opts, headers: { ...opts.headers, cookie } });
+  }
+
+  async function createUser(displayName: string, tz?: string): Promise<number> {
+    const res = await auth({
+      method: "POST",
+      url: "/api/users",
+      payload: tz === undefined ? { displayName } : { displayName, tz },
+    });
+    expect(res.statusCode).toBe(201);
+    return res.json().id as number;
+  }
+
+  function createClient(hostname: string): number {
+    const row = harness.db
+      .insert(clients)
+      .values({ hostname, sshUser: "pct-agent" })
+      .returning({ id: clients.id })
+      .get();
+    if (row === undefined) throw new Error("client insert returned no row");
+    return row.id;
+  }
+
+  function createActivity(matcher: string): number {
+    const row = harness.db
+      .insert(activities)
+      .values({ kind: "app", matcher })
+      .returning({ id: activities.id })
+      .get();
+    if (row === undefined) throw new Error("activity insert returned no row");
+    return row.id;
+  }
+
+  describe("GET /api/users/:userId/usage/burndown", () => {
+    it("rejects anonymous access with a 401 envelope", async () => {
+      const userId = await createUser("Alice");
+      const res = await harness.app.inject({
+        method: "GET",
+        url: `/api/users/${userId}/usage/burndown`,
+      });
+      expect(res.statusCode).toBe(401);
+      expect(res.json().error.code).toBe("unauthorized");
+    });
+
+    it("returns 404 for an unknown user", async () => {
+      const res = await auth({ method: "GET", url: "/api/users/9999/usage/burndown" });
+      expect(res.statusCode).toBe(404);
+      expect(res.json().error.code).toBe("not_found");
+    });
+
+    it("rejects an unknown window with a 400", async () => {
+      const userId = await createUser("Alice");
+      const res = await auth({
+        method: "GET",
+        url: `/api/users/${userId}/usage/burndown?window=yearly`,
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error.code).toBe("validation_error");
+    });
+
+    it("composes overall, per-activity, and group consumption against the budgets", async () => {
+      const userId = await createUser("Alice"); // tz null → UTC
+      const clientId = createClient("mint-01");
+      const games = createActivity("steam");
+      const social = createActivity("discord");
+
+      // Group "Fun" containing only the Games activity.
+      const group = harness.db
+        .insert(activityGroups)
+        .values({ name: "Fun" })
+        .returning({ id: activityGroups.id })
+        .get();
+      if (group === undefined) throw new Error("group insert returned no row");
+      harness.db.insert(activitiesToGroups).values({ activityId: games, groupId: group.id }).run();
+
+      // Daily budgets: overall, the Games activity, and the Fun group.
+      harness.db
+        .insert(budgets)
+        .values([
+          { userId, scope: "overall", targetId: null, window: "daily", secondsAllowed: 7200 },
+          { userId, scope: "activity", targetId: games, window: "daily", secondsAllowed: 3600 },
+          { userId, scope: "group", targetId: group.id, window: "daily", secondsAllowed: 5400 },
+          // A weekly budget that must NOT leak into the daily view.
+          { userId, scope: "overall", targetId: null, window: "weekly", secondsAllowed: 36000 },
+        ])
+        .run();
+
+      // 30 min of Games + 10 min of Social, both squarely within today.
+      harness.db
+        .insert(usageSamples)
+        .values([
+          { userId, clientId, activityId: games, startedAt: todayAt(60), endedAt: todayAt(90) },
+          { userId, clientId, activityId: social, startedAt: todayAt(120), endedAt: todayAt(130) },
+        ])
+        .run();
+
+      const res = await auth({
+        method: "GET",
+        url: `/api/users/${userId}/usage/burndown?window=daily`,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.window).toBe("daily");
+      expect(body.tz).toBe("UTC");
+
+      interface BurndownRow {
+        scope: string;
+        targetId: number | null;
+        allowedSeconds: number;
+        consumedSeconds: number;
+      }
+      const byKey = new Map<string, BurndownRow>(
+        (body.budgets as BurndownRow[]).map((b) => [`${b.scope}:${b.targetId ?? "null"}`, b]),
+      );
+      // Only the three daily budgets; the weekly one is filtered out.
+      expect(body.budgets).toHaveLength(3);
+      expect(byKey.get("overall:null")).toMatchObject({
+        allowedSeconds: 7200,
+        consumedSeconds: 2400, // 1800 Games + 600 Social
+      });
+      expect(byKey.get(`activity:${games}`)).toMatchObject({
+        allowedSeconds: 3600,
+        consumedSeconds: 1800,
+      });
+      expect(byKey.get(`group:${group.id}`)).toMatchObject({
+        allowedSeconds: 5400,
+        consumedSeconds: 1800, // only Games is in the group
+      });
+    });
+
+    it("defaults to the daily window when none is given", async () => {
+      const userId = await createUser("Alice");
+      const res = await auth({ method: "GET", url: `/api/users/${userId}/usage/burndown` });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.window).toBe("daily");
+      // No budgets defined → no rows, but the window bounds are still returned.
+      expect(body.budgets).toEqual([]);
+      expect(body.windowStart).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(body.windowEnd).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("resolves the window in the user's effective timezone", async () => {
+      const userId = await createUser("Tokyo Kid", "Asia/Tokyo");
+      const res = await auth({ method: "GET", url: `/api/users/${userId}/usage/burndown` });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.tz).toBe("Asia/Tokyo");
+      // A Tokyo daily window opens at 15:00 UTC the prior day (UTC+9 midnight).
+      expect(body.windowStart.slice(11, 16)).toBe("15:00");
+    });
+  });
+
+  describe("GET /api/users/:userId/usage/timeline", () => {
+    it("rejects anonymous access with a 401 envelope", async () => {
+      const userId = await createUser("Alice");
+      const res = await harness.app.inject({
+        method: "GET",
+        url: `/api/users/${userId}/usage/timeline`,
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("returns 404 for an unknown user", async () => {
+      const res = await auth({ method: "GET", url: "/api/users/9999/usage/timeline" });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("rejects an inverted range with a 400", async () => {
+      const userId = await createUser("Alice");
+      const res = await auth({
+        method: "GET",
+        url: `/api/users/${userId}/usage/timeline?from=2026-06-20T10:00:00.000Z&to=2026-06-20T09:00:00.000Z`,
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error.code).toBe("validation_error");
+    });
+
+    it("returns the intervals overlapping the range plus their activity labels", async () => {
+      const userId = await createUser("Alice");
+      const clientId = createClient("mint-02");
+      const games = createActivity("steam");
+
+      const from = "2026-06-20T00:00:00.000Z";
+      const to = "2026-06-20T23:59:59.000Z";
+      harness.db
+        .insert(usageSamples)
+        .values({
+          userId,
+          clientId,
+          activityId: games,
+          startedAt: new Date("2026-06-20T08:00:00.000Z"),
+          endedAt: new Date("2026-06-20T08:30:00.000Z"),
+        })
+        .run();
+
+      const res = await auth({
+        method: "GET",
+        url: `/api/users/${userId}/usage/timeline?from=${from}&to=${to}`,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.from).toBe(from);
+      expect(body.to).toBe(to);
+      expect(body.activities).toEqual([{ id: games, kind: "app", matcher: "steam" }]);
+      expect(body.samples).toEqual([
+        {
+          activityId: games,
+          startedAt: "2026-06-20T08:00:00.000Z",
+          endedAt: "2026-06-20T08:30:00.000Z",
+        },
+      ]);
+    });
+
+    it("defaults the range to the user's daily window", async () => {
+      const userId = await createUser("Alice");
+      const res = await auth({ method: "GET", url: `/api/users/${userId}/usage/timeline` });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.from).toBe(utcMidnight().toISOString());
+      expect(body.samples).toEqual([]);
+      expect(body.activities).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Exposes the existing `policy/usage.ts` rollups (#88) over `/api` and ships the two Phase-5 derived-view components — closing the gap that left #62's "rendering half" with nothing to read.
- **Backend:** `GET /api/users/:userId/usage/burndown?window=daily|weekly|monthly` (per-budget `allowedSeconds` vs `consumedSeconds`) and `GET /api/users/:userId/usage/timeline?from&to` (raw per-activity intervals + activity labels), both admin-guarded and resolved over the effective-TZ window (ADR 0001/0003), mirroring `GET /users/:userId/effective` (#143).
- **Frontend:** typed `$lib/api/usage` wrapper; pure DOM-free geometry/format helpers (`$lib/charts/*`, `$lib/format/duration`); `BudgetBurndown` (remaining-budget SVG curve + ideal-pace line + "now" marker + Today/Week/Month toggle + per-budget bars) and `ActivityTimeline` (per-activity lanes). No new dependency — hand-rolled SVG.

## Plan

Linked plan: `.claude/plans/usage-views-api.md`
Roadmap: `docs/roadmap.md` → Phase 5 ("Key derived views" in `docs/architecture.md`).

## License-boundary note

N/A — no transport or packaging changes. Plain TypeScript + zod + Drizzle over the policy model; the frontend consumes the contract as **type-only** imports (erased by `vite build`). No GPL linkage, no Docker image change.

## Deferred work (tracked in #280)

- **Discrete grant-bump markers** on the burndown need the Phase-10 Grant ledger / grant endpoints (#113…), which aren't built yet — `effectivePolicy` already folds grant *totals* into the daily budget, but per-event markers need ledger timestamps.
- Wiring the components into a concrete `/admin` user-detail route (composes with the #53/#63 shell). This PR ships them as the reusable building blocks the issue calls for (also reused by the "My Time" dashboard, #61).
- Real-browser (Playwright) E2E — out of scope per the implement-issue guide; headless component tests cover the logic.

## Test plan

- [x] `npm run typecheck` (server) — clean
- [x] `npm run lint` (server) — clean
- [x] `npm test` (server) — 1243 unit tests pass; `src/api/usage` 100% lines
- [x] `cd server/frontend && npm run check` (svelte-check) — 0 errors
- [x] `cd server/frontend && npm test` — 105 tests pass (incl. 2 new component suites + chart/format/usage-wrapper unit tests)
- [x] `cd server/frontend && npm run build` — succeeds, no artifacts committed

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)