### PR TITLE
feat(transport): key policy-push dispatch on Client.platform, not implicit Linux (#232)

### DIFF
--- a/.claude/plans/issue-232-platform-keyed-transport-dispatch.md
+++ b/.claude/plans/issue-232-platform-keyed-transport-dispatch.md
@@ -1,0 +1,73 @@
+# Issue #232 — Key transport-facade per-client dispatch on platform/capability, not `if (linux)`
+
+Roadmap: `docs/roadmap.md` → Phase 4 (SSH + `timekpra` transport).
+Design source: `docs/windows-client-support.md` → "Modularity tweaks to make
+cheaply now" item 6; `Client.platform` column from #229.
+
+## Problem
+
+The live policy-push path (`transport/policy-push`) is the one place that wires
+real **per-client** dispatch today, and it bakes in "every client is Linux":
+`createPolicyPushExecutor` loads the `ClientRow` (which already carries
+`client.platform`, `linux`/`windows`) and then **unconditionally** builds a
+`timekpra`-over-SSH client and pushes. There is no seam where a future
+`WindowsAgentRunner` could be selected.
+
+Item 6 of the Windows design doc asks us to make that seam **now**: route
+per-client dispatch on the client's declared platform, defaulting to the Linux
+runner, so Windows is purely additive.
+
+## Decision
+
+Introduce a small **platform-keyed runner registry** local to `policy-push`.
+The executor becomes a thin, platform-agnostic dispatcher that:
+
+1. parses the payload and runs the existing platform-agnostic no-op branches
+   (`userId === null`, missing client, missing user-client link);
+2. selects a `PlatformPolicyRunner` by `client.platform` from the registry;
+3. if none is registered for that platform -> log a warning and no-op
+   (consistent with the module's existing warn+no-op branches);
+4. otherwise resolves the platform-agnostic enforcement context (tz, schedules,
+   budgets, now) and delegates to `runner.enforce(ctx)`.
+
+Selection is exact-match, not "default to Linux for anything unknown" — pushing
+`timekpra` to a Windows box would be wrong. The registry is seeded with the
+Linux runner; since `Client.platform` defaults to `linux` and is the only
+platform with a runner, every real client today still resolves to Linux —
+behaviour unchanged.
+
+## Shape
+
+- New `platform-runner.ts`: `PolicyEnforcementContext`, `PlatformPolicyRunner`,
+  `PlatformRunnerRegistry`, `createPlatformRunnerRegistry` (throws on duplicate
+  platform).
+- New `linux-runner.ts`: `createLinuxPolicyRunner({ buildClient, log? })` —
+  `platform: "linux"`, `enforce` = the exact body lifted from today's executor
+  (resolvePolicyPush -> timekpr setters -> full-lockout allowed-hours skip). The
+  `PolicyPushClient*` types move/re-export here.
+- `executor.ts`: swap `buildClient` option for `registry`; keep db/defaultTz/
+  log?/now?.
+- `bootstrap.ts`: wrap the existing audited Linux runner in a registry, pass it
+  to the executor. No behavioural change in production.
+
+## Tests (unit only — pure TS, no Docker)
+
+- `platform-runner.test.ts`: resolve registered/unregistered, `platforms`,
+  duplicate-registration throws.
+- `linux-runner.test.ts`: setter sequence, full-lockout skip + warn, error
+  propagation — reusing the existing recording-client fake.
+- `executor.test.ts` (updated): wrap recording client in runner + registry; add
+  an unsupported-platform (windows) -> warn + no-op case; keep all existing
+  no-op/error cases green.
+
+## Out of scope (tracked follow-up)
+
+- Ansible re-apply path (`transport/reapply`) also iterates clients
+  Linux-unconditionally but is not live-wired yet -> file + link a follow-up.
+- No `WindowsAgentRunner` is implemented (seam only).
+
+## License boundary
+
+Unchanged — still exec-over-SSH of `timekpra` (GPL) as a subprocess via the
+existing audited facade. No in-process GPL linkage, no GPL binary, no new
+dependency, no boundary collapsed.

--- a/server/src/transport/policy-push/bootstrap.ts
+++ b/server/src/transport/policy-push/bootstrap.ts
@@ -54,6 +54,8 @@ import { POLICY_PUSH_KIND } from "../queue/policy-push.js";
 import { TimekprClient } from "../timekpr/index.js";
 import { createPolicyPushDispatcher } from "./dispatcher.js";
 import { createPolicyPushExecutor } from "./executor.js";
+import { createLinuxPolicyRunner } from "./linux-runner.js";
+import { createPlatformRunnerRegistry } from "./platform-runner.js";
 
 /**
  * The SSH transport surface the bootstrap needs: the audited-command surface
@@ -161,17 +163,28 @@ export function createPolicyPushTransport(
   const sink = new DrizzleAuditSink(db, log);
   const auditing = new AuditingTransport(ssh, sink);
 
-  const executor = createPolicyPushExecutor({
-    db,
-    defaultTz: settings.defaultTz,
+  // The platform seam (#232): the live executor selects a runner per client by
+  // `Client.platform`. Linux (`timekpra`-over-SSH) is the only registration
+  // today — `Client.platform` defaults to `linux`, so every enrolled client
+  // resolves here; a future `WindowsAgentRunner` is registered beside it without
+  // touching the executor or the call sites.
+  const linuxRunner = createLinuxPolicyRunner({
     log,
-    ...(options.now !== undefined ? { now: options.now } : {}),
     buildClient: ({ client, username, userId, reason }) =>
       new TimekprClient(
         auditing.withContext({ clientId: client.id, userId, reason }),
         targetFromClient(client, credentials),
         username,
       ),
+  });
+  const registry = createPlatformRunnerRegistry([linuxRunner]);
+
+  const executor = createPolicyPushExecutor({
+    db,
+    registry,
+    defaultTz: settings.defaultTz,
+    log,
+    ...(options.now !== undefined ? { now: options.now } : {}),
   });
 
   const dispatcher = createPolicyPushDispatcher({ db, executor, log });

--- a/server/src/transport/policy-push/executor.ts
+++ b/server/src/transport/policy-push/executor.ts
@@ -1,42 +1,49 @@
 /**
- * The live policy-push {@link ActionExecutor} (#201, Phase 4).
+ * The live policy-push {@link ActionExecutor} (#201, Phase 4) — now the
+ * **platform-agnostic dispatcher** in front of the per-platform runners (#232).
  *
  * This is the concrete executor the offline queue (#84) was built against: given
- * one `policy.push` action — the {@link import("../stub.js").PolicyPushCommand}
+ * one `policy.push` action — the {@link import("./platform-runner.js").PolicyEnforcementContext}
  * a CRUD mutation computed, adapted by {@link queuedActionFromPolicyPush} — it
- * recomputes the affected user's effective overall policy for the target client
- * and pushes it over the SSH + `timekpra` transport. `pushOrEnqueue` (the live
- * call site) and `drainClient` (the replay loop) both drive this same executor,
- * so an online push and an offline replay run identical code.
+ * loads the affected `(client, user)` rows, runs the platform-agnostic no-op
+ * branches, then selects the {@link import("./platform-runner.js").PlatformPolicyRunner}
+ * for the client's declared `platform` and delegates the actual enforcement to
+ * it. `pushOrEnqueue` (the live call site) and `drainClient` (the replay loop)
+ * both drive this same executor, so an online push and an offline replay run
+ * identical code.
  *
- * The `timekpra` client is supplied by an injected {@link PolicyPushClientFactory}
- * so this module is unit-testable without SSH and stays decoupled from the
- * concrete transport/credentials/audit wiring (assembled in `./bootstrap.ts`):
- * production builds a real {@link import("../timekpr/client.js").TimekprClient}
- * over the audited SSH facade; a test passes a recording fake.
+ * The platform seam (#232): rather than baking in "every client is Linux", the
+ * runner is chosen by `client.platform` (`Client.platform`, #229) from the
+ * injected {@link PlatformRunnerRegistry}. The Linux runner (`./linux-runner.ts`,
+ * `timekpra`-over-SSH) is the only registration today; a future
+ * `WindowsAgentRunner` is additive. Selection is exact-match — a client whose
+ * platform has no registered runner is a **warn-and-no-op** (a `windows` client
+ * today is known-not-yet-supported, not a command failure to dead-letter), not
+ * silently coerced onto the Linux path. The runner owns *both* the normal push
+ * (`enforce`) and the unlink unmanage push (`unmanage`, #253).
  *
  * **No-op branches** (resolve to nothing to push, never an error):
- * - a **client-scoped** change (`userId === null`): `timekpra` is per-user;
+ * - a **client-scoped** change (`userId === null`): per-user enforcement only;
  * - a **missing client** (deleted before replay);
+ * - a **client on an unsupported platform** (no registered runner);
  * - a **missing `(user, client)` link** that is *not* an explicit unlink — e.g.
  *   a user-scoped edit for a user since unlinked from this client: there is
  *   nothing left to enforce here.
  *
  * **Unmanage branch** (#253): a `link.deleted` action whose `detail` carries the
  * `os_username` the route captured before the link cascaded away. The link row
- * is gone, but the dashboard still owes the client one push — it pushes the
- * fully-{@link unrestrictedPolicyPush unrestricted} config so a now-unlinked
- * account isn't left enforced by whatever limits/allowed-hours were last pushed.
+ * is gone, but the dashboard still owes the client one push — the runner pushes
+ * the fully-unrestricted config (`unmanage`) so a now-unlinked account isn't left
+ * enforced by whatever limits/allowed-hours were last pushed.
  *
- * Errors propagate the SSH taxonomy unchanged so the queue classifies them: an
- * `SshUnreachableError`/timeout (retriable) keeps the action queued for replay;
- * an `SshCommandError`/`TimekprArgumentError` (non-retriable) is surfaced to the
- * caller (online) or dead-lettered (replay). Auditing is automatic — the
- * injected client runs over the {@link import("../audit/transport.js").AuditingTransport}.
+ * Errors from the selected runner propagate unchanged so the queue classifies
+ * them: an `SshUnreachableError`/timeout (retriable) keeps the action queued for
+ * replay; an `SshCommandError`/`TimekprArgumentError` (non-retriable) is
+ * surfaced to the caller (online) or dead-lettered (replay).
  *
  * License boundary: none touched — orchestration over Drizzle + the injected
- * `timekpra` client, which execs over the existing SSH subprocess facade. No GPL
- * code is linked in-process (`CLAUDE.md` → "License boundaries").
+ * platform runner(s); the Linux runner execs over the existing SSH subprocess
+ * facade. No GPL code is linked in-process (`CLAUDE.md` → "License boundaries").
  */
 import { z } from "zod";
 
@@ -47,12 +54,10 @@ import {
   listUserBudgets,
   listUserLinks,
   listUserSchedules,
-  type ClientRow,
 } from "../../policy/repository.js";
-import type { WeeklyAllowedWindows } from "../timekpr/allowed-hours.js";
 import type { ActionExecutor, QueuedAction } from "../queue/types.js";
 import { policyPushPayloadSchema } from "./payload.js";
-import { resolvePolicyPush, unrestrictedPolicyPush, type ResolvedPolicyPush } from "./resolve.js";
+import type { PlatformRunnerRegistry } from "./platform-runner.js";
 
 /** The push reason that marks an explicit user↔client unlink (#253). */
 const LINK_DELETED_REASON = "link.deleted";
@@ -65,40 +70,15 @@ const LINK_DELETED_REASON = "link.deleted";
  */
 const unlinkDetailSchema = z.object({ osUsername: z.string().min(1) });
 
-/**
- * The slice of {@link import("../timekpr/client.js").TimekprClient} the executor
- * drives. Declared structurally so the real client satisfies it and a test can
- * pass a recording fake without an `as` cast — the same pattern as
- * `TimekprTransport`. The setters return the transport's `ExecResult`(s); typed
- * as `unknown` here because the executor only awaits them for ordering/failure.
- */
-export interface PolicyPushClient {
-  setTimeLimits(perDaySeconds: readonly number[]): Promise<unknown>;
-  setTimeLimitWeek(seconds: number): Promise<unknown>;
-  setTimeLimitMonth(seconds: number): Promise<unknown>;
-  setWeeklyAllowedHours(weekly: WeeklyAllowedWindows): Promise<unknown>;
-}
+// The `timekpra` client surface + factory now live with the Linux runner; the
+// re-exports keep `bootstrap.ts` and existing importers' paths unchanged.
+export type {
+  PolicyPushClient,
+  PolicyPushClientFactory,
+  PolicyPushClientTarget,
+} from "./linux-runner.js";
 
-/** Attribution + addressing for the {@link PolicyPushClientFactory}. */
-export interface PolicyPushClientTarget {
-  /** The enrolled client the commands are dispatched to. */
-  readonly client: ClientRow;
-  /** The supervised Linux account `timekpra` acts on (from the user↔client link). */
-  readonly username: string;
-  /** The affected supervised user's id (audit attribution). */
-  readonly userId: number;
-  /** The mutation reason that triggered the push (audit attribution). */
-  readonly reason: string;
-}
-
-/**
- * Builds the {@link PolicyPushClient} for one (client, user) push. Production
- * returns a `TimekprClient` over the audited SSH transport bound to the client's
- * {@link import("../ssh/facade.js").SshTarget}; tests return a recording fake.
- */
-export type PolicyPushClientFactory = (target: PolicyPushClientTarget) => PolicyPushClient;
-
-/** The slice of a logger the executor uses (for the full-lockout skip notice). */
+/** The slice of a logger the executor uses (for the unsupported-platform skip). */
 export interface PolicyPushExecutorLogger {
   warn(obj: object, msg: string): void;
 }
@@ -107,11 +87,11 @@ export interface PolicyPushExecutorLogger {
 export interface PolicyPushExecutorOptions {
   /** The shared policy-store handle the affected rows are read from. */
   readonly db: PolicyDb;
-  /** Builds the `timekpra` client for one push (the SSH/credentials/audit seam). */
-  readonly buildClient: PolicyPushClientFactory;
+  /** Per-platform runners, keyed by `Client.platform`. Linux is the default. */
+  readonly registry: PlatformRunnerRegistry;
   /** Server-default timezone for users with no `tz` override. */
   readonly defaultTz: string;
-  /** Optional logger; records the full-lockout allowed-hours skip (see below). */
+  /** Optional logger; records the unsupported-platform skip (see below). */
   readonly log?: PolicyPushExecutorLogger;
   /** Clock for the reference instant; overridable in tests. Defaults to `new Date()`. */
   readonly now?: () => Date;
@@ -119,50 +99,12 @@ export interface PolicyPushExecutorOptions {
 
 /**
  * Build the live policy-push {@link ActionExecutor}. The returned executor is
- * idempotent (the `timekpra` setters assert desired state, not a delta), as the
+ * idempotent (the runners assert desired state, not a delta), as the
  * at-least-once queue contract requires.
  */
 export function createPolicyPushExecutor(options: PolicyPushExecutorOptions): ActionExecutor {
-  const { db, buildClient, defaultTz, log } = options;
+  const { db, registry, defaultTz, log } = options;
   const now = options.now ?? ((): Date => new Date());
-
-  /**
-   * Drive one {@link ResolvedPolicyPush} through the `timekpra` setters, in
-   * order. Shared by the normal policy push and the unlink unmanage push so both
-   * apply limits identically and idempotently.
-   */
-  async function applyResolvedPush(
-    timekpr: PolicyPushClient,
-    resolved: ResolvedPolicyPush,
-    clientId: number,
-    userId: number,
-  ): Promise<void> {
-    if (resolved.perWeekdaySeconds !== null) {
-      await timekpr.setTimeLimits(resolved.perWeekdaySeconds);
-    }
-    if (resolved.weeklySeconds !== null) {
-      await timekpr.setTimeLimitWeek(resolved.weeklySeconds);
-    }
-    if (resolved.monthlySeconds !== null) {
-      await timekpr.setTimeLimitMonth(resolved.monthlySeconds);
-    }
-
-    // A fully-denied week has no allowed weekday, which `timekpra` allowed-hours
-    // cannot represent (`--setalloweddays` rejects an empty set). Pushing it
-    // would throw a *non-retriable* error and dead-letter the whole action —
-    // silently dropping the limits above too. Full lockout is enforced via a
-    // zero daily limit / session-kill (Phase 8c), not allowed-hours, so skip
-    // the allowed-hours push here and surface the gap rather than failing.
-    // (The unmanage push is all-hours-every-day, so it never takes this branch.)
-    if ([...resolved.weekly.values()].some((windows) => windows.length > 0)) {
-      await timekpr.setWeeklyAllowedHours(resolved.weekly);
-    } else {
-      log?.warn(
-        { clientId, userId },
-        "policy denies all access all week; allowed-hours push skipped (full lockout is Phase 8c: zero daily limit / session-kill, not allowed-hours)",
-      );
-    }
-  }
 
   return async function execute(action: QueuedAction): Promise<void> {
     const { userId, reason, detail } = policyPushPayloadSchema.parse(action.payload);
@@ -174,18 +116,30 @@ export function createPolicyPushExecutor(options: PolicyPushExecutorOptions): Ac
     const client = getClient(db, action.clientId);
     if (client === undefined) return;
 
+    // The platform seam (#232): pick the runner for this client's platform — it
+    // owns both the enforce and unmanage pushes below. No runner registered (a
+    // `windows` client today) → warn + no-op rather than pushing the Linux
+    // `timekpra` path to a non-Linux box.
+    const runner = registry.resolve(client.platform);
+    if (runner === undefined) {
+      log?.warn(
+        { clientId: action.clientId, userId, platform: client.platform },
+        "no transport runner registered for client platform; policy push skipped (Linux is the only supported platform today, #232)",
+      );
+      return;
+    }
+
     // Resolve the supervised account on this client.
     const link = listUserLinks(db, userId).find((l) => l.clientId === action.clientId);
     if (link === undefined) {
       // The link is gone. An explicit unlink (`link.deleted`) still owes the
-      // client one *unmanage* push: lift this user's timekpra limits back to
-      // unrestricted, using the username the route captured before the row
-      // cascaded away (#253). Any other missing-link case has nothing to do.
+      // client one *unmanage* push: lift this user's limits back to unrestricted,
+      // using the username the route captured before the row cascaded away
+      // (#253). Any other missing-link case has nothing to do.
       if (reason !== LINK_DELETED_REASON) return;
       const unlink = unlinkDetailSchema.safeParse(detail);
       if (!unlink.success) return;
-      const timekpr = buildClient({ client, username: unlink.data.osUsername, userId, reason });
-      await applyResolvedPush(timekpr, unrestrictedPolicyPush(), action.clientId, userId);
+      await runner.unmanage({ client, username: unlink.data.osUsername, userId, reason });
       return;
     }
 
@@ -197,10 +151,15 @@ export function createPolicyPushExecutor(options: PolicyPushExecutorOptions): Ac
     const budgets = listUserBudgets(db, userId);
     const schedules = listUserSchedules(db, userId);
 
-    const resolved = resolvePolicyPush({ tz, schedules, budgets, now: now() });
-
-    const timekpr = buildClient({ client, username: link.osUsername, userId, reason });
-
-    await applyResolvedPush(timekpr, resolved, action.clientId, userId);
+    await runner.enforce({
+      client,
+      username: link.osUsername,
+      userId,
+      reason,
+      tz,
+      schedules,
+      budgets,
+      now: now(),
+    });
   };
 }

--- a/server/src/transport/policy-push/index.ts
+++ b/server/src/transport/policy-push/index.ts
@@ -3,8 +3,11 @@
  * stub (`../stub.ts`) to a real `timekpra`-over-SSH dispatch.
  *
  * Layering: {@link ./resolve.js} (pure policy → `timekpra` inputs) ←
- * {@link ./executor.js} (the offline-queue {@link import("../queue/types.js").ActionExecutor},
- * shared by the online push and the replay loop) ← {@link ./dispatcher.js} (the
+ * {@link ./linux-runner.js} (the Linux {@link import("./platform-runner.js").PlatformPolicyRunner},
+ * `timekpra`-over-SSH) ← {@link ./executor.js} (the offline-queue
+ * {@link import("../queue/types.js").ActionExecutor} that selects a runner per
+ * client by `Client.platform` via {@link ./platform-runner.js}, shared by the
+ * online push and the replay loop) ← {@link ./dispatcher.js} (the
  * {@link import("../stub.js").PolicyPushStub} the CRUD routes call, over
  * `pushOrEnqueue`). {@link ./bootstrap.js} assembles them with the SSH facade,
  * the audit log (#85), and the drainer (#84) — or the logging fallback when no
@@ -29,12 +32,23 @@ export {
 } from "./diff.js";
 export {
   createPolicyPushExecutor,
-  type PolicyPushClient,
-  type PolicyPushClientFactory,
-  type PolicyPushClientTarget,
   type PolicyPushExecutorLogger,
   type PolicyPushExecutorOptions,
 } from "./executor.js";
+export {
+  createPlatformRunnerRegistry,
+  type PlatformPolicyRunner,
+  type PlatformRunnerRegistry,
+  type PolicyEnforcementContext,
+} from "./platform-runner.js";
+export {
+  createLinuxPolicyRunner,
+  type LinuxPolicyRunnerOptions,
+  type PolicyPushClient,
+  type PolicyPushClientFactory,
+  type PolicyPushClientTarget,
+  type PolicyPushRunnerLogger,
+} from "./linux-runner.js";
 export {
   createPolicyPushDispatcher,
   POLICY_PUSH_COMPONENT,

--- a/server/src/transport/policy-push/linux-runner.ts
+++ b/server/src/transport/policy-push/linux-runner.ts
@@ -1,0 +1,152 @@
+/**
+ * The Linux {@link PlatformPolicyRunner} (#232) — the `timekpra`-over-SSH
+ * enforcement that *was* the body of {@link import("./executor.js")} before the
+ * platform seam was extracted. It is the default (and today only) registration
+ * in the {@link import("./platform-runner.js").PlatformRunnerRegistry}; the
+ * executor selects it for every `platform: "linux"` client (the schema default,
+ * so every real client today).
+ *
+ * Given the platform-agnostic {@link PolicyEnforcementContext} the executor
+ * resolved, it recomputes the user's effective overall `timekpra` inputs
+ * ({@link resolvePolicyPush}) and drives the setters. The `timekpra` client is
+ * supplied by an injected {@link PolicyPushClientFactory} so this module is
+ * unit-testable without SSH and stays decoupled from the concrete
+ * transport/credentials/audit wiring (assembled in `./bootstrap.ts`).
+ *
+ * Errors propagate the SSH taxonomy unchanged so the offline queue classifies
+ * them (retriable → keep queued; non-retriable → dead-letter), exactly as
+ * before the extraction.
+ *
+ * License boundary: none touched — orchestration over Drizzle + the injected
+ * `timekpra` client, which execs over the existing SSH subprocess facade. No GPL
+ * code is linked in-process (`CLAUDE.md` → "License boundaries").
+ */
+import type { ClientRow } from "../../policy/repository.js";
+import type { WeeklyAllowedWindows } from "../timekpr/allowed-hours.js";
+import type {
+  PlatformPolicyRunner,
+  PolicyEnforcementContext,
+  PolicyUnmanageContext,
+} from "./platform-runner.js";
+import { resolvePolicyPush, unrestrictedPolicyPush, type ResolvedPolicyPush } from "./resolve.js";
+
+/**
+ * The slice of {@link import("../timekpr/client.js").TimekprClient} the Linux
+ * runner drives. Declared structurally so the real client satisfies it and a
+ * test can pass a recording fake without an `as` cast. The setters return the
+ * transport's `ExecResult`(s); typed as `unknown` here because the runner only
+ * awaits them for ordering/failure.
+ */
+export interface PolicyPushClient {
+  setTimeLimits(perDaySeconds: readonly number[]): Promise<unknown>;
+  setTimeLimitWeek(seconds: number): Promise<unknown>;
+  setTimeLimitMonth(seconds: number): Promise<unknown>;
+  setWeeklyAllowedHours(weekly: WeeklyAllowedWindows): Promise<unknown>;
+}
+
+/** Attribution + addressing for the {@link PolicyPushClientFactory}. */
+export interface PolicyPushClientTarget {
+  /** The enrolled client the commands are dispatched to. */
+  readonly client: ClientRow;
+  /** The supervised Linux account `timekpra` acts on (from the user↔client link). */
+  readonly username: string;
+  /** The affected supervised user's id (audit attribution). */
+  readonly userId: number;
+  /** The mutation reason that triggered the push (audit attribution). */
+  readonly reason: string;
+}
+
+/**
+ * Builds the {@link PolicyPushClient} for one (client, user) push. Production
+ * returns a `TimekprClient` over the audited SSH transport bound to the client's
+ * {@link import("../ssh/facade.js").SshTarget}; tests return a recording fake.
+ */
+export type PolicyPushClientFactory = (target: PolicyPushClientTarget) => PolicyPushClient;
+
+/** The slice of a logger the Linux runner uses (for the full-lockout skip notice). */
+export interface PolicyPushRunnerLogger {
+  warn(obj: object, msg: string): void;
+}
+
+/** Construction options for {@link createLinuxPolicyRunner}. */
+export interface LinuxPolicyRunnerOptions {
+  /** Builds the `timekpra` client for one push (the SSH/credentials/audit seam). */
+  readonly buildClient: PolicyPushClientFactory;
+  /** Optional logger; records the full-lockout allowed-hours skip (see below). */
+  readonly log?: PolicyPushRunnerLogger;
+}
+
+/**
+ * Build the Linux {@link PlatformPolicyRunner}. Idempotent (the `timekpra`
+ * setters assert desired state, not a delta), as the at-least-once queue
+ * contract requires.
+ */
+export function createLinuxPolicyRunner(options: LinuxPolicyRunnerOptions): PlatformPolicyRunner {
+  const { buildClient, log } = options;
+
+  /**
+   * Drive one {@link ResolvedPolicyPush} through the `timekpra` setters, in
+   * order. Shared by the normal `enforce` push and the `unmanage` unlink push so
+   * both apply limits identically and idempotently.
+   */
+  async function applyResolvedPush(
+    timekpr: PolicyPushClient,
+    resolved: ResolvedPolicyPush,
+    clientId: number,
+    userId: number,
+  ): Promise<void> {
+    if (resolved.perWeekdaySeconds !== null) {
+      await timekpr.setTimeLimits(resolved.perWeekdaySeconds);
+    }
+    if (resolved.weeklySeconds !== null) {
+      await timekpr.setTimeLimitWeek(resolved.weeklySeconds);
+    }
+    if (resolved.monthlySeconds !== null) {
+      await timekpr.setTimeLimitMonth(resolved.monthlySeconds);
+    }
+
+    // A fully-denied week has no allowed weekday, which `timekpra` allowed-hours
+    // cannot represent (`--setalloweddays` rejects an empty set). Pushing it
+    // would throw a *non-retriable* error and dead-letter the whole action —
+    // silently dropping the limits above too. Full lockout is enforced via a
+    // zero daily limit / session-kill (Phase 8c), not allowed-hours, so skip
+    // the allowed-hours push here and surface the gap rather than failing.
+    // (The unmanage push is all-hours-every-day, so it never takes this branch.)
+    if ([...resolved.weekly.values()].some((windows) => windows.length > 0)) {
+      await timekpr.setWeeklyAllowedHours(resolved.weekly);
+    } else {
+      log?.warn(
+        { clientId, userId },
+        "policy denies all access all week; allowed-hours push skipped (full lockout is Phase 8c: zero daily limit / session-kill, not allowed-hours)",
+      );
+    }
+  }
+
+  return {
+    platform: "linux",
+    async enforce(ctx: PolicyEnforcementContext): Promise<void> {
+      const resolved = resolvePolicyPush({
+        tz: ctx.tz,
+        schedules: ctx.schedules,
+        budgets: ctx.budgets,
+        now: ctx.now,
+      });
+      const timekpr = buildClient({
+        client: ctx.client,
+        username: ctx.username,
+        userId: ctx.userId,
+        reason: ctx.reason,
+      });
+      await applyResolvedPush(timekpr, resolved, ctx.client.id, ctx.userId);
+    },
+    async unmanage(ctx: PolicyUnmanageContext): Promise<void> {
+      const timekpr = buildClient({
+        client: ctx.client,
+        username: ctx.username,
+        userId: ctx.userId,
+        reason: ctx.reason,
+      });
+      await applyResolvedPush(timekpr, unrestrictedPolicyPush(), ctx.client.id, ctx.userId);
+    },
+  };
+}

--- a/server/src/transport/policy-push/platform-runner.ts
+++ b/server/src/transport/policy-push/platform-runner.ts
@@ -1,0 +1,114 @@
+/**
+ * The platform-keyed runner seam for live policy push (#232).
+ *
+ * The dashboard supervises a fleet of clients that are *Linux today* but need
+ * not be forever (`docs/windows-client-support.md` → "Modularity tweaks to make
+ * cheaply now", item 6; `Client.platform` from #229). This module is the seam
+ * that keeps the per-client dispatch from baking in "every client is Linux":
+ * the {@link import("./executor.js").createPolicyPushExecutor live executor}
+ * resolves a platform-agnostic {@link PolicyEnforcementContext} for one push and
+ * then delegates to the {@link PlatformPolicyRunner} registered for that
+ * client's {@link import("../../policy/enums.js").Platform}. The Linux runner
+ * (`./linux-runner.ts`, `timekpra`-over-SSH) is the only registration today; a
+ * future `WindowsAgentRunner` is purely additive — register it beside the Linux
+ * runner and no call site changes.
+ *
+ * Selection is **exact-match**, not "default to Linux for anything unknown": the
+ * point of the seam is to stop treating every client as Linux, so pushing
+ * `timekpra` to a non-Linux box would be the very bug this prevents. A client
+ * whose platform has no registered runner is handled by the executor as a
+ * warn-and-no-op (see there), not silently coerced onto the Linux path.
+ *
+ * License boundary: none touched — this is a pure in-process dispatch table over
+ * the existing runner(s); the Linux runner still execs `timekpra` over the SSH
+ * subprocess facade. No GPL code is linked in-process (`CLAUDE.md` → "License
+ * boundaries").
+ */
+import type { Platform } from "../../policy/enums.js";
+import type { BudgetRow, ClientRow, ScheduleRow } from "../../policy/repository.js";
+
+/**
+ * The platform-agnostic inputs for one `(client, user)` policy push, resolved by
+ * the executor before it picks a runner. A {@link PlatformPolicyRunner} turns
+ * this into platform-specific enforcement (the Linux runner resolves it to the
+ * `timekpra` limits/allowed-hours and pushes over SSH).
+ */
+export interface PolicyEnforcementContext {
+  /** The enrolled client the push targets (carries `platform`, addressing). */
+  readonly client: ClientRow;
+  /** The supervised OS account to act on (from the user↔client link). */
+  readonly username: string;
+  /** The affected supervised user's id (audit attribution). */
+  readonly userId: number;
+  /** The mutation reason that triggered the push (audit attribution). */
+  readonly reason: string;
+  /** The user's effective timezone (`User.tz ?? PCT_DEFAULT_TZ`). */
+  readonly tz: string;
+  /** The user's schedule rules (precedence order applied downstream). */
+  readonly schedules: readonly ScheduleRow[];
+  /** The user's budgets (overall + per-activity). */
+  readonly budgets: readonly BudgetRow[];
+  /** The reference instant the week and "today" are resolved against. */
+  readonly now: Date;
+}
+
+/**
+ * The inputs to *unmanage* one supervised account on a client (#253): lift its
+ * enforcement back to unrestricted after the user↔client link was deleted. There
+ * are no policy rows to resolve (the link is gone) — just the account to address
+ * and the audit attribution; the runner pushes a fixed unrestricted config.
+ */
+export interface PolicyUnmanageContext {
+  /** The enrolled client the unmanage push targets. */
+  readonly client: ClientRow;
+  /** The OS account to lift limits from (captured before the link cascaded away). */
+  readonly username: string;
+  /** The affected supervised user's id (audit attribution). */
+  readonly userId: number;
+  /** The mutation reason that triggered the push (audit attribution). */
+  readonly reason: string;
+}
+
+/**
+ * Enforces an effective policy on one client of a given platform. The executor
+ * holds the platform-agnostic plumbing (load rows, run the no-op branches, pick
+ * the runner); each runner owns the platform-specific translation + push, for
+ * both the normal push (`enforce`) and the unlink unmanage push (`unmanage`).
+ */
+export interface PlatformPolicyRunner {
+  /** The {@link Platform} this runner enforces (its registry key). */
+  readonly platform: Platform;
+  /** Push the resolved effective policy to the client. */
+  enforce(ctx: PolicyEnforcementContext): Promise<void>;
+  /** Lift the account's enforcement back to unrestricted after an unlink (#253). */
+  unmanage(ctx: PolicyUnmanageContext): Promise<void>;
+}
+
+/** A read-only lookup from {@link Platform} to its {@link PlatformPolicyRunner}. */
+export interface PlatformRunnerRegistry {
+  /** The runner for `platform`, or `undefined` when none is registered. */
+  resolve(platform: Platform): PlatformPolicyRunner | undefined;
+  /** The platforms that have a registered runner (for diagnostics/tests). */
+  readonly platforms: readonly Platform[];
+}
+
+/**
+ * Build a {@link PlatformRunnerRegistry} from a set of runners. Throws on a
+ * duplicate platform registration — two runners claiming the same platform is a
+ * wiring bug (which would silently win is undefined), not a recoverable state.
+ */
+export function createPlatformRunnerRegistry(
+  runners: readonly PlatformPolicyRunner[],
+): PlatformRunnerRegistry {
+  const byPlatform = new Map<Platform, PlatformPolicyRunner>();
+  for (const runner of runners) {
+    if (byPlatform.has(runner.platform)) {
+      throw new Error(`duplicate transport runner registered for platform "${runner.platform}"`);
+    }
+    byPlatform.set(runner.platform, runner);
+  }
+  return {
+    resolve: (platform) => byPlatform.get(platform),
+    platforms: [...byPlatform.keys()],
+  };
+}

--- a/server/tests/transport/policy-push/executor.test.ts
+++ b/server/tests/transport/policy-push/executor.test.ts
@@ -1,8 +1,13 @@
 /**
- * Unit tests for the live policy-push executor (#201): resolving a user's
- * effective overall policy from the store and driving the `timekpra` setters,
- * the no-op branches (client-scoped / missing client / missing link), and the
- * error propagation the offline queue classifies on.
+ * Unit tests for the live policy-push executor (#201, #232): the
+ * platform-agnostic dispatch in front of the per-platform runners —
+ * the no-op branches (client-scoped / missing client / missing link /
+ * unsupported platform), runner selection by `Client.platform`, payload
+ * validation, and the error propagation the offline queue classifies on.
+ *
+ * The Linux runner's enforcement detail (the `timekpra` setter sequence and the
+ * full-lockout skip) is exercised here through the real runner and also in
+ * isolation in `linux-runner.test.ts`; the registry in `platform-runner.test.ts`.
  */
 import { describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
@@ -14,12 +19,20 @@ import {
   createUser,
   upsertLink,
 } from "../../../src/policy/repository.js";
+import { clients } from "../../../src/policy/schema.js";
 import {
   createPolicyPushExecutor,
-  type PolicyPushClient,
-  type PolicyPushClientTarget,
+  type PolicyPushExecutorLogger,
 } from "../../../src/transport/policy-push/executor.js";
-import type { QueuedAction } from "../../../src/transport/queue/types.js";
+import {
+  createLinuxPolicyRunner,
+  type PolicyPushClient,
+  type PolicyPushClientFactory,
+  type PolicyPushClientTarget,
+  type PolicyPushRunnerLogger,
+} from "../../../src/transport/policy-push/linux-runner.js";
+import { createPlatformRunnerRegistry } from "../../../src/transport/policy-push/platform-runner.js";
+import type { ActionExecutor, QueuedAction } from "../../../src/transport/queue/types.js";
 import { SshCommandError, SshUnreachableError } from "../../../src/transport/ssh/errors.js";
 import { testDb, type TestDb } from "../../helpers/db.js";
 
@@ -59,6 +72,31 @@ function recordingClient(behaviour?: { rejectWith?: Error }): RecordedClient {
     },
   };
   return rec;
+}
+
+/**
+ * Build the executor wired with a Linux-only registry — the production default.
+ * `runnerLog` is the Linux runner's logger (the full-lockout skip notice);
+ * `executorLog` is the dispatcher's logger (the unsupported-platform skip).
+ */
+function linuxExecutor(args: {
+  db: TestDb;
+  defaultTz: string;
+  buildClient: PolicyPushClientFactory;
+  runnerLog?: PolicyPushRunnerLogger;
+  executorLog?: PolicyPushExecutorLogger;
+}): ActionExecutor {
+  const runner = createLinuxPolicyRunner({
+    buildClient: args.buildClient,
+    ...(args.runnerLog !== undefined ? { log: args.runnerLog } : {}),
+  });
+  const registry = createPlatformRunnerRegistry([runner]);
+  return createPolicyPushExecutor({
+    db: args.db,
+    defaultTz: args.defaultTz,
+    registry,
+    ...(args.executorLog !== undefined ? { log: args.executorLog } : {}),
+  });
 }
 
 /** A user-scoped `policy.push` action targeting `clientId` for `userId`. */
@@ -105,7 +143,7 @@ describe("createPolicyPushExecutor", () => {
     createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 7200 });
 
     const rec = recordingClient();
-    const executor = createPolicyPushExecutor({
+    const executor = linuxExecutor({
       db,
       defaultTz: "UTC",
       buildClient: (t) => {
@@ -130,11 +168,7 @@ describe("createPolicyPushExecutor", () => {
     createBudget(db, { userId, scope: "overall", window: "monthly", secondsAllowed: 100000 });
 
     const rec = recordingClient();
-    const executor = createPolicyPushExecutor({
-      db,
-      defaultTz: "UTC",
-      buildClient: () => rec.client,
-    });
+    const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: () => rec.client });
 
     await executor(action(clientId, userId));
 
@@ -149,11 +183,7 @@ describe("createPolicyPushExecutor", () => {
   it("still pushes the allowed-hours grid for a user with no budgets", async () => {
     const { userId, clientId } = setup();
     const rec = recordingClient();
-    const executor = createPolicyPushExecutor({
-      db,
-      defaultTz: "UTC",
-      buildClient: () => rec.client,
-    });
+    const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: () => rec.client });
 
     await executor(action(clientId, userId));
 
@@ -168,10 +198,10 @@ describe("createPolicyPushExecutor", () => {
 
     const rec = recordingClient();
     const warn = vi.fn();
-    const executor = createPolicyPushExecutor({
+    const executor = linuxExecutor({
       db,
       defaultTz: "UTC",
-      log: { warn },
+      runnerLog: { warn },
       buildClient: () => rec.client,
     });
 
@@ -197,7 +227,7 @@ describe("createPolicyPushExecutor", () => {
     });
 
     const rec = recordingClient();
-    const executor = createPolicyPushExecutor({
+    const executor = linuxExecutor({
       db,
       defaultTz: "America/New_York",
       buildClient: () => rec.client,
@@ -211,7 +241,7 @@ describe("createPolicyPushExecutor", () => {
   it("is a no-op for a client-scoped change (null user)", async () => {
     const { clientId } = setup();
     const build = vi.fn();
-    const executor = createPolicyPushExecutor({ db, defaultTz: "UTC", buildClient: build });
+    const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: build });
 
     await executor(action(clientId, null));
     expect(build).not.toHaveBeenCalled();
@@ -220,7 +250,7 @@ describe("createPolicyPushExecutor", () => {
   it("is a no-op when the client no longer exists", async () => {
     const { userId } = setup();
     const build = vi.fn();
-    const executor = createPolicyPushExecutor({ db, defaultTz: "UTC", buildClient: build });
+    const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: build });
 
     await executor(action(9999, userId));
     expect(build).not.toHaveBeenCalled();
@@ -230,7 +260,7 @@ describe("createPolicyPushExecutor", () => {
     const { userId, clientId } = setup();
     const otherClientId = createClient(db, { hostname: "mint-09", sshUser: "pct-agent" }).id;
     const build = vi.fn();
-    const executor = createPolicyPushExecutor({ db, defaultTz: "UTC", buildClient: build });
+    const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: build });
 
     // The user is linked to `clientId`, not `otherClientId`.
     expect(otherClientId).not.toBe(clientId);
@@ -250,7 +280,7 @@ describe("createPolicyPushExecutor", () => {
     it("pushes the fully-unrestricted config when a link is deleted", async () => {
       const { userId, clientId } = unlinkedSetup();
       const rec = recordingClient();
-      const executor = createPolicyPushExecutor({
+      const executor = linuxExecutor({
         db,
         defaultTz: "UTC",
         buildClient: (t) => {
@@ -282,7 +312,7 @@ describe("createPolicyPushExecutor", () => {
       createSchedule(db, { userId, targetKind: "overall", action: "deny" });
 
       const rec = recordingClient();
-      const executor = createPolicyPushExecutor({
+      const executor = linuxExecutor({
         db,
         defaultTz: "UTC",
         buildClient: () => rec.client,
@@ -301,7 +331,7 @@ describe("createPolicyPushExecutor", () => {
     it("is a no-op when the link.deleted detail carries no usable username", async () => {
       const { userId, clientId } = unlinkedSetup();
       const build = vi.fn();
-      const executor = createPolicyPushExecutor({ db, defaultTz: "UTC", buildClient: build });
+      const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: build });
 
       await executor(unlinkAction(clientId, userId, {}));
       await executor(unlinkAction(clientId, userId, { osUsername: "" }));
@@ -311,7 +341,7 @@ describe("createPolicyPushExecutor", () => {
     it("does not unmanage a non-link.deleted reason for an unlinked user", async () => {
       const { userId, clientId } = unlinkedSetup();
       const build = vi.fn();
-      const executor = createPolicyPushExecutor({ db, defaultTz: "UTC", buildClient: build });
+      const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: build });
 
       // Same missing-link state, but a user-scoped edit reason — nothing to do.
       await executor({
@@ -326,22 +356,47 @@ describe("createPolicyPushExecutor", () => {
     it("is a no-op when the client no longer exists, even for a link.deleted", async () => {
       const { userId } = unlinkedSetup();
       const build = vi.fn();
-      const executor = createPolicyPushExecutor({ db, defaultTz: "UTC", buildClient: build });
+      const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: build });
 
       await executor(unlinkAction(9999, userId));
       expect(build).not.toHaveBeenCalled();
     });
   });
 
+  it("warns and no-ops for a client on a platform with no registered runner (#232)", async () => {
+    const { userId } = setup();
+    // A `windows` client: the Linux-only registry has no runner for it, so the
+    // dispatcher must skip rather than push the `timekpra` path to a non-Linux box.
+    const winClientId = db
+      .insert(clients)
+      .values({ hostname: "win-01", sshUser: "pct-agent", platform: "windows" })
+      .returning()
+      .get().id;
+    upsertLink(db, userId, winClientId, { osUsername: "alice", osUserRef: "1001" });
+    createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 7200 });
+
+    const build = vi.fn();
+    const warn = vi.fn();
+    const executor = linuxExecutor({
+      db,
+      defaultTz: "UTC",
+      buildClient: build,
+      executorLog: { warn },
+    });
+
+    // Resolves without throwing (not a command failure → not dead-lettered)…
+    await executor(action(winClientId, userId));
+    // …no Linux client is ever built, and the skip is surfaced once.
+    expect(build).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatchObject({ platform: "windows", userId });
+  });
+
   it("propagates a retriable (unreachable) failure for the queue to keep", async () => {
     const { userId, clientId } = setup();
     createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 7200 });
     const rec = recordingClient({ rejectWith: new SshUnreachableError(target) });
-    const executor = createPolicyPushExecutor({
-      db,
-      defaultTz: "UTC",
-      buildClient: () => rec.client,
-    });
+    const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: () => rec.client });
 
     await expect(executor(action(clientId, userId))).rejects.toBeInstanceOf(SshUnreachableError);
   });
@@ -357,18 +412,14 @@ describe("createPolicyPushExecutor", () => {
         signal: null,
       }),
     });
-    const executor = createPolicyPushExecutor({
-      db,
-      defaultTz: "UTC",
-      buildClient: () => rec.client,
-    });
+    const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: () => rec.client });
 
     await expect(executor(action(clientId, userId))).rejects.toBeInstanceOf(SshCommandError);
   });
 
   it("rejects a malformed queue payload rather than mis-pushing", async () => {
     const { clientId } = setup();
-    const executor = createPolicyPushExecutor({
+    const executor = linuxExecutor({
       db,
       defaultTz: "UTC",
       buildClient: () => recordingClient().client,

--- a/server/tests/transport/policy-push/linux-runner.test.ts
+++ b/server/tests/transport/policy-push/linux-runner.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for the Linux {@link PlatformPolicyRunner} (#232) in isolation: the
+ * `timekpra`-over-SSH enforcement lifted out of the executor. The runner is
+ * driven directly with a hand-resolved {@link PolicyEnforcementContext} — it
+ * touches no DB itself, which is the seam's point — covering the setter
+ * sequence, the full-lockout allowed-hours skip + warn, and error propagation.
+ *
+ * Dispatch (runner *selection* by platform, the no-op branches) lives in
+ * `executor.test.ts`; the registry in `platform-runner.test.ts`.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createBudget,
+  createClient,
+  createSchedule,
+  createUser,
+  getClient,
+  listUserBudgets,
+  listUserSchedules,
+  type ClientRow,
+} from "../../../src/policy/repository.js";
+import {
+  createLinuxPolicyRunner,
+  type PolicyPushClient,
+} from "../../../src/transport/policy-push/linux-runner.js";
+import type { PolicyEnforcementContext } from "../../../src/transport/policy-push/platform-runner.js";
+import { SshCommandError, SshUnreachableError } from "../../../src/transport/ssh/errors.js";
+import { testDb, type TestDb } from "../../helpers/db.js";
+
+const target = { host: "mint-01", port: 22, username: "pct-agent" } as const;
+
+/** A recording `PolicyPushClient` capturing the setter calls in order. */
+function recordingClient(behaviour?: { rejectWith?: Error }): {
+  client: PolicyPushClient;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const maybeReject = async (): Promise<void> => {
+    if (behaviour?.rejectWith) throw behaviour.rejectWith;
+  };
+  return {
+    calls,
+    client: {
+      async setTimeLimits(perDay) {
+        calls.push(`setTimeLimits:${perDay.join(",")}`);
+        await maybeReject();
+      },
+      async setTimeLimitWeek(seconds) {
+        calls.push(`setTimeLimitWeek:${seconds}`);
+        await maybeReject();
+      },
+      async setTimeLimitMonth(seconds) {
+        calls.push(`setTimeLimitMonth:${seconds}`);
+        await maybeReject();
+      },
+      async setWeeklyAllowedHours(weekly) {
+        calls.push(`setWeeklyAllowedHours:${weekly.size}`);
+        await maybeReject();
+      },
+    },
+  };
+}
+
+/** Build a resolved enforcement context for `userId` from the store rows. */
+function contextFor(db: TestDb, userId: number, client: ClientRow): PolicyEnforcementContext {
+  return {
+    client,
+    username: "alice",
+    userId,
+    reason: "budget.updated",
+    tz: "UTC",
+    schedules: listUserSchedules(db, userId),
+    budgets: listUserBudgets(db, userId),
+    now: new Date("2026-06-24T12:00:00Z"),
+  };
+}
+
+describe("createLinuxPolicyRunner", () => {
+  let db: TestDb;
+
+  function setup(): { userId: number; client: ClientRow } {
+    db = testDb();
+    const userId = createUser(db, { displayName: "Alice", tz: "UTC" }).id;
+    const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+    const client = getClient(db, clientId);
+    if (client === undefined) throw new Error("client not created");
+    return { userId, client };
+  }
+
+  it("reports the linux platform", () => {
+    const runner = createLinuxPolicyRunner({ buildClient: () => recordingClient().client });
+    expect(runner.platform).toBe("linux");
+  });
+
+  it("drives the daily limit and allowed-hours setters from the resolved context", async () => {
+    const { userId, client } = setup();
+    createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 7200 });
+
+    const rec = recordingClient();
+    let builtFor: string | undefined;
+    const runner = createLinuxPolicyRunner({
+      buildClient: (t) => {
+        builtFor = t.username;
+        return rec.client;
+      },
+    });
+
+    await runner.enforce(contextFor(db, userId, client));
+
+    expect(builtFor).toBe("alice");
+    expect(rec.calls).toEqual([
+      "setTimeLimits:7200,7200,7200,7200,7200,7200,7200",
+      "setWeeklyAllowedHours:7",
+    ]);
+  });
+
+  it("unmanage pushes the fully-unrestricted config, ignoring any stale rows (#253)", async () => {
+    const { userId, client } = setup();
+    // Leftover policy rows must not shape the unmanage push — it is always the
+    // fixed unrestricted config (all-hours-every-day, so allowed-hours is sent).
+    createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 3600 });
+    createSchedule(db, { userId, targetKind: "overall", action: "deny" });
+
+    const rec = recordingClient();
+    let builtFor: string | undefined;
+    const runner = createLinuxPolicyRunner({
+      buildClient: (t) => {
+        builtFor = t.username;
+        return rec.client;
+      },
+    });
+
+    await runner.unmanage({ client, username: "alice", userId, reason: "link.deleted" });
+
+    expect(builtFor).toBe("alice");
+    expect(rec.calls).toEqual([
+      "setTimeLimits:86400,86400,86400,86400,86400,86400,86400",
+      "setTimeLimitWeek:604800",
+      "setTimeLimitMonth:2678400",
+      "setWeeklyAllowedHours:7",
+    ]);
+  });
+
+  it("skips the allowed-hours push and warns for a fully-denied week", async () => {
+    const { userId, client } = setup();
+    createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 3600 });
+    createSchedule(db, { userId, targetKind: "overall", action: "deny" });
+
+    const rec = recordingClient();
+    const warn = vi.fn();
+    const runner = createLinuxPolicyRunner({ buildClient: () => rec.client, log: { warn } });
+
+    await runner.enforce(contextFor(db, userId, client));
+
+    expect(rec.calls).toEqual(["setTimeLimits:3600,3600,3600,3600,3600,3600,3600"]);
+    expect(rec.calls).not.toContain("setWeeklyAllowedHours:7");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatchObject({ clientId: client.id, userId });
+  });
+
+  it("propagates a retriable failure unchanged", async () => {
+    const { userId, client } = setup();
+    createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 7200 });
+    const rec = recordingClient({ rejectWith: new SshUnreachableError(target) });
+    const runner = createLinuxPolicyRunner({ buildClient: () => rec.client });
+
+    await expect(runner.enforce(contextFor(db, userId, client))).rejects.toBeInstanceOf(
+      SshUnreachableError,
+    );
+  });
+
+  it("propagates a non-retriable command failure unchanged", async () => {
+    const { userId, client } = setup();
+    createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 7200 });
+    const rec = recordingClient({
+      rejectWith: new SshCommandError(target, ["timekpra"], {
+        stdout: "",
+        stderr: "boom",
+        code: 1,
+        signal: null,
+      }),
+    });
+    const runner = createLinuxPolicyRunner({ buildClient: () => rec.client });
+
+    await expect(runner.enforce(contextFor(db, userId, client))).rejects.toBeInstanceOf(
+      SshCommandError,
+    );
+  });
+});

--- a/server/tests/transport/policy-push/platform-runner.test.ts
+++ b/server/tests/transport/policy-push/platform-runner.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the platform-keyed runner registry (#232): the dispatch table
+ * the live executor uses to pick a {@link PlatformPolicyRunner} by
+ * `Client.platform`. Exact-match lookup, registration listing, and the
+ * duplicate-registration guard.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createPlatformRunnerRegistry,
+  type PlatformPolicyRunner,
+} from "../../../src/transport/policy-push/platform-runner.js";
+
+/** A do-nothing runner for a given platform (the registry never calls its methods). */
+function stubRunner(platform: PlatformPolicyRunner["platform"]): PlatformPolicyRunner {
+  return {
+    platform,
+    enforce: async (): Promise<void> => undefined,
+    unmanage: async (): Promise<void> => undefined,
+  };
+}
+
+describe("createPlatformRunnerRegistry", () => {
+  it("resolves a registered platform to its runner", () => {
+    const linux = stubRunner("linux");
+    const registry = createPlatformRunnerRegistry([linux]);
+
+    expect(registry.resolve("linux")).toBe(linux);
+  });
+
+  it("returns undefined for a platform with no registered runner", () => {
+    const registry = createPlatformRunnerRegistry([stubRunner("linux")]);
+
+    // `windows` is a valid `Client.platform` value with no runner today.
+    expect(registry.resolve("windows")).toBeUndefined();
+  });
+
+  it("lists the registered platforms", () => {
+    const registry = createPlatformRunnerRegistry([stubRunner("linux"), stubRunner("windows")]);
+
+    expect([...registry.platforms].sort()).toEqual(["linux", "windows"]);
+    expect(registry.resolve("windows")).toBeDefined();
+  });
+
+  it("is empty when constructed with no runners", () => {
+    const registry = createPlatformRunnerRegistry([]);
+
+    expect(registry.platforms).toEqual([]);
+    expect(registry.resolve("linux")).toBeUndefined();
+  });
+
+  it("throws on a duplicate platform registration (a wiring bug)", () => {
+    expect(() => createPlatformRunnerRegistry([stubRunner("linux"), stubRunner("linux")])).toThrow(
+      /duplicate transport runner.*linux/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The live policy-push executor implicitly assumed **every client is Linux** — it loaded the `ClientRow` (which already carries `platform`, #229) and then *unconditionally* built a `timekpra`-over-SSH client and pushed. This introduces the dispatch seam item 6 of the Windows design doc asks for, while it's cheap.
- New `platform-runner.ts` (`PlatformPolicyRunner` + a `PlatformRunnerRegistry` keyed on `Client.platform`, throwing on a duplicate registration) and `linux-runner.ts` (the Linux runner — `resolvePolicyPush` + the `timekpra` setter sequence incl. the full-lockout allowed-hours skip, lifted verbatim out of the executor; the `PolicyPushClient*` types move here).
- `executor.ts` is now a thin, platform-agnostic dispatcher: run the existing no-op branches → select the runner for `client.platform` → delegate. An unsupported platform (a `windows` client today) is a **warn-and-no-op**, not the Linux path pushed at a non-Linux box — selection is exact-match, **not** "default to Linux for anything unknown".
- `bootstrap.ts` wraps the existing audited Linux runner in a registry. `Client.platform` defaults to `linux`, so every enrolled client still resolves to the Linux runner — **production behaviour is unchanged**. A future `WindowsAgentRunner` is purely additive: register it beside the Linux runner; no call site changes.

## Plan

Linked plan: `.claude/plans/issue-232-platform-keyed-transport-dispatch.md`
Roadmap: `docs/roadmap.md` → Phase 4 (SSH + `timekpra` transport). Design source: `docs/windows-client-support.md` → "Modularity tweaks to make cheaply now" item 6.

## Scope / deferred work (tracked)

This is the **policy-push half** — the live, wired per-client dispatch. The Ansible re-apply path (`transport/reapply`) makes the same Linux-unconditional assumption but is **not live-wired yet**, so keying it on platform is split out as a focused follow-up → **#325**.

No `WindowsAgentRunner` is implemented here (the ticket is explicit: seam only).

## License-boundary note

Unchanged — still exec-over-SSH of `timekpra` (GPL) as a subprocess via the existing audited facade. No in-process GPL linkage, no GPL binary added to the image, no transport/REST boundary collapsed, **no new dependency**. `license-guard` unaffected (no packaging change).

## Test plan

- [x] New `platform-runner.test.ts` — registry resolution (hit/miss), `platforms` listing, empty registry, duplicate-registration guard.
- [x] New `linux-runner.test.ts` — the Linux runner in isolation (DB-free context): setter sequence, full-lockout allowed-hours skip + warn, retriable/non-retriable error propagation.
- [x] Updated `executor.test.ts` — dispatcher runner-selection + the new unsupported-platform (`windows`) warn-and-no-op; every prior no-op/error/payload case kept green.
- [x] Full gate from `server/`: `format:check` / `lint` / `typecheck` clean; `npm test` — **1513 unit tests pass**, coverage **98.95%** (gate 80%); the three new/changed source files (`executor.ts`, `linux-runner.ts`, `platform-runner.ts`) at **100%**.

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0151g95mhBPakzKD91RYF9ZC)_