### PR TITLE
Serve install-client.sh from dashboard at GET /install-client.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,11 @@ jobs:
         run: |
           if [ -f server/Dockerfile ]; then
             docker buildx build \
+              --file server/Dockerfile \
               --cache-from type=gha \
               --cache-to type=gha,mode=max \
               --tag pct-dashboard:ci \
-              server/
+              .
           else
             echo "server/Dockerfile not yet present — skipping Docker build"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,8 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: server
+          context: .
+          file: server/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,8 +10,8 @@
 # docs/server-deployment.md and docs/licensing-analysis.md, enforced by
 # .github/workflows/license-guard.yml.
 #
-# Build context is server/ (see .github/workflows/ci.yml → docker-build),
-# so server/frontend/ is in scope for the frontend build stage.
+# Build context is the repo root (see .github/workflows/ci.yml → docker-build),
+# so both server/ and client/ are in scope.
 
 # ---------------------------------------------------------------------------
 # Stage 1: build the SvelteKit frontend (/admin + /app) to static assets.
@@ -20,10 +20,10 @@
 FROM node:22-slim AS frontend-builder
 WORKDIR /app/frontend
 
-COPY frontend/package.json frontend/package-lock.json ./
+COPY server/frontend/package.json server/frontend/package-lock.json ./
 RUN npm ci
 
-COPY frontend/ ./
+COPY server/frontend/ ./
 RUN npm run build
 
 # ---------------------------------------------------------------------------
@@ -40,11 +40,11 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ \
   && rm -rf /var/lib/apt/lists/*
 
-COPY package.json package-lock.json ./
+COPY server/package.json server/package-lock.json ./
 RUN npm ci
 
-COPY tsconfig.json tsconfig.build.json ./
-COPY src/ ./src/
+COPY server/tsconfig.json server/tsconfig.build.json ./
+COPY server/src/ ./src/
 RUN npm run build
 
 # Strip dev dependencies in place, leaving the already-compiled native
@@ -75,14 +75,18 @@ COPY --from=builder /app/package.json ./package.json
 # Committed drizzle-kit migrations, reconciled into /data on start (Phase 2).
 # Copied straight from the build context (not the builder stage, which only
 # carries the TypeScript sources it compiles).
-COPY drizzle ./drizzle
+COPY server/drizzle ./drizzle
 
 # Prerendered frontend (served at /admin and /app once the static mount
 # lands in Phase 2; carried in the image now so the asset path is settled).
 COPY --from=frontend-builder /app/frontend/build ./frontend
 
+# install-client.sh — served at GET /install-client.sh so a client device can
+# bootstrap with a single curl command (docs/client-install.md).
+COPY client/install-client.sh ./client-scripts/install-client.sh
+
 # First-run setup + server launch.
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY server/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Canonical policy store, Ansible venv, AdGuard payload, logs, secrets.

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -231,6 +231,17 @@ const settingsSchema = z
       })
       .default("2.18.1"),
     /**
+     * Path to the bundled `install-client.sh` served at `GET /install-client.sh`
+     * (`PCT_INSTALL_CLIENT_SCRIPT_PATH`). Defaults to the in-image path the
+     * Dockerfile copies the script into. Overridable so dev and tests can point
+     * at a different path; if absent the route 404s with a startup warning rather
+     * than blocking startup.
+     */
+    installClientScriptPath: z
+      .string()
+      .min(1)
+      .default("/app/client-scripts/install-client.sh"),
+    /**
      * Read-only, in-image source directory the first-run bootstrap (#39) syncs
      * playbooks from into `<ansibleDir>/playbooks/` (`PCT_ANSIBLE_PLAYBOOK_SRC`).
      * Defaults to the path the image is expected to ship them at. A missing
@@ -436,6 +447,7 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
     adminPassword: env.PCT_ADMIN_PASSWORD,
     ansibleDir: env.PCT_ANSIBLE_DIR,
     ansibleCoreVersion: env.PCT_ANSIBLE_CORE_VERSION,
+    installClientScriptPath: env.PCT_INSTALL_CLIENT_SCRIPT_PATH,
     ansiblePlaybookSourceDir: env.PCT_ANSIBLE_PLAYBOOK_SRC,
     sshPublicKeyPath: env.PCT_SSH_PUBLIC_KEY_PATH,
     sshPrivateKeyPath: env.PCT_SSH_PRIVATE_KEY_PATH,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -237,10 +237,7 @@ const settingsSchema = z
      * at a different path; if absent the route 404s with a startup warning rather
      * than blocking startup.
      */
