### PR TITLE
feat(frontend): /admin/notifications per-user policy editor (#105)

### DIFF
--- a/.claude/plans/issue-105-admin-notifications-ui.md
+++ b/.claude/plans/issue-105-admin-notifications-ui.md
@@ -1,0 +1,65 @@
+# Issue #105 — Admin UI: `/admin/notifications`
+
+Roadmap: `docs/roadmap.md` → Phase 8b ("Admin UI under `/admin/notifications`").
+
+## Goal
+
+The `/admin` surface for editing each user's `NotificationPolicy`: master
+enable/disable, sound profile (`off`/`subtle`/`prominent`), and grace-period
+override (0–60s). The backend already ships the full contract — this PR is the
+consuming UI only.
+
+## What already exists (no backend work needed)
+
+- API routes (`src/api/policy/routes.ts`, #104):
+  - `GET    /api/users/:userId/notification-policy` → always returns a
+    `NotificationPolicyResponse` (persisted row, or the documented defaults when
+    none is stored — every user always *has* an effective policy).
+  - `PUT    /api/users/:userId/notification-policy` → upsert; partial body, at
+    least one field; fans out `notification.upserted` push.
+  - `DELETE /api/users/:userId/notification-policy` → revert to defaults (204);
+    404 when already at defaults.
+- DTOs (`src/api/policy/dtos.ts`): `notificationPolicyResponseSchema`,
+  `upsertNotificationPolicySchema`, `NotificationPolicyResponse`,
+  `UpsertNotificationPolicyRequest`.
+- Bounds/enums single-sourced in `src/policy/notification.ts` +
+  `src/policy/enums.ts` (`soundProfileValues`, `GRACE_SECONDS_MIN/MAX`,
+  defaults).
+
+## Deliverables
+
+1. `frontend/src/lib/api/notifications.ts` — typed wrappers over the three
+   endpoints (`getNotificationPolicy`, `upsertNotificationPolicy`,
+   `deleteNotificationPolicy`), same shape as `$lib/api/budgets`.
+2. `frontend/src/lib/api/contract.ts` — re-export `NotificationPolicyResponse` +
+   `UpsertNotificationPolicyRequest` (from `api/policy/dtos`) and the
+   `SoundProfile` enum type (from `policy/enums`, alongside `Scope`/`ScheduleAction`).
+3. `frontend/src/lib/views/NotificationsView.svelte` — pick a user, load their
+   effective policy, edit `enabled` / `soundProfile` / `graceSeconds`, **Save**
+   (PUT), and **Reset to defaults** (DELETE). Surfaces whether the user has
+   custom per-budget cadence overrides and offers "clear" (PUT
+   `cadenceOverrides: null`); a structured per-budget cadence editor is out of
+   scope (see Deferred).
+4. Wire into `routes/admin/+page.svelte`: nav item `notifications` + the
+   `{#if activeView === "notifications"}` branch.
+5. Tests:
+   - `frontend/tests/api/notifications.test.ts` — URL/method/body of each wrapper
+     (mirrors `tests/api/budgets.test.ts`).
+   - `frontend/tests/components/notifications-view.test.ts` — load/edit/save/reset
+     flow, grace-bound gating, empty-state when no users (mirrors
+     `tests/components/budgets-view.test.ts`).
+
+## Cadence overrides — scoped to "view + clear"
+
+`cadenceOverrides` is a deliberately loose `Record<string, unknown>` (`null` =
+the built-in 15/5/1-minute cadence). Its per-budget structure is not pinned by
+any schema, so a structured editor would need its own design. This PR therefore
+**surfaces** whether overrides exist and lets the admin clear them, and defers a
+structured per-budget cadence editor to a follow-up issue linked from the PR.
+
+## Validation / boundaries
+
+- Local gate from `server/`: format / lint / typecheck / unit+coverage.
+- Frontend build the CI way: `cd server/frontend && npm ci && npm run build`.
+- License boundary: untouched — type-only consumption of the existing JSON `/api`
+  (`CLAUDE.md` → "License boundaries"). No transport/packaging/Docker changes.

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -51,6 +51,8 @@ export type {
   AdjustTimeTodayRequest,
   TimeTodayResponse,
   ClientAdjustmentResultDto,
+  NotificationPolicyResponse,
+  UpsertNotificationPolicyRequest,
 } from "../../../../src/api/policy/dtos.js";
 export type { AuditEntryResponse, AuditListResponse } from "../../../../src/api/audit/dtos.js";
 export type {
@@ -83,6 +85,7 @@ export type {
   Scope,
   BudgetWindow,
   ScheduleAction,
+  SoundProfile,
   AuditOutcome,
 } from "../../../../src/policy/enums.js";
 export type { ErrorEnvelope, ErrorDetail } from "../../../../src/api/errors.js";

--- a/server/frontend/src/lib/api/notifications.ts
+++ b/server/frontend/src/lib/api/notifications.ts
@@ -1,0 +1,50 @@
+/**
+ * Per-user `NotificationPolicy` calls (#104 contract, #105 editor).
+ *
+ * Same thin-wrapper shape as `$lib/api/budgets`: typed calls over
+ * {@link apiFetch}, with the request/response types imported from the shared
+ * `/api` contract so the frontend never re-declares a DTO. A notification
+ * policy is 1:1 with a user and controls the supervised-user notification
+ * experience (`docs/client-notifications.md`): the master `enabled` switch, the
+ * `soundProfile`, the `graceSeconds` countdown, and optional per-budget
+ * `cadenceOverrides`.
+ *
+ * Every user always *has* an effective policy: `getNotificationPolicy` returns
+ * the persisted row or the documented defaults, `upsertNotificationPolicy`
+ * customises it, and `deleteNotificationPolicy` reverts to defaults.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type { NotificationPolicyResponse, UpsertNotificationPolicyRequest } from "./contract.js";
+
+/**
+ * Read a user's effective notification policy. The server always returns a
+ * policy — the persisted row, or the documented defaults when none is stored.
+ */
+export function getNotificationPolicy(userId: number): Promise<NotificationPolicyResponse> {
+  return apiFetch<NotificationPolicyResponse>(`/users/${userId}/notification-policy`);
+}
+
+/**
+ * Upsert a user's notification policy. `input` is a partial body (at least one
+ * field); omitted fields take the documented default on first write or are left
+ * unchanged on a later write. Returns the resulting effective policy.
+ */
+export function upsertNotificationPolicy(
+  userId: number,
+  input: UpsertNotificationPolicyRequest,
+): Promise<NotificationPolicyResponse> {
+  return apiFetch<NotificationPolicyResponse>(`/users/${userId}/notification-policy`, {
+    method: "PUT",
+    body: input,
+  });
+}
+
+/**
+ * Revert a user to the documented default notification policy. Resolves on the
+ * server's `204`; the server returns `404` when the user is already at defaults.
+ */
+export function deleteNotificationPolicy(userId: number): Promise<void> {
+  return apiFetch<void>(`/users/${userId}/notification-policy`, { method: "DELETE" });
+}

--- a/server/frontend/src/lib/views/NotificationsView.svelte
+++ b/server/frontend/src/lib/views/NotificationsView.svelte
@@ -1,0 +1,452 @@
+<!--
+  Notifications editor (#105): the `/admin/notifications` surface for a user's
+  `NotificationPolicy` (#104). Repeats the per-user editor pattern (load users
+  on mount, pick one, load/edit/save its policy) used by the other views (#53).
+
+  A `NotificationPolicy` is 1:1 with a user and shapes the supervised-user
+  notification experience (`docs/client-notifications.md`): the master `enabled`
+  switch, the `soundProfile` (`off` / `subtle` / `prominent`), and the
+  `graceSeconds` end-of-budget countdown (0–60s, 0 disables grace). Every user
+  always *has* an effective policy — the server returns the documented defaults
+  until the admin customises it — so this view never shows an empty policy, and
+  "Reset to defaults" (DELETE) reverts a user to that baseline.
+
+  Per-budget `cadenceOverrides` are a deliberately loose, unpinned structure;
+  this view surfaces whether a user has any and lets the admin clear them, but a
+  structured cadence editor is a separate piece of work (see the PR for #105).
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ApiError } from "$lib/api/client.js";
+  import type {
+    NotificationPolicyResponse,
+    SoundProfile,
+    UserResponse,
+  } from "$lib/api/contract.js";
+  import {
+    getNotificationPolicy,
+    upsertNotificationPolicy,
+    deleteNotificationPolicy,
+  } from "$lib/api/notifications.js";
+  import { listUsers } from "$lib/api/users.js";
+
+  // Documented bounds + vocabulary (`docs/client-notifications.md`, mirrored by
+  // `server/src/policy/notification.ts`'s single-source constants). Hardcoded
+  // here because the contract is type-only — no server runtime values cross the
+  // bundle boundary — and kept in step with that source.
+  const GRACE_SECONDS_MIN = 0;
+  const GRACE_SECONDS_MAX = 60;
+
+  const SOUND_PROFILE_OPTIONS: ReadonlyArray<{ value: SoundProfile; label: string }> = [
+    { value: "off", label: "Off — no sounds" },
+    { value: "subtle", label: "Subtle (default)" },
+    { value: "prominent", label: "Prominent" },
+  ];
+
+  let users = $state<UserResponse[]>([]);
+  let loadingUsers = $state(true);
+  let error = $state<string | null>(null);
+  let notice = $state<string | null>(null);
+
+  // The user whose policy is being edited, and that policy's loaded state.
+  let selectedUserId = $state<number | null>(null);
+  let policy = $state<NotificationPolicyResponse | null>(null);
+  let loadingPolicy = $state(false);
+
+  // Editable form fields, hydrated from the loaded policy.
+  let formEnabled = $state(true);
+  let formSoundProfile = $state<SoundProfile>("subtle");
+  let formGraceSeconds = $state(15);
+  let saving = $state(false);
+  let resetting = $state(false);
+  let clearingCadence = $state(false);
+
+  onMount(loadUsers);
+
+  async function loadUsers(): Promise<void> {
+    loadingUsers = true;
+    error = null;
+    try {
+      users = await listUsers();
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loadingUsers = false;
+    }
+  }
+
+  // (Re)load the selected user's effective policy and hydrate the form. The
+  // server always returns a policy (persisted row or documented defaults).
+  async function loadPolicy(userId: number): Promise<void> {
+    loadingPolicy = true;
+    error = null;
+    notice = null;
+    try {
+      const loaded = await getNotificationPolicy(userId);
+      policy = loaded;
+      formEnabled = loaded.enabled;
+      formSoundProfile = loaded.soundProfile;
+      formGraceSeconds = loaded.graceSeconds;
+    } catch (err) {
+      policy = null;
+      error = messageOf(err);
+    } finally {
+      loadingPolicy = false;
+    }
+  }
+
+  function onSelectUser(): void {
+    if (selectedUserId === null) {
+      policy = null;
+      return;
+    }
+    void loadPolicy(selectedUserId);
+  }
+
+  function userName(id: number): string {
+    return users.find((u) => u.id === id)?.displayName ?? `User ${id}`;
+  }
+
+  // The grace input is bounded client-side to mirror the server's `CHECK` /
+  // zod bound so the admin gets fast feedback instead of a 400.
+  let graceInvalid = $derived(
+    !Number.isInteger(formGraceSeconds) ||
+      formGraceSeconds < GRACE_SECONDS_MIN ||
+      formGraceSeconds > GRACE_SECONDS_MAX,
+  );
+
+  // Enable Save only when something actually differs from the loaded policy, so
+  // a no-op PUT (and its push fan-out) isn't issued on an unchanged form.
+  let dirty = $derived(
+    policy !== null &&
+      (formEnabled !== policy.enabled ||
+        formSoundProfile !== policy.soundProfile ||
+        formGraceSeconds !== policy.graceSeconds),
+  );
+
+  let hasCustomCadence = $derived(policy !== null && policy.cadenceOverrides !== null);
+
+  async function handleSave(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    if (selectedUserId === null || graceInvalid || !dirty) {
+      return;
+    }
+    saving = true;
+    error = null;
+    notice = null;
+    try {
+      policy = await upsertNotificationPolicy(selectedUserId, {
+        enabled: formEnabled,
+        soundProfile: formSoundProfile,
+        graceSeconds: formGraceSeconds,
+      });
+      notice = `Saved notification settings for ${userName(selectedUserId)}.`;
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleReset(): Promise<void> {
+    if (selectedUserId === null) {
+      return;
+    }
+    if (!confirm(`Reset ${userName(selectedUserId)} to the default notification settings?`)) {
+      return;
+    }
+    resetting = true;
+    error = null;
+    notice = null;
+    // Capture the outcome message and apply it *after* the reload below —
+    // `loadPolicy` clears `notice`, so setting it inside the try would be wiped.
+    let outcome: string | null = null;
+    try {
+      await deleteNotificationPolicy(selectedUserId);
+      outcome = `Reset ${userName(selectedUserId)} to the default notification settings.`;
+    } catch (err) {
+      // A 404 here means "already at defaults" — not an error worth alarming the
+      // admin with; just reload and say so.
+      if (err instanceof ApiError && err.status === 404) {
+        outcome = `${userName(selectedUserId)} was already using the default settings.`;
+      } else {
+        error = messageOf(err);
+      }
+    } finally {
+      resetting = false;
+      // Reload so the form reflects the (now default) effective policy.
+      await loadPolicy(selectedUserId);
+    }
+    // Surface the outcome only when the reload itself didn't error.
+    if (outcome !== null && error === null) {
+      notice = outcome;
+    }
+  }
+
+  async function handleClearCadence(): Promise<void> {
+    if (selectedUserId === null) {
+      return;
+    }
+    clearingCadence = true;
+    error = null;
+    notice = null;
+    try {
+      policy = await upsertNotificationPolicy(selectedUserId, { cadenceOverrides: null });
+      notice = `Cleared the custom warning cadence for ${userName(selectedUserId)}.`;
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      clearingCadence = false;
+    }
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.message;
+    }
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>Notifications</h1>
+    <p class="hint">
+      Per-user notification settings for the supervised desktop: the master
+      on/off switch, the sound theme, and the end-of-budget grace countdown.
+      Changes are pushed to the user's linked clients with the rest of their
+      policy.
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+  {#if notice}
+    <p class="notice" role="status">{notice}</p>
+  {/if}
+
+  {#if loadingUsers}
+    <p class="muted">Loading users…</p>
+  {:else if users.length === 0}
+    <p class="muted">Add a user first — notification settings always belong to a user.</p>
+  {:else}
+    <label class="field user-picker">
+      <span>User</span>
+      <select bind:value={selectedUserId} onchange={onSelectUser} aria-label="User">
+        <option value={null} disabled selected>Choose a user…</option>
+        {#each users as user (user.id)}
+          <option value={user.id}>{user.displayName}</option>
+        {/each}
+      </select>
+    </label>
+
+    {#if selectedUserId === null}
+      <p class="muted">Choose a user to view and edit their notification settings.</p>
+    {:else if loadingPolicy}
+      <p class="muted">Loading settings…</p>
+    {:else if policy !== null}
+      <form class="editor" onsubmit={handleSave}>
+        <label class="row toggle">
+          <input type="checkbox" bind:checked={formEnabled} aria-label="Notifications enabled" />
+          <span>
+            <strong>Notifications enabled</strong>
+            <small>Master switch — when off, the client shows no toasts or sounds.</small>
+          </span>
+        </label>
+
+        <label class="row">
+          <span class="label">Sound profile</span>
+          <select bind:value={formSoundProfile} aria-label="Sound profile">
+            {#each SOUND_PROFILE_OPTIONS as option (option.value)}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
+        </label>
+
+        <label class="row">
+          <span class="label">Grace period (seconds)</span>
+          <input
+            type="number"
+            min={GRACE_SECONDS_MIN}
+            max={GRACE_SECONDS_MAX}
+            step="1"
+            bind:value={formGraceSeconds}
+            aria-label="Grace period seconds"
+            aria-invalid={graceInvalid}
+          />
+        </label>
+        <p class="sublabel">
+          How long the user has after a per-app budget runs out before it is
+          force-closed. {GRACE_SECONDS_MIN}–{GRACE_SECONDS_MAX}s; 0 disables the grace countdown.
+        </p>
+        {#if graceInvalid}
+          <p class="warn" role="alert">
+            Grace period must be a whole number between {GRACE_SECONDS_MIN} and {GRACE_SECONDS_MAX}.
+          </p>
+        {/if}
+
+        <div class="cadence">
+          {#if hasCustomCadence}
+            <p class="muted">
+              This user has a custom per-budget warning cadence. Clear it to fall
+              back to the built-in 15/5/1-minute warnings.
+            </p>
+            <button
+              type="button"
+              class="ghost"
+              onclick={handleClearCadence}
+              disabled={clearingCadence}
+            >
+              {clearingCadence ? "Clearing…" : "Clear custom cadence"}
+            </button>
+          {:else}
+            <p class="muted">Using the built-in 15/5/1-minute warning cadence.</p>
+          {/if}
+        </div>
+
+        <div class="actions">
+          <button type="submit" disabled={saving || resetting || graceInvalid || !dirty}>
+            {saving ? "Saving…" : "Save"}
+          </button>
+          <button type="button" class="ghost" onclick={handleReset} disabled={saving || resetting}>
+            {resetting ? "Resetting…" : "Reset to defaults"}
+          </button>
+        </div>
+      </form>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+    max-width: 40rem;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    font-size: 0.75rem;
+    color: #6b7280;
+  }
+  .user-picker {
+    margin-bottom: 1.25rem;
+    max-width: 20rem;
+  }
+  select,
+  input[type="number"] {
+    padding: 0.5rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    background: #fff;
+    font-size: 0.9rem;
+  }
+  .editor {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 32rem;
+    padding: 1.25rem;
+    background: #fff;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  .row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .row .label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #374151;
+  }
+  .toggle {
+    flex-direction: row;
+    align-items: start;
+    gap: 0.6rem;
+  }
+  .toggle input {
+    margin-top: 0.2rem;
+  }
+  .toggle span {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+  .toggle small,
+  .sublabel {
+    color: #6b7280;
+    font-size: 0.8rem;
+  }
+  .sublabel {
+    margin: -0.6rem 0 0;
+    max-width: 32rem;
+  }
+  .cadence {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid #f3f4f6;
+  }
+  .cadence .muted {
+    margin: 0;
+  }
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    padding-top: 0.5rem;
+  }
+  button {
+    padding: 0.5rem 0.9rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.9rem;
+    align-self: start;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  .muted {
+    color: #6b7280;
+    font-size: 0.9rem;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+  .notice {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #ecfdf5;
+    color: #047857;
+    font-size: 0.85rem;
+  }
+  .warn {
+    margin: -0.6rem 0 0;
+    color: #b45309;
+    font-size: 0.8rem;
+  }
+</style>

--- a/server/frontend/src/routes/admin/+page.svelte
+++ b/server/frontend/src/routes/admin/+page.svelte
@@ -29,6 +29,7 @@
   import BudgetsView from "$lib/views/BudgetsView.svelte";
   import SchedulesView from "$lib/views/SchedulesView.svelte";
   import ExceptionsView from "$lib/views/ExceptionsView.svelte";
+  import NotificationsView from "$lib/views/NotificationsView.svelte";
   import LinksView from "$lib/views/LinksView.svelte";
   import IntegrationTokensView from "$lib/views/IntegrationTokensView.svelte";
   import AuditLogView from "$lib/views/AuditLogView.svelte";
@@ -51,6 +52,7 @@
     { id: "budgets", label: "Budgets" },
     { id: "schedules", label: "Schedules" },
     { id: "exceptions", label: "Exceptions" },
+    { id: "notifications", label: "Notifications" },
     { id: "integrations", label: "Integrations" },
     { id: "audit", label: "Audit log" },
   ];
@@ -139,6 +141,8 @@
       <SchedulesView />
     {:else if activeView === "exceptions"}
       <ExceptionsView />
+    {:else if activeView === "notifications"}
+      <NotificationsView />
     {:else if activeView === "integrations"}
       <IntegrationTokensView />
     {:else if activeView === "audit"}

--- a/server/frontend/tests/api/notifications.test.ts
+++ b/server/frontend/tests/api/notifications.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getNotificationPolicy,
+  upsertNotificationPolicy,
+  deleteNotificationPolicy,
+} from "../../src/lib/api/notifications.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("notifications API", () => {
+  it("getNotificationPolicy GETs /api/users/:id/notification-policy", async () => {
+    const policy = {
+      userId: 7,
+      enabled: true,
+      soundProfile: "subtle",
+      graceSeconds: 15,
+      cadenceOverrides: null,
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, policy));
+
+    const result = await getNotificationPolicy(7);
+
+    expect(result).toEqual(policy);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/users/7/notification-policy");
+    // The wrapper defaults to a GET when no method is supplied.
+    expect((init as RequestInit).method).toBe("GET");
+  });
+
+  it("upsertNotificationPolicy PUTs the partial body", async () => {
+    const body = { enabled: false, soundProfile: "prominent" as const, graceSeconds: 30 };
+    const updated = { userId: 7, ...body, cadenceOverrides: null };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, updated));
+
+    const result = await upsertNotificationPolicy(7, body);
+
+    expect(result).toEqual(updated);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/users/7/notification-policy");
+    expect((init as RequestInit).method).toBe("PUT");
+    expect((init as RequestInit).body).toBe(JSON.stringify(body));
+  });
+
+  it("upsertNotificationPolicy can clear cadence overrides with an explicit null", async () => {
+    const updated = {
+      userId: 7,
+      enabled: true,
+      soundProfile: "subtle",
+      graceSeconds: 15,
+      cadenceOverrides: null,
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, updated));
+
+    await upsertNotificationPolicy(7, { cadenceOverrides: null });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).body).toBe(JSON.stringify({ cadenceOverrides: null }));
+  });
+
+  it("deleteNotificationPolicy DELETEs and resolves on 204", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(204, undefined));
+
+    await expect(deleteNotificationPolicy(7)).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/users/7/notification-policy");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+});

--- a/server/frontend/tests/components/notifications-view.test.ts
+++ b/server/frontend/tests/components/notifications-view.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Smoke test for `NotificationsView` (#105). The CRUD-skeleton shape is proven
+ * elsewhere; this suite targets the logic this view adds: pick-a-user →
+ * load-and-hydrate the effective policy, the dirty-gating on Save, the
+ * grace-bound validation, Save sending the three knobs, Reset → DELETE +
+ * reload, and the custom-cadence surface (indicator + clear). The
+ * `$lib/api/notifications` + `$lib/api/users` wrappers are mocked; the real
+ * `ApiError` is used so the "already at defaults" 404 path is exercised.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "../../src/lib/api/client.js";
+import type { NotificationPolicyResponse, UserResponse } from "../../src/lib/api/contract.js";
+
+const listUsers = vi.fn<() => Promise<UserResponse[]>>();
+const getNotificationPolicy = vi.fn<(userId: number) => Promise<NotificationPolicyResponse>>();
+const upsertNotificationPolicy =
+  vi.fn<(userId: number, input: unknown) => Promise<NotificationPolicyResponse>>();
+const deleteNotificationPolicy = vi.fn<(userId: number) => Promise<void>>();
+
+vi.mock("$lib/api/users", () => ({ listUsers: () => listUsers() }));
+vi.mock("$lib/api/notifications", () => ({
+  getNotificationPolicy: (userId: number) => getNotificationPolicy(userId),
+  upsertNotificationPolicy: (userId: number, input: unknown) =>
+    upsertNotificationPolicy(userId, input),
+  deleteNotificationPolicy: (userId: number) => deleteNotificationPolicy(userId),
+}));
+
+const { default: NotificationsView } = await import(
+  "../../src/lib/views/NotificationsView.svelte"
+);
+
+function user(overrides: Partial<UserResponse> = {}): UserResponse {
+  return {
+    id: 1,
+    displayName: "Alice",
+    tz: "Europe/London",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as UserResponse;
+}
+
+function policy(overrides: Partial<NotificationPolicyResponse> = {}): NotificationPolicyResponse {
+  return {
+    userId: 1,
+    enabled: true,
+    soundProfile: "subtle",
+    graceSeconds: 15,
+    cadenceOverrides: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  listUsers.mockReset().mockResolvedValue([user()]);
+  getNotificationPolicy.mockReset().mockResolvedValue(policy());
+  upsertNotificationPolicy.mockReset().mockResolvedValue(policy());
+  deleteNotificationPolicy.mockReset().mockResolvedValue();
+  vi.spyOn(globalThis, "confirm").mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function selectUser(value = "1"): Promise<void> {
+  await fireEvent.change(await screen.findByLabelText("User"), { target: { value } });
+}
+
+describe("NotificationsView", () => {
+  it("prompts to add a user first when none exist", async () => {
+    listUsers.mockResolvedValue([]);
+
+    render(NotificationsView);
+
+    expect(
+      await screen.findByText(
+        "Add a user first — notification settings always belong to a user.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("loads and hydrates the selected user's policy", async () => {
+    getNotificationPolicy.mockResolvedValue(
+      policy({ enabled: false, soundProfile: "prominent", graceSeconds: 30 }),
+    );
+
+    render(NotificationsView);
+    await selectUser();
+
+    await waitFor(() => expect(getNotificationPolicy).toHaveBeenCalledWith(1));
+    const enabled = (await screen.findByLabelText(
+      "Notifications enabled",
+    )) as HTMLInputElement;
+    expect(enabled.checked).toBe(false);
+    expect((screen.getByLabelText("Sound profile") as HTMLSelectElement).value).toBe("prominent");
+    expect((screen.getByLabelText("Grace period seconds") as HTMLInputElement).value).toBe("30");
+  });
+
+  it("keeps Save disabled until a field changes, then PUTs the three knobs", async () => {
+    upsertNotificationPolicy.mockResolvedValue(
+      policy({ soundProfile: "prominent", graceSeconds: 30 }),
+    );
+
+    render(NotificationsView);
+    await selectUser();
+
+    const save = await screen.findByRole("button", { name: "Save" });
+    // Unchanged form → no-op PUT is gated.
+    expect(save).toBeDisabled();
+
+    await fireEvent.change(screen.getByLabelText("Sound profile"), {
+      target: { value: "prominent" },
+    });
+    await fireEvent.input(screen.getByLabelText("Grace period seconds"), {
+      target: { value: "30" },
+    });
+    expect(save).toBeEnabled();
+
+    await fireEvent.click(save);
+
+    expect(upsertNotificationPolicy).toHaveBeenCalledWith(1, {
+      enabled: true,
+      soundProfile: "prominent",
+      graceSeconds: 30,
+    });
+    expect(await screen.findByText("Saved notification settings for Alice.")).toBeInTheDocument();
+  });
+
+  it("blocks Save and warns when the grace period is out of bounds", async () => {
+    render(NotificationsView);
+    await selectUser();
+    await screen.findByLabelText("Grace period seconds");
+
+    await fireEvent.input(screen.getByLabelText("Grace period seconds"), {
+      target: { value: "999" },
+    });
+
+    expect(
+      screen.getByText("Grace period must be a whole number between 0 and 60."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(upsertNotificationPolicy).not.toHaveBeenCalled();
+  });
+
+  it("resets to defaults via DELETE and reloads the effective policy", async () => {
+    render(NotificationsView);
+    await selectUser();
+    await screen.findByRole("button", { name: "Reset to defaults" });
+
+    getNotificationPolicy.mockClear();
+    await fireEvent.click(screen.getByRole("button", { name: "Reset to defaults" }));
+
+    await waitFor(() => expect(deleteNotificationPolicy).toHaveBeenCalledWith(1));
+    // The view reloads the now-default policy after a reset.
+    expect(getNotificationPolicy).toHaveBeenCalledWith(1);
+    expect(
+      await screen.findByText("Reset Alice to the default notification settings."),
+    ).toBeInTheDocument();
+  });
+
+  it("treats a 404 on reset as 'already at defaults' rather than an error", async () => {
+    deleteNotificationPolicy.mockRejectedValue(
+      new ApiError(404, "not_found", "no custom policy"),
+    );
+
+    render(NotificationsView);
+    await selectUser();
+    await fireEvent.click(await screen.findByRole("button", { name: "Reset to defaults" }));
+
+    expect(
+      await screen.findByText("Alice was already using the default settings."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a custom cadence and clears it with an explicit null", async () => {
+    getNotificationPolicy.mockResolvedValue(
+      policy({ cadenceOverrides: { "budget:1": { warnAt: [10] } } }),
+    );
+    upsertNotificationPolicy.mockResolvedValue(policy({ cadenceOverrides: null }));
+
+    render(NotificationsView);
+    await selectUser();
+
+    const clear = await screen.findByRole("button", { name: "Clear custom cadence" });
+    await fireEvent.click(clear);
+
+    expect(upsertNotificationPolicy).toHaveBeenCalledWith(1, { cadenceOverrides: null });
+    expect(
+      await screen.findByText("Using the built-in 15/5/1-minute warning cadence."),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `/admin/notifications` admin surface: a per-user editor for the existing `NotificationPolicy` (#104) — master `enabled` switch, `soundProfile` (`off`/`subtle`/`prominent`), and the `graceSeconds` end-of-budget countdown (0–60s).
- Consuming UI only — the backend contract already ships (`GET/PUT/DELETE /api/users/:id/notification-policy` with `notification.*` push fan-out). New: `lib/api/notifications.ts`, `lib/views/NotificationsView.svelte`, contract re-exports (notification DTOs + `SoundProfile`), and nav/router wiring in `routes/admin/+page.svelte`.
- Save is dirty-gated (no no-op PUT), grace is validated client-side against the documented 0–60s bound, Reset-to-defaults uses DELETE (treating the `404 "already at defaults"` as a friendly notice, not an error), and custom per-budget cadence overrides are surfaced + clearable.

## Plan

Linked plan: `.claude/plans/issue-105-admin-notifications-ui.md`
Roadmap: docs/roadmap.md → Phase 8b ("Admin UI under `/admin/notifications`")

## License-boundary note

N/A — type-only consumption of the existing JSON `/api`. No transport, packaging, or Docker-image changes; no GPL surface touched.

## Deferred work

`cadenceOverrides` is a deliberately loose, unpinned `Record<string, unknown>` (per-budget warning cadence; `null` = the built-in 15/5/1-minute cadence). A structured per-budget cadence **editor** would need its own design, so this PR only **surfaces** whether overrides exist and lets the admin **clear** them. Tracked as follow-up #302.

## Test plan

- [x] `tests/api/notifications.test.ts` — URL/method/body of each wrapper (incl. clearing cadence with an explicit `null`).
- [x] `tests/components/notifications-view.test.ts` — load/hydrate, dirty-gating, grace-bound block, Save body, Reset → DELETE + reload, the 404 "already at defaults" path, and cadence clear.
- [x] `cd server/frontend && npm run check && npm test && npm run build` — svelte-check 0 errors, 185/185 tests, build OK (mirrors the CI `frontend-build` job).
- [x] `cd server && npm run typecheck` — clean.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)