### PR TITLE
feat(transport/adguard): managed-mode supervisor — first-run fetch + child-process supervision (#96)

### DIFF
--- a/.claude/plans/issue-96-adguard-managed-supervisor.md
+++ b/.claude/plans/issue-96-adguard-managed-supervisor.md
@@ -1,0 +1,115 @@
+# Issue #96 — AdGuard managed-mode supervisor (first-run fetch + child-process supervision)
+
+Roadmap: `docs/roadmap.md` → Phase 7 (DNS filtering, optional).
+
+## Goal
+
+When `PCT_ADGUARD_MODE=managed`, fetch AdGuard Home from upstream releases into
+the data volume on first run, then supervise it as a **child process** —
+per `docs/server-deployment.md` → "First-run setup" step 3 and "AdGuard Home
+deployment modes". AdGuard binaries are **never** baked into the dashboard
+image (license boundary, `docs/licensing-analysis.md`): they are fetched at
+runtime and run as a separate process, exactly the boundary the REST-only
+integration already preserves.
+
+## Decision: child process, not sidecar container (ADR 0009)
+
+The issue leaves "child process vs sibling container" open. We pick **child
+process**, recorded in `docs/adr/0009-adguard-managed-supervisor.md`:
+
+- It is what `docs/server-deployment.md` already documents ("supervises it as a
+  child process", "runs AdGuard as a separate child process under
+  `/data/adguard/`").
+- It mirrors the established first-run pattern (`setup/ansible-venv.ts` spawns
+  `python3`/`pip` as subprocesses) — one runtime, one lifecycle, in-process
+  supervision with a status the admin UI can read.
+- A sidecar container would require the dashboard to drive a container runtime
+  from inside its own container (docker-in-docker / compose orchestration),
+  adding a heavyweight dependency for no license or isolation benefit — the
+  process boundary that satisfies the GPL analysis is identical either way.
+
+## Scope (this PR — the issue's literal title)
+
+A unit-testable slice with injected seams (no Docker, no real network — the
+same posture `setup/ansible-venv.ts` and the SSH transport tests use):
+
+1. **Release helpers** (`transport/adguard/release.ts`) — pure: map
+   `process.platform`/`arch` → AdGuard asset name (`AdGuardHome_linux_amd64`,
+   `_arm64`, `_386`, `_armv7`); build the release download URL + the
+   `checksums.txt` URL for a version tag; the `/releases/latest` API URL.
+2. **Tar extraction** (`transport/adguard/targz.ts`) — pure: `gunzipSync`
+   (`node:zlib`) + a minimal USTAR reader that returns one regular-file entry
+   by suffix (`AdGuardHome/AdGuardHome`). No new dependency — a tar is 512-byte
+   header blocks; extracting one file is ~50 lines and fully unit-testable.
+3. **Acquisition** (`transport/adguard/acquire.ts`) — `acquireAdGuardHome`:
+   idempotent (presence + version sentinel); resolve version (pinned
+   `PCT_ADGUARD_VERSION`, else `/releases/latest`); download the tarball +
+   `checksums.txt` via injected `fetch`; **verify SHA-256** (`node:crypto`)
+   against the checksum line for our asset; extract the binary; write `0755` +
+   a version sentinel. Injected `fetch` + fs seams; never touches the real
+   network in tests.
+4. **Seed config** (`transport/adguard/managed-config.ts`) — render a minimal
+   dashboard-owned `AdGuardHome.yaml` (web UI bound to `127.0.0.1:<adminPort>`,
+   DNS to `PCT_ADGUARD_BIND_ADDR`) **only when absent**, so AdGuard boots
+   headless instead of serving its install wizard. Documented as a seed AdGuard
+   migrates/expands on first boot; not clobbered on subsequent runs.
+5. **Supervisor** (`transport/adguard/supervisor.ts`) —
+   `AdGuardManagedSupervisor`: a state machine
+   (`idle`/`fetching`/`starting`/`running`/`stopped`/`failed`) with a
+   `status` snapshot, mirroring `AnsibleVenvSupervisor`. `bootstrap(logger)`
+   never throws: acquire → seed config → `start()`. `start()` spawns the binary
+   (`-c <conf> -w <dir> --no-check-update`) via an injected `spawn`; on an
+   unexpected exit it restarts with capped backoff (injected `delay`), giving up
+   to `failed` after a cap; `stop()` (used by `onClose`) sends `SIGTERM` then
+   escalates to `SIGKILL` after a deadline.
+6. **API status** — `GET /api/system/adguard-managed` mirroring
+   `/api/system/ansible`: a read-only `requireAdmin` snapshot for the admin UI.
+   DTO + mapper in `api/system/dtos.ts`.
+7. **Wiring** — `config.ts` gains `version?` + `dataDir` on the managed branch;
+   `buildApp` decorates `app.adguardManaged` (built only in managed mode, else a
+   null-object inert supervisor); `main.ts` fires `bootstrap()` after `listen`
+   (backgrounded, never blocks startup) and `stop()`s it on shutdown.
+
+## Deferred (tracked follow-up — will file + link)
+
+- Wiring the **running managed instance into `AdGuardService.getClient()`** +
+  live REST health polling (so `GET /api/dns` health reflects the managed
+  instance). That is the consumer the per-client-blocklist work (#97) needs and
+  composes cleanly on top of the running process. Filed as a new issue, linked
+  from the PR.
+- Live managed-mode bring-up against the **real** AdGuard binary (needs a
+  container / Docker daemon not available in the scheduled-run sandbox — the
+  #157 → #207 posture). The config schema + CLI args are modelled from upstream
+  docs and noted as such in the ADR.
+
+## License boundary
+
+Unchanged. AdGuard Home is fetched from upstream **at runtime** into the data
+volume and run as a **separate child process**; no GPL code is linked in-process
+and no GPL binary is added to the dashboard image (`CLAUDE.md` → "License
+boundaries" rule 5; `docs/licensing-analysis.md`). `license-guard` unaffected.
+No new dependency.
+
+## Tests
+
+- `release.test.ts` — platform/arch mapping, URL builders.
+- `targz.test.ts` — extract a file from a hand-built gzip+tar buffer; missing
+  entry → error.
+- `acquire.test.ts` — idempotent no-op when present; download + checksum verify
+  happy path; checksum mismatch → error (no binary written); version resolution
+  (pinned vs latest); fetch failure surfaced.
+- `managed-config.test.ts` — renders expected YAML; no-clobber when present.
+- `supervisor.test.ts` — bootstrap happy path (fetching→running); acquire
+  failure → failed (never throws); unexpected exit → restart with backoff;
+  restart cap → failed; `stop()` SIGTERM→SIGKILL escalation; status snapshot.
+- `system` route test — `GET /api/system/adguard-managed` behind `requireAdmin`,
+  serialises the snapshot; inert in non-managed modes.
+
+Full local gate (format/lint/typecheck/unit+coverage ≥80%) is verifiable here.
+
+## Phasing
+
+- **Phase A:** release helpers + targz + acquire + config template (+ tests).
+- **Phase B:** supervisor + facade + ADR (+ tests).
+- **Phase C:** config fields + DTO/route + app/main wiring + doc update
+  (+ tests). Open the draft PR at the first push.

--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,5 @@
 # PCT_ADGUARD_MODE=managed
 # PCT_ADGUARD_BIND_ADDR=0.0.0.0:53
 # PCT_ADGUARD_ADMIN_PORT=3000
+# PCT_ADGUARD_DATA_DIR=/data/adguard   # binary + config + work dir live here
+# PCT_ADGUARD_VERSION=v0.107.65        # optional: pin a release; latest if unset

--- a/docs/adr/0009-adguard-managed-supervisor.md
+++ b/docs/adr/0009-adguard-managed-supervisor.md
@@ -66,9 +66,14 @@ child process is the simplest correct answer.
 
 - The dashboard image must ship nothing AdGuard-related; the binary lives only
   in the data volume, fetched at runtime. `license-guard` stays green.
-- AdGuard Home's own auto-update is left enabled at the binary level by intent
-  for an unpinned install; a pinned `PCT_ADGUARD_VERSION` reconciles on a
-  sentinel mismatch (mirroring the Ansible-core pin).
+- The managed instance is run with `--no-check-update`: the dashboard, not
+  AdGuard Home, owns the binary's version, so its self-updater is disabled to
+  keep the on-disk binary in step with the version sentinel. Updates are
+  dashboard-driven — set or raise `PCT_ADGUARD_VERSION` and the binary is
+  re-fetched on the next boot's sentinel mismatch (mirroring the Ansible-core
+  pin). An unpinned install fetches the latest release on first run and then
+  stays on it until a pin is set; "always track latest" is intentionally not a
+  silent background auto-update.
 - The **live REST wiring** — feeding the running instance into
   `AdGuardService.getClient()` and polling its health — is deferred to a tracked
   follow-up that #97 builds on; this ADR/PR delivers the fetch + supervision

--- a/docs/adr/0009-adguard-managed-supervisor.md
+++ b/docs/adr/0009-adguard-managed-supervisor.md
@@ -1,0 +1,80 @@
+# ADR 0009 — AdGuard Home managed mode runs as a child process
+
+- **Status:** Accepted (2026-06-23)
+- **Issue:** [#96](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/96)
+- **Phase:** 7 (DNS filtering, optional). Implements the managed-mode supervisor
+  the mode router ([#95](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/95))
+  already forward-declares; the per-client-blocklist work
+  ([#97](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/97))
+  consumes the running instance.
+
+## Context
+
+`PCT_ADGUARD_MODE=managed` means "the dashboard hosts AdGuard Home itself".
+`docs/server-deployment.md` already sketches the behaviour — fetch AdGuard Home
+from upstream releases on first run, verify it, write it under `/data/adguard/`,
+and **supervise it** — but #96 explicitly left the *supervision mechanism*
+("child process **or** sibling container") to be decided here and recorded in an
+ADR.
+
+The hard constraint is the license boundary (`CLAUDE.md` → "License boundaries"
+rule 5; `docs/licensing-analysis.md`): AdGuard Home is GPL, so it must never be
+linked into the dashboard process or baked into the dashboard image. It has to
+be fetched at runtime and reached **only over its REST API**. Both candidate
+mechanisms satisfy that — the question is purely operational.
+
+## Decision
+
+**Run AdGuard Home as a child process** of the dashboard, supervised in-process
+by `transport/adguard/supervisor.ts` (`AdGuardManagedSupervisor`):
+
+- First-run acquisition (`acquire.ts`) downloads the pinned/latest release,
+  SHA-256-verifies it against `checksums.txt`, and extracts the binary to
+  `/data/adguard/AdGuardHome`.
+- A minimal dashboard-owned seed `AdGuardHome.yaml` (`managed-config.ts`) is
+  written once so the process boots headless instead of serving its install
+  wizard; the web/REST UI binds `127.0.0.1:<PCT_ADGUARD_ADMIN_PORT>`
+  (container-local — only the co-located dashboard reaches it), DNS binds
+  `PCT_ADGUARD_BIND_ADDR`.
+- The supervisor spawns it via `node:child_process`, restarts it with capped
+  exponential backoff on an unexpected exit (resetting the counter after a
+  stable run), and stops it gracefully (`SIGTERM`, escalating to `SIGKILL`) on
+  dashboard shutdown. `bootstrap()` runs in the background after `listen` and
+  never throws — a failed fetch leaves managed DNS `failed` with the reason on
+  `GET /api/system/adguard-managed`, exactly the "feature disabled + error
+  surfaced" posture the rest of first-run setup uses.
+
+### Why not a sibling container
+
+A sidecar/sibling container would require the dashboard to drive a container
+runtime from inside its own container (docker-in-docker, or compose
+orchestration of a peer service). That adds a heavyweight, environment-specific
+dependency and a second deployment artefact, for **no** license or isolation
+benefit: the GPL-satisfying boundary (separate process, REST-only integration)
+is identical either way. A child process is also what `docs/server-deployment.md`
+already documents and what the established first-run pattern
+(`setup/ansible-venv.ts`, which spawns `python3`/`pip`) uses — one runtime, one
+lifecycle, one status surface.
+
+If a future deployment genuinely needs AdGuard Home as a separate container
+(e.g. an operator running it on a different host), that is already served by
+**`external` mode** — point the dashboard at it over REST. Managed mode exists
+precisely for the "let the dashboard run it for me" case, where an in-container
+child process is the simplest correct answer.
+
+## Consequences
+
+- The dashboard image must ship nothing AdGuard-related; the binary lives only
+  in the data volume, fetched at runtime. `license-guard` stays green.
+- AdGuard Home's own auto-update is left enabled at the binary level by intent
+  for an unpinned install; a pinned `PCT_ADGUARD_VERSION` reconciles on a
+  sentinel mismatch (mirroring the Ansible-core pin).
+- The **live REST wiring** — feeding the running instance into
+  `AdGuardService.getClient()` and polling its health — is deferred to a tracked
+  follow-up that #97 builds on; this ADR/PR delivers the fetch + supervision
+  lifecycle only.
+- The seed-config field set and the binary's CLI flags are modelled from
+  upstream AdGuard Home documentation. A live round-trip against the real binary
+  needs a container/Docker daemon not available in the scheduled-run sandbox
+  (the [#157](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/157)
+  → #207 posture); it is verified separately.

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -112,13 +112,22 @@ idempotently:
    admin UI.
 3. **AdGuard Home bootstrap** — driven by `PCT_ADGUARD_MODE` (see
    "AdGuard Home deployment modes" below). In `managed` mode, the
-   first-time fetch downloads the latest stable release from
-   `github.com/AdguardTeam/AdGuardHome/releases`, verifies the
-   checksum, and writes it to `/data/adguard/AdGuardHome`; the
-   dashboard then supervises it as a child process. In `external` mode,
-   the dashboard skips the download entirely and validates that it can
-   reach the configured AdGuard Home instance's REST API. In `disabled`
-   mode (the default), neither happens.
+   first-time fetch downloads a release from
+   `github.com/AdguardTeam/AdGuardHome/releases` (the latest stable, or a
+   release pinned with `PCT_ADGUARD_VERSION`), verifies its SHA-256
+   against the release `checksums.txt`, and writes it to
+   `<PCT_ADGUARD_DATA_DIR>/AdGuardHome` (default `/data/adguard/`). A
+   minimal dashboard-owned seed `AdGuardHome.yaml` is written once (web/REST
+   UI bound to `127.0.0.1:<PCT_ADGUARD_ADMIN_PORT>`, DNS to
+   `PCT_ADGUARD_BIND_ADDR`) so it boots headless, then the dashboard
+   supervises it as a child process — restarting it with capped backoff on
+   an unexpected exit and stopping it gracefully on shutdown. Like the
+   Ansible bootstrap, this runs in the background after the HTTP listener is
+   up and never crashes the process: a failed fetch leaves managed DNS
+   disabled with the reason surfaced at `GET /api/system/adguard-managed`.
+   In `external` mode, the dashboard skips the download entirely and
+   validates that it can reach the configured AdGuard Home instance's REST
+   API. In `disabled` mode (the default), neither happens.
 4. **SSH key bootstrap** — if `/data/secrets/ssh/id_ed25519` is absent, the
    Node server generates an Ed25519 key pair **in-process on boot** (issue #39,
    via `node:crypto` — the runtime image ships no `ssh-keygen` binary, mirroring
@@ -162,8 +171,10 @@ Set via environment variables:
 
 # managed — dashboard hosts AdGuard Home
 PCT_ADGUARD_MODE=managed
-PCT_ADGUARD_BIND_ADDR=0.0.0.0:53   # what AdGuard listens on
-PCT_ADGUARD_ADMIN_PORT=3000        # AdGuard's own web UI; optional
+PCT_ADGUARD_BIND_ADDR=0.0.0.0:53   # what AdGuard's DNS server listens on
+PCT_ADGUARD_ADMIN_PORT=3000        # AdGuard's web/REST UI (bound to localhost)
+PCT_ADGUARD_DATA_DIR=/data/adguard # binary + seed config + work dir
+PCT_ADGUARD_VERSION=v0.107.65      # optional: pin a release; latest stable if unset
 
 # external — point at your existing instance
 PCT_ADGUARD_MODE=external

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -157,6 +157,9 @@ export {
   ansibleVenvStateSchema,
   ansibleVenvStatusResponseSchema,
   type AnsibleVenvStatusResponse,
+  adGuardManagedStateSchema,
+  adGuardManagedStatusResponseSchema,
+  type AdGuardManagedStatusResponse,
 } from "./system/index.js";
 
 // Auth DTOs (#52). Re-exported here so the frontend imports the auth contract

--- a/server/src/api/system/dtos.ts
+++ b/server/src/api/system/dtos.ts
@@ -11,6 +11,7 @@
 import { z } from "zod";
 
 import type { AnsibleVenvStatus } from "../../setup/ansible-venv.js";
+import type { AdGuardManagedStatus } from "../../transport/adguard/index.js";
 
 /** Lifecycle state of the first-run Ansible venv bootstrap. */
 export const ansibleVenvStateSchema = z.enum(["idle", "bootstrapping", "ready", "unavailable"]);
@@ -35,6 +36,70 @@ export function toAnsibleVenvStatusResponse(status: AnsibleVenvStatus): AnsibleV
     binaryPath: status.binaryPath,
     playbooksDir: status.playbooksDir,
     coreVersion: status.coreVersion,
+    checkedAt: status.checkedAt,
+    detail: status.detail,
+  };
+}
+
+/** Lifecycle state of the managed AdGuard Home process (#96). */
+export const adGuardManagedStateSchema = z.enum([
+  "idle",
+  "fetching",
+  "starting",
+  "running",
+  "stopped",
+  "failed",
+]);
+
+/**
+ * Response shape of `GET /api/system/adguard-managed`.
+ *
+ * `enabled` is `true` only when `PCT_ADGUARD_MODE=managed`; in every other mode
+ * there is no supervised process and the remaining fields are `null`. The
+ * non-null branch mirrors {@link AdGuardManagedStatus}, and
+ * {@link toAdGuardManagedStatusResponse} is the single conversion point, so the
+ * transport-side enum and this schema cannot drift silently.
+ */
+export const adGuardManagedStatusResponseSchema = z.object({
+  enabled: z.boolean(),
+  state: adGuardManagedStateSchema.nullable(),
+  binaryPath: z.string().nullable(),
+  version: z.string().nullable(),
+  adminEndpoint: z.string().nullable(),
+  restarts: z.number().nullable(),
+  checkedAt: z.string().nullable(),
+  detail: z.string().nullable(),
+});
+
+/** The inferred `GET /api/system/adguard-managed` response type, shared with the frontend. */
+export type AdGuardManagedStatusResponse = z.infer<typeof adGuardManagedStatusResponseSchema>;
+
+/**
+ * Map the managed-supervisor snapshot onto the wire contract. `null` (managed
+ * mode not enabled) collapses to `enabled: false` with null fields.
+ */
+export function toAdGuardManagedStatusResponse(
+  status: AdGuardManagedStatus | null,
+): AdGuardManagedStatusResponse {
+  if (status === null) {
+    return {
+      enabled: false,
+      state: null,
+      binaryPath: null,
+      version: null,
+      adminEndpoint: null,
+      restarts: null,
+      checkedAt: null,
+      detail: null,
+    };
+  }
+  return {
+    enabled: true,
+    state: status.state,
+    binaryPath: status.binaryPath,
+    version: status.version,
+    adminEndpoint: status.adminEndpoint,
+    restarts: status.restarts,
     checkedAt: status.checkedAt,
     detail: status.detail,
   };

--- a/server/src/api/system/index.ts
+++ b/server/src/api/system/index.ts
@@ -6,5 +6,9 @@ export {
   ansibleVenvStatusResponseSchema,
   toAnsibleVenvStatusResponse,
   type AnsibleVenvStatusResponse,
+  adGuardManagedStateSchema,
+  adGuardManagedStatusResponseSchema,
+  toAdGuardManagedStatusResponse,
+  type AdGuardManagedStatusResponse,
 } from "./dtos.js";
 export { registerSystemRoutes } from "./routes.js";

--- a/server/src/api/system/routes.ts
+++ b/server/src/api/system/routes.ts
@@ -1,14 +1,15 @@
 /**
- * Read-only system-status routes (#39): `GET /api/system/ansible`.
+ * Read-only system-status routes (#39): `GET /api/system/ansible` and
+ * `GET /api/system/adguard-managed` (#96).
  *
- * Registered inside the `/api` plugin scope (after `registerAuth`) so it
- * inherits the zod validator + shared error envelope and sits behind
- * `requireAdmin` — first-run subsystem health is admin information. The handler
- * is thin: read the {@link AnsibleVenvStatus} snapshot off the `app.ansibleVenv`
- * supervisor decorated in `buildApp` and serialise it.
+ * Registered inside the `/api` plugin scope (after `registerAuth`) so they
+ * inherit the zod validator + shared error envelope and sit behind
+ * `requireAdmin` — first-run subsystem health is admin information. Each handler
+ * is thin: read the snapshot off the supervisor decorated in `buildApp` and
+ * serialise it.
  *
- * This is the contract the admin UI consumes to surface whether Ansible is
- * ready (and, on a network-less first run, *why* it isn't) — the
+ * This is the contract the admin UI consumes to surface whether a first-run
+ * subsystem is ready (and, on a network-less first run, *why* it isn't) — the
  * "feature disabled + error surfaced" behaviour `docs/server-deployment.md` →
  * "First-run setup" requires.
  *
@@ -17,12 +18,17 @@
 import type { FastifyInstance } from "fastify";
 
 import type { ZodTypeProvider } from "../validation.js";
-import { toAnsibleVenvStatusResponse, type AnsibleVenvStatusResponse } from "./dtos.js";
+import {
+  toAdGuardManagedStatusResponse,
+  toAnsibleVenvStatusResponse,
+  type AdGuardManagedStatusResponse,
+  type AnsibleVenvStatusResponse,
+} from "./dtos.js";
 
 /**
  * Register the system-status read routes on an already-`/api`-prefixed scope.
  * Call after {@link registerAuth} so `scope.requireAdmin` is decorated; reads
- * the `ansibleVenv` supervisor decorated onto the app in `buildApp`.
+ * the supervisors decorated onto the app in `buildApp`.
  */
 export function registerSystemRoutes(scope: FastifyInstance): void {
   const typed = scope.withTypeProvider<ZodTypeProvider>();
@@ -32,5 +38,12 @@ export function registerSystemRoutes(scope: FastifyInstance): void {
     { preHandler: scope.requireAdmin },
     async (): Promise<AnsibleVenvStatusResponse> =>
       toAnsibleVenvStatusResponse(scope.ansibleVenv.status),
+  );
+
+  typed.get(
+    "/system/adguard-managed",
+    { preHandler: scope.requireAdmin },
+    async (): Promise<AdGuardManagedStatusResponse> =>
+      toAdGuardManagedStatusResponse(scope.adguardManaged?.status ?? null),
   );
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -73,6 +73,18 @@ const adguardSchema = z.discriminatedUnion("mode", [
     mode: z.literal("managed"),
     bindAddr: z.string().min(1).default("0.0.0.0:53"),
     adminPort: z.coerce.number().int().positive().default(3000),
+    /**
+     * Data-volume directory the managed AdGuard Home binary, seed config, and
+     * work dir live under (`PCT_ADGUARD_DATA_DIR`). Defaults to the documented
+     * `/data/adguard` layout (`docs/server-deployment.md` → "Volume layout").
+     */
+    dataDir: z.string().min(1).default("/data/adguard"),
+    /**
+     * Optional pinned AdGuard Home release tag (`PCT_ADGUARD_VERSION`, e.g.
+     * `v0.107.65`). When unset, the managed supervisor fetches the latest stable
+     * release on first run and then leaves the installed binary in place (#96).
+     */
+    version: z.string().min(1).optional(),
   }),
 ]);
 
@@ -372,6 +384,8 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
       apiTokenFile: env.PCT_ADGUARD_API_TOKEN_FILE,
       bindAddr: env.PCT_ADGUARD_BIND_ADDR,
       adminPort: env.PCT_ADGUARD_ADMIN_PORT,
+      dataDir: env.PCT_ADGUARD_DATA_DIR,
+      version: env.PCT_ADGUARD_VERSION,
     },
   });
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -66,6 +66,16 @@ async function main(): Promise<void> {
   // records `unavailable` and the reason is surfaced at GET /api/system/ansible
   // (docs/server-deployment.md → "First-run setup") — so a bare `void` is safe.
   void app.ansibleVenv.bootstrap(app.log);
+
+  // Bootstrap the managed AdGuard Home instance (#96, Phase-7 step) in the
+  // background too, for the same reason — a first-run release download must not
+  // delay startup. Present only when PCT_ADGUARD_MODE=managed; `bootstrap()`
+  // never throws (a failed fetch records `failed`, surfaced at
+  // GET /api/system/adguard-managed), so a bare `void` is safe. It is stopped
+  // on shutdown by the onClose hook in buildApp.
+  if (app.adguardManaged !== null) {
+    void app.adguardManaged.bootstrap(app.log);
+  }
 }
 
 void main();

--- a/server/src/transport/adguard/acquire.ts
+++ b/server/src/transport/adguard/acquire.ts
@@ -1,0 +1,240 @@
+/**
+ * First-run acquisition of the AdGuard Home binary for managed mode (#96).
+ *
+ * Downloads the upstream release archive into the data volume, verifies its
+ * SHA-256 against the release `checksums.txt`, and extracts the `AdGuardHome`
+ * binary — the "fetched from upstream at runtime" half of the managed-mode
+ * license posture (`docs/server-deployment.md` → "License posture is identical
+ * in both modes"; `docs/licensing-analysis.md`). The binary is **never** baked
+ * into the dashboard image.
+ *
+ * Every side-effecting boundary (network, filesystem, clock) is an injected seam
+ * so the whole module is unit-testable without touching the real network or
+ * disk — the same posture as `setup/ansible-venv.ts`.
+ *
+ * License boundary: the artefact is fetched at runtime and later run as a
+ * separate child process (`./supervisor.ts`); nothing here links or imports
+ * AdGuard code (`CLAUDE.md` → "License boundaries" rule 5).
+ */
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  ARCHIVE_BINARY_SUFFIX,
+  BINARY_FILENAME,
+  LATEST_RELEASE_API_URL,
+  assetUrl,
+  checksumsUrl,
+  findChecksum,
+  resolveAsset,
+  type ReleaseAsset,
+} from "./release.js";
+import { extractFileFromTarGz } from "./targz.js";
+
+/** Filename of the version sentinel written beside the binary. */
+const VERSION_SENTINEL = ".pct-adguard-version";
+
+/** The `0755` mode the extracted binary is made executable with. */
+const BINARY_MODE = 0o755;
+
+/**
+ * The minimal `fetch` surface acquisition uses — a superset of the REST client's
+ * `FetchLike` (it also reads binary bodies and text). Structural so the Node 22
+ * global `fetch` satisfies it and a test can pass a recording fake without a
+ * cast.
+ */
+export type DownloadFetch = (
+  input: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}>;
+
+/** Configuration acquisition needs (a slice of {@link Settings}'s managed branch). */
+export interface AcquireConfig {
+  /** Data-volume directory the binary + sentinel live under (e.g. `/data/adguard`). */
+  dataDir: string;
+  /**
+   * Pinned release tag (`PCT_ADGUARD_VERSION`, e.g. `v0.107.65`). When omitted,
+   * the latest non-prerelease tag is resolved from the GitHub API on first
+   * acquisition; an already-installed binary is then left in place (AdGuard
+   * Home self-updates) rather than re-checked every boot.
+   */
+  version?: string;
+}
+
+/** Injectable seams so tests never hit the network or real disk. */
+export interface AcquireDeps {
+  /** `fetch` for downloads + the latest-release lookup; defaults to the global `fetch`. */
+  fetch?: DownloadFetch;
+  /** Existence check; defaults to `node:fs` `existsSync`. */
+  fileExists?: (path: string) => boolean;
+  /** Read the recorded version sentinel, or `null` if absent/unreadable. */
+  readSentinel?: (path: string) => string | null;
+  /** Recursively create a directory (and parents). */
+  makeDir?: (path: string) => void;
+  /** Write the extracted binary, then mark it executable. */
+  writeBinary?: (path: string, contents: Buffer) => void;
+  /** Record the acquired version. */
+  writeSentinel?: (path: string, value: string) => void;
+  /** Resolve the host's release asset; defaults to {@link resolveAsset}. */
+  resolveAsset?: () => ReleaseAsset;
+}
+
+/** Outcome of an {@link acquireAdGuardHome} call. */
+export interface AcquireResult {
+  /** Absolute path to the (now-present) AdGuard Home binary. */
+  readonly binaryPath: string;
+  /** The release tag the binary corresponds to. */
+  readonly version: string;
+  /** True when this call downloaded the binary; false when it was already present. */
+  readonly fetched: boolean;
+}
+
+/** Thrown when a downloaded archive's SHA-256 does not match `checksums.txt`. */
+export class AdGuardChecksumError extends Error {
+  constructor(
+    readonly assetName: string,
+    readonly expected: string,
+    readonly actual: string,
+  ) {
+    super(
+      `AdGuard Home archive ${assetName} failed checksum verification ` +
+        `(expected ${expected}, got ${actual})`,
+    );
+    this.name = "AdGuardChecksumError";
+  }
+}
+
+/** Thrown when a download or the latest-release lookup returns a non-2xx status. */
+export class AdGuardDownloadError extends Error {
+  constructor(
+    readonly url: string,
+    readonly status: number,
+    statusText: string,
+  ) {
+    super(`AdGuard Home download failed: ${status} ${statusText} for ${url}`.trimEnd());
+    this.name = "AdGuardDownloadError";
+  }
+}
+
+function defaultReadSentinel(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+function defaultWriteBinary(path: string, contents: Buffer): void {
+  writeFileSync(path, contents);
+  chmodSync(path, BINARY_MODE);
+}
+
+interface ResolvedDeps {
+  fetch: DownloadFetch;
+  fileExists: (path: string) => boolean;
+  readSentinel: (path: string) => string | null;
+  makeDir: (path: string) => void;
+  writeBinary: (path: string, contents: Buffer) => void;
+  writeSentinel: (path: string, value: string) => void;
+  resolveAsset: () => ReleaseAsset;
+}
+
+function resolveDeps(deps: AcquireDeps): ResolvedDeps {
+  return {
+    fetch: deps.fetch ?? ((input, init) => fetch(input, init)),
+    fileExists: deps.fileExists ?? existsSync,
+    readSentinel: deps.readSentinel ?? defaultReadSentinel,
+    makeDir: deps.makeDir ?? ((path) => void mkdirSync(path, { recursive: true })),
+    writeBinary: deps.writeBinary ?? defaultWriteBinary,
+    writeSentinel: deps.writeSentinel ?? ((path, value) => writeFileSync(path, `${value}\n`)),
+    resolveAsset: deps.resolveAsset ?? (() => resolveAsset()),
+  };
+}
+
+/** GET a URL and return the response, throwing {@link AdGuardDownloadError} on non-2xx. */
+async function getOk(
+  fetchImpl: DownloadFetch,
+  url: string,
+): Promise<Awaited<ReturnType<DownloadFetch>>> {
+  const response = await fetchImpl(url, {
+    headers: { "user-agent": "linux-parental-controls-toolkit" },
+  });
+  if (!response.ok) {
+    throw new AdGuardDownloadError(url, response.status, response.statusText);
+  }
+  return response;
+}
+
+/** Resolve the latest non-prerelease tag from the GitHub releases API. */
+async function resolveLatestVersion(fetchImpl: DownloadFetch): Promise<string> {
+  const response = await getOk(fetchImpl, LATEST_RELEASE_API_URL);
+  const body = await response.json();
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("tag_name" in body) ||
+    typeof body.tag_name !== "string" ||
+    body.tag_name === ""
+  ) {
+    throw new Error("AdGuard Home latest-release lookup returned no tag_name");
+  }
+  return body.tag_name;
+}
+
+/**
+ * Ensure the AdGuard Home binary is present under `config.dataDir`, downloading
+ * and verifying it on first run.
+ *
+ * Idempotent: when the binary already exists, a pinned `version` is honoured
+ * (re-acquired only on a sentinel mismatch) and an unpinned install is left in
+ * place. Throws on any download/checksum/extraction failure so the caller (the
+ * supervisor's `bootstrap`) can record `failed` with the reason — it does not
+ * swallow errors itself.
+ */
+export async function acquireAdGuardHome(
+  config: AcquireConfig,
+  deps: AcquireDeps = {},
+): Promise<AcquireResult> {
+  const d = resolveDeps(deps);
+  const binaryPath = join(config.dataDir, BINARY_FILENAME);
+  const sentinelPath = join(config.dataDir, VERSION_SENTINEL);
+
+  if (d.fileExists(binaryPath)) {
+    // Pinned: re-acquire only when the recorded version drifts from the pin.
+    if (config.version === undefined || d.readSentinel(sentinelPath) === config.version) {
+      const version = config.version ?? d.readSentinel(sentinelPath) ?? "unknown";
+      return { binaryPath, version, fetched: false };
+    }
+  }
+
+  const asset = d.resolveAsset();
+  const version = config.version ?? (await resolveLatestVersion(d.fetch));
+
+  const archiveResponse = await getOk(d.fetch, assetUrl(version, asset));
+  const archive = Buffer.from(await archiveResponse.arrayBuffer());
+
+  const checksumsResponse = await getOk(d.fetch, checksumsUrl(version));
+  const expected = findChecksum(await checksumsResponse.text(), asset.assetName);
+  if (expected === null) {
+    throw new Error(`checksums.txt for ${version} has no entry for ${asset.assetName}`);
+  }
+  const actual = createHash("sha256").update(archive).digest("hex");
+  if (actual !== expected) {
+    throw new AdGuardChecksumError(asset.assetName, expected, actual);
+  }
+
+  const binary = extractFileFromTarGz(archive, ARCHIVE_BINARY_SUFFIX);
+  d.makeDir(config.dataDir);
+  d.writeBinary(binaryPath, binary);
+  d.writeSentinel(sentinelPath, version);
+
+  return { binaryPath, version, fetched: true };
+}

--- a/server/src/transport/adguard/index.ts
+++ b/server/src/transport/adguard/index.ts
@@ -33,6 +33,24 @@ export {
   type PreflightLogger,
 } from "./service.js";
 export {
+  AdGuardManagedSupervisor,
+  createAdGuardManagedSupervisor,
+  type AdGuardManagedConfig,
+  type AdGuardManagedDeps,
+  type AdGuardManagedLogger,
+  type AdGuardManagedState,
+  type AdGuardManagedStatus,
+  type ManagedProcess,
+  type SpawnManaged,
+} from "./supervisor.js";
+export {
+  acquireAdGuardHome,
+  AdGuardChecksumError,
+  AdGuardDownloadError,
+  type AcquireConfig,
+  type AcquireResult,
+} from "./acquire.js";
+export {
   adGuardClientSchema,
   adGuardClientsResponseSchema,
   adGuardFilteringStatusSchema,

--- a/server/src/transport/adguard/managed-config.ts
+++ b/server/src/transport/adguard/managed-config.ts
@@ -1,0 +1,95 @@
+/**
+ * Seed `AdGuardHome.yaml` for managed mode (#96).
+ *
+ * AdGuard Home serves a first-run *installation wizard* when it boots with no
+ * config file. To run it headless under supervision we write a minimal,
+ * dashboard-owned seed config the first time — binding AdGuard's own web UI to
+ * `127.0.0.1:<adminPort>` (container-local; only the co-located dashboard
+ * reaches it) and DNS to `PCT_ADGUARD_BIND_ADDR`. AdGuard rewrites and expands
+ * this file on first boot (filters, schema migration, etc.); we therefore write
+ * it **only when absent** and never clobber the admin's / AdGuard's own edits on
+ * subsequent runs (`docs/server-deployment.md` → "managed … owns the config
+ * under `/data/adguard/`").
+ *
+ * The field set is modelled from upstream AdGuard Home docs (the live schema is
+ * verified against the real binary separately — no Docker in the scheduled-run
+ * sandbox; see the ADR). It is deliberately minimal: enough to boot headless,
+ * leaving everything else to AdGuard's defaults.
+ *
+ * License boundary: none touched — we write a YAML file AdGuard reads; no
+ * AdGuard code is linked (`CLAUDE.md` → "License boundaries").
+ */
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+/** Inputs to {@link renderSeedConfig}, derived from the managed-mode settings. */
+export interface SeedConfigOptions {
+  /** Port AdGuard's web UI binds on (`PCT_ADGUARD_ADMIN_PORT`); bound to localhost. */
+  adminPort: number;
+  /** `host:port` AdGuard's DNS server listens on (`PCT_ADGUARD_BIND_ADDR`). */
+  bindAddr: string;
+}
+
+/** A DNS `host` + numeric `port`, split from a `host:port` bind address. */
+interface HostPort {
+  host: string;
+  port: number;
+}
+
+/**
+ * Split a `host:port` bind address on its final colon (so an IPv6 host keeps its
+ * inner colons). Falls back to port 53 when no parseable port is present.
+ */
+function splitBindAddr(bindAddr: string): HostPort {
+  const lastColon = bindAddr.lastIndexOf(":");
+  if (lastColon === -1) return { host: bindAddr, port: 53 };
+  const host = bindAddr.slice(0, lastColon);
+  const port = Number.parseInt(bindAddr.slice(lastColon + 1), 10);
+  return { host: host === "" ? "0.0.0.0" : host, port: Number.isNaN(port) ? 53 : port };
+}
+
+/** Render the minimal seed `AdGuardHome.yaml` body. */
+export function renderSeedConfig(options: SeedConfigOptions): string {
+  const dns = splitBindAddr(options.bindAddr);
+  return [
+    "# Managed by linux-parental-controls-toolkit (PCT_ADGUARD_MODE=managed).",
+    "# Minimal seed so AdGuard Home boots headless instead of its install wizard;",
+    "# AdGuard rewrites/expands this on first boot and the dashboard never",
+    "# clobbers it afterwards (#96).",
+    "http:",
+    `  address: 127.0.0.1:${options.adminPort}`,
+    "users: []",
+    "dns:",
+    "  bind_hosts:",
+    `    - ${dns.host}`,
+    `  port: ${dns.port}`,
+    "",
+  ].join("\n");
+}
+
+/** Injectable seams so tests do not touch the real filesystem. */
+export interface SeedConfigDeps {
+  fileExists?: (path: string) => boolean;
+  makeDir?: (path: string) => void;
+  writeFile?: (path: string, contents: string) => void;
+}
+
+/**
+ * Write the seed config at {@link configPath} only when it does not already
+ * exist. Returns `true` when a file was written, `false` when one was already
+ * present (the no-clobber case).
+ */
+export function writeSeedConfigIfAbsent(
+  configPath: string,
+  options: SeedConfigOptions,
+  deps: SeedConfigDeps = {},
+): boolean {
+  const fileExists = deps.fileExists ?? existsSync;
+  if (fileExists(configPath)) return false;
+
+  const makeDir = deps.makeDir ?? ((path) => void mkdirSync(path, { recursive: true }));
+  const writeFile = deps.writeFile ?? ((path, contents) => writeFileSync(path, contents));
+  makeDir(dirname(configPath));
+  writeFile(configPath, renderSeedConfig(options));
+  return true;
+}

--- a/server/src/transport/adguard/release.ts
+++ b/server/src/transport/adguard/release.ts
@@ -1,0 +1,116 @@
+/**
+ * AdGuard Home upstream-release coordinates (managed mode, #96).
+ *
+ * Pure helpers that map the host platform to an AdGuard Home release asset and
+ * build the upstream download URLs. No I/O — the acquisition module (#96
+ * `acquire.ts`) does the fetching against these.
+ *
+ * Asset naming follows AdGuard's GoReleaser convention
+ * (`github.com/AdguardTeam/AdGuardHome/releases`): a per-platform archive
+ * `AdGuardHome_<os>_<arch>.tar.gz` whose top-level directory holds the
+ * `AdGuardHome` binary, alongside a single `checksums.txt` listing the SHA-256
+ * of every asset.
+ *
+ * License boundary: none touched — these are plain URL/string helpers; the
+ * binary they point at is fetched at runtime and run as a separate process
+ * (`CLAUDE.md` → "License boundaries" rule 5; `docs/licensing-analysis.md`).
+ */
+
+/** The GitHub owner/repo AdGuard Home releases are published under. */
+export const ADGUARD_REPO = "AdguardTeam/AdGuardHome";
+
+/** Base for release-asset downloads (`…/download/<tag>/<asset>`). */
+const RELEASE_DOWNLOAD_BASE = `https://github.com/${ADGUARD_REPO}/releases/download`;
+
+/** GitHub API endpoint resolving the latest non-prerelease release. */
+export const LATEST_RELEASE_API_URL = `https://api.github.com/repos/${ADGUARD_REPO}/releases/latest`;
+
+/** The path *inside* every Linux archive at which the binary lives. */
+export const ARCHIVE_BINARY_SUFFIX = "AdGuardHome/AdGuardHome";
+
+/** The bare binary filename written into the data volume. */
+export const BINARY_FILENAME = "AdGuardHome";
+
+/**
+ * A resolved release asset for the running host: the archive filename and the
+ * suffix of the in-archive entry to extract.
+ */
+export interface ReleaseAsset {
+  /** AdGuard's `<os>_<arch>` token, e.g. `linux_amd64`. */
+  readonly platform: string;
+  /** The `.tar.gz` asset filename, e.g. `AdGuardHome_linux_amd64.tar.gz`. */
+  readonly assetName: string;
+}
+
+/**
+ * Map Node's `process.arch` to AdGuard's release-asset arch token.
+ *
+ * Covers the architectures AdGuard publishes Linux archives for; anything else
+ * (e.g. a future `riscv64`) is unmapped and rejected by {@link resolveAsset} so
+ * managed mode fails loudly rather than downloading a wrong-arch binary.
+ */
+const ARCH_TOKENS: Readonly<Record<string, string>> = {
+  x64: "amd64",
+  arm64: "arm64",
+  ia32: "386",
+  arm: "armv7",
+};
+
+/** Thrown when the host platform has no published AdGuard Home Linux archive. */
+export class UnsupportedPlatformError extends Error {
+  constructor(platform: NodeJS.Platform, arch: string) {
+    super(
+      `AdGuard Home managed mode has no release archive for ${platform}/${arch}; ` +
+        `use PCT_ADGUARD_MODE=external instead`,
+    );
+    this.name = "UnsupportedPlatformError";
+  }
+}
+
+/**
+ * Resolve the AdGuard Home release asset for the running host.
+ *
+ * Managed mode is a Linux-only, in-container concern (the dashboard image is
+ * `node:22-slim`), so only `linux` is supported; the arch is mapped via
+ * {@link ARCH_TOKENS}. Throws {@link UnsupportedPlatformError} otherwise.
+ */
+export function resolveAsset(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): ReleaseAsset {
+  const archToken = ARCH_TOKENS[arch];
+  if (platform !== "linux" || archToken === undefined) {
+    throw new UnsupportedPlatformError(platform, arch);
+  }
+  const token = `linux_${archToken}`;
+  return { platform: token, assetName: `AdGuardHome_${token}.tar.gz` };
+}
+
+/** The download URL for a release asset at a given version tag (e.g. `v0.107.65`). */
+export function assetUrl(version: string, asset: ReleaseAsset): string {
+  return `${RELEASE_DOWNLOAD_BASE}/${version}/${asset.assetName}`;
+}
+
+/** The download URL for a release's `checksums.txt` at a given version tag. */
+export function checksumsUrl(version: string): string {
+  return `${RELEASE_DOWNLOAD_BASE}/${version}/checksums.txt`;
+}
+
+/**
+ * Find the SHA-256 hex digest for {@link assetName} in a `checksums.txt` body.
+ *
+ * GoReleaser emits `<hex>␠␠<filename>` lines; the filename may carry a `./`
+ * prefix. Returns the lower-cased digest, or `null` when the asset is absent.
+ */
+export function findChecksum(checksumsBody: string, assetName: string): string | null {
+  for (const line of checksumsBody.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    const match = /^([0-9a-fA-F]{64})\s+\.?\/?(\S+)$/.exec(trimmed);
+    const [, digest, name] = match ?? [];
+    if (digest !== undefined && name === assetName) {
+      return digest.toLowerCase();
+    }
+  }
+  return null;
+}

--- a/server/src/transport/adguard/supervisor.ts
+++ b/server/src/transport/adguard/supervisor.ts
@@ -271,25 +271,36 @@ export class AdGuardManagedSupervisor {
 
   /** Spawn the child and wire its exit/error handlers. */
   #spawnChild(): void {
+    // A stop() that lands while bootstrap() was still awaiting the first-run
+    // download (state `fetching`, no child yet) must not spawn an unsupervised
+    // process the already-returned stop() can never reap.
+    if (this.#stopping) return;
+
     this.#settle("starting", null, "starting AdGuard Home");
     const args = ["--no-check-update", "--config", this.#configPath, "--work-dir", this.#workDir];
     const child = this.#deps.spawn(this.#binaryPath, args);
     this.#child = child;
     this.#startedAt = this.#deps.now().getTime();
 
-    child.onError((err) => this.#onSpawnError(err));
-    child.onExit((code, signal) => this.#onExit(code, signal));
+    // Capture `child` so a stale event from a previous process is ignored. Node
+    // emits BOTH `error` and `exit` for a failed spawn; whichever fires first
+    // nulls `#child`, so the second sees `#child !== child` and is a no-op —
+    // preventing a spawn failure from also triggering a restart.
+    child.onError((err) => this.#onSpawnError(child, err));
+    child.onExit((code, signal) => this.#onExit(child, code, signal));
 
     this.#settle("running", null, `AdGuard Home running (pid ${String(child.pid ?? "unknown")})`);
   }
 
-  #onSpawnError(err: Error): void {
+  #onSpawnError(child: ManagedProcess, err: Error): void {
+    if (this.#child !== child) return;
     this.#child = null;
     this.#releaseExitWaiters();
     this.#settle("failed", err.message, `AdGuard Home failed to start: ${err.message}`, "error");
   }
 
-  #onExit(code: number | null, signal: NodeJS.Signals | null): void {
+  #onExit(child: ManagedProcess, code: number | null, signal: NodeJS.Signals | null): void {
+    if (this.#child !== child) return;
     this.#child = null;
     this.#releaseExitWaiters();
 

--- a/server/src/transport/adguard/supervisor.ts
+++ b/server/src/transport/adguard/supervisor.ts
@@ -1,0 +1,367 @@
+/**
+ * AdGuard Home managed-mode supervisor (#96).
+ *
+ * When `PCT_ADGUARD_MODE=managed`, this owns the lifecycle of a locally-run
+ * AdGuard Home instance: acquire the binary on first run (`./acquire.ts`), seed
+ * a minimal headless config (`./managed-config.ts`), spawn it as a **child
+ * process**, and keep it running — restarting it with capped backoff on an
+ * unexpected exit and stopping it gracefully on shutdown. It mirrors
+ * `setup/ansible-venv.ts`: a never-throwing `bootstrap()` run in the background
+ * after `listen`, an immutable `status` snapshot the admin UI reads, and every
+ * side-effecting boundary injected so the whole class is unit-testable without
+ * spawning a real process.
+ *
+ * Why a child process (not a sidecar container): recorded in
+ * `docs/adr/0009-adguard-managed-supervisor.md`. It is what
+ * `docs/server-deployment.md` already documents and matches the established
+ * first-run subprocess pattern; the GPL-satisfying process boundary is identical
+ * either way (`CLAUDE.md` → "License boundaries" rule 5;
+ * `docs/licensing-analysis.md`). AdGuard Home is fetched at runtime and run
+ * out-of-process — never linked, never baked into the image.
+ */
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+
+import { acquireAdGuardHome, type AcquireConfig, type AcquireResult } from "./acquire.js";
+import { writeSeedConfigIfAbsent, type SeedConfigOptions } from "./managed-config.js";
+
+/**
+ * Lifecycle state of the managed AdGuard Home process.
+ *
+ * - `idle` — built but not yet bootstrapped (a freshly constructed supervisor;
+ *   building the app spawns nothing).
+ * - `fetching` — `bootstrap()` is acquiring the binary / seeding config.
+ * - `starting` — the child process is being spawned.
+ * - `running` — the child is up.
+ * - `stopped` — stopped on purpose (graceful shutdown).
+ * - `failed` — acquisition failed, the process could not be spawned, or it
+ *   exited unexpectedly too many times; `detail` says why.
+ */
+export type AdGuardManagedState =
+  | "idle"
+  | "fetching"
+  | "starting"
+  | "running"
+  | "stopped"
+  | "failed";
+
+/** An immutable snapshot of the supervisor's last-observed state. */
+export interface AdGuardManagedStatus {
+  /** Lifecycle state (see {@link AdGuardManagedState}). */
+  readonly state: AdGuardManagedState;
+  /** Path the AdGuard Home binary is run from. */
+  readonly binaryPath: string;
+  /** The release tag in use, or `null` before the first successful acquisition. */
+  readonly version: string | null;
+  /** The localhost REST/admin endpoint the dashboard targets the instance at. */
+  readonly adminEndpoint: string;
+  /** How many times the process has been restarted after an unexpected exit. */
+  readonly restarts: number;
+  /** ISO-8601 timestamp of the last state transition, or `null` if never run. */
+  readonly checkedAt: string | null;
+  /** Human-readable reason when not `running`, else `null`. */
+  readonly detail: string | null;
+}
+
+/** Minimal structural logger the supervisor uses (Fastify's pino `app.log` fits). */
+export interface AdGuardManagedLogger {
+  info(obj: object, msg?: string): void;
+  warn(obj: object, msg?: string): void;
+  error(obj: object, msg?: string): void;
+}
+
+/**
+ * A spawned child as the supervisor needs it. Deliberately narrower than Node's
+ * `ChildProcess` (typed per-event handlers, no event-name strings) so the
+ * default adapter wraps `node:child_process` without an `as` cast and a test can
+ * drive a fully-controllable fake.
+ */
+export interface ManagedProcess {
+  /** OS process id, or `undefined` if the spawn failed synchronously. */
+  readonly pid: number | undefined;
+  /** Register the one-shot exit handler. */
+  onExit(listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+  /** Register the spawn-error handler (e.g. the binary is missing/not executable). */
+  onError(listener: (err: Error) => void): void;
+  /** Send a signal to the process. */
+  kill(signal: NodeJS.Signals): void;
+}
+
+/** Spawns the AdGuard Home binary and returns a {@link ManagedProcess}. */
+export type SpawnManaged = (command: string, args: string[]) => ManagedProcess;
+
+/** Configuration the supervisor needs (the managed-mode slice of {@link Settings}). */
+export interface AdGuardManagedConfig {
+  /** Data-volume root for the binary + config (`PCT_ADGUARD_DATA_DIR`, e.g. `/data/adguard`). */
+  dataDir: string;
+  /** Pinned release tag (`PCT_ADGUARD_VERSION`); latest when omitted. */
+  version?: string;
+  /** `host:port` AdGuard's DNS server binds (`PCT_ADGUARD_BIND_ADDR`). */
+  bindAddr: string;
+  /** Port AdGuard's web/REST UI binds on localhost (`PCT_ADGUARD_ADMIN_PORT`). */
+  adminPort: number;
+}
+
+/** Injectable seams + restart tuning so tests never spawn a process or wait on real time. */
+export interface AdGuardManagedDeps {
+  /** Acquire the binary; defaults to {@link acquireAdGuardHome}. */
+  acquire?: (config: AcquireConfig) => Promise<AcquireResult>;
+  /** Seed the headless config; defaults to {@link writeSeedConfigIfAbsent}. */
+  writeSeedConfig?: (configPath: string, options: SeedConfigOptions) => boolean;
+  /** Spawn the process; defaults to wrapping `node:child_process` `spawn`. */
+  spawn?: SpawnManaged;
+  /** Delay used for restart backoff + stop escalation; defaults to a real timer. */
+  delay?: (ms: number) => Promise<void>;
+  /** Clock for `checkedAt`; defaults to `() => new Date()`. */
+  now?: () => Date;
+  /** Max consecutive restarts before giving up to `failed`. Defaults to 5. */
+  maxRestarts?: number;
+  /** Uptime (ms) after which a run is "stable" and the restart counter resets. Defaults to 60_000. */
+  stableMs?: number;
+  /** Grace (ms) after `SIGTERM` before escalating to `SIGKILL` on stop. Defaults to 10_000. */
+  stopTimeoutMs?: number;
+  /** Base backoff (ms) between restarts (doubles per attempt). Defaults to 1_000. */
+  backoffBaseMs?: number;
+  /** Backoff ceiling (ms). Defaults to 60_000. */
+  backoffMaxMs?: number;
+}
+
+/** Default `spawn` adapter: detach stdio and surface only exit/error. */
+const defaultSpawn: SpawnManaged = (command, args) => {
+  const child = spawn(command, args, { stdio: "ignore" });
+  return {
+    pid: child.pid,
+    onExit: (listener) => void child.on("exit", listener),
+    onError: (listener) => void child.on("error", listener),
+    kill: (signal) => void child.kill(signal),
+  };
+};
+
+interface ResolvedDeps {
+  acquire: (config: AcquireConfig) => Promise<AcquireResult>;
+  writeSeedConfig: (configPath: string, options: SeedConfigOptions) => boolean;
+  spawn: SpawnManaged;
+  delay: (ms: number) => Promise<void>;
+  now: () => Date;
+  maxRestarts: number;
+  stableMs: number;
+  stopTimeoutMs: number;
+  backoffBaseMs: number;
+  backoffMaxMs: number;
+}
+
+/** Filename of the seed config under `<dataDir>/conf/`. */
+const CONFIG_FILENAME = "AdGuardHome.yaml";
+
+/**
+ * Owns the managed AdGuard Home child process. Construct via
+ * {@link createAdGuardManagedSupervisor}; build once per app and decorate it onto
+ * Fastify so the status route reads the same instance.
+ */
+export class AdGuardManagedSupervisor {
+  readonly #config: AdGuardManagedConfig;
+  readonly #deps: ResolvedDeps;
+  readonly #binaryPath: string;
+  readonly #configPath: string;
+  readonly #workDir: string;
+  readonly #adminEndpoint: string;
+
+  #status: AdGuardManagedStatus;
+  #version: string | null = null;
+  #child: ManagedProcess | null = null;
+  #stopping = false;
+  #restarts = 0;
+  #startedAt: number | null = null;
+  #logger: AdGuardManagedLogger | undefined;
+  /** Resolvers awaiting the current child's exit (used by {@link stop}). */
+  #exitWaiters: (() => void)[] = [];
+
+  constructor(config: AdGuardManagedConfig, deps: AdGuardManagedDeps = {}) {
+    this.#config = config;
+    this.#deps = {
+      acquire: deps.acquire ?? acquireAdGuardHome,
+      writeSeedConfig: deps.writeSeedConfig ?? writeSeedConfigIfAbsent,
+      spawn: deps.spawn ?? defaultSpawn,
+      delay: deps.delay ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
+      now: deps.now ?? (() => new Date()),
+      maxRestarts: deps.maxRestarts ?? 5,
+      stableMs: deps.stableMs ?? 60_000,
+      stopTimeoutMs: deps.stopTimeoutMs ?? 10_000,
+      backoffBaseMs: deps.backoffBaseMs ?? 1_000,
+      backoffMaxMs: deps.backoffMaxMs ?? 60_000,
+    };
+
+    this.#binaryPath = join(config.dataDir, "AdGuardHome");
+    this.#configPath = join(config.dataDir, "conf", CONFIG_FILENAME);
+    this.#workDir = join(config.dataDir, "work");
+    this.#adminEndpoint = `http://127.0.0.1:${config.adminPort}`;
+
+    this.#status = {
+      state: "idle",
+      binaryPath: this.#binaryPath,
+      version: null,
+      adminEndpoint: this.#adminEndpoint,
+      restarts: 0,
+      checkedAt: null,
+      detail: null,
+    };
+  }
+
+  /** An immutable snapshot of the current status. */
+  get status(): AdGuardManagedStatus {
+    return { ...this.#status };
+  }
+
+  /**
+   * Acquire (if needed), seed the config, and start the process.
+   *
+   * Never throws — an acquisition or spawn failure is recorded as `failed` with
+   * a `detail` and logged, so the caller (`main.ts`, after `listen`) can fire it
+   * with a bare `void`. Idempotent acquisition means it is safe on every boot.
+   */
+  async bootstrap(logger?: AdGuardManagedLogger): Promise<AdGuardManagedStatus> {
+    this.#logger = logger;
+    this.#stopping = false;
+    this.#settle("fetching", null, "acquiring AdGuard Home");
+    try {
+      const result = await this.#deps.acquire({
+        dataDir: this.#config.dataDir,
+        ...(this.#config.version !== undefined ? { version: this.#config.version } : {}),
+      });
+      this.#version = result.version;
+      this.#deps.writeSeedConfig(this.#configPath, {
+        adminPort: this.#config.adminPort,
+        bindAddr: this.#config.bindAddr,
+      });
+      this.#spawnChild();
+      return this.status;
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      this.#settle("failed", detail, `AdGuard Home managed bootstrap failed: ${detail}`, "error");
+      return this.status;
+    }
+  }
+
+  /**
+   * Stop the managed process: send `SIGTERM`, then escalate to `SIGKILL` after
+   * the stop grace. Used by the app's `onClose` hook. Safe to call when nothing
+   * is running.
+   */
+  async stop(): Promise<void> {
+    this.#stopping = true;
+    const child = this.#child;
+    if (child === null) {
+      this.#settle("stopped", null, "AdGuard Home managed supervisor stopped (nothing running)");
+      return;
+    }
+
+    const exited = new Promise<void>((resolve) => this.#exitWaiters.push(resolve));
+    child.kill("SIGTERM");
+
+    let escalated = false;
+    await Promise.race([
+      exited,
+      this.#deps.delay(this.#deps.stopTimeoutMs).then(() => {
+        escalated = true;
+        child.kill("SIGKILL");
+      }),
+    ]);
+    if (escalated) await exited;
+  }
+
+  /** Spawn the child and wire its exit/error handlers. */
+  #spawnChild(): void {
+    this.#settle("starting", null, "starting AdGuard Home");
+    const args = ["--no-check-update", "--config", this.#configPath, "--work-dir", this.#workDir];
+    const child = this.#deps.spawn(this.#binaryPath, args);
+    this.#child = child;
+    this.#startedAt = this.#deps.now().getTime();
+
+    child.onError((err) => this.#onSpawnError(err));
+    child.onExit((code, signal) => this.#onExit(code, signal));
+
+    this.#settle("running", null, `AdGuard Home running (pid ${String(child.pid ?? "unknown")})`);
+  }
+
+  #onSpawnError(err: Error): void {
+    this.#child = null;
+    this.#releaseExitWaiters();
+    this.#settle("failed", err.message, `AdGuard Home failed to start: ${err.message}`, "error");
+  }
+
+  #onExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.#child = null;
+    this.#releaseExitWaiters();
+
+    if (this.#stopping) {
+      this.#settle("stopped", null, "AdGuard Home stopped");
+      return;
+    }
+
+    // Reset the consecutive-restart counter when the run was stable long enough,
+    // so a single crash after days of uptime is not counted against the cap.
+    const startedAt = this.#startedAt;
+    if (startedAt !== null && this.#deps.now().getTime() - startedAt >= this.#deps.stableMs) {
+      this.#restarts = 0;
+    }
+
+    const reason = `exited unexpectedly (code ${String(code)}, signal ${String(signal)})`;
+    if (this.#restarts >= this.#deps.maxRestarts) {
+      const detail = `${reason}; exceeded the restart cap (${this.#deps.maxRestarts})`;
+      this.#settle("failed", detail, `AdGuard Home ${detail}`, "error");
+      return;
+    }
+
+    this.#restarts += 1;
+    const backoff = Math.min(
+      this.#deps.backoffBaseMs * 2 ** (this.#restarts - 1),
+      this.#deps.backoffMaxMs,
+    );
+    this.#logger?.warn(
+      { event: "adguard_managed", restarts: this.#restarts, backoffMs: backoff },
+      `AdGuard Home ${reason}; restarting in ${backoff}ms (attempt ${this.#restarts})`,
+    );
+    void this.#scheduleRestart(backoff);
+  }
+
+  async #scheduleRestart(backoffMs: number): Promise<void> {
+    await this.#deps.delay(backoffMs);
+    if (this.#stopping) return;
+    this.#spawnChild();
+  }
+
+  /** Resolve and clear any promises awaiting the current child's exit. */
+  #releaseExitWaiters(): void {
+    const waiters = this.#exitWaiters;
+    this.#exitWaiters = [];
+    for (const resolve of waiters) resolve();
+  }
+
+  #settle(
+    state: AdGuardManagedState,
+    detail: string | null,
+    msg: string,
+    level: "info" | "error" = "info",
+  ): void {
+    this.#status = {
+      state,
+      binaryPath: this.#binaryPath,
+      version: this.#version,
+      adminEndpoint: this.#adminEndpoint,
+      restarts: this.#restarts,
+      checkedAt: this.#deps.now().toISOString(),
+      detail,
+    };
+    const fields = { event: "adguard_managed", state };
+    if (level === "error") this.#logger?.error(fields, msg);
+    else this.#logger?.info(fields, msg);
+  }
+}
+
+/** Build an {@link AdGuardManagedSupervisor} from the managed-mode settings. */
+export function createAdGuardManagedSupervisor(
+  config: AdGuardManagedConfig,
+  deps: AdGuardManagedDeps = {},
+): AdGuardManagedSupervisor {
+  return new AdGuardManagedSupervisor(config, deps);
+}

--- a/server/src/transport/adguard/targz.ts
+++ b/server/src/transport/adguard/targz.ts
@@ -1,0 +1,89 @@
+/**
+ * Minimal `.tar.gz` reader for the AdGuard Home managed-mode acquisition (#96).
+ *
+ * AdGuard's Linux release archives are gzip-compressed USTAR tarballs whose only
+ * file of interest is the `AdGuardHome` binary. Rather than take a `tar`
+ * dependency to pull one regular file out, this decompresses with `node:zlib`
+ * and walks the 512-byte tar blocks itself — the format is simple and the reader
+ * is fully unit-testable against a hand-built buffer (`CLAUDE.md` → "Do not
+ * introduce a new dependency without … why an existing one doesn't suffice":
+ * extracting a single entry is ~50 lines, not worth a dependency).
+ *
+ * License boundary: none touched — pure decompression/parsing over `node:zlib`
+ * (the runtime's own module). No AdGuard code linked.
+ */
+import { gunzipSync } from "node:zlib";
+
+/** tar blocks are a fixed 512 bytes. */
+const BLOCK_SIZE = 512;
+/** Offsets/lengths of the USTAR header fields this reader needs. */
+const NAME_OFFSET = 0;
+const NAME_LENGTH = 100;
+const SIZE_OFFSET = 124;
+const SIZE_LENGTH = 12;
+const TYPEFLAG_OFFSET = 156;
+const PREFIX_OFFSET = 345;
+const PREFIX_LENGTH = 155;
+
+/** Thrown when no regular-file entry matching the requested suffix is found. */
+export class TarEntryNotFoundError extends Error {
+  constructor(suffix: string) {
+    super(`no regular-file entry ending in ${JSON.stringify(suffix)} found in archive`);
+    this.name = "TarEntryNotFoundError";
+  }
+}
+
+/** Read a NUL-terminated ASCII field out of a tar header block. */
+function readString(block: Buffer, offset: number, length: number): string {
+  const raw = block.subarray(offset, offset + length);
+  const end = raw.indexOf(0);
+  return raw.toString("ascii", 0, end === -1 ? raw.length : end).trim();
+}
+
+/** Parse a tar octal numeric field (size is stored as zero-padded octal ASCII). */
+function readOctal(block: Buffer, offset: number, length: number): number {
+  const text = readString(block, offset, length);
+  return text === "" ? 0 : Number.parseInt(text, 8);
+}
+
+/** The full entry path, combining the USTAR `prefix` and `name` fields. */
+function entryPath(block: Buffer): string {
+  const name = readString(block, NAME_OFFSET, NAME_LENGTH);
+  const prefix = readString(block, PREFIX_OFFSET, PREFIX_LENGTH);
+  return prefix === "" ? name : `${prefix}/${name}`;
+}
+
+/**
+ * Extract the first **regular-file** entry whose path ends with {@link suffix}
+ * from a gzip-compressed tarball.
+ *
+ * @throws TarEntryNotFoundError when no such entry exists.
+ */
+export function extractFileFromTarGz(archive: Buffer, suffix: string): Buffer {
+  const tar = gunzipSync(archive);
+  let offset = 0;
+
+  while (offset + BLOCK_SIZE <= tar.length) {
+    const header = tar.subarray(offset, offset + BLOCK_SIZE);
+    offset += BLOCK_SIZE;
+
+    const path = entryPath(header);
+    // Two consecutive all-zero blocks mark end-of-archive; an empty name is the
+    // first of them, so stop walking.
+    if (path === "") break;
+
+    const size = readOctal(header, SIZE_OFFSET, SIZE_LENGTH);
+    // typeflag '0' or NUL both denote a regular file (older archives use NUL).
+    const typeflag = tar[offset - BLOCK_SIZE + TYPEFLAG_OFFSET];
+    const isRegularFile = typeflag === 0x30 || typeflag === 0x00;
+
+    if (isRegularFile && path.endsWith(suffix)) {
+      return Buffer.from(tar.subarray(offset, offset + size));
+    }
+
+    // Advance past this entry's data, rounded up to the next block boundary.
+    offset += Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE;
+  }
+
+  throw new TarEntryNotFoundError(suffix);
+}

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -17,7 +17,12 @@ import { loadSettings, type Settings } from "../config.js";
 import { EventHub } from "../events/index.js";
 import { createDb, type PolicyDb } from "../policy/db.js";
 import { createAnsibleVenvSupervisor, type AnsibleVenvSupervisor } from "../setup/ansible-venv.js";
-import { createAdGuardService, type AdGuardService } from "../transport/adguard/index.js";
+import {
+  createAdGuardManagedSupervisor,
+  createAdGuardService,
+  type AdGuardManagedSupervisor,
+  type AdGuardService,
+} from "../transport/adguard/index.js";
 import { createPolicyPushTransport } from "../transport/policy-push/index.js";
 import { registerFrontend } from "./frontend.js";
 import { REQUEST_ID_HEADER, buildLoggerOptions, genRequestId, type LogStream } from "./logger.js";
@@ -44,6 +49,15 @@ declare module "fastify" {
      * app — including in tests — spawns nothing.
      */
     ansibleVenv: AnsibleVenvSupervisor;
+    /**
+     * The managed-mode AdGuard Home supervisor (#96), or `null` when
+     * `PCT_ADGUARD_MODE` is not `managed`. `GET /api/system/adguard-managed`
+     * reads its `status`. Built (or injected) here so the route has a snapshot
+     * to serialise, but **not** run by `buildApp`: `main.ts` fires `bootstrap()`
+     * after `listen` (a first-run download must not block startup), and it is
+     * `stop()`ped on `app.close()`.
+     */
+    adguardManaged: AdGuardManagedSupervisor | null;
   }
 }
 
@@ -78,6 +92,13 @@ export interface BuildAppOptions {
    * constructing the app.
    */
   ansibleVenv?: AnsibleVenvSupervisor;
+  /**
+   * Inject an {@link AdGuardManagedSupervisor} (tests pass one with fake
+   * acquire/spawn seams), or `null` to force the not-managed contract. When
+   * omitted, {@link buildApp} builds one only in `managed` mode (else `null`)
+   * and never calls `bootstrap()`, so constructing the app spawns nothing.
+   */
+  adguardManaged?: AdGuardManagedSupervisor | null;
 }
 
 /**
@@ -146,6 +167,31 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
       playbookSourceDir: settings.ansiblePlaybookSourceDir,
     });
   app.decorate("ansibleVenv", ansibleVenv);
+
+  // The managed-mode AdGuard Home supervisor (#96), read by
+  // GET /api/system/adguard-managed. Built only in `managed` mode (else null);
+  // like ansibleVenv it is decorated here but bootstrapped by main.ts after
+  // listen, so constructing the app — including tests — spawns no process. An
+  // explicitly-injected value (including null) is honoured as-is.
+  const adguardManaged =
+    options.adguardManaged !== undefined
+      ? options.adguardManaged
+      : settings.adguard.mode === "managed"
+        ? createAdGuardManagedSupervisor({
+            dataDir: settings.adguard.dataDir,
+            bindAddr: settings.adguard.bindAddr,
+            adminPort: settings.adguard.adminPort,
+            ...(settings.adguard.version !== undefined
+              ? { version: settings.adguard.version }
+              : {}),
+          })
+        : null;
+  app.decorate("adguardManaged", adguardManaged);
+  if (adguardManaged !== null) {
+    app.addHook("onClose", async () => {
+      await adguardManaged.stop();
+    });
+  }
 
   app.get("/", async (_request, reply) => {
     return reply.type("text/plain").send("hello, no policy yet");

--- a/server/tests/api/dns.test.ts
+++ b/server/tests/api/dns.test.ts
@@ -136,7 +136,12 @@ describe("GET /api/dns", () => {
 
   it("surfaces managed mode as unknown, deferring to the supervisor (#96)", async () => {
     const built = await harnessWith(
-      createAdGuardService({ mode: "managed", bindAddr: "0.0.0.0:53", adminPort: 3000 }),
+      createAdGuardService({
+        mode: "managed",
+        bindAddr: "0.0.0.0:53",
+        adminPort: 3000,
+        dataDir: "/data/adguard",
+      }),
     );
     harness = built.harness;
     const res = await harness.app.inject({

--- a/server/tests/api/system.test.ts
+++ b/server/tests/api/system.test.ts
@@ -18,6 +18,11 @@ import {
   type AnsibleVenvSupervisor,
   type RunCommand,
 } from "../../src/setup/ansible-venv.js";
+import {
+  createAdGuardManagedSupervisor,
+  type AdGuardManagedSupervisor,
+  type SpawnManaged,
+} from "../../src/transport/adguard/index.js";
 import { buildTestApp, type TestApp } from "../helpers/app.js";
 
 const CORE_VERSION = "2.18.1";
@@ -155,6 +160,103 @@ describe("GET /api/system/ansible", () => {
         headers: { cookie },
       });
       expect(res.json().state).toBe("idle");
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+/**
+ * A spawn whose child exits cleanly on `SIGTERM`, so the managed supervisor
+ * reaches `running` and the app's `onClose` `stop()` resolves promptly (paired
+ * with an immediate `delay` below) rather than waiting on the real stop timer.
+ */
+const gracefulSpawn: SpawnManaged = () => {
+  let onExit: ((code: number | null, signal: NodeJS.Signals | null) => void) | null = null;
+  return {
+    pid: 1,
+    onExit: (listener) => {
+      onExit = listener;
+    },
+    onError: () => undefined,
+    kill: (signal) => onExit?.(0, signal),
+  };
+};
+
+/** Build the test app around an injected managed supervisor (or null) + admin login. */
+async function harnessWithManaged(
+  adguardManaged: AdGuardManagedSupervisor | null,
+): Promise<{ harness: TestApp; cookie: string }> {
+  const harness = buildTestApp({
+    appOptions: { settings: configuredSettings(), adguardManaged },
+  });
+  await harness.app.ready();
+  const login = await harness.app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    payload: { username: "ben", password: "hunter2" },
+  });
+  return { harness, cookie: sessionCookie(login) };
+}
+
+describe("GET /api/system/adguard-managed", () => {
+  it("rejects an anonymous request with 401", async () => {
+    const { harness } = await harnessWithManaged(null);
+    try {
+      const res = await harness.app.inject({ method: "GET", url: "/api/system/adguard-managed" });
+      expect(res.statusCode).toBe(401);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("reports enabled:false with null fields when not in managed mode", async () => {
+    const { harness, cookie } = await harnessWithManaged(null);
+    try {
+      const res = await harness.app.inject({
+        method: "GET",
+        url: "/api/system/adguard-managed",
+        headers: { cookie },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.enabled).toBe(false);
+      expect(body.state).toBeNull();
+      expect(body.adminEndpoint).toBeNull();
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("serialises a running managed snapshot for an admin", async () => {
+    const supervisor = createAdGuardManagedSupervisor(
+      { dataDir: "/data/adguard", bindAddr: "0.0.0.0:53", adminPort: 3000 },
+      {
+        acquire: async () => ({
+          binaryPath: "/data/adguard/AdGuardHome",
+          version: "v0.107.65",
+          fetched: true,
+        }),
+        writeSeedConfig: () => true,
+        spawn: gracefulSpawn,
+        delay: () => Promise.resolve(),
+      },
+    );
+    await supervisor.bootstrap();
+    const { harness, cookie } = await harnessWithManaged(supervisor);
+    try {
+      const res = await harness.app.inject({
+        method: "GET",
+        url: "/api/system/adguard-managed",
+        headers: { cookie },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.enabled).toBe(true);
+      expect(body.state).toBe("running");
+      expect(body.version).toBe("v0.107.65");
+      expect(body.adminEndpoint).toBe("http://127.0.0.1:3000");
+      expect(typeof body.checkedAt).toBe("string");
     } finally {
       await harness.close();
     }

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -216,13 +216,27 @@ describe("loadSettings", () => {
   });
 
   describe("managed mode", () => {
-    it("defaults bind address and admin port", () => {
+    it("defaults bind address, admin port, and data dir (version unset)", () => {
       const settings = loadSettings({ PCT_ADGUARD_MODE: "managed" });
 
       expect(settings.adguard).toEqual({
         mode: "managed",
         bindAddr: "0.0.0.0:53",
         adminPort: 3000,
+        dataDir: "/data/adguard",
+      });
+    });
+
+    it("honours an explicit data dir and pinned version", () => {
+      const settings = loadSettings({
+        PCT_ADGUARD_MODE: "managed",
+        PCT_ADGUARD_DATA_DIR: "/srv/adguard",
+        PCT_ADGUARD_VERSION: "v0.107.65",
+      });
+
+      expect(settings.adguard).toMatchObject({
+        dataDir: "/srv/adguard",
+        version: "v0.107.65",
       });
     });
 

--- a/server/tests/transport/adguard/acquire.test.ts
+++ b/server/tests/transport/adguard/acquire.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for the AdGuard Home first-run acquisition (#96).
+ *
+ * Network (`fetch`) and filesystem are injected, so no test touches the real
+ * network or disk: a fake `fetch` serves a hand-built release archive +
+ * `checksums.txt` + latest-release JSON, and an in-memory file map stands in for
+ * the data volume. Covers idempotency, checksum verification, version
+ * resolution, and the download/parse failure paths.
+ */
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  acquireAdGuardHome,
+  AdGuardChecksumError,
+  AdGuardDownloadError,
+  type AcquireDeps,
+  type DownloadFetch,
+} from "../../../src/transport/adguard/acquire.js";
+
+const DATA_DIR = "/data/adguard";
+const BINARY_PATH = join(DATA_DIR, "AdGuardHome");
+const SENTINEL_PATH = join(DATA_DIR, ".pct-adguard-version");
+const ASSET = "AdGuardHome_linux_amd64.tar.gz";
+const VERSION = "v0.107.65";
+const BLOCK = 512;
+
+const BINARY_BODY = Buffer.from("#!/bin/sh\necho adguard-home\n");
+
+function tarEntry(name: string, contents: Buffer): Buffer {
+  const header = Buffer.alloc(BLOCK);
+  header.write(name, 0, "ascii");
+  header.write(contents.length.toString(8).padStart(11, "0"), 124, "ascii");
+  header.write("0", 156, "ascii");
+  header.write("ustar\0", 257, "ascii");
+  const data = Buffer.alloc(Math.ceil(contents.length / BLOCK) * BLOCK);
+  contents.copy(data);
+  return Buffer.concat([header, data]);
+}
+
+function buildArchive(): Buffer {
+  const trailer = Buffer.alloc(BLOCK * 2);
+  return gzipSync(Buffer.concat([tarEntry("AdGuardHome/AdGuardHome", BINARY_BODY), trailer]));
+}
+
+const ARCHIVE = buildArchive();
+const ARCHIVE_SHA256 = createHash("sha256").update(ARCHIVE).digest("hex");
+
+/** Build a fake `fetch` serving the release endpoints; missing URLs 404. */
+function fakeFetch(routes: { archive?: Buffer; checksums?: string; latestTag?: string }): {
+  fetch: DownloadFetch;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const fetch: DownloadFetch = async (input) => {
+    const url = input;
+    calls.push(url);
+    const notFound = {
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      arrayBuffer: async () => new ArrayBuffer(0),
+      text: async () => "",
+      json: async () => ({}),
+    };
+    if (url.endsWith("/releases/latest")) {
+      if (routes.latestTag === undefined) return notFound;
+      return {
+        ...notFound,
+        ok: true,
+        status: 200,
+        json: async () => ({ tag_name: routes.latestTag }),
+      };
+    }
+    if (url.endsWith("checksums.txt")) {
+      const body = routes.checksums;
+      if (body === undefined) return notFound;
+      return { ...notFound, ok: true, status: 200, text: async () => body };
+    }
+    if (url.endsWith(ASSET)) {
+      if (routes.archive === undefined) return notFound;
+      const buf = routes.archive;
+      return {
+        ...notFound,
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => {
+          const ab = new ArrayBuffer(buf.byteLength);
+          new Uint8Array(ab).set(buf);
+          return ab;
+        },
+      };
+    }
+    return notFound;
+  };
+  return { fetch, calls };
+}
+
+/** In-memory filesystem seams over a `Map<path, contents>`. */
+function memFs(initial: Record<string, string> = {}): {
+  files: Map<string, Buffer | string>;
+  deps: Pick<
+    AcquireDeps,
+    "fileExists" | "readSentinel" | "makeDir" | "writeBinary" | "writeSentinel"
+  >;
+} {
+  const files = new Map<string, Buffer | string>(Object.entries(initial));
+  return {
+    files,
+    deps: {
+      fileExists: (p) => files.has(p),
+      readSentinel: (p) => {
+        const v = files.get(p);
+        return typeof v === "string" ? v.trim() : null;
+      },
+      makeDir: () => undefined,
+      writeBinary: (p, c) => void files.set(p, c),
+      writeSentinel: (p, v) => void files.set(p, `${v}\n`),
+    },
+  };
+}
+
+describe("acquireAdGuardHome", () => {
+  it("downloads, verifies the checksum, and extracts the binary (pinned)", async () => {
+    const { fetch, calls } = fakeFetch({
+      archive: ARCHIVE,
+      checksums: `${ARCHIVE_SHA256}  ${ASSET}\n`,
+    });
+    const { files, deps } = memFs();
+
+    const result = await acquireAdGuardHome(
+      { dataDir: DATA_DIR, version: VERSION },
+      { fetch, ...deps },
+    );
+
+    expect(result).toEqual({ binaryPath: BINARY_PATH, version: VERSION, fetched: true });
+    expect((files.get(BINARY_PATH) as Buffer).equals(BINARY_BODY)).toBe(true);
+    expect(files.get(SENTINEL_PATH)).toBe(`${VERSION}\n`);
+    // Pinned: never calls the latest-release API.
+    expect(calls.some((u) => u.endsWith("/releases/latest"))).toBe(false);
+  });
+
+  it("resolves the latest tag when unpinned and absent", async () => {
+    const { fetch, calls } = fakeFetch({
+      archive: ARCHIVE,
+      checksums: `${ARCHIVE_SHA256}  ${ASSET}\n`,
+      latestTag: VERSION,
+    });
+    const { deps } = memFs();
+
+    const result = await acquireAdGuardHome({ dataDir: DATA_DIR }, { fetch, ...deps });
+
+    expect(result.version).toBe(VERSION);
+    expect(result.fetched).toBe(true);
+    expect(calls[0]).toContain("/releases/latest");
+  });
+
+  it("is a no-op when the binary is already present and unpinned", async () => {
+    const { fetch, calls } = fakeFetch({});
+    const { deps } = memFs({ [BINARY_PATH]: "existing", [SENTINEL_PATH]: "v0.107.60" });
+
+    const result = await acquireAdGuardHome({ dataDir: DATA_DIR }, { fetch, ...deps });
+
+    expect(result).toEqual({ binaryPath: BINARY_PATH, version: "v0.107.60", fetched: false });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("is a no-op when present and the pinned version matches the sentinel", async () => {
+    const { fetch, calls } = fakeFetch({});
+    const { deps } = memFs({ [BINARY_PATH]: "existing", [SENTINEL_PATH]: VERSION });
+
+    const result = await acquireAdGuardHome(
+      { dataDir: DATA_DIR, version: VERSION },
+      { fetch, ...deps },
+    );
+
+    expect(result.fetched).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("re-acquires when present but the pinned version drifts from the sentinel", async () => {
+    const { fetch } = fakeFetch({ archive: ARCHIVE, checksums: `${ARCHIVE_SHA256}  ${ASSET}\n` });
+    const { files, deps } = memFs({ [BINARY_PATH]: "old", [SENTINEL_PATH]: "v0.107.60" });
+
+    const result = await acquireAdGuardHome(
+      { dataDir: DATA_DIR, version: VERSION },
+      { fetch, ...deps },
+    );
+
+    expect(result.fetched).toBe(true);
+    expect(files.get(SENTINEL_PATH)).toBe(`${VERSION}\n`);
+  });
+
+  it("rejects a checksum mismatch and writes no binary", async () => {
+    const { fetch } = fakeFetch({ archive: ARCHIVE, checksums: `${"0".repeat(64)}  ${ASSET}\n` });
+    const { files, deps } = memFs();
+
+    await expect(
+      acquireAdGuardHome({ dataDir: DATA_DIR, version: VERSION }, { fetch, ...deps }),
+    ).rejects.toBeInstanceOf(AdGuardChecksumError);
+    expect(files.has(BINARY_PATH)).toBe(false);
+  });
+
+  it("throws when checksums.txt has no entry for the asset", async () => {
+    const { fetch } = fakeFetch({
+      archive: ARCHIVE,
+      checksums: `${ARCHIVE_SHA256}  some-other.tar.gz\n`,
+    });
+    const { deps } = memFs();
+
+    await expect(
+      acquireAdGuardHome({ dataDir: DATA_DIR, version: VERSION }, { fetch, ...deps }),
+    ).rejects.toThrow(/no entry for/);
+  });
+
+  it("surfaces a non-2xx download as AdGuardDownloadError", async () => {
+    const { fetch } = fakeFetch({ checksums: `${ARCHIVE_SHA256}  ${ASSET}\n` }); // archive 404s
+    const { deps } = memFs();
+
+    await expect(
+      acquireAdGuardHome({ dataDir: DATA_DIR, version: VERSION }, { fetch, ...deps }),
+    ).rejects.toBeInstanceOf(AdGuardDownloadError);
+  });
+
+  it("throws when the latest-release lookup returns no tag_name", async () => {
+    const { fetch } = fakeFetch({
+      archive: ARCHIVE,
+      checksums: `${ARCHIVE_SHA256}  ${ASSET}\n`,
+      latestTag: "", // 200 OK but an empty tag_name
+    });
+    const { deps } = memFs();
+
+    await expect(acquireAdGuardHome({ dataDir: DATA_DIR }, { fetch, ...deps })).rejects.toThrow(
+      /no tag_name/,
+    );
+  });
+});
+
+/**
+ * Default-deps path: only `fetch` and `resolveAsset` are injected (the asset is
+ * fixed so the test is host-arch-independent), so the real filesystem seams
+ * (write the binary `0755`, write/read the sentinel, mkdir) run against a temp
+ * dir — covering the production defaults the in-memory fakes above stand in for.
+ */
+describe("acquireAdGuardHome (default filesystem seams)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pct-adguard-acquire-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes an executable binary + sentinel, then no-ops on a matching re-run", async () => {
+    const { fetch } = fakeFetch({ archive: ARCHIVE, checksums: `${ARCHIVE_SHA256}  ${ASSET}\n` });
+    const resolveAsset = (): { platform: string; assetName: string } => ({
+      platform: "linux_amd64",
+      assetName: ASSET,
+    });
+
+    const first = await acquireAdGuardHome(
+      { dataDir: dir, version: VERSION },
+      { fetch, resolveAsset },
+    );
+    expect(first.fetched).toBe(true);
+
+    const binaryPath = join(dir, "AdGuardHome");
+    expect(readFileSync(binaryPath).equals(BINARY_BODY)).toBe(true);
+    // 0o111 = any execute bit set.
+    expect(statSync(binaryPath).mode & 0o111).not.toBe(0);
+    expect(readFileSync(join(dir, ".pct-adguard-version"), "utf8").trim()).toBe(VERSION);
+
+    // Second run reads the on-disk sentinel via the default reader → no-op.
+    const second = await acquireAdGuardHome(
+      { dataDir: dir, version: VERSION },
+      { fetch, resolveAsset },
+    );
+    expect(second.fetched).toBe(false);
+  });
+});

--- a/server/tests/transport/adguard/acquire.test.ts
+++ b/server/tests/transport/adguard/acquire.test.ts
@@ -204,6 +204,7 @@ describe("acquireAdGuardHome", () => {
       acquireAdGuardHome({ dataDir: DATA_DIR, version: VERSION }, { fetch, ...deps }),
     ).rejects.toBeInstanceOf(AdGuardChecksumError);
     expect(files.has(BINARY_PATH)).toBe(false);
+    expect(files.has(SENTINEL_PATH)).toBe(false); // nothing persisted on mismatch
   });
 
   it("throws when checksums.txt has no entry for the asset", async () => {

--- a/server/tests/transport/adguard/managed-config.test.ts
+++ b/server/tests/transport/adguard/managed-config.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the managed-mode seed `AdGuardHome.yaml` (#96): rendering and the
+ * no-clobber write. Filesystem seams are injected.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  renderSeedConfig,
+  writeSeedConfigIfAbsent,
+} from "../../../src/transport/adguard/managed-config.js";
+
+describe("renderSeedConfig", () => {
+  it("binds the web UI to localhost and DNS to the bind address", () => {
+    const yaml = renderSeedConfig({ adminPort: 3000, bindAddr: "0.0.0.0:53" });
+    expect(yaml).toContain("address: 127.0.0.1:3000");
+    expect(yaml).toContain("- 0.0.0.0");
+    expect(yaml).toContain("port: 53");
+    expect(yaml).toContain("users: []");
+  });
+
+  it("splits a host:port bind address on the final colon", () => {
+    const yaml = renderSeedConfig({ adminPort: 8080, bindAddr: "192.168.1.2:5353" });
+    expect(yaml).toContain("- 192.168.1.2");
+    expect(yaml).toContain("port: 5353");
+  });
+
+  it("defaults the DNS port to 53 when the bind address has no port", () => {
+    const yaml = renderSeedConfig({ adminPort: 3000, bindAddr: "0.0.0.0" });
+    expect(yaml).toContain("port: 53");
+  });
+});
+
+describe("writeSeedConfigIfAbsent", () => {
+  it("writes the seed config when absent", () => {
+    const writes: { path: string; contents: string }[] = [];
+    const written = writeSeedConfigIfAbsent(
+      "/data/adguard/conf/AdGuardHome.yaml",
+      { adminPort: 3000, bindAddr: "0.0.0.0:53" },
+      {
+        fileExists: () => false,
+        makeDir: () => undefined,
+        writeFile: (path, contents) => void writes.push({ path, contents }),
+      },
+    );
+    expect(written).toBe(true);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.path).toBe("/data/adguard/conf/AdGuardHome.yaml");
+  });
+
+  it("does not clobber an existing config", () => {
+    const writes: string[] = [];
+    const written = writeSeedConfigIfAbsent(
+      "/data/adguard/conf/AdGuardHome.yaml",
+      { adminPort: 3000, bindAddr: "0.0.0.0:53" },
+      { fileExists: () => true, makeDir: () => undefined, writeFile: (p) => void writes.push(p) },
+    );
+    expect(written).toBe(false);
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/server/tests/transport/adguard/release.test.ts
+++ b/server/tests/transport/adguard/release.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the AdGuard Home release-coordinate helpers (#96): platform/arch →
+ * asset mapping, URL builders, and checksum-line parsing. All pure — no I/O.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  ADGUARD_REPO,
+  assetUrl,
+  checksumsUrl,
+  findChecksum,
+  resolveAsset,
+  UnsupportedPlatformError,
+} from "../../../src/transport/adguard/release.js";
+
+describe("resolveAsset", () => {
+  it.each([
+    ["x64", "linux_amd64"],
+    ["arm64", "linux_arm64"],
+    ["ia32", "linux_386"],
+    ["arm", "linux_armv7"],
+  ])("maps linux/%s to %s", (arch, token) => {
+    const asset = resolveAsset("linux", arch);
+    expect(asset.platform).toBe(token);
+    expect(asset.assetName).toBe(`AdGuardHome_${token}.tar.gz`);
+  });
+
+  it("rejects a non-linux platform", () => {
+    expect(() => resolveAsset("darwin", "x64")).toThrow(UnsupportedPlatformError);
+  });
+
+  it("rejects an unmapped architecture", () => {
+    expect(() => resolveAsset("linux", "riscv64")).toThrow(UnsupportedPlatformError);
+  });
+});
+
+describe("URL builders", () => {
+  const asset = resolveAsset("linux", "x64");
+
+  it("builds the asset download URL", () => {
+    expect(assetUrl("v0.107.65", asset)).toBe(
+      `https://github.com/${ADGUARD_REPO}/releases/download/v0.107.65/AdGuardHome_linux_amd64.tar.gz`,
+    );
+  });
+
+  it("builds the checksums URL", () => {
+    expect(checksumsUrl("v0.107.65")).toBe(
+      `https://github.com/${ADGUARD_REPO}/releases/download/v0.107.65/checksums.txt`,
+    );
+  });
+});
+
+describe("findChecksum", () => {
+  const digest = "a".repeat(64);
+  const other = "b".repeat(64);
+
+  it("finds the digest for the requested asset", () => {
+    const body = `${other}  AdGuardHome_linux_arm64.tar.gz\n${digest}  AdGuardHome_linux_amd64.tar.gz\n`;
+    expect(findChecksum(body, "AdGuardHome_linux_amd64.tar.gz")).toBe(digest);
+  });
+
+  it("tolerates a ./ filename prefix and upper-case hex", () => {
+    const body = `${digest.toUpperCase()}  ./AdGuardHome_linux_amd64.tar.gz`;
+    expect(findChecksum(body, "AdGuardHome_linux_amd64.tar.gz")).toBe(digest);
+  });
+
+  it("returns null when the asset is absent", () => {
+    const body = `${other}  AdGuardHome_linux_arm64.tar.gz`;
+    expect(findChecksum(body, "AdGuardHome_linux_amd64.tar.gz")).toBeNull();
+  });
+
+  it("ignores blank and malformed lines", () => {
+    const body = `\n   \nnot-a-checksum-line\n${digest}  AdGuardHome_linux_amd64.tar.gz`;
+    expect(findChecksum(body, "AdGuardHome_linux_amd64.tar.gz")).toBe(digest);
+  });
+});

--- a/server/tests/transport/adguard/service.test.ts
+++ b/server/tests/transport/adguard/service.test.ts
@@ -73,7 +73,12 @@ describe("AdGuardService — disabled mode", () => {
 
 describe("AdGuardService — managed mode", () => {
   it("routes the mode only, deferring the instance to the supervisor (#96)", async () => {
-    const svc = createAdGuardService({ mode: "managed", bindAddr: "0.0.0.0:53", adminPort: 3000 });
+    const svc = createAdGuardService({
+      mode: "managed",
+      bindAddr: "0.0.0.0:53",
+      adminPort: 3000,
+      dataDir: "/data/adguard",
+    });
     expect(svc.mode).toBe("managed");
     expect(svc.status).toMatchObject({
       mode: "managed",

--- a/server/tests/transport/adguard/supervisor.test.ts
+++ b/server/tests/transport/adguard/supervisor.test.ts
@@ -126,6 +126,25 @@ describe("AdGuardManagedSupervisor.bootstrap", () => {
     expect(sup.status.state).toBe("failed");
     expect(sup.status.detail).toContain("ENOENT");
   });
+
+  it("ignores the exit Node emits after a spawn error (no restart)", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn,
+      delay: () => Promise.resolve(),
+    });
+
+    await sup.bootstrap();
+    // Node emits `error` then `exit` for a failed spawn; the exit must be a no-op.
+    only(procs, 0).triggerError(new Error("ENOENT"));
+    only(procs, 0).triggerExit(null, null);
+    await flush();
+
+    expect(sup.status.state).toBe("failed");
+    expect(procs).toHaveLength(1); // no restart spawned
+  });
 });
 
 describe("AdGuardManagedSupervisor restart-on-exit", () => {
@@ -270,6 +289,31 @@ describe("AdGuardManagedSupervisor.stop", () => {
     await flush();
 
     expect(procs).toHaveLength(1); // no restart spawned
+    expect(sup.status.state).toBe("stopped");
+  });
+
+  it("does not spawn a child if stop() lands during the fetch phase", async () => {
+    const { spawn, procs } = fakeSpawn();
+    let resolveAcquire: (result: AcquireResult) => void = () => undefined;
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: () =>
+        new Promise<AcquireResult>((resolve) => {
+          resolveAcquire = resolve;
+        }),
+      writeSeedConfig: () => true,
+      spawn,
+    });
+
+    const booting = sup.bootstrap(); // suspends awaiting acquire (state: fetching)
+    await sup.stop(); // no child yet → stopped, and #stopping latched
+    resolveAcquire({
+      binaryPath: "/data/adguard/AdGuardHome",
+      version: "v0.107.65",
+      fetched: true,
+    });
+    await booting;
+
+    expect(procs).toHaveLength(0); // the post-fetch spawn was suppressed
     expect(sup.status.state).toBe("stopped");
   });
 });

--- a/server/tests/transport/adguard/supervisor.test.ts
+++ b/server/tests/transport/adguard/supervisor.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for the AdGuard Home managed-mode supervisor (#96).
+ *
+ * The acquisition, config seed, process spawn, clock, and backoff/stop delays
+ * are all injected, so no test spawns a real process or waits on real time: a
+ * controllable fake process drives exit/error, and a fake `delay` either
+ * resolves immediately (restart backoff) or never (stop grace) per test.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { AcquireResult } from "../../../src/transport/adguard/acquire.js";
+import {
+  createAdGuardManagedSupervisor,
+  type ManagedProcess,
+  type SpawnManaged,
+} from "../../../src/transport/adguard/supervisor.js";
+
+const CONFIG = { dataDir: "/data/adguard", bindAddr: "0.0.0.0:53", adminPort: 3000 };
+
+/** A fully-controllable {@link ManagedProcess} for tests. */
+class FakeProcess implements ManagedProcess {
+  pid: number | undefined = 4242;
+  #exit: ((code: number | null, signal: NodeJS.Signals | null) => void) | null = null;
+  #error: ((err: Error) => void) | null = null;
+  readonly kills: NodeJS.Signals[] = [];
+  /** When set, killing with this signal auto-fires `exit`. */
+  autoExitOn: NodeJS.Signals | null = null;
+
+  onExit(listener: (code: number | null, signal: NodeJS.Signals | null) => void): void {
+    this.#exit = listener;
+  }
+  onError(listener: (err: Error) => void): void {
+    this.#error = listener;
+  }
+  kill(signal: NodeJS.Signals): void {
+    this.kills.push(signal);
+    if (signal === this.autoExitOn) this.triggerExit(null, signal);
+  }
+  triggerExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.#exit?.(code, signal);
+  }
+  triggerError(err: Error): void {
+    this.#error?.(err);
+  }
+}
+
+/** A spawn factory recording every spawned fake process. */
+function fakeSpawn(): { spawn: SpawnManaged; procs: FakeProcess[] } {
+  const procs: FakeProcess[] = [];
+  const spawn: SpawnManaged = () => {
+    const proc = new FakeProcess();
+    procs.push(proc);
+    return proc;
+  };
+  return { spawn, procs };
+}
+
+/** Index into a process list, asserting presence (keeps tests free of `!`). */
+function only(procs: FakeProcess[], index: number): FakeProcess {
+  const proc = procs[index];
+  if (proc === undefined) throw new Error(`no spawned process at index ${index}`);
+  return proc;
+}
+
+const okAcquire = async (): Promise<AcquireResult> => ({
+  binaryPath: "/data/adguard/AdGuardHome",
+  version: "v0.107.65",
+  fetched: true,
+});
+
+/** Let queued microtasks (immediate-`delay` restarts) settle. */
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("AdGuardManagedSupervisor.bootstrap", () => {
+  it("acquires, seeds config, and reaches running", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const seeds: string[] = [];
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: (path) => {
+        seeds.push(path);
+        return true;
+      },
+      spawn,
+    });
+
+    const status = await sup.bootstrap();
+
+    expect(status.state).toBe("running");
+    expect(status.version).toBe("v0.107.65");
+    expect(status.adminEndpoint).toBe("http://127.0.0.1:3000");
+    expect(procs).toHaveLength(1);
+    expect(seeds).toEqual(["/data/adguard/conf/AdGuardHome.yaml"]);
+  });
+
+  it("records failed (never throws) when acquisition fails", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: () => Promise.reject(new Error("network down")),
+      writeSeedConfig: () => true,
+      spawn,
+    });
+
+    const status = await sup.bootstrap();
+
+    expect(status.state).toBe("failed");
+    expect(status.detail).toContain("network down");
+    expect(procs).toHaveLength(0);
+  });
+
+  it("records failed on a spawn error", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn,
+    });
+
+    await sup.bootstrap();
+    expect(sup.status.state).toBe("running");
+
+    only(procs, 0).triggerError(new Error("ENOENT"));
+    expect(sup.status.state).toBe("failed");
+    expect(sup.status.detail).toContain("ENOENT");
+  });
+});
+
+describe("AdGuardManagedSupervisor restart-on-exit", () => {
+  it("restarts with backoff on an unexpected exit", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const delays: number[] = [];
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn,
+      delay: async (ms) => {
+        delays.push(ms);
+      },
+      backoffBaseMs: 1000,
+      stableMs: 60_000,
+      now: () => new Date(0), // every run looks instantaneous → no stable reset
+    });
+
+    await sup.bootstrap();
+    only(procs, 0).triggerExit(1, null);
+    await flush();
+
+    expect(delays).toEqual([1000]); // base backoff, first attempt
+    expect(procs).toHaveLength(2); // restarted
+    expect(sup.status.state).toBe("running");
+    expect(sup.status.restarts).toBe(1);
+  });
+
+  it("gives up to failed after exceeding the restart cap", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn,
+      delay: () => Promise.resolve(),
+      maxRestarts: 2,
+      stableMs: 60_000,
+      now: () => new Date(0),
+    });
+
+    await sup.bootstrap();
+    // Crash repeatedly: 2 restarts allowed, the 3rd unexpected exit gives up.
+    for (let i = 0; i < 3; i++) {
+      only(procs, procs.length - 1).triggerExit(1, null);
+      await flush();
+    }
+
+    expect(sup.status.state).toBe("failed");
+    expect(sup.status.detail).toContain("restart cap");
+    expect(procs).toHaveLength(3); // initial + 2 restarts; no 4th spawn
+  });
+
+  it("resets the restart counter after a stable run", async () => {
+    const { spawn, procs } = fakeSpawn();
+    let clock = 0;
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn,
+      delay: () => Promise.resolve(),
+      maxRestarts: 2,
+      stableMs: 1000,
+      now: () => new Date(clock),
+    });
+
+    await sup.bootstrap();
+    // First crash is immediate (uptime 0 < stableMs) → restarts = 1.
+    only(procs, procs.length - 1).triggerExit(1, null);
+    await flush();
+    expect(sup.status.restarts).toBe(1);
+
+    // Advance the clock past stableMs before the next crash → counter resets to 0
+    // then increments to 1, never reaching the cap.
+    clock = 5000;
+    only(procs, procs.length - 1).triggerExit(1, null);
+    await flush();
+    expect(sup.status.restarts).toBe(1);
+    expect(sup.status.state).toBe("running");
+  });
+});
+
+describe("AdGuardManagedSupervisor.stop", () => {
+  it("sends SIGTERM and resolves when the child exits", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn,
+      delay: () => new Promise<void>(() => undefined), // stop grace never elapses
+    });
+
+    await sup.bootstrap();
+    const stopping = sup.stop();
+    only(procs, 0).triggerExit(0, "SIGTERM");
+    await stopping;
+
+    expect(only(procs, 0).kills).toEqual(["SIGTERM"]);
+    expect(sup.status.state).toBe("stopped");
+  });
+
+  it("escalates to SIGKILL when the child ignores SIGTERM", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn,
+      delay: () => Promise.resolve(), // stop grace elapses immediately
+    });
+
+    await sup.bootstrap();
+    only(procs, 0).autoExitOn = "SIGKILL"; // dies only on the hard kill
+    await sup.stop();
+
+    expect(only(procs, 0).kills).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(sup.status.state).toBe("stopped");
+  });
+
+  it("is a no-op when nothing is running", async () => {
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn: fakeSpawn().spawn,
+    });
+
+    await sup.stop();
+    expect(sup.status.state).toBe("stopped");
+  });
+
+  it("does not restart after a stop-initiated exit", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn,
+      delay: () => Promise.resolve(),
+    });
+
+    await sup.bootstrap();
+    const stopping = sup.stop();
+    only(procs, 0).triggerExit(0, "SIGTERM");
+    await stopping;
+    await flush();
+
+    expect(procs).toHaveLength(1); // no restart spawned
+    expect(sup.status.state).toBe("stopped");
+  });
+});
+
+describe("createAdGuardManagedSupervisor", () => {
+  it("starts idle before bootstrap and spawns nothing", () => {
+    const spy = vi.fn();
+    const sup = createAdGuardManagedSupervisor(CONFIG, { spawn: spy });
+    expect(sup.status.state).toBe("idle");
+    expect(sup.status.binaryPath).toBe("/data/adguard/AdGuardHome");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/transport/adguard/targz.test.ts
+++ b/server/tests/transport/adguard/targz.test.ts
@@ -15,13 +15,13 @@ import {
 
 const BLOCK = 512;
 
-/** Build a single USTAR header + padded data blocks for one regular file. */
-function tarEntry(name: string, contents: Buffer): Buffer {
+/** Build a single USTAR header + padded data blocks for one entry. */
+function tarEntry(name: string, contents: Buffer, typeflag = "0"): Buffer {
   const header = Buffer.alloc(BLOCK);
   header.write(name, 0, "ascii");
   // size field at offset 124: 11 octal digits + NUL.
   header.write(contents.length.toString(8).padStart(11, "0"), 124, "ascii");
-  header.write("0", 156, "ascii"); // typeflag: regular file
+  header.write(typeflag, 156, "ascii"); // '0' regular file, '5' directory
   header.write("ustar\0", 257, "ascii");
   const dataBlocks = Math.ceil(contents.length / BLOCK) * BLOCK;
   const data = Buffer.alloc(dataBlocks);
@@ -30,8 +30,8 @@ function tarEntry(name: string, contents: Buffer): Buffer {
 }
 
 /** Assemble entries into a gzip-compressed tarball ending in two zero blocks. */
-function buildTarGz(entries: { name: string; contents: Buffer }[]): Buffer {
-  const blocks = entries.map((e) => tarEntry(e.name, e.contents));
+function buildTarGz(entries: { name: string; contents: Buffer; typeflag?: string }[]): Buffer {
+  const blocks = entries.map((e) => tarEntry(e.name, e.contents, e.typeflag ?? "0"));
   const trailer = Buffer.alloc(BLOCK * 2);
   return gzipSync(Buffer.concat([...blocks, trailer]));
 }
@@ -59,6 +59,16 @@ describe("extractFileFromTarGz", () => {
 
   it("throws when no entry matches the suffix", () => {
     const archive = buildTarGz([{ name: "AdGuardHome/README.md", contents: Buffer.from("x") }]);
+    expect(() => extractFileFromTarGz(archive, "AdGuardHome/AdGuardHome")).toThrow(
+      TarEntryNotFoundError,
+    );
+  });
+
+  it("skips a non-regular (directory) entry matching the suffix", () => {
+    // A directory entry (typeflag '5') named like the target must not be returned.
+    const archive = buildTarGz([
+      { name: "AdGuardHome/AdGuardHome", contents: Buffer.alloc(0), typeflag: "5" },
+    ]);
     expect(() => extractFileFromTarGz(archive, "AdGuardHome/AdGuardHome")).toThrow(
       TarEntryNotFoundError,
     );

--- a/server/tests/transport/adguard/targz.test.ts
+++ b/server/tests/transport/adguard/targz.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the minimal `.tar.gz` reader (#96): extract one regular-file entry
+ * by suffix from a hand-built gzip+tar buffer. Exercises the multi-entry walk,
+ * the block-rounding of entry data, and the not-found path — no real archive
+ * needed.
+ */
+import { gzipSync } from "node:zlib";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  extractFileFromTarGz,
+  TarEntryNotFoundError,
+} from "../../../src/transport/adguard/targz.js";
+
+const BLOCK = 512;
+
+/** Build a single USTAR header + padded data blocks for one regular file. */
+function tarEntry(name: string, contents: Buffer): Buffer {
+  const header = Buffer.alloc(BLOCK);
+  header.write(name, 0, "ascii");
+  // size field at offset 124: 11 octal digits + NUL.
+  header.write(contents.length.toString(8).padStart(11, "0"), 124, "ascii");
+  header.write("0", 156, "ascii"); // typeflag: regular file
+  header.write("ustar\0", 257, "ascii");
+  const dataBlocks = Math.ceil(contents.length / BLOCK) * BLOCK;
+  const data = Buffer.alloc(dataBlocks);
+  contents.copy(data);
+  return Buffer.concat([header, data]);
+}
+
+/** Assemble entries into a gzip-compressed tarball ending in two zero blocks. */
+function buildTarGz(entries: { name: string; contents: Buffer }[]): Buffer {
+  const blocks = entries.map((e) => tarEntry(e.name, e.contents));
+  const trailer = Buffer.alloc(BLOCK * 2);
+  return gzipSync(Buffer.concat([...blocks, trailer]));
+}
+
+describe("extractFileFromTarGz", () => {
+  it("extracts a file matching the suffix", () => {
+    const body = Buffer.from("#!/bin/sh\necho adguard\n");
+    const archive = buildTarGz([
+      { name: "AdGuardHome/LICENSE.txt", contents: Buffer.from("license") },
+      { name: "AdGuardHome/AdGuardHome", contents: body },
+    ]);
+    const extracted = extractFileFromTarGz(archive, "AdGuardHome/AdGuardHome");
+    expect(extracted.equals(body)).toBe(true);
+  });
+
+  it("handles a multi-block entry preceding the target", () => {
+    const big = Buffer.alloc(BLOCK + 100, 0x41); // spans two blocks
+    const body = Buffer.from("binary-bytes");
+    const archive = buildTarGz([
+      { name: "AdGuardHome/CHANGELOG.md", contents: big },
+      { name: "AdGuardHome/AdGuardHome", contents: body },
+    ]);
+    expect(extractFileFromTarGz(archive, "AdGuardHome/AdGuardHome").equals(body)).toBe(true);
+  });
+
+  it("throws when no entry matches the suffix", () => {
+    const archive = buildTarGz([{ name: "AdGuardHome/README.md", contents: Buffer.from("x") }]);
+    expect(() => extractFileFromTarGz(archive, "AdGuardHome/AdGuardHome")).toThrow(
+      TarEntryNotFoundError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **AdGuard Home managed-mode supervisor** (`PCT_ADGUARD_MODE=managed`): fetch AdGuard Home from upstream releases into the data volume on first run, verify it, and supervise it as a **child process** — the deliberately-deferred follow-up the `AdGuardService` already flags as "#96".

- **Acquisition** (`release.ts` / `targz.ts` / `acquire.ts`): platform/arch → release asset; idempotent download (pinned `PCT_ADGUARD_VERSION` or `/releases/latest`); **SHA-256 verification** against `checksums.txt`; extraction to `/data/adguard/AdGuardHome` with a version sentinel. A hand-rolled gzip+USTAR reader avoids a `tar` dependency.
- **Seed config** (`managed-config.ts`): a minimal dashboard-owned `AdGuardHome.yaml` (web/REST UI bound to `127.0.0.1:<adminPort>`, DNS to `PCT_ADGUARD_BIND_ADDR`) so AdGuard boots headless instead of its install wizard; written only when absent (no-clobber).
- **Supervisor** (`supervisor.ts`): never-throwing `bootstrap()` → acquire → seed → spawn; restart-with-capped-backoff on unexpected exit (counter resets after a stable run); graceful `SIGTERM`→`SIGKILL` stop on shutdown; state-machine status snapshot mirroring `AnsibleVenvSupervisor`.
- **Wiring**: `PCT_ADGUARD_DATA_DIR` + optional `PCT_ADGUARD_VERSION` config; `GET /api/system/adguard-managed` (`requireAdmin`); `app.adguardManaged` decorated (managed mode only, stopped on close); `main.ts` bootstraps it in the background after `listen`.
- **ADR** `docs/adr/0009-adguard-managed-supervisor.md`: child process over sidecar container. Deployment doc + `.env.example` updated.

## Plan

Linked plan: `.claude/plans/issue-96-adguard-managed-supervisor.md`
Roadmap: `docs/roadmap.md` → Phase 7 (DNS filtering, optional).

## License-boundary note

Unchanged. AdGuard Home is fetched from upstream **at runtime** into the data volume and run as a **separate child process**, reached only over REST — never bundled into the dashboard image, never linked in-process (`CLAUDE.md` → "License boundaries" rule 5; `docs/licensing-analysis.md`). `license-guard` unaffected. **No new dependency** (the tar reader is hand-rolled over `node:zlib` precisely to avoid one).

## Deferred → tracked in #283

Feeding the running managed instance into `AdGuardService.getClient()` + live REST health polling (the consumer #97 needs) is filed as **#283** and composes on top of this. Live bring-up against the real binary needs a container/Docker daemon not available in the scheduled-run sandbox (the #157 → #207 posture); the seed-config schema + CLI flags are modelled from upstream docs and noted as such in the ADR.

## Test plan

- [x] `release` / `targz` / `acquire` / `managed-config` / `supervisor` unit tests (network, fs, spawn, clock, backoff all injected — no real process/network).
- [x] `GET /api/system/adguard-managed` route tests (401 guard, not-managed `enabled:false`, running snapshot) + config tests for the new vars.
- [x] Full local gate green: `format:check` / `lint` / `typecheck` / `test` — **1277 unit tests pass, coverage 98.77%** (gate 80%).
- [ ] Live managed-mode bring-up against the real binary — deferred (no Docker in sandbox); modelled from upstream docs.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)