### PR TITLE
feat(transport,api): save-and-push preview diff for policy changes (#64)

### DIFF
--- a/.claude/plans/issue-64-policy-push-preview-diff.md
+++ b/.claude/plans/issue-64-policy-push-preview-diff.md
@@ -1,0 +1,92 @@
+# Issue #64 — Admin "preview diff" before save-and-push
+
+Roadmap: `docs/roadmap.md` → Phase 4 (SSH + `timekpra` transport).
+
+## Goal
+
+Let the admin see **what will change on each affected client** before a policy
+save is pushed. The visible affordance is the save-and-push bar mocked in PR
+#60; this issue's data flow is the per-client diff + offline-queue annotation in
+`docs/architecture.md` → "Outbound (server → client) — policy push".
+
+## Why a backend slice (deferred work)
+
+The full feature spans a diff engine, a preview API, **and** the `/admin`
+SvelteKit rendering of the diff bar. The SvelteKit editor work composes with the
+per-user/group schedule editors (#53/#63) that are still in flight, so this PR
+lands the **engine + contract** cleanly first and defers the UI rendering and a
+couple of refinements to tracked follow-ups (see "Deferred").
+
+## Deliverables
+
+1. **`server/src/transport/policy-push/diff.ts`** — a pure, I/O-free diff engine
+   over the existing `ResolvedPolicyPush` (`./resolve.ts`): given a `before` and
+   `after` resolved push, produce structured, human-readable `PolicyPushChange`
+   rows for
+   - the **daily overall** limit (per-weekday; collapses to one whole-week row
+     when uniform, which is the only shape the resolver emits today),
+   - the **rolling weekly** and **monthly** limits, and
+   - the **allowed-hours/days** grid, per weekday.
+   Each row carries `field`, `kind` (`added`/`removed`/`changed`), an optional
+   `weekday`, human `before`/`after` strings, and a one-line `summary`. Durations
+   render as `2h 30m`; windows as `08:00–21:00`.
+2. **`server/src/api/policy/preview-dtos.ts`** — zod request/response DTOs:
+   - request: a *proposed* policy = `budgets[]` + `schedules[]` reusing the
+     **single-source** `budgetResponseSchema` / `scheduleResponseSchema` (what
+     the editor already holds after a GET — no parallel wire shape), plus an
+     optional reference instant for tests.
+   - response: `{ userId, hasChanges, changes[], affectedClients[] }`.
+3. **`server/src/api/policy/preview-routes.ts`** —
+   `POST /api/users/:userId/policy-preview` (behind `requireAdmin`):
+   resolve the user's *current* persisted policy → `before`; resolve the
+   request's *proposed* policy → `after`; diff them; and list the user's
+   **affected clients** (`listUserLinks` → hostname via `getClient`) annotated
+   with each client's current **pending-queue depth** (`listForClient`) and
+   `lastSeen`. Wired beside `registerEffectiveRoutes` in `api/plugin.ts`. A new
+   route file keeps it out of the 1017-line `routes.ts` (low merge-conflict
+   surface).
+
+   **Fidelity (caught by a concurrent session's notes on #64):** current policy
+   is read with `listUserSchedules` + `listUserBudgets` — the user's **own**
+   rules, exactly what the live executor (`policy-push/executor.ts`) resolves and
+   pushes — **not** the group-merged `gatherUserScheduleRules` that `effective.ts`
+   uses. Group schedules aren't pushed over `timekpra` yet, so diffing against
+   them would show windows the push never sends.
+4. Tests: `tests/transport/policy-push/diff.test.ts` (engine) +
+   `tests/api/policy/policy-preview.test.ts` (route round-trips, 404, auth,
+   affected-client annotation).
+
+## Side-effect-free by design
+
+Preview performs **no** SSH probe and **no** push — it is a read + pure compute.
+It reports each affected client's last-known `lastSeen` and current
+`pendingQueueDepth` so the UI can convey "this client already has N changes
+queued"; the actual push-vs-queue decision still happens at push time against
+live reachability (`pushOrEnqueue`). This honesty is deliberate: a preview must
+not mutate transport state.
+
+## Scope boundary
+
+- **SSH + `timekpra` session limits only.** That is the transport that exists on
+  `main` (`resolve.ts` → `ResolvedPolicyPush`). The **Ansible-side** diff
+  (e2guardian / iptables filter changes) is Phase 6 (#90, in PR #217) and is a
+  tracked follow-up.
+- Diffing is at the **semantic `ResolvedPolicyPush`** level (limits + windows),
+  not raw `timekpra` argv — that is what is human-readable and what the executor
+  consumes.
+
+## Deferred (tracked with a new follow-up issue, linked from the PR)
+
+- `/admin` save-and-push **UI rendering** of the diff bar (the visible
+  affordance) — composes with #53/#63.
+- **Future-dated** preview (`?date=`): `resolvePolicyPush` is `now`-based; the
+  whole-week recurring picture is already captured at "now", so a future
+  reference instant is a refinement, not core.
+- **Live-reachability** annotation (probe-on-preview) and the **Ansible-side**
+  diff.
+
+## License boundary
+
+Unchanged — pure TypeScript over the policy model + zod + the existing
+read-only queue/repository seams. No GPL linkage, no subprocess/REST boundary
+crossed, no Docker-image change. `CLAUDE.md` → "License boundaries".

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -17,7 +17,11 @@ import { registerClientEnrolmentRoutes, registerClientHealthRoutes } from "./cli
 import { registerDnsRoutes } from "./dns/index.js";
 import { registerIntegrationRoutes } from "./integrations/index.js";
 import { registerMetaRoute } from "./meta.js";
-import { registerEffectiveRoutes, registerPolicyRoutes } from "./policy/index.js";
+import {
+  registerEffectiveRoutes,
+  registerPolicyRoutes,
+  registerPreviewRoutes,
+} from "./policy/index.js";
 import { registerSystemRoutes } from "./system/index.js";
 import { installApiConventions } from "./validation.js";
 
@@ -56,6 +60,9 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   // Effective-policy preview (#143): GET /users/:userId/effective. Needs
   // `settings` for the server-default timezone of users with no `tz`.
   registerEffectiveRoutes(scope, opts.settings);
+  // Save-and-push preview (#64): POST /users/:userId/policy-preview — the
+  // side-effect-free "what will change on each client" diff before a save.
+  registerPreviewRoutes(scope, opts.settings);
   // Client enrolment (#77): admin-minted token + the install script's enrol
   // exchange. `settings` carries the SSH-public-key path the enrol response returns.
   registerClientEnrolmentRoutes(scope, opts.settings);

--- a/server/src/api/policy/index.ts
+++ b/server/src/api/policy/index.ts
@@ -12,6 +12,16 @@ export {
   effectivePolicyResponseSchema,
   type EffectivePolicyResponse,
 } from "./effective.js";
+export { registerPreviewRoutes } from "./preview-routes.js";
+export {
+  policyPreviewRequestSchema,
+  policyPreviewResponseSchema,
+  policyPushChangeResponseSchema,
+  previewAffectedClientSchema,
+  type PolicyPreviewRequest,
+  type PolicyPreviewResponse,
+  type PreviewAffectedClient,
+} from "./preview-dtos.js";
 export {
   // Account/device core (#51)
   clientResponseSchema,

--- a/server/src/api/policy/preview-dtos.ts
+++ b/server/src/api/policy/preview-dtos.ts
@@ -1,0 +1,79 @@
+/**
+ * DTOs for the save-and-push **preview** endpoint (#64):
+ * `POST /api/users/:userId/policy-preview`.
+ *
+ * The request carries a *proposed* policy — the budgets and schedule rules the
+ * admin is about to save — as the **same** `budgetResponseSchema` /
+ * `scheduleResponseSchema` the editor already holds after a GET (no parallel
+ * wire shape). The endpoint resolves it against the user's *current* persisted
+ * policy and returns the human-readable change set plus the clients the push
+ * would fan out to. The change/response shapes mirror the pure diff engine
+ * (`transport/policy-push/diff.ts`) so the frontend renders exactly what the
+ * engine computes.
+ *
+ * License boundary: none touched — zod over plain objects.
+ */
+import { z } from "zod";
+
+import { budgetResponseSchema, scheduleResponseSchema } from "./dtos.js";
+
+/**
+ * The proposed-policy preview request body. `budgets`/`schedules` reuse the
+ * single-source response DTOs (what the editor holds), so a proposed rule
+ * carries its `id`/`ordinal` — which the resolver needs for precedence. `now`
+ * is an optional reference instant (ISO-8601) the proposed/current resolution
+ * is computed against; it exists for deterministic tests and future-dated
+ * previews, and defaults to the current time when absent.
+ */
+export const policyPreviewRequestSchema = z.object({
+  budgets: z.array(budgetResponseSchema).default([]),
+  schedules: z.array(scheduleResponseSchema).default([]),
+  now: z.string().datetime().optional(),
+});
+
+export type PolicyPreviewRequest = z.infer<typeof policyPreviewRequestSchema>;
+
+/** Which resolved-push field a preview change row concerns. */
+export const policyPushChangeFieldSchema = z.enum([
+  "daily-overall",
+  "weekly-limit",
+  "monthly-limit",
+  "allowed-hours",
+]);
+
+/** Whether a value was added, removed, or changed. */
+export const policyPushChangeKindSchema = z.enum(["added", "removed", "changed"]);
+
+/** One human-readable difference between the current and proposed push. */
+export const policyPushChangeResponseSchema = z.object({
+  field: policyPushChangeFieldSchema,
+  kind: policyPushChangeKindSchema,
+  weekday: z.number().int().min(1).max(7).nullable(),
+  before: z.string().nullable(),
+  after: z.string().nullable(),
+  summary: z.string(),
+});
+
+/**
+ * A client the push would fan out to, with the side-effect-free annotation the
+ * preview can offer: when the client was last seen, and how many actions are
+ * already queued for it. The live push-vs-queue decision still happens at push
+ * time against real reachability — preview never probes.
+ */
+export const previewAffectedClientSchema = z.object({
+  clientId: z.number().int(),
+  hostname: z.string(),
+  lastSeen: z.string().nullable(),
+  pendingQueueDepth: z.number().int().nonnegative(),
+});
+
+/** The preview response: the change set + the clients it would reach. */
+export const policyPreviewResponseSchema = z.object({
+  userId: z.number().int(),
+  hasChanges: z.boolean(),
+  changes: z.array(policyPushChangeResponseSchema),
+  affectedClients: z.array(previewAffectedClientSchema),
+});
+
+export type PolicyPreviewResponse = z.infer<typeof policyPreviewResponseSchema>;
+export type PreviewAffectedClient = z.infer<typeof previewAffectedClientSchema>;

--- a/server/src/api/policy/preview-dtos.ts
+++ b/server/src/api/policy/preview-dtos.ts
@@ -24,6 +24,16 @@ import { budgetResponseSchema, scheduleResponseSchema } from "./dtos.js";
  * is an optional reference instant (ISO-8601) the proposed/current resolution
  * is computed against; it exists for deterministic tests and future-dated
  * previews, and defaults to the current time when absent.
+ *
+ * Note: `scheduleResponseSchema` validates the recurrence fields only
+ * structurally (each `int | null`), not the cross-field invariants the write
+ * path enforces (`scheduleRecurrenceSchema`: both-or-neither minutes,
+ * `start < end`, `effectiveFrom < effectiveTo`). That is acceptable here — the
+ * body is the already-validated rows the admin editor holds, the route is
+ * `requireAdmin`-only, and preview neither persists nor pushes; a malformed
+ * proposed rule at worst yields a misleading *preview*, never a bad write. If a
+ * non-editor caller is ever given this endpoint, tighten this to apply
+ * `scheduleRecurrenceSchema`'s refinements.
  */
 export const policyPreviewRequestSchema = z.object({
   budgets: z.array(budgetResponseSchema).default([]),

--- a/server/src/api/policy/preview-routes.ts
+++ b/server/src/api/policy/preview-routes.ts
@@ -1,0 +1,160 @@
+/**
+ * The save-and-push **preview** endpoint (#64, Phase 4):
+ * `POST /api/users/:userId/policy-preview`.
+ *
+ * Before an admin commits a policy edit, this shows exactly what the push would
+ * change — and which clients it would reach. It resolves the user's *current*
+ * persisted policy and the *proposed* policy in the request body through the one
+ * Phase-4 resolver (`transport/policy-push/resolve.ts`), diffs the two resolved
+ * pushes (`transport/policy-push/diff.ts`), and lists the user's linked clients
+ * annotated with their last-seen time and current offline-queue depth.
+ *
+ * **Faithful to what is actually pushed.** Current policy is read with
+ * `listUserSchedules` + `listUserBudgets` — the user's **own** rules, exactly
+ * what the live executor (`transport/policy-push/executor.ts`) resolves and
+ * pushes. It deliberately does *not* use the group-merged `gatherUserScheduleRules`
+ * that the read-only `effective.ts` preview uses: group schedules are not pushed
+ * over `timekpra` yet, so diffing against them would show windows the push never
+ * sends.
+ *
+ * **Side-effect-free.** Preview reads + computes only: no SSH probe, no push, no
+ * queue write. The per-client push-vs-queue decision still happens at push time
+ * against live reachability (`pushOrEnqueue`); the annotations here are the
+ * honest, cheap signals available without touching a client.
+ *
+ * **Scope.** SSH + `timekpra` session limits (what `resolve.ts` models on
+ * `main`). The Ansible-side filter diff (e2guardian / iptables) is Phase 6 (#90)
+ * and is a tracked follow-up.
+ *
+ * License boundary: none touched — plain TypeScript + zod + Drizzle over the
+ * read-only policy/queue seams.
+ */
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+
+import type { Settings } from "../../config.js";
+import { resolveEffectiveTz } from "../../policy/budget-window.js";
+import type { PolicyDb } from "../../policy/db.js";
+import * as repo from "../../policy/repository.js";
+import type { BudgetInput } from "../../policy/resolve.js";
+import type { ScheduleRule } from "../../policy/schedule-precedence.js";
+import { diffResolvedPush } from "../../transport/policy-push/diff.js";
+import { resolvePolicyPush } from "../../transport/policy-push/resolve.js";
+import { listForClient } from "../../transport/queue/index.js";
+import { ApiError } from "../errors.js";
+import type { ZodTypeProvider } from "../validation.js";
+import {
+  policyPreviewRequestSchema,
+  type PolicyPreviewRequest,
+  type PolicyPreviewResponse,
+  type PreviewAffectedClient,
+} from "./preview-dtos.js";
+
+/** `:userId` path param for the preview route. */
+const previewParamsSchema = z.object({ userId: z.coerce.number().int().positive() });
+
+/** Map a proposed budget DTO onto the resolver's {@link BudgetInput}. */
+function toBudgetInput(b: PolicyPreviewRequest["budgets"][number]): BudgetInput {
+  return {
+    scope: b.scope,
+    targetId: b.targetId,
+    window: b.window,
+    secondsAllowed: b.secondsAllowed,
+  };
+}
+
+/** Map a proposed schedule DTO onto the resolver's {@link ScheduleRule}. */
+function toScheduleRule(s: PolicyPreviewRequest["schedules"][number]): ScheduleRule {
+  return {
+    id: s.id,
+    ordinal: s.ordinal,
+    targetKind: s.targetKind,
+    targetId: s.targetId,
+    action: s.action,
+    recurrenceDays: s.recurrenceDays,
+    recurrenceStartMinute: s.recurrenceStartMinute,
+    recurrenceEndMinute: s.recurrenceEndMinute,
+    effectiveFrom: s.effectiveFrom === null ? null : new Date(s.effectiveFrom),
+    effectiveTo: s.effectiveTo === null ? null : new Date(s.effectiveTo),
+  };
+}
+
+/**
+ * The clients the user's push fans out to, each annotated with the
+ * side-effect-free signals preview can offer (last seen + pending-queue depth).
+ * Ascending by client id for a stable render.
+ */
+function affectedClientsForUser(db: PolicyDb, userId: number): PreviewAffectedClient[] {
+  const result: PreviewAffectedClient[] = [];
+  for (const link of repo.listUserLinks(db, userId)) {
+    const client = repo.getClient(db, link.clientId);
+    if (client === undefined) continue;
+    const pendingQueueDepth = listForClient(db, client.id).filter(
+      (row) => row.status === "pending",
+    ).length;
+    result.push({
+      clientId: client.id,
+      hostname: client.hostname,
+      lastSeen: client.lastSeen === null ? null : client.lastSeen.toISOString(),
+      pendingQueueDepth,
+    });
+  }
+  return result.sort((a, b) => a.clientId - b.clientId);
+}
+
+/**
+ * Register `POST /api/users/:userId/policy-preview` on an already-`/api`-prefixed
+ * scope. Call after {@link registerAuth} so `scope.requireAdmin` exists;
+ * `settings` supplies the server-default timezone for users with no `tz`.
+ */
+export function registerPreviewRoutes(scope: FastifyInstance, settings: Settings): void {
+  const typed = scope.withTypeProvider<ZodTypeProvider>();
+  const guard = { preHandler: scope.requireAdmin };
+
+  typed.post(
+    "/users/:userId/policy-preview",
+    { ...guard, schema: { params: previewParamsSchema, body: policyPreviewRequestSchema } },
+    async (request): Promise<PolicyPreviewResponse> => {
+      const { userId } = request.params;
+      const user = repo.getUser(scope.db, userId);
+      if (user === undefined) {
+        throw new ApiError(404, "not_found", `User ${userId} not found`);
+      }
+
+      const tz = resolveEffectiveTz(user.tz, settings.defaultTz);
+      const now = request.body.now === undefined ? new Date() : new Date(request.body.now);
+
+      // Current policy mirrors the live executor: the user's OWN schedules +
+      // budgets (group schedules are not pushed over timekpra yet), resolved at
+      // the same reference instant.
+      const before = resolvePolicyPush({
+        tz,
+        schedules: repo.listUserSchedules(scope.db, userId),
+        budgets: repo.listUserBudgets(scope.db, userId),
+        now,
+      });
+      const after = resolvePolicyPush({
+        tz,
+        schedules: request.body.schedules.map(toScheduleRule),
+        budgets: request.body.budgets.map(toBudgetInput),
+        now,
+      });
+
+      const diff = diffResolvedPush(before, after);
+
+      return {
+        userId,
+        hasChanges: diff.hasChanges,
+        changes: diff.changes.map((c) => ({
+          field: c.field,
+          kind: c.kind,
+          weekday: c.weekday,
+          before: c.before,
+          after: c.after,
+          summary: c.summary,
+        })),
+        affectedClients: affectedClientsForUser(scope.db, userId),
+      };
+    },
+  );
+}

--- a/server/src/transport/policy-push/diff.ts
+++ b/server/src/transport/policy-push/diff.ts
@@ -1,0 +1,263 @@
+/**
+ * The save-and-push **preview diff** engine (#64, Phase 4).
+ *
+ * Given the {@link ResolvedPolicyPush} a user's policy resolves to *today*
+ * (`before`) and the one a *proposed* edit would resolve to (`after`), this
+ * produces a structured, human-readable change set — the "what will change on
+ * the client before I push" the admin sees in the save-and-push bar
+ * (`docs/architecture.md` → "Outbound (server → client) — policy push").
+ *
+ * It diffs at the **semantic** `ResolvedPolicyPush` level (daily/weekly/monthly
+ * overall limits + the recurring allowed-hours grid), not raw `timekpra` argv:
+ * that is the level the resolver (#143/#140) produces and the executor (#201)
+ * consumes, and it is what reads naturally to a human ("overall daily 2h →
+ * 2h 30m") rather than a `--settimelimits` vector.
+ *
+ * Everything here is **pure** — no I/O, no clock, no policy-layer imports beyond
+ * the transport types. The preview route (`api/policy/preview-routes.ts`)
+ * resolves `before`/`after` and hands them in.
+ *
+ * **Scope.** The SSH + `timekpra` session-limit transport that exists on `main`.
+ * The Ansible-side filter diff (e2guardian / iptables) is Phase 6 (#90) and is
+ * not modelled here.
+ *
+ * License boundary: none touched — plain TypeScript over the transport's own
+ * resolved-push struct.
+ */
+import type { IsoWeekday } from "../timekpr/commands.js";
+import type { TimeWindow } from "../timekpr/allowed-hours.js";
+import type { ResolvedPolicyPush } from "./resolve.js";
+
+/** Every ISO weekday, ascending — the iteration order for a full-week diff. */
+const ALL_ISO_WEEKDAYS: readonly IsoWeekday[] = [1, 2, 3, 4, 5, 6, 7];
+
+/** Short weekday labels (index by ISO weekday `1`=Mon … `7`=Sun). */
+const WEEKDAY_LABELS: Readonly<Record<IsoWeekday, string>> = {
+  1: "Mon",
+  2: "Tue",
+  3: "Wed",
+  4: "Thu",
+  5: "Fri",
+  6: "Sat",
+  7: "Sun",
+};
+
+const SECONDS_PER_HOUR = 3600;
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+
+/** Which resolved-push field a change concerns. */
+export type PolicyPushChangeField =
+  | "daily-overall"
+  | "weekly-limit"
+  | "monthly-limit"
+  | "allowed-hours";
+
+/** Whether a value appeared, disappeared, or changed between `before` and `after`. */
+export type PolicyPushChangeKind = "added" | "removed" | "changed";
+
+/** One human-readable difference between the `before` and `after` resolved push. */
+export interface PolicyPushChange {
+  /** The resolved-push field this row concerns. */
+  readonly field: PolicyPushChangeField;
+  /** Whether the value was added, removed, or changed. */
+  readonly kind: PolicyPushChangeKind;
+  /**
+   * The ISO weekday (`1`=Mon … `7`=Sun) for a per-weekday row
+   * (`allowed-hours`, or `daily-overall` when weekdays differ); `null` for a
+   * whole-week row (the uniform daily limit, or the rolling weekly/monthly).
+   */
+  readonly weekday: IsoWeekday | null;
+  /** The prior value, rendered for display; `null` when there was none. */
+  readonly before: string | null;
+  /** The proposed value, rendered for display; `null` when there is none. */
+  readonly after: string | null;
+  /** A one-line description, e.g. `Daily overall limit: 2h → 2h 30m`. */
+  readonly summary: string;
+}
+
+/** The full preview diff between a current and a proposed resolved push. */
+export interface PolicyPushDiff {
+  /** `true` when {@link changes} is non-empty (the push would be a no-op if not). */
+  readonly hasChanges: boolean;
+  /** The ordered change set (daily, weekly, monthly, then allowed-hours). */
+  readonly changes: readonly PolicyPushChange[];
+}
+
+/** Render a non-negative seconds duration as `2h 30m` / `45m` / `2h` / `0m`. */
+export function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / SECONDS_PER_HOUR);
+  const minutes = Math.floor((seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h`;
+  return `${minutes}m`;
+}
+
+/** Render a `null`-or-seconds limit: `null` → `no limit`, else {@link formatDuration}. */
+function formatLimit(seconds: number | null): string {
+  return seconds === null ? "no limit" : formatDuration(seconds);
+}
+
+/** Render a minute-of-day (`0`–`1440`) as `HH:MM` (`1440` → `24:00`). */
+function formatMinuteOfDay(minute: number): string {
+  const hour = Math.floor(minute / MINUTES_PER_HOUR);
+  const min = minute % MINUTES_PER_HOUR;
+  return `${String(hour).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
+}
+
+/** Render a day's allowed windows as `08:00–12:00, 13:00–21:00`, or `none`. */
+function formatWindows(windows: readonly TimeWindow[]): string {
+  if (windows.length === 0) return "none";
+  return windows.map((w) => `${formatMinuteOfDay(w.start)}–${formatMinuteOfDay(w.end)}`).join(", ");
+}
+
+/** Are two window lists structurally identical (same order, same bounds)? */
+function windowsEqual(a: readonly TimeWindow[], b: readonly TimeWindow[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((w, i) => {
+    const other = b[i];
+    return other !== undefined && w.start === other.start && w.end === other.end;
+  });
+}
+
+/** The add/remove/change kind for a `before`/`after` pair of nullable values. */
+function changeKind(before: unknown, after: unknown): PolicyPushChangeKind {
+  if (before === null) return "added";
+  if (after === null) return "removed";
+  return "changed";
+}
+
+/** Build a single scalar-limit change row (daily-uniform, weekly, or monthly). */
+function scalarLimitChange(
+  field: PolicyPushChangeField,
+  label: string,
+  before: number | null,
+  after: number | null,
+): PolicyPushChange | null {
+  if (before === after) return null;
+  return {
+    field,
+    kind: changeKind(before, after),
+    weekday: null,
+    before: before === null ? null : formatLimit(before),
+    after: after === null ? null : formatLimit(after),
+    summary: `${label}: ${formatLimit(before)} → ${formatLimit(after)}`,
+  };
+}
+
+/** Are all seven daily values equal (the only shape the resolver emits today)? */
+function isUniform(perWeekday: readonly number[]): boolean {
+  const first = perWeekday[0];
+  return perWeekday.every((v) => v === first);
+}
+
+/** The daily-overall seconds for `weekday`, or `null` when there's no daily limit. */
+function dailyFor(perWeekday: readonly number[] | null, weekday: IsoWeekday): number | null {
+  if (perWeekday === null) return null;
+  // perWeekdaySeconds is a 7-element Mon..Sun list; index by weekday-1.
+  return perWeekday[weekday - 1] ?? null;
+}
+
+/**
+ * Diff the daily overall limit. When both sides are weekday-uniform (today's
+ * only shape) a single whole-week row is emitted; if a future weekday-varying
+ * budget (#141) makes days differ, per-weekday rows are emitted for the days
+ * that changed.
+ */
+function diffDailyOverall(
+  before: readonly number[] | null,
+  after: readonly number[] | null,
+): PolicyPushChange[] {
+  if (before === null && after === null) return [];
+
+  const bothUniform =
+    (before === null || isUniform(before)) && (after === null || isUniform(after));
+  if (bothUniform) {
+    const change = scalarLimitChange(
+      "daily-overall",
+      "Daily overall limit",
+      dailyFor(before, 1),
+      dailyFor(after, 1),
+    );
+    return change === null ? [] : [change];
+  }
+
+  const changes: PolicyPushChange[] = [];
+  for (const weekday of ALL_ISO_WEEKDAYS) {
+    const b = dailyFor(before, weekday);
+    const a = dailyFor(after, weekday);
+    if (b === a) continue;
+    changes.push({
+      field: "daily-overall",
+      kind: changeKind(b, a),
+      weekday,
+      before: b === null ? null : formatLimit(b),
+      after: a === null ? null : formatLimit(a),
+      summary: `Daily overall limit (${WEEKDAY_LABELS[weekday]}): ${formatLimit(b)} → ${formatLimit(a)}`,
+    });
+  }
+  return changes;
+}
+
+/** Diff the recurring allowed-hours grid, one row per weekday whose windows differ. */
+function diffAllowedHours(
+  before: ResolvedPolicyPush["weekly"],
+  after: ResolvedPolicyPush["weekly"],
+): PolicyPushChange[] {
+  const changes: PolicyPushChange[] = [];
+  for (const weekday of ALL_ISO_WEEKDAYS) {
+    const b = before.get(weekday) ?? [];
+    const a = after.get(weekday) ?? [];
+    if (windowsEqual(a, b)) continue;
+    // "added" when the day was fully denied before and now has windows;
+    // "removed" when it had windows and is now fully denied; else "changed".
+    const kind: PolicyPushChangeKind =
+      b.length === 0 ? "added" : a.length === 0 ? "removed" : "changed";
+    changes.push({
+      field: "allowed-hours",
+      kind,
+      weekday,
+      before: formatWindows(b),
+      after: formatWindows(a),
+      summary: `Allowed hours (${WEEKDAY_LABELS[weekday]}): ${formatWindows(b)} → ${formatWindows(a)}`,
+    });
+  }
+  return changes;
+}
+
+/**
+ * Compute the human-readable preview diff between a user's current resolved
+ * push (`before`) and the one a proposed edit resolves to (`after`).
+ *
+ * Rows are ordered daily-overall → weekly → monthly → allowed-hours (the order
+ * the admin reads them in the save bar). An empty change set means the proposed
+ * edit would push nothing new ({@link PolicyPushDiff.hasChanges} `false`).
+ */
+export function diffResolvedPush(
+  before: ResolvedPolicyPush,
+  after: ResolvedPolicyPush,
+): PolicyPushDiff {
+  const changes: PolicyPushChange[] = [
+    ...diffDailyOverall(before.perWeekdaySeconds, after.perWeekdaySeconds),
+  ];
+
+  const weekly = scalarLimitChange(
+    "weekly-limit",
+    "Weekly overall limit",
+    before.weeklySeconds,
+    after.weeklySeconds,
+  );
+  if (weekly !== null) changes.push(weekly);
+
+  const monthly = scalarLimitChange(
+    "monthly-limit",
+    "Monthly overall limit",
+    before.monthlySeconds,
+    after.monthlySeconds,
+  );
+  if (monthly !== null) changes.push(monthly);
+
+  changes.push(...diffAllowedHours(before.weekly, after.weekly));
+
+  return { hasChanges: changes.length > 0, changes };
+}

--- a/server/src/transport/policy-push/diff.ts
+++ b/server/src/transport/policy-push/diff.ts
@@ -199,11 +199,30 @@ function diffDailyOverall(
   return changes;
 }
 
-/** Diff the recurring allowed-hours grid, one row per weekday whose windows differ. */
+/** Does any weekday in the grid carry at least one allowed window? */
+function hasAnyAllowedWindow(weekly: ResolvedPolicyPush["weekly"]): boolean {
+  return [...weekly.values()].some((windows) => windows.length > 0);
+}
+
+/**
+ * Diff the recurring allowed-hours grid, one row per weekday whose windows
+ * differ.
+ *
+ * **Mirrors the executor's full-lockout skip.** When the *proposed* week denies
+ * access on every day, the live executor (`policy-push/executor.ts`) does **not**
+ * push the allowed-hours grid at all (`--setalloweddays` cannot take an empty
+ * set; a fully-denied week is enforced via a zero daily limit / session-kill in
+ * Phase 8c, not allowed-hours). Emitting `removed` rows here would tell the admin
+ * the grid will change when no `setWeeklyAllowedHours` call is made — exactly the
+ * "windows the push never sends" the preview's fidelity contract avoids. So when
+ * `after` has no allowed window on any day, no allowed-hours rows are produced.
+ */
 function diffAllowedHours(
   before: ResolvedPolicyPush["weekly"],
   after: ResolvedPolicyPush["weekly"],
 ): PolicyPushChange[] {
+  if (!hasAnyAllowedWindow(after)) return [];
+
   const changes: PolicyPushChange[] = [];
   for (const weekday of ALL_ISO_WEEKDAYS) {
     const b = before.get(weekday) ?? [];

--- a/server/src/transport/policy-push/index.ts
+++ b/server/src/transport/policy-push/index.ts
@@ -19,6 +19,14 @@ export {
   type ResolvedPolicyPush,
 } from "./resolve.js";
 export {
+  diffResolvedPush,
+  formatDuration,
+  type PolicyPushChange,
+  type PolicyPushChangeField,
+  type PolicyPushChangeKind,
+  type PolicyPushDiff,
+} from "./diff.js";
+export {
   createPolicyPushExecutor,
   type PolicyPushClient,
   type PolicyPushClientFactory,

--- a/server/tests/api/policy-preview.test.ts
+++ b/server/tests/api/policy-preview.test.ts
@@ -105,10 +105,14 @@ describe("POST /api/users/:userId/policy-preview", () => {
   }
 
   /** Insert a client + link it to the user, returning the client id. */
-  function linkClient(userId: number, hostname: string): number {
+  function linkClient(userId: number, hostname: string, lastSeen?: Date): number {
     const client = harness.db
       .insert(clients)
-      .values({ hostname, sshUser: "pct-agent" })
+      .values(
+        lastSeen === undefined
+          ? { hostname, sshUser: "pct-agent" }
+          : { hostname, sshUser: "pct-agent", lastSeen },
+      )
       .returning({ id: clients.id })
       .get();
     if (client === undefined) throw new Error("client insert returned no row");
@@ -296,5 +300,53 @@ describe("POST /api/users/:userId/policy-preview", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().affectedClients).toEqual([]);
+  });
+
+  it("serializes a non-null lastSeen and orders multiple clients by id", async () => {
+    const userId = await createUser("Alice");
+    const seen = new Date("2026-06-16T08:30:00Z");
+    // Link in reverse hostname order to prove the sort is by clientId, not insert order.
+    const firstId = linkClient(userId, "desk-pc", seen);
+    const secondId = linkClient(userId, "mint-laptop");
+
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [], now: "2026-06-17T12:00:00Z" },
+    });
+    expect(res.statusCode).toBe(200);
+    const ids = res.json().affectedClients.map((c: { clientId: number }) => c.clientId);
+    expect(ids).toEqual([firstId, secondId].sort((a, b) => a - b));
+    const first = res
+      .json()
+      .affectedClients.find((c: { clientId: number }) => c.clientId === firstId);
+    expect(first.lastSeen).toBe(seen.toISOString());
+  });
+
+  it("defaults the reference instant to now when `now` is omitted", async () => {
+    const userId = await createUser("Alice");
+    harness.db
+      .insert(budgets)
+      .values({ userId, scope: "overall", targetId: null, window: "daily", secondsAllowed: 7200 })
+      .run();
+
+    // No `now` in the body → handler uses new Date(); a 2h→2h30 daily change
+    // is date-independent, so the diff is deterministic regardless of clock.
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [proposedBudget({ userId, secondsAllowed: 9000 })], schedules: [] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().changes).toEqual([
+      {
+        field: "daily-overall",
+        kind: "changed",
+        weekday: null,
+        before: "2h",
+        after: "2h 30m",
+        summary: "Daily overall limit: 2h → 2h 30m",
+      },
+    ]);
   });
 });

--- a/server/tests/api/policy-preview.test.ts
+++ b/server/tests/api/policy-preview.test.ts
@@ -1,0 +1,300 @@
+/**
+ * HTTP tests for the save-and-push preview route (#64):
+ * `POST /api/users/:userId/policy-preview`, driven through the real app via
+ * `app.inject()` with a genuine admin session cookie. Covers the anonymous-401
+ * guard, 404 for an unknown user, body validation (400), the happy-path diff
+ * (current persisted policy vs a proposed edit), a no-op (no changes), the
+ * own-rules-not-group-rules fidelity guard, and the affected-client annotation
+ * (hostname, lastSeen, pending-queue depth).
+ */
+import type { InjectOptions } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SESSION_COOKIE } from "../../src/auth/session.js";
+import { loadSettings } from "../../src/config.js";
+import {
+  budgets,
+  clients,
+  groupSchedules,
+  userGroupMemberships,
+  userGroups,
+  usersOnClients,
+} from "../../src/policy/schema.js";
+import { enqueue } from "../../src/transport/queue/index.js";
+import { buildTestApp, type TestApp } from "../helpers/app.js";
+
+function configuredSettings() {
+  return loadSettings({
+    PCT_LOG_LEVEL: "silent",
+    PCT_SECRET_KEY: "preview-test-secret",
+    PCT_ADMIN_USERNAME: "ben",
+    PCT_ADMIN_PASSWORD: "hunter2",
+  });
+}
+
+function sessionCookie(res: { headers: Record<string, unknown> }): string {
+  const raw = res.headers["set-cookie"];
+  const headers = Array.isArray(raw) ? (raw as string[]) : [String(raw ?? "")];
+  const match = headers.find((h) => h.startsWith(`${SESSION_COOKIE}=`));
+  if (match === undefined) throw new Error("no session cookie set");
+  return match.split(";")[0] ?? "";
+}
+
+/** A proposed schedule rule in the `scheduleResponseSchema` wire shape. */
+function proposedSchedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    userId: 1,
+    targetKind: "overall",
+    targetId: null,
+    action: "allow",
+    recurrenceDays: null,
+    recurrenceStartMinute: null,
+    recurrenceEndMinute: null,
+    effectiveFrom: null,
+    effectiveTo: null,
+    ordinal: 0,
+    ...overrides,
+  };
+}
+
+/** A proposed budget in the `budgetResponseSchema` wire shape. */
+function proposedBudget(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    userId: 1,
+    scope: "overall",
+    targetId: null,
+    window: "daily",
+    secondsAllowed: 7200,
+    ...overrides,
+  };
+}
+
+describe("POST /api/users/:userId/policy-preview", () => {
+  let harness: TestApp;
+  let cookie: string;
+
+  beforeEach(async () => {
+    harness = buildTestApp({ appOptions: { settings: configuredSettings() } });
+    await harness.app.ready();
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    cookie = sessionCookie(login);
+  });
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  function auth(opts: InjectOptions) {
+    return harness.app.inject({ ...opts, headers: { ...opts.headers, cookie } });
+  }
+
+  async function createUser(displayName: string, tz?: string): Promise<number> {
+    const res = await auth({
+      method: "POST",
+      url: "/api/users",
+      payload: tz === undefined ? { displayName } : { displayName, tz },
+    });
+    expect(res.statusCode).toBe(201);
+    return res.json().id as number;
+  }
+
+  /** Insert a client + link it to the user, returning the client id. */
+  function linkClient(userId: number, hostname: string): number {
+    const client = harness.db
+      .insert(clients)
+      .values({ hostname, sshUser: "pct-agent" })
+      .returning({ id: clients.id })
+      .get();
+    if (client === undefined) throw new Error("client insert returned no row");
+    harness.db
+      .insert(usersOnClients)
+      .values({ userId, clientId: client.id, osUsername: "alice", osUserRef: `1000-${client.id}` })
+      .run();
+    return client.id;
+  }
+
+  it("rejects anonymous access with a 401 envelope", async () => {
+    const userId = await createUser("Alice");
+    const res = await harness.app.inject({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [] },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error.code).toBe("unauthorized");
+  });
+
+  it("returns 404 for an unknown user", async () => {
+    const res = await auth({
+      method: "POST",
+      url: "/api/users/9999/policy-preview",
+      payload: { budgets: [], schedules: [] },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+  });
+
+  it("rejects a malformed body with a 400", async () => {
+    const userId = await createUser("Alice");
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [{ scope: "overall", window: "daily" }] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("reports no changes when the proposed policy matches the current one", async () => {
+    const userId = await createUser("Alice"); // tz null → UTC
+    harness.db
+      .insert(budgets)
+      .values({ userId, scope: "overall", targetId: null, window: "daily", secondsAllowed: 7200 })
+      .run();
+
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: {
+        budgets: [proposedBudget({ userId, secondsAllowed: 7200 })],
+        schedules: [],
+        now: "2026-06-17T12:00:00Z",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().hasChanges).toBe(false);
+    expect(res.json().changes).toEqual([]);
+  });
+
+  it("diffs the proposed daily overall limit against the current one", async () => {
+    const userId = await createUser("Alice");
+    harness.db
+      .insert(budgets)
+      .values({ userId, scope: "overall", targetId: null, window: "daily", secondsAllowed: 7200 })
+      .run();
+
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: {
+        budgets: [proposedBudget({ userId, secondsAllowed: 9000 })], // 2h → 2h30
+        schedules: [],
+        now: "2026-06-17T12:00:00Z",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.hasChanges).toBe(true);
+    expect(body.changes).toHaveLength(1);
+    expect(body.changes[0]).toMatchObject({
+      field: "daily-overall",
+      kind: "changed",
+      weekday: null,
+      before: "2h",
+      after: "2h 30m",
+    });
+  });
+
+  it("diffs against the user's OWN rules, not inherited group schedules (#182 fidelity)", async () => {
+    const userId = await createUser("Alice"); // tz null → UTC
+    // A group deny the user inherits. The live push does NOT send group rules,
+    // so the preview must treat the *current* push as "no schedule" and show the
+    // proposed user rule as a fresh change — not diff against the group window.
+    const group = harness.db
+      .insert(userGroups)
+      .values({ name: "Kids" })
+      .returning({ id: userGroups.id })
+      .get();
+    if (group === undefined) throw new Error("group insert returned no row");
+    harness.db.insert(userGroupMemberships).values({ userId, groupId: group.id }).run();
+    harness.db
+      .insert(groupSchedules)
+      .values({ userGroupId: group.id, targetKind: "overall", targetId: null, action: "deny" })
+      .run();
+
+    // Proposed: the user's own deny 22:00–24:00 (1320..1440) → allowed windows
+    // become 00:00–22:00. If the preview had diffed against the inherited group
+    // deny (fully denied), the "before" allowed windows would differ.
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: {
+        budgets: [],
+        schedules: [
+          proposedSchedule({
+            userId,
+            action: "deny",
+            recurrenceStartMinute: 1320,
+            recurrenceEndMinute: 1440,
+          }),
+        ],
+        now: "2026-06-17T12:00:00Z",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // The current push has no allowed-hours grid (no own rules → fully allowed
+    // is the resolver's no-schedule shape, which `resolvePolicyPush` renders as
+    // a full-week allow). The proposed deny carves out 22:00–24:00, so each day
+    // changes from full-day to 00:00–22:00.
+    const allowedHoursRows = body.changes.filter(
+      (c: { field: string }) => c.field === "allowed-hours",
+    );
+    expect(allowedHoursRows.length).toBeGreaterThan(0);
+    expect(allowedHoursRows[0]).toMatchObject({
+      field: "allowed-hours",
+      before: "00:00–24:00",
+      after: "00:00–22:00",
+    });
+  });
+
+  it("lists affected clients with hostname, lastSeen, and pending-queue depth", async () => {
+    const userId = await createUser("Alice");
+    const clientId = linkClient(userId, "mint-laptop");
+    // Two pending queued actions for the client → depth 2.
+    enqueue(harness.db, {
+      clientId,
+      coalesceKey: `policy.push:${userId}`,
+      kind: "policy.push",
+      payload: { userId, reason: "budget.updated", detail: {} },
+    });
+    enqueue(harness.db, {
+      clientId,
+      coalesceKey: `policy.push:${userId}:other`,
+      kind: "policy.push",
+      payload: { userId, reason: "schedule.updated", detail: {} },
+    });
+
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [], now: "2026-06-17T12:00:00Z" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().affectedClients).toEqual([
+      {
+        clientId,
+        hostname: "mint-laptop",
+        lastSeen: null,
+        pendingQueueDepth: 2,
+      },
+    ]);
+  });
+
+  it("returns an empty affected-clients list for a user with no linked clients", async () => {
+    const userId = await createUser("Alice");
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().affectedClients).toEqual([]);
+  });
+});

--- a/server/tests/transport/policy-push/diff.test.ts
+++ b/server/tests/transport/policy-push/diff.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for the save-and-push preview diff engine (#64): the pure
+ * `before`/`after` `ResolvedPolicyPush` → human-readable change set.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { IsoWeekday } from "../../../src/transport/timekpr/commands.js";
+import type {
+  TimeWindow,
+  WeeklyAllowedWindows,
+} from "../../../src/transport/timekpr/allowed-hours.js";
+import { diffResolvedPush, formatDuration } from "../../../src/transport/policy-push/diff.js";
+import type { ResolvedPolicyPush } from "../../../src/transport/policy-push/resolve.js";
+
+/** A uniform 7-day daily-limit list of `seconds`. */
+function uniformDaily(seconds: number): number[] {
+  return Array.from({ length: 7 }, () => seconds);
+}
+
+/** Build a `WeeklyAllowedWindows` from a partial weekday→windows map. */
+function weekly(entries: Partial<Record<IsoWeekday, readonly TimeWindow[]>>): WeeklyAllowedWindows {
+  const map = new Map<IsoWeekday, readonly TimeWindow[]>();
+  for (const [day, windows] of Object.entries(entries)) {
+    if (windows !== undefined) map.set(Number(day) as IsoWeekday, windows);
+  }
+  return map;
+}
+
+/** A resolved push with the all-null/empty base, overridable per field. */
+function push(overrides: Partial<ResolvedPolicyPush> = {}): ResolvedPolicyPush {
+  return {
+    perWeekdaySeconds: null,
+    weeklySeconds: null,
+    monthlySeconds: null,
+    weekly: weekly({}),
+    ...overrides,
+  };
+}
+
+const TWO_HOURS = 2 * 3600;
+const TWO_AND_A_HALF_HOURS = 2 * 3600 + 30 * 60;
+
+describe("formatDuration", () => {
+  it("renders hours and minutes", () => {
+    expect(formatDuration(TWO_AND_A_HALF_HOURS)).toBe("2h 30m");
+  });
+
+  it("renders whole hours without a minute part", () => {
+    expect(formatDuration(TWO_HOURS)).toBe("2h");
+  });
+
+  it("renders sub-hour durations as minutes", () => {
+    expect(formatDuration(45 * 60)).toBe("45m");
+  });
+
+  it("renders zero as 0m", () => {
+    expect(formatDuration(0)).toBe("0m");
+  });
+
+  it("truncates stray seconds to whole minutes", () => {
+    expect(formatDuration(90)).toBe("1m");
+  });
+});
+
+describe("diffResolvedPush — no changes", () => {
+  it("reports hasChanges=false for identical pushes", () => {
+    const a = push({ perWeekdaySeconds: uniformDaily(TWO_HOURS), weeklySeconds: 10 * 3600 });
+    const diff = diffResolvedPush(a, push({ ...a }));
+    expect(diff.hasChanges).toBe(false);
+    expect(diff.changes).toEqual([]);
+  });
+
+  it("treats equal allowed-window grids as unchanged regardless of map identity", () => {
+    const w: TimeWindow[] = [{ start: 480, end: 1260 }];
+    const before = push({ weekly: weekly({ 1: w, 2: w }) });
+    const after = push({
+      weekly: weekly({ 1: [{ start: 480, end: 1260 }], 2: [{ start: 480, end: 1260 }] }),
+    });
+    expect(diffResolvedPush(before, after).hasChanges).toBe(false);
+  });
+});
+
+describe("diffResolvedPush — daily overall limit", () => {
+  it("emits one whole-week row when a uniform limit changes", () => {
+    const before = push({ perWeekdaySeconds: uniformDaily(TWO_HOURS) });
+    const after = push({ perWeekdaySeconds: uniformDaily(TWO_AND_A_HALF_HOURS) });
+    const diff = diffResolvedPush(before, after);
+    expect(diff.changes).toHaveLength(1);
+    expect(diff.changes[0]).toMatchObject({
+      field: "daily-overall",
+      kind: "changed",
+      weekday: null,
+      before: "2h",
+      after: "2h 30m",
+      summary: "Daily overall limit: 2h → 2h 30m",
+    });
+  });
+
+  it("marks an added daily limit (none → value)", () => {
+    const diff = diffResolvedPush(push(), push({ perWeekdaySeconds: uniformDaily(TWO_HOURS) }));
+    expect(diff.changes[0]).toMatchObject({
+      field: "daily-overall",
+      kind: "added",
+      before: null,
+      after: "2h",
+      summary: "Daily overall limit: no limit → 2h",
+    });
+  });
+
+  it("marks a removed daily limit (value → none)", () => {
+    const diff = diffResolvedPush(push({ perWeekdaySeconds: uniformDaily(TWO_HOURS) }), push());
+    expect(diff.changes[0]).toMatchObject({
+      field: "daily-overall",
+      kind: "removed",
+      before: "2h",
+      after: null,
+    });
+  });
+
+  it("emits per-weekday rows only for the days that differ when not uniform", () => {
+    // Weekend bumped to 3h, weekdays stay 2h (a weekday-varying #141-shaped push).
+    const before = push({ perWeekdaySeconds: uniformDaily(TWO_HOURS) });
+    const weekendBump = [TWO_HOURS, TWO_HOURS, TWO_HOURS, TWO_HOURS, TWO_HOURS, 3 * 3600, 3 * 3600];
+    const after = push({ perWeekdaySeconds: weekendBump });
+    const diff = diffResolvedPush(before, after);
+    expect(diff.changes).toHaveLength(2);
+    expect(diff.changes.map((c) => c.weekday)).toEqual([6, 7]);
+    expect(diff.changes[0]).toMatchObject({
+      field: "daily-overall",
+      weekday: 6,
+      summary: "Daily overall limit (Sat): 2h → 3h",
+    });
+  });
+
+  it("emits no daily row when both sides have no daily limit", () => {
+    const diff = diffResolvedPush(push(), push());
+    expect(diff.changes.some((c) => c.field === "daily-overall")).toBe(false);
+  });
+
+  it("adds per-weekday rows when a weekday-varying limit replaces no limit", () => {
+    // before: no daily limit at all; after: weekday 2h, weekend 3h (non-uniform).
+    const weekendBump = [TWO_HOURS, TWO_HOURS, TWO_HOURS, TWO_HOURS, TWO_HOURS, 3 * 3600, 3 * 3600];
+    const diff = diffResolvedPush(push(), push({ perWeekdaySeconds: weekendBump }));
+    expect(diff.changes).toHaveLength(7);
+    expect(diff.changes.every((c) => c.kind === "added" && c.before === null)).toBe(true);
+    expect(diff.changes[5]).toMatchObject({
+      weekday: 6,
+      after: "3h",
+      summary: "Daily overall limit (Sat): no limit → 3h",
+    });
+  });
+});
+
+describe("diffResolvedPush — rolling weekly/monthly limits", () => {
+  it("reports a weekly limit change", () => {
+    const before = push({ weeklySeconds: 10 * 3600 });
+    const after = push({ weeklySeconds: 12 * 3600 });
+    const diff = diffResolvedPush(before, after);
+    expect(diff.changes).toHaveLength(1);
+    expect(diff.changes[0]).toMatchObject({
+      field: "weekly-limit",
+      kind: "changed",
+      weekday: null,
+      summary: "Weekly overall limit: 10h → 12h",
+    });
+  });
+
+  it("reports an added monthly limit", () => {
+    const diff = diffResolvedPush(push(), push({ monthlySeconds: 40 * 3600 }));
+    expect(diff.changes[0]).toMatchObject({
+      field: "monthly-limit",
+      kind: "added",
+      before: null,
+      after: "40h",
+    });
+  });
+});
+
+describe("diffResolvedPush — allowed-hours grid", () => {
+  it("marks a window added when a day goes from denied to allowed", () => {
+    const after = push({ weekly: weekly({ 1: [{ start: 480, end: 1260 }] }) });
+    const diff = diffResolvedPush(push(), after);
+    expect(diff.changes).toHaveLength(1);
+    expect(diff.changes[0]).toMatchObject({
+      field: "allowed-hours",
+      kind: "added",
+      weekday: 1,
+      before: "none",
+      after: "08:00–21:00",
+      summary: "Allowed hours (Mon): none → 08:00–21:00",
+    });
+  });
+
+  it("marks a window removed when a day goes from allowed to fully denied", () => {
+    const before = push({ weekly: weekly({ 3: [{ start: 0, end: 1440 }] }) });
+    const diff = diffResolvedPush(before, push());
+    expect(diff.changes[0]).toMatchObject({
+      field: "allowed-hours",
+      kind: "removed",
+      weekday: 3,
+      before: "00:00–24:00",
+      after: "none",
+    });
+  });
+
+  it("marks a window changed and renders multiple windows", () => {
+    const before = push({ weekly: weekly({ 5: [{ start: 480, end: 1260 }] }) });
+    const after = push({
+      weekly: weekly({
+        5: [
+          { start: 360, end: 720 },
+          { start: 780, end: 1260 },
+        ],
+      }),
+    });
+    const diff = diffResolvedPush(before, after);
+    expect(diff.changes[0]).toMatchObject({
+      field: "allowed-hours",
+      kind: "changed",
+      weekday: 5,
+      before: "08:00–21:00",
+      after: "06:00–12:00, 13:00–21:00",
+    });
+  });
+
+  it("emits one row per differing weekday, ascending", () => {
+    const before = push({ weekly: weekly({ 1: [{ start: 480, end: 1260 }] }) });
+    const after = push({
+      weekly: weekly({ 1: [{ start: 480, end: 1260 }], 6: [{ start: 540, end: 1320 }] }),
+    });
+    const diff = diffResolvedPush(before, after);
+    expect(diff.changes.map((c) => c.weekday)).toEqual([6]);
+  });
+});
+
+describe("diffResolvedPush — combined ordering", () => {
+  it("orders rows daily → weekly → monthly → allowed-hours", () => {
+    const before = push({
+      perWeekdaySeconds: uniformDaily(TWO_HOURS),
+      weeklySeconds: 10 * 3600,
+      monthlySeconds: 40 * 3600,
+      weekly: weekly({ 1: [{ start: 480, end: 1260 }] }),
+    });
+    const after = push({
+      perWeekdaySeconds: uniformDaily(TWO_AND_A_HALF_HOURS),
+      weeklySeconds: 11 * 3600,
+      monthlySeconds: 41 * 3600,
+      weekly: weekly({ 1: [{ start: 420, end: 1260 }] }),
+    });
+    const diff = diffResolvedPush(before, after);
+    expect(diff.changes.map((c) => c.field)).toEqual([
+      "daily-overall",
+      "weekly-limit",
+      "monthly-limit",
+      "allowed-hours",
+    ]);
+    expect(diff.hasChanges).toBe(true);
+  });
+});

--- a/server/tests/transport/policy-push/diff.test.ts
+++ b/server/tests/transport/policy-push/diff.test.ts
@@ -191,9 +191,14 @@ describe("diffResolvedPush — allowed-hours grid", () => {
     });
   });
 
-  it("marks a window removed when a day goes from allowed to fully denied", () => {
-    const before = push({ weekly: weekly({ 3: [{ start: 0, end: 1440 }] }) });
-    const diff = diffResolvedPush(before, push());
+  it("marks a window removed when a day goes from allowed to fully denied (week still has an allowed day)", () => {
+    // Mon stays allowed (so the grid is still pushed); Wed loses its window.
+    const before = push({
+      weekly: weekly({ 1: [{ start: 480, end: 1260 }], 3: [{ start: 0, end: 1440 }] }),
+    });
+    const after = push({ weekly: weekly({ 1: [{ start: 480, end: 1260 }] }) });
+    const diff = diffResolvedPush(before, after);
+    expect(diff.changes).toHaveLength(1);
     expect(diff.changes[0]).toMatchObject({
       field: "allowed-hours",
       kind: "removed",
@@ -230,6 +235,21 @@ describe("diffResolvedPush — allowed-hours grid", () => {
     });
     const diff = diffResolvedPush(before, after);
     expect(diff.changes.map((c) => c.weekday)).toEqual([6]);
+  });
+
+  it("suppresses allowed-hours rows when the proposed week is fully denied (executor skips the push)", () => {
+    // before allows Mon–Fri; after denies every day. The executor would NOT
+    // call setWeeklyAllowedHours (no allowed weekday), so the preview must not
+    // claim the grid changes — even though the windows literally differ.
+    const before = push({
+      weekly: weekly({
+        1: [{ start: 480, end: 1260 }],
+        2: [{ start: 480, end: 1260 }],
+      }),
+    });
+    const after = push({ weekly: weekly({}) });
+    const diff = diffResolvedPush(before, after);
+    expect(diff.changes.some((c) => c.field === "allowed-hours")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Diff engine** (`transport/policy-push/diff.ts`): a pure, I/O-free comparison of the `before`/`after` `ResolvedPolicyPush` into structured, human-readable change rows for the daily/weekly/monthly overall limits and the recurring allowed-hours grid (`added`/`removed`/`changed`; one whole-week row when uniform, per-weekday rows when not — ready for #141). Durations render as `2h 30m`, windows as `08:00–21:00`.
- **Preview API** (`POST /api/users/:userId/policy-preview`, `requireAdmin`): resolves the user's current vs. proposed policy, diffs them, and lists the affected clients (`hostname`, `lastSeen`, `pendingQueueDepth`). **Side-effect-free** — no SSH probe, no push, no queue write.
- **Fidelity to the live push** (mirrors `policy-push/executor.ts`):
  - Current policy is read with the user's **own** `listUserSchedules`/`listUserBudgets` — not the group-merged `gatherUserScheduleRules` that `effective.ts` uses — so the diff reflects what `timekpra` actually sends. (Caught by a concurrent session's design notes on #64 — credit there.)
  - Allowed-hours rows are **suppressed when the proposed week is fully denied**, matching the executor's full-lockout skip of `setWeeklyAllowedHours` (a fully-denied week is enforced via zero daily limit / session-kill in Phase 8c, not allowed-hours). Caught in first-pass review.
- The proposed payload reuses the single-source `budgetResponseSchema` / `scheduleResponseSchema` (what the editor already holds), not a new wire shape.

## Plan

Linked plan: `.claude/plans/issue-64-policy-push-preview-diff.md`
Roadmap: `docs/roadmap.md` → Phase 4.

## License-boundary note

N/A — pure TypeScript over the policy model + zod + read-only queue/repository seams. No GPL imports, no GPL binaries added to the image, no subprocess/REST boundary crossed or collapsed. `license-guard` unaffected. **No new dependency.**

## Deferred (tracked → #281)

- `/admin` rendering of the diff bar (the visible affordance; composes with #53/#63).
- Live-reachability annotation (opt-in probe-on-preview).
- Future-dated preview (`?date=`/`now`), meaningful once #141/#142 land in the resolver.
- Ansible-side filter diff (e2guardian / iptables) — Phase 6 (#90, PR #217); nothing to diff against on `main` yet.

## Test plan

- [x] `tests/transport/policy-push/diff.test.ts` — duration/window formatting, no-op, daily uniform/added/removed, per-weekday non-uniform (incl. weekday-varying-from-none), weekly/monthly, allowed-hours add/remove/change/multi-window, **full-lockout suppression**, ordering. `diff.ts` 100% lines/funcs, 97.4% branch (remainder is unreachable defensive `?? null`).
- [x] `tests/api/policy-preview.test.ts` — 401 guard, 404 unknown user, 400 body validation, no-op, daily diff, **own-rules-not-group-rules fidelity guard**, affected-client annotation (hostname/lastSeen/queue depth), empty-clients, **non-null lastSeen + multi-client ordering**, **now-defaulting path**.
- [x] Full gate green from `server/`: `format:check` / `lint` / `typecheck` / `test` — **1263 unit tests pass**, coverage gate (80%) satisfied.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)