-    installClientScriptPath: z
-      .string()
-      .min(1)
-      .default("/app/client-scripts/install-client.sh"),
+    installClientScriptPath: z.string().min(1).default("/app/client-scripts/install-client.sh"),
     /**
      * Read-only, in-image source directory the first-run bootstrap (#39) syncs
      * playbooks from into `<ansibleDir>/playbooks/` (`PCT_ANSIBLE_PLAYBOOK_SRC`).

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -29,6 +29,7 @@ import {
   type PolicyPushTransport,
 } from "../transport/policy-push/index.js";
 import { registerFrontend } from "./frontend.js";
+import { registerInstallScript } from "./install-script.js";
 import { REQUEST_ID_HEADER, buildLoggerOptions, genRequestId, type LogStream } from "./logger.js";
 
 declare module "fastify" {
@@ -267,6 +268,10 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
     policyPush.adjustTimeToday,
     options.eventStream,
   );
+
+  // Serve the client install script at /install-client.sh. Skipped (with a
+  // warning) when the bundled file is absent, so other routes are unaffected.
+  registerInstallScript(app, settings);
 
   // Serve the prerendered SvelteKit build at /admin and /app (#40). Skipped
   // (with a warning) when the build directory is absent, so /, /healthz, and

--- a/server/src/web/install-script.ts
+++ b/server/src/web/install-script.ts
@@ -1,0 +1,47 @@
+/**
+ * Serve the client install script at `GET /install-client.sh` (#itoffd).
+ *
+ * The script is bundled into the image at build time
+ * (`COPY client/install-client.sh ./client-scripts/install-client.sh`) and
+ * served directly from disk. A client device can bootstrap with:
+ *
+ *   sudo bash <(curl -fsSL https://<dashboard>/install-client.sh) \
+ *       --server-url https://<dashboard> \
+ *       --enrolment-token <token> \
+ *       --supervised-user <username>
+ *
+ * If the script is absent (e.g. a dev build without the client directory in
+ * scope), the route 404s and a startup warning is emitted — startup is never
+ * blocked on the presence of the file.
+ *
+ * License boundary: none touched — plain Fastify + Node.js fs streaming.
+ */
+import { createReadStream, existsSync } from "node:fs";
+import type { FastifyInstance } from "fastify";
+import type { Settings } from "../config.js";
+import { componentLogger } from "./logger.js";
+
+/**
+ * Register `GET /install-client.sh` on the app.
+ *
+ * Streams the bundled script with `Content-Type: text/x-shellscript`. If the
+ * file is absent the route returns 404; a warning is also emitted at startup
+ * so the operator notices before a client tries to download it.
+ */
+export function registerInstallScript(app: FastifyInstance, settings: Settings): void {
+  const scriptPath = settings.installClientScriptPath;
+
+  if (!existsSync(scriptPath)) {
+    componentLogger(app, "web/install-script").warn(
+      { installClientScriptPath: scriptPath },
+      "install-client.sh not found; GET /install-client.sh will 404 until it is present",
+    );
+  }
+
+  app.get("/install-client.sh", async (_request, reply) => {
+    if (!existsSync(scriptPath)) {
+      return reply.code(404).type("text/plain").send("install-client.sh not found");
+    }
+    return reply.type("text/x-shellscript").send(createReadStream(scriptPath));
+  });
+}

