### PR TITLE
refactor(policy,auth,transport): name time constants & drop unchecked `as` (#227)

### DIFF
--- a/server/src/auth/session.ts
+++ b/server/src/auth/session.ts
@@ -21,7 +21,11 @@ import { z } from "zod";
 /** Cookie name for the admin session. */
 export const SESSION_COOKIE = "pct_session";
 
-/** How long a session is valid, in seconds (7 days). */
+/**
+ * How long a session is valid, in seconds (7 days). A week balances not
+ * nagging the single household admin to re-authenticate during ordinary use
+ * against bounding how long a leaked/stale cookie stays usable.
+ */
 export const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 /** The signed session payload. `sub` is the admin username; `iat` is epoch seconds. */

--- a/server/src/enforcement/evaluate.ts
+++ b/server/src/enforcement/evaluate.ts
@@ -36,7 +36,12 @@ import { groupSecondsInWindow, usageByActivityInWindow } from "../policy/usage.j
 
 import { decideEnforcement, type EnforcementOutcome } from "./decision.js";
 
-/** The schema default for `notification_policies.grace_seconds` (used when no row). */
+/**
+ * The schema default for `notification_policies.grace_seconds`, applied when a
+ * user has no notification-policy row. One minute gives the supervised user a
+ * short, predictable window to wrap up after the warning before enforcement
+ * acts, without materially extending the budget.
+ */
 const DEFAULT_GRACE_SECONDS = 60;
 
 /** Inputs to {@link evaluateUserEnforcement}. */

--- a/server/src/policy/recurrence.ts
+++ b/server/src/policy/recurrence.ts
@@ -35,10 +35,17 @@ export const WEEKDAY_MASK_MIN = 1;
 /** Largest valid weekday mask: all seven ISO weekdays set (`0b1111111`). */
 export const WEEKDAY_MASK_MAX = 127;
 
+/**
+ * Minutes in a full day — the single source for the `1440` that recurs across
+ * the policy layer (the exclusive end of the intra-day window space). Named
+ * once here and imported elsewhere so the magic number is not redefined.
+ */
+export const MINUTES_PER_DAY = 1440;
+
 /** Earliest local minute-of-day a window may reference (00:00). */
 export const MINUTE_OF_DAY_MIN = 0;
 /** Latest local minute-of-day a window may reference (24:00, the exclusive end). */
-export const MINUTE_OF_DAY_MAX = 1440;
+export const MINUTE_OF_DAY_MAX = MINUTES_PER_DAY;
 
 /**
  * A 7-bit ISO-weekday mask (`1..127`). Bit *i* set ⇒ active on ISO weekday

--- a/server/src/policy/resolve.ts
+++ b/server/src/policy/resolve.ts
@@ -41,10 +41,8 @@ import {
   localCalendarDate,
 } from "./budget-window.js";
 import type { BudgetWindow, Scope, ScheduleAction } from "./enums.js";
+import { MINUTES_PER_DAY } from "./recurrence.js";
 import { byOrdinal, type RuleActivePredicate, type ScheduleRule } from "./schedule-precedence.js";
-
-/** Minutes in a full day; the exclusive end of the intra-day window space. */
-const MINUTES_PER_DAY = 1440;
 
 /**
  * The subset of a {@link import("./schema.js").budgets} row the resolver reads.

--- a/server/src/transport/audit/recorder.ts
+++ b/server/src/transport/audit/recorder.ts
@@ -76,8 +76,16 @@ export const REDACTED = "[redacted]";
  */
 export function redactArgv(argv: readonly string[]): string[] {
   const out: string[] = [];
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i] as string;
+  // `argv.entries()` yields a properly-typed `arg` (no `as string` cast,
+  // per CLAUDE.md). The value following a sensitive flag is masked and then
+  // skipped on the next iteration via `skipNext`, since a `for...of` loop
+  // can't advance its own index the way the old counter loop did.
+  let skipNext = false;
+  for (const [i, arg] of argv.entries()) {
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
     const eq = arg.indexOf("=");
     if (eq > 0 && SENSITIVE_FLAG.test(arg.slice(0, eq))) {
       out.push(`${arg.slice(0, eq)}=${REDACTED}`);
@@ -86,7 +94,7 @@ export function redactArgv(argv: readonly string[]): string[] {
     out.push(arg);
     if (SENSITIVE_FLAG.test(arg) && i + 1 < argv.length) {
       out.push(REDACTED);
-      i += 1;
+      skipNext = true;
     }
   }
   return out;


### PR DESCRIPTION
## Summary

A small, behaviour-preserving grab-bag of readability/convention nits from the 2026-06-20 code review (issue #227):

- **`transport/audit/recorder.ts`** — `redactArgv` no longer uses an unchecked `as string` (CLAUDE.md → "no unchecked `as` casts"). `argv.entries()` yields a properly-typed `arg`; the value following a sensitive flag is masked and skipped on the next iteration via a `skipNext` flag, since a `for...of` loop can't advance its own index the way the old counter loop did. Exact redaction behaviour (trailing-flag and adjacent-sensitive-flag cases included) is preserved and still covered by the existing recorder tests.
- **`policy/recurrence.ts` + `policy/resolve.ts`** — dedupe the `1440` literal that was named twice. `recurrence.ts` now exports one `MINUTES_PER_DAY`, `MINUTE_OF_DAY_MAX` is sourced from it, and `resolve.ts` imports it instead of redefining a private copy. Cycle-free — `recurrence.ts` imports only `zod`.
- **`auth/session.ts`, `enforcement/evaluate.ts`** — add a one-line rationale to `SESSION_TTL_SECONDS` (why 7 days) and `DEFAULT_GRACE_SECONDS` (why 60 s); both previously documented *what* but not *why*. The 60 s grace rationale matches the `enforce.force_close`-after-grace flow documented in the same file.

The two other constants the review listed — activitywatch `DEFAULT_AW_PORT` and `DEFAULT_FUTURE_TOLERANCE_SECONDS` — **already carry rationale comments on current `main`** (the review predates them), so they are intentionally left unchanged.

## Plan

Linked plan: none (small cleanup; scope is fully specified by the issue).
Roadmap: not phase-gated — a `code-review` cleanup item.

## License-boundary note

N/A — no transport or packaging changes. Pure TypeScript: comment/constant edits and one loop rewrite; no GPL imports, no Docker image change, no process/network boundary touched.

## Test plan

- [x] `npm run format:check` / `npm run lint` clean
- [x] `npm run typecheck` (`tsc --noEmit`) passes
- [x] `npm test` — 1232 unit tests pass, coverage 98.92% (gate 80%)
- [x] No behavioural change — existing `redactArgv` and resolver tests still pass unchanged

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016go5CSEQAnW57fmCoFihKM)_