### PR TITLE
ci(release): prerelease-aware releases + fix broken image build step (+ deploy-doc env vars)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 
 on:
   push:
-    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # stable: vMAJOR.MINOR.PATCH
+      - "v[0-9]+.[0-9]+.[0-9]+-*" # prerelease: vMAJOR.MINOR.PATCH-alpha.N etc.
 
 permissions:
   contents: write   # create GitHub Releases
@@ -52,30 +54,35 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/benseymourodb/linux-parental-controls-toolkit
+          # latest=auto: `latest` (and the {{major}}.{{minor}} alias) apply only to
+          # a stable release. A prerelease tag (vX.Y.Z-alpha.N) publishes the exact
+          # {{version}} only, so an alpha never moves `latest`.
+          flavor: |
+            latest=auto
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
 
+      # metadata-action emits newline-separated `tags`/`labels`; feed them to
+      # build-push-action's multiline inputs (a single `docker buildx --tag`
+      # would collapse them into one malformed reference).
       - name: Build and push image
-        run: |
-          if [ -f server/Dockerfile ]; then
-            docker buildx build \
-              --push \
-              --cache-from type=gha \
-              --cache-to type=gha,mode=max \
-              --tag "${{ steps.meta.outputs.tags }}" \
-              --label "${{ steps.meta.outputs.labels }}" \
-              server/
-          else
-            echo "server/Dockerfile not yet present — skipping Docker publish"
-          fi
+        uses: docker/build-push-action@v6
+        with:
+          context: server
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Publish a GitHub Release; attach install-client.sh so the server can
       # serve it from /install-client.sh at the matching tagged version.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Any prerelease tag (vX.Y.Z-<suffix>) is flagged as a GitHub pre-release.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             client/install-client.sh
           generate_release_notes: true

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -130,26 +130,34 @@ trees skip cleanly (see issue #19).
 
 ## `release.yml` — Release and publish
 
-Triggered by pushing a semver tag (e.g. `git tag v1.2.0 && git push --tags`).
+Triggered by pushing a semver tag — a stable `vMAJOR.MINOR.PATCH` or a
+prerelease `vMAJOR.MINOR.PATCH-<suffix>` (e.g. `v1.2.0` or `v0.1.0-alpha.1`).
 
 ### Steps
 
 1. **Unit test gate** — runs the full unit suite. A failing test blocks the
    release; do not bypass this.
 2. **Docker build and push** — builds the server image and pushes it to
-   `ghcr.io/benseymourodb/linux-parental-controls-toolkit` with three tags:
-   `v1.2.0`, `v1.2`, and `latest`.
+   `ghcr.io/benseymourodb/linux-parental-controls-toolkit`. A **stable** tag
+   publishes three tags (`1.2.0`, `1.2`, and `latest`); a **prerelease** tag
+   publishes only the exact version (`0.1.0-alpha.1`) and does **not** move
+   `latest` or the `{{major}}.{{minor}}` alias (`flavor: latest=auto`).
 3. **GitHub Release** — creates a GitHub Release with auto-generated notes
-   and attaches `client/install-client.sh` as a release artifact. This means
-   a server running a tagged release can serve the matching install script
-   at `/install-client.sh`.
+   and attaches `client/install-client.sh` as a release artifact (so a server
+   running a tagged release can serve the matching install script at
+   `/install-client.sh`). A prerelease tag (any `-<suffix>`) is marked as a
+   GitHub **pre-release**.
 
 ### How to cut a release
 
 ```bash
 # Ensure main is clean and CI is green first.
-git tag v1.2.0
+git tag v1.2.0            # stable
 git push origin v1.2.0
+
+# or a prerelease (does not move `latest`):
+git tag v0.1.0-alpha.1
+git push origin v0.1.0-alpha.1
 ```
 
 The workflow does the rest. Do not push tags from feature branches.

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -224,8 +224,8 @@ services:
     volumes:
       - pct_data:/data
     environment:
-      - PCT_BASE_URL=https://parentalcontrols.lan
-      - PCT_TIMEZONE=America/New_York
+      - PCT_SECRET_KEY=change-me-to-a-long-random-string # required: signs the session cookie
+      - PCT_DEFAULT_TZ=America/New_York # server-default timezone for budget rollover
       - PCT_ADGUARD_MODE=external
       - PCT_ADGUARD_URL=https://adguard.lan
       - PCT_ADGUARD_USERNAME=parental-controls
@@ -255,8 +255,8 @@ services:
     volumes:
       - pct_data:/data
     environment:
-      - PCT_BASE_URL=https://parentalcontrols.lan
-      - PCT_TIMEZONE=America/New_York
+      - PCT_SECRET_KEY=change-me-to-a-long-random-string # required: signs the session cookie
+      - PCT_DEFAULT_TZ=America/New_York # server-default timezone for budget rollover
       - PCT_ADGUARD_MODE=managed
 volumes:
   pct_data:


### PR DESCRIPTION
## Why

Tagging **`v0.1-alpha.1`** produced **no Actions run at all**: `release.yml` only triggered on `v[0-9]+.[0-9]+.[0-9]+`, which a prerelease tag can't match — so GitHub filtered the push out before scheduling anything. And even on a *matching* tag, the publish step would have failed: it fed metadata-action's newline-separated `outputs.tags`/`outputs.labels` into a single `docker buildx build --tag "…"`, collapsing them into one malformed reference.

## What changed

**`.github/workflows/release.yml`**
- **Trigger on prereleases too:** adds `"v[0-9]+.[0-9]+.[0-9]+-*"` alongside the stable `"v[0-9]+.[0-9]+.[0-9]+"` (three-part numeric core retained, per request — `v0.1.0-alpha.1`, not `v0.1-alpha.1`).
- **Fix the build step:** replaces the hand-rolled `docker buildx build` with `docker/build-push-action@v6`, which consumes the multiline `tags`/`labels` correctly.
- **`flavor: latest=auto`** (drops the unconditional `type=raw,value=latest`): a stable tag publishes `{{version}}` + `{{major}}.{{minor}}` + `latest`; a **prerelease** publishes only the exact `{{version}}` and never moves `latest`.
- **Marks prerelease tags as GitHub pre-releases** (`prerelease: ${{ contains(github.ref_name, '-') }}`).

**`docs/server-deployment.md`** — the two TrueNAS compose examples set `PCT_BASE_URL` and `PCT_TIMEZONE`, neither of which `config.ts` parses. Replaced with the canonical **`PCT_DEFAULT_TZ`** (per `.env.example`) and added the **required `PCT_SECRET_KEY`** (without it the dashboard's own auth fails closed with `503`).

**`docs/ci-cd.md`** — updated the `release.yml` description to document the stable-vs-prerelease tag behaviour and the `latest=auto` rule.

## After this merges

Delete the non-conforming tag/release, then cut a compliant prerelease off `main` (the workflow runs as it exists on the tagged commit, so the fix must be on `main` first):

```bash
git push origin :refs/tags/v0.1-alpha.1   # + delete the GitHub Release in the UI
git tag v0.1.0-alpha.1                     # off main, after this PR merges
git push origin v0.1.0-alpha.1
```

That publishes `ghcr.io/benseymourodb/linux-parental-controls-toolkit:0.1.0-alpha.1` (without touching `latest`) and a pre-release with `install-client.sh` attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fNQWA6jFZjbDCkam5k7dm

---
_Generated by [Claude Code](https://claude.ai/code/session_015fNQWA6jFZjbDCkam5k7dm)_