--- a/server/src/web/install-script.ts
+++ b/server/src/web/install-script.ts
@@ -31,7 +31,12 @@ import { componentLogger } from "./logger.js";
 export function registerInstallScript(app: FastifyInstance, settings: Settings): void {
   const scriptPath = settings.installClientScriptPath;
 
-  if (!existsSync(scriptPath)) {
+  // Cache presence at registration time: the file is baked into the image and
+  // never appears or disappears at runtime, so re-checking on every request
+  // is both redundant and a blocking syscall on the event loop.
+  const scriptPresent = existsSync(scriptPath);
+
+  if (!scriptPresent) {
     componentLogger(app, "web/install-script").warn(
       { installClientScriptPath: scriptPath },
       "install-client.sh not found; GET /install-client.sh will 404 until it is present",
@@ -39,9 +44,17 @@ export function registerInstallScript(app: FastifyInstance, settings: Settings):
   }
 
   app.get("/install-client.sh", async (_request, reply) => {
-    if (!existsSync(scriptPath)) {
+    if (!scriptPresent) {
       return reply.code(404).type("text/plain").send("install-client.sh not found");
     }
-    return reply.type("text/x-shellscript").send(createReadStream(scriptPath));
+    const stream = createReadStream(scriptPath);
+    stream.on("error", (err) => {
+      if (!reply.sent) {
+        void reply.code(500).type("text/plain").send("Failed to read install-client.sh");
+      } else {
+        app.log.error({ err }, "install-client.sh stream error after headers sent");
+      }
+    });
+    return reply.type("text/x-shellscript").send(stream);
   });
 }

--- a/server/tests/web/install-script.test.ts
+++ b/server/tests/web/install-script.test.ts
@@ -19,10 +19,11 @@ const SCRIPT_CONTENT = "#!/usr/bin/env bash\necho 'install-client'\n";
 describe("GET /install-client.sh (script present)", () => {
   let app: FastifyInstance;
   let db: TestDb;
+  let dir: string;
   let scriptPath: string;
 
   beforeEach(() => {
-    const dir = mkdtempSync(join(tmpdir(), "pct-install-script-"));
+    dir = mkdtempSync(join(tmpdir(), "pct-install-script-"));
     scriptPath = join(dir, "install-client.sh");
     writeFileSync(scriptPath, SCRIPT_CONTENT);
     db = testDb();
@@ -38,7 +39,7 @@ describe("GET /install-client.sh (script present)", () => {
   afterEach(async () => {
     await app.close();
     db.$client.close();
-    rmSync(scriptPath, { force: true });
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("returns 200 with the script content", async () => {
@@ -60,13 +61,15 @@ describe("GET /install-client.sh (script present)", () => {
 });
 
 describe("GET /install-client.sh (script absent)", () => {
-  let app: FastifyInstance;
-  let db: TestDb;
+  let app: FastifyInstance | undefined;
+  let db: TestDb | undefined;
   const missingPath = join(tmpdir(), "pct-install-script-does-not-exist.sh");
 
   afterEach(async () => {
-    await app.close();
-    db.$client.close();
+    await app?.close();
+    db?.$client.close();
+    app = undefined;
+    db = undefined;
   });
 
   it("404s and emits a startup warning", async () => {

--- a/server/tests/web/install-script.test.ts
+++ b/server/tests/web/install-script.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for GET /install-client.sh (#itoffd).
+ *
+ * Follows the same fixture pattern as frontend.test.ts: write a temporary
+ * file, point `PCT_INSTALL_CLIENT_SCRIPT_PATH` at it, then exercise the route
+ * via `app.inject()` — no sockets.
+ */
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../../src/web/app.js";
+import { loadSettings } from "../../src/config.js";
+import { testDb, type TestDb } from "../helpers/db.js";
+
+const SCRIPT_CONTENT = "#!/usr/bin/env bash\necho 'install-client'\n";
+
+describe("GET /install-client.sh (script present)", () => {
+  let app: FastifyInstance;
+  let db: TestDb;
+  let scriptPath: string;
+
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), "pct-install-script-"));
+    scriptPath = join(dir, "install-client.sh");
+    writeFileSync(scriptPath, SCRIPT_CONTENT);
+    db = testDb();
+    app = buildApp({
+      settings: loadSettings({
+        PCT_LOG_LEVEL: "silent",
+        PCT_INSTALL_CLIENT_SCRIPT_PATH: scriptPath,
+      }),
+      db,
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.$client.close();
+    rmSync(scriptPath, { force: true });
+  });
+
+  it("returns 200 with the script content", async () => {
+    const res = await app.inject({ method: "GET", url: "/install-client.sh" });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe(SCRIPT_CONTENT);
+  });
+
+  it("sets Content-Type to text/x-shellscript", async () => {
+    const res = await app.inject({ method: "GET", url: "/install-client.sh" });
+    expect(res.headers["content-type"]).toContain("text/x-shellscript");
+  });
+
+  it("does not shadow other routes", async () => {
+    const health = await app.inject({ method: "GET", url: "/healthz" });
+    expect(health.statusCode).toBe(200);
+    expect(health.json()).toEqual({ status: "ok" });
+  });
+});
+
+describe("GET /install-client.sh (script absent)", () => {
+  let app: FastifyInstance;
+  let db: TestDb;
+  const missingPath = join(tmpdir(), "pct-install-script-does-not-exist.sh");
+
+  afterEach(async () => {
+    await app.close();
+    db.$client.close();
+  });
+
+  it("404s and emits a startup warning", async () => {
+    const lines: Record<string, unknown>[] = [];
+    const stream = {
+      write(msg: string) {
+        lines.push(JSON.parse(msg) as Record<string, unknown>);
+      },
+    };
+    db = testDb();
+    app = buildApp({
+      settings: loadSettings({
+        PCT_LOG_LEVEL: "warn",
+        PCT_INSTALL_CLIENT_SCRIPT_PATH: missingPath,
+      }),
+      loggerStream: stream,
+      db,
+    });
+
+    const res = await app.inject({ method: "GET", url: "/install-client.sh" });
+    expect(res.statusCode).toBe(404);
+
+    const warning = lines.find((l) => l.component === "web/install-script");
+    expect(warning).toBeDefined();
+    expect(warning?.level).toBe(40); // pino "warn"
+    expect(warning?.installClientScriptPath).toBe(missingPath);
+    expect(warning?.msg).toContain("not found");
+  });
+
+  it("does not block startup or affect other routes when absent", async () => {
+    db = testDb();
+    app = buildApp({
+      settings: loadSettings({
+        PCT_LOG_LEVEL: "silent",
+        PCT_INSTALL_CLIENT_SCRIPT_PATH: missingPath,
+      }),
+      db,
+    });
+
+    const health = await app.inject({ method: "GET", url: "/healthz" });
+    expect(health.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

The script existed in the repo and was attached to GitHub Releases, but was never bundled into the Docker image or exposed via an HTTP route — so `curl https://<dashboard>/install-client.sh` returned 404 from a deployed alpha instance.

- **Widen Docker build context** from `server/` to the repo root; prefix all `COPY` paths with `server/` and copy `client/install-client.sh` into the image at `./client-scripts/install-client.sh`
- **Update CI/release workflows** to pass `--file server/Dockerfile` with `.` as the build context (`ci.yml` docker-build job; `release.yml` build-and-push step)
- **Add `installClientScriptPath` to `Settings`** (`PCT_INSTALL_CLIENT_SCRIPT_PATH`, default `/app/client-scripts/install-client.sh`) so dev and tests can override it
- **New `web/install-script.ts`**: registers `GET /install-client.sh`, streams the script with `Content-Type: text/x-shellscript`, warns at startup (and 404s at request time) when the file is absent — same graceful-degradation pattern as `web/frontend.ts`
- **Wire `registerInstallScript`** into `buildApp` alongside `registerFrontend`
- **New `tests/web/install-script.test.ts`**: 5 tests covering script-present (200, correct content type, other routes unaffected) and script-absent (404, startup warning, other routes unaffected) cases

After this lands, a client device can bootstrap with:

```bash
sudo bash <(curl -fsSL https://<dashboard>/install-client.sh) \
    --server-url https://<dashboard> \
    --enrolment-token <token> \
    --supervised-user <username>
```

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (5 new tests in `install-script.test.ts`, all green)
- [ ] Docker image builds with the widened context (`docker buildx build --file server/Dockerfile .`)
- [ ] `GET /install-client.sh` on a deployed container returns 200 with the script content


---
_Generated by [Claude Code](https://claude.ai/code/session_01Maq6PcuFdhRPFzDy2wq1uT)_