### PR TITLE
docs: roadmap for user-initiated NDWC point→time redemption

### DIFF
--- a/design/client/notifications.html
+++ b/design/client/notifications.html
@@ -79,7 +79,7 @@
           <div class="d">Minecraft will close in</div>
           <div class="big-count" style="color:#ff9b91;">0:11</div>
           <div class="gauge"><span style="width:73%;background:var(--red);"></span></div>
-          <div class="actions"><button class="tbtn">Save &amp; quit now</button></div>
+          <div class="actions"><button class="tbtn">Close now</button></div>
           <div class="app"><span>My Time · keeps reappearing until done</span><span>now</span></div>
         </div>
       </div>

--- a/docs/ndwc-reward-redemption-roadmap.md
+++ b/docs/ndwc-reward-redemption-roadmap.md
@@ -95,7 +95,8 @@ Everything else **reuses existing machinery** rather than reinventing it.
 | Outbound NDWC client in the dashboard | R1 | REST client + per-integration outbound endpoint config; reverse of the inbound path. |
 | Reward-mapping model + admin UI | R2 | Bind an NDWC reward → grant `scope`/`target`/`seconds`; surface point cost. |
 | Redemption engine (server) | R3 | Affordability check → idempotent debit → `Grant` → recompute/push → `grant.applied`. New user/agent-facing `/api` routes. |
-| Interactive notification framework | R4 | Action-button frame (capability-gated), agent button rendering, client→server redeem action over the bridge. |
+| **Generic** interactive-notification framework | **R4a (Phase 8b)** | Agent renders toast action buttons; a generic, capability-gated client→server action frame. *Infrastructure, not redemption-specific — see "Should the buttons move earlier?" below.* |
+| Redemption **binding** of the framework | R4b | The `redeem.offer`/`redeem.action` semantics layered on R4a. |
 | Running-activity → reward resolution + affordability UX | R5 | Agent surfaces the *right* offer for the active budget; redeem-vs-"earn more" gating. |
 | Redemption controls, audit, edge cases | R6 | Per-user self-redeem policy + caps, redemption ledger view, offline/abuse/failure handling. |
 
@@ -263,23 +264,37 @@ The transaction core. Headless — drivable from `/api` before any client UI.
 - **Depends on:** R1, R2, #113/#117 (grant write + recompute), #108 (unlock
   for the overall-budget case).
 
-### R4 — Interactive notification framework
+### R4a — Generic interactive-notification framework *(proposed for Phase 8b)*
 
-Make the button real and make the click reach R3.
+Make toast buttons that call home a real, reusable capability — independent
+of redemption. See "Should the buttons move earlier?" below for why this
+belongs in Phase 8b rather than here.
 
-- New capability-gated frame types under ADR 0007: `redeem.offer` (server→
-  client, carries the quote) and `redeem.action` (client→server, carries the
-  click + `source_ref`). Bump `eventProtocol`; advertise the capability in
-  the bridge `hello` (#303/#288); model the client→server direction on the
-  pause-on-lock frame (#316).
-- `pct-client-agent`: render action buttons via `gdbus`
+- `pct-client-agent`: render toast action buttons via `gdbus`
   `org.freedesktop.Notifications` actions (it already uses `gdbus` for the
   in-place countdown), with a `notify-send --action` fallback; wire the
-  button's invoked-action signal to send `redeem.action` over the AF_UNIX
-  socket to the bridge.
-- Bridge: forward `redeem.action` to the dashboard and route the resulting
-  `grant.applied` back to the agent (existing path).
-- **Depends on:** R3, #101/#103, #288/#303, ADR 0007.
+  button's invoked-action signal to a handler.
+- A **generic** capability-gated client→server action frame (`notif.action`
+  with a typed payload) under ADR 0007: bump `eventProtocol`, advertise the
+  capability in the bridge `hello` (#303/#288), model the client→server
+  direction on the pause-on-lock frame (#316). The bridge forwards the action
+  to the dashboard; an old agent simply renders no buttons.
+- First consumer is the *local* "Save & quit now" force-close button the
+  Phase 8b mockup already shows; the frame lets later features (redemption,
+  "ask a parent for more time") add new action types without new transport.
+- **Depends on:** #101/#103, #288/#303, ADR 0007. **Does not depend on the
+  NDWC work** — that is the point of pulling it forward.
+
+### R4b — Redemption binding of the framework
+
+Layer the redeem semantics on R4a's generic frame.
+
+- Define the `redeem.offer` (server→client quote) and `redeem.action`
+  (client→client→server redeem + `source_ref`) action types on top of R4a.
+- Agent renders the redeem button from an offer and routes the click; bridge
+  forwards it to R3 and routes the resulting `grant.applied` back (existing
+  path).
+- **Depends on:** R3, R4a.
 
 ### R5 — Running-activity resolution + affordability UX
 
@@ -321,6 +336,41 @@ Make it safe for a non-technical household (Alpha-2 bar).
 
 ---
 
+## Should the interactive buttons move earlier?
+
+**Yes — the generic half (R4a), into Phase 8b.** The design has *already*
+reached for clickable notification actions without a backing plan:
+[`design/client/notifications.html`](../design/client/notifications.html)
+defines a `.toast .actions` row, a `.tbtn` action button, **and a primary
+`.tbtn.go` variant that is styled but never used** — and the one rendered
+button, *"Save & quit now,"* is a Phase 8b force-close affordance. The "earn
+more / want more time?" framing recurs across the `My Time` (#61) and
+`child-status` surfaces. The UI keeps gesturing at "a button on the toast that
+does something," but nothing in the build plan delivers the ability to *render
+an action button and route its click*.
+
+That capability is **infrastructure, not redemption-specific**, and three
+things argue for building it in Phase 8b alongside the agent/bridge:
+
+1. **The substrate is being built there anyway.** The client→server frame
+   direction already lands in Phase 8b via the pause-on-lock frame (#316), and
+   the capability-gating + handshake via #288/#303. Action-button rendering is
+   the same `gdbus` notification surface #103 already uses for the countdown.
+2. **It's cheap now, awkward later.** ADR 0007's N-1 window exists precisely so
+   new frame types reach already-deployed clients gracefully — but the agent's
+   *ability to render actions at all* and a *generic action envelope* are far
+   cheaper to establish while the agent is first written than to retrofit. One
+   capability flag in the `hello` now buys every future button.
+3. **It has non-redemption consumers.** The local "Save & quit now" button
+   (Phase 8b) and a Phase 8c "ask a parent for more time" button both want it.
+   Redemption is just the first *remote* action type.
+
+So **R4a (generic framework) is proposed for Phase 8b**, filed as a `phase-8b`
+issue and cross-linked from #103/#316. **R4b (the redeem-specific binding)
+stays here**, dependent on R4a and the R3 engine. The redemption *feature*
+still lands in its natural late slot; only the reusable *capability* moves
+forward.
+
 ## What we need from NDWC (their repo)
 
 Tracked in next-digital-wall-calendar; listed here so the contract is
@@ -352,6 +402,10 @@ after the Phase 10 grant core and the Phase 8b agent are in place:
   flow), well after the Alpha-2 gate (which already requires Phase 8b).
 - R0 (contract + ADR) can begin **now**, in parallel with Phase 10, because
   it's coordination, not code — exactly like #118 started before #113.
+- **R4a is pulled forward to Phase 8b** (see "Should the buttons move
+  earlier?"); it is the only piece of this roadmap that does not depend on the
+  NDWC work, and it unblocks the local "Save & quit now" button and a Phase 8c
+  "ask a parent" button regardless of whether redemption ever ships.
 
 ## License & tamper-resistance notes
 

--- a/docs/ndwc-reward-redemption-roadmap.md
+++ b/docs/ndwc-reward-redemption-roadmap.md
@@ -195,10 +195,21 @@ lands, the same way #118 pins the inbound grant contract.
 
 ## Milestones
 
-Each milestone is roughly one PR-sized slice and should become one or more
-issues on the [roadmap project](https://github.com/users/BenSeymourODB/projects/2),
-labelled against Phase 10 (or a new `phase-10b` milestone). Dependencies are
-called out so they can be sequenced against the existing build plan.
+Each milestone is roughly one PR-sized slice and is tracked by an issue on the
+[roadmap project](https://github.com/users/BenSeymourODB/projects/2).
+Dependencies are called out so they can be sequenced against the existing
+build plan.
+
+| Milestone | Issue | Label |
+|---|---|---|
+| R0 — contract + ADR 0011 | [#333](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/333) | `phase-10` |
+| R1 — outbound NDWC client | [#334](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/334) | `phase-10` |
+| R2 — reward mapping + admin UI | [#335](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/335) | `phase-10` |
+| R3 — redemption engine | [#336](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/336) | `phase-10` |
+| R4a — generic interactive-notification framework | [#337](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/337) | **`phase-8b`** |
+| R4b — redeem.offer/redeem.action binding | [#338](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/338) | `phase-10` |
+| R5 — running-activity resolution + affordability UX | [#339](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/339) | `phase-10` |
+| R6 — controls, audit & edge cases | [#340](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/340) | `phase-10` |
 
 ### R0 — Joint API contract + ADR (coordination gate)
 

--- a/docs/ndwc-reward-redemption-roadmap.md
+++ b/docs/ndwc-reward-redemption-roadmap.md
@@ -62,9 +62,9 @@ against the issue tracker through #327):
    built — as a read/write client, not just a webhook.
 2. **The notification channel must carry a user action back to the server.**
    `client-notifications.md` and the `pct-client-agent` (#103) render
-   notifications **one-way**. The agent has local buttons (*"Save & quit
-   now"*) but none that call home. We need an interactive button whose handler
-   reaches the dashboard.
+   notifications **one-way**. The agent has a local force-close button on the
+   grace toast but none that call home. We need an interactive button whose
+   handler reaches the dashboard.
 
 Everything else **reuses existing machinery** rather than reinventing it.
 
@@ -290,9 +290,11 @@ belongs in Phase 8b rather than here.
   capability in the bridge `hello` (#303/#288), model the client→server
   direction on the pause-on-lock frame (#316). The bridge forwards the action
   to the dashboard; an old agent simply renders no buttons.
-- First consumer is the *local* "Save & quit now" force-close button the
-  Phase 8b mockup already shows; the frame lets later features (redemption,
-  "ask a parent for more time") add new action types without new transport.
+- First consumer is the *local* force-close button on the grace toast —
+  honestly labelled "Close now" / "Quit now" (`SIGTERM`→`SIGKILL`, no server
+  round-trip); the frame lets later features (redemption, "ask a parent for
+  more time") add new action types without new transport. (The mockup's
+  "Save & quit now" label overstates feasibility — see the note below.)
 - **Depends on:** #101/#103, #288/#303, ADR 0007. **Does not depend on the
   NDWC work** — that is the point of pulling it forward.
 
@@ -354,11 +356,22 @@ reached for clickable notification actions without a backing plan:
 [`design/client/notifications.html`](../design/client/notifications.html)
 defines a `.toast .actions` row, a `.tbtn` action button, **and a primary
 `.tbtn.go` variant that is styled but never used** — and the one rendered
-button, *"Save & quit now,"* is a Phase 8b force-close affordance. The "earn
+button is a Phase 8b force-close affordance (mislabelled *"Save & quit now"* —
+see the feasibility caveat below). The "earn
 more / want more time?" framing recurs across the `My Time` (#61) and
 `child-status` surfaces. The UI keeps gesturing at "a button on the toast that
 does something," but nothing in the build plan delivers the ability to *render
 an action button and route its click*.
+
+> **Feasibility caveat on that button.** The mockup labels the force-close
+> button *"Save & quit now,"* but the agent **cannot** make an arbitrary
+> application save its work — it can only force-close the process
+> (`SIGTERM`→`SIGKILL`, per [`client-notifications.md`](client-notifications.md)).
+> Treat "Save & quit" as an *unfeasible example*: the honest local action is
+> "Close now," with the user saving manually during the grace countdown. What
+> endures — and what R4a builds — is the general capability of
+> *context-sensitive actions invokable from a notification*, not the
+> "save the app for you" framing. (Recorded as a note on #103.)
 
 That capability is **infrastructure, not redemption-specific**, and three
 things argue for building it in Phase 8b alongside the agent/bridge:
@@ -372,8 +385,9 @@ things argue for building it in Phase 8b alongside the agent/bridge:
    *ability to render actions at all* and a *generic action envelope* are far
    cheaper to establish while the agent is first written than to retrofit. One
    capability flag in the `hello` now buys every future button.
-3. **It has non-redemption consumers.** The local "Save & quit now" button
-   (Phase 8b) and a Phase 8c "ask a parent for more time" button both want it.
+3. **It has non-redemption consumers.** The local "Close now" force-close
+   button (Phase 8b) and a Phase 8c "ask a parent for more time" button both
+   want it.
    Redemption is just the first *remote* action type.
 
 So **R4a (generic framework) is proposed for Phase 8b**, filed as a `phase-8b`
@@ -415,8 +429,8 @@ after the Phase 10 grant core and the Phase 8b agent are in place:
   it's coordination, not code — exactly like #118 started before #113.
 - **R4a is pulled forward to Phase 8b** (see "Should the buttons move
   earlier?"); it is the only piece of this roadmap that does not depend on the
-  NDWC work, and it unblocks the local "Save & quit now" button and a Phase 8c
-  "ask a parent" button regardless of whether redemption ever ships.
+  NDWC work, and it unblocks the local "Close now" force-close button and a
+  Phase 8c "ask a parent" button regardless of whether redemption ever ships.
 
 ## License & tamper-resistance notes
 

--- a/docs/ndwc-reward-redemption-roadmap.md
+++ b/docs/ndwc-reward-redemption-roadmap.md
@@ -1,0 +1,379 @@
+# Roadmap — NDWC reward redemption (user-initiated time extensions)
+
+- **Status:** Draft (2026-06-29). Forward-looking; no feature code has landed.
+- **Owner doc:** extends [`roadmap.md`](roadmap.md) Phase 10 ("External
+  integrations: family-calendar rewards") and the integration design in
+  [`architecture.md`](architecture.md) → "External integrations".
+- **Companion docs:** [`client-notifications.md`](client-notifications.md)
+  (the agent/bridge channel this extends),
+  [`adr/0007-event-stream-version-compatibility.md`](adr/0007-event-stream-version-compatibility.md)
+  (the capability-negotiation contract a new interactive frame must obey),
+  [`licensing-analysis.md`](licensing-analysis.md) (the boundary an
+  *outbound* integration client must respect).
+
+This document plans a second, deeper integration between this toolkit and
+[next-digital-wall-calendar](https://github.com/BenSeymourODB/next-digital-wall-calendar)
+(**NDWC**). It is a roadmap and a set of design decisions to ratify, not an
+implementation.
+
+---
+
+## The feature in one paragraph
+
+A supervised user is told their screen time (or a specific app/activity's
+time) is running low. The low-time toast carries a **button**: *"Redeem 50
+points for +30 min of Games."* Clicking it spends points the user has
+already earned in NDWC and grants the matching screen-time extension —
+without a parent in the loop, within rules the parent set in advance. If the
+user can't afford the extension, the toast says so and points them at the
+chores that would earn the rest. This is the **inverse direction** of the
+Phase 10 flow already designed: there, NDWC *pushes* a grant to the dashboard
+when a chore is completed; here, the *user* pulls an extension at the moment
+of need and the dashboard *spends their points* in NDWC to pay for it.
+
+---
+
+## How this differs from what Phase 10 already plans
+
+Phase 10 (issues #113/#117/#118) is **integrator-initiated, inbound, push**:
+
+```
+NDWC backend  ──POST /api/integrations/grants──▶  Dashboard  ──timekpra──▶  client
+              (chore completed → +30 min)
+```
+
+This feature is **user-initiated, outbound, pull**:
+
+```
+client (agent) ──redeem action──▶ Dashboard ──debit points──▶ NDWC
+                                  Dashboard ◀──balance/ok──── NDWC
+                                  Dashboard ──Grant + timekpra──▶ client
+```
+
+Two things are genuinely new and neither exists in the repo today (confirmed
+against the issue tracker through #327):
+
+1. **The dashboard must call *out* to NDWC.** Every integration so far is
+   inbound-only — NDWC, AdGuard-external, ActivityWatch are all *we read from
+   them* or *they call us*. `architecture.md` explicitly parks the reciprocal
+   direction: *"The reciprocal direction (dashboard → calendar … is out of
+   scope for now but stays open: same pattern, the dashboard would hold a
+   per-integration outbound webhook URL."* This roadmap is where that gets
+   built — as a read/write client, not just a webhook.
+2. **The notification channel must carry a user action back to the server.**
+   `client-notifications.md` and the `pct-client-agent` (#103) render
+   notifications **one-way**. The agent has local buttons (*"Save & quit
+   now"*) but none that call home. We need an interactive button whose handler
+   reaches the dashboard.
+
+Everything else **reuses existing machinery** rather than reinventing it.
+
+---
+
+## Build-on / net-new inventory
+
+### Reuse (do not rebuild)
+
+| Existing piece | Issue | How this feature uses it |
+|---|---|---|
+| `Grant` ledger (immutable, additive, `source`/`source_ref`) | architecture "Policy model" | A redemption **is** a grant: `source = "integration:ndwc-redemption"`, `source_ref =` the redemption id. No new time-accounting primitive. |
+| `POST /api/integrations/grants` + idempotency-by-`source_ref` | #113 | The redemption engine writes a grant through the **same** path/semantics; the difference is *who* triggers it and that a point-debit happens first. |
+| Grant recompute pipeline (`effective = policy + Σ grants` → push → `grant.applied`) | #117 | Unchanged. A redemption grant recomputes and pushes exactly like a calendar grant. |
+| Grant-unlock loop (`grant.applied` on overall → unlock → `lockout.cleared`) | #108 | A redemption against the *overall* budget after a lockout clears it for free. |
+| `IntegrationToken` (scoped, revocable, rate-limited) | #113/#115 | The **inbound** half. We add an **outbound** credential record (see R1); the admin manages both on one page. |
+| `pct-client-bridge` WS + AF_UNIX dispatch | #101 | The transport for the new interactive frame and the redeem action. |
+| `pct-client-agent` notifications/cadence | #103 | Extended with action-button rendering (R4). |
+| Capability-gated frames + ADR-0007 handshake | #288/#303 | A redeem-offer / redeem-action frame is a **new capability-gated frame type**, negotiated, never sent to a client that didn't advertise it. The client→server pause-on-lock frame (#316) is the precedent for client→server frames. |
+| Activity matcher grammar + `buildActivityQuotas` | ADR 0006, #307 | Resolving "which activity is running" and "which scope a reward maps to" reuse the matcher and the `"scope:targetId"` quota keying. |
+| Per-token rate limiting | #115 | Applies to outbound debits too (don't hammer NDWC; bound abuse). |
+
+### Net-new (needs new issues)
+
+| New piece | Milestone | Sketch |
+|---|---|---|
+| NDWC read/write API (their repo) | R0 | Point-balance read, reward catalog read, **idempotent** point-debit write. |
+| Outbound NDWC client in the dashboard | R1 | REST client + per-integration outbound endpoint config; reverse of the inbound path. |
+| Reward-mapping model + admin UI | R2 | Bind an NDWC reward → grant `scope`/`target`/`seconds`; surface point cost. |
+| Redemption engine (server) | R3 | Affordability check → idempotent debit → `Grant` → recompute/push → `grant.applied`. New user/agent-facing `/api` routes. |
+| Interactive notification framework | R4 | Action-button frame (capability-gated), agent button rendering, client→server redeem action over the bridge. |
+| Running-activity → reward resolution + affordability UX | R5 | Agent surfaces the *right* offer for the active budget; redeem-vs-"earn more" gating. |
+| Redemption controls, audit, edge cases | R6 | Per-user self-redeem policy + caps, redemption ledger view, offline/abuse/failure handling. |
+
+---
+
+## End-to-end sequence
+
+```mermaid
+sequenceDiagram
+    participant A as pct-client-agent
+    participant Br as pct-client-bridge
+    participant D as Dashboard
+    participant N as NDWC
+
+    Note over A: local countdown hits a low-time threshold<br/>on an active budget (e.g. Games ≤5 min)
+    A->>A: resolve running activity → mapped reward(s) (cached map)
+    A->>Br: offer? {user, scope, target, rewardId}
+    Br->>D: redeem.offer.request (capability-gated frame)
+    D->>N: GET balance(user)
+    N-->>D: balance = 30 pts
+    D-->>Br: offer {affordable:false, cost:50, balance:30, short:20, label:"+30 min Games"}
+    Br-->>A: offer
+    A->>A: render toast — "Need 20 more points · finish a chore"
+    Note over A,N: ...user completes a chore in NDWC, balance now 60...
+    A->>Br: offer? (next warning tick)
+    Br->>D: redeem.offer.request
+    D->>N: GET balance(user)
+    N-->>D: balance = 60 pts
+    D-->>Br: offer {affordable:true, cost:50, label:"+30 min Games"}
+    Br-->>A: offer
+    A->>A: toast — [Redeem 50 pts → +30 min Games]
+    A->>Br: redeem.action {rewardId, source_ref}
+    Br->>D: redeem.action (client→server frame)
+    D->>D: re-validate (activity active? mapped? self-redeem allowed? cap not hit?)
+    D->>N: POST debit {user, points:50, source_ref}  (idempotent)
+    N-->>D: ok {balance:10}
+    D->>D: write Grant (source=integration:ndwc-redemption, source_ref)
+    D->>D: recompute effective budget (#117) → push timekpra
+    D-->>Br: grant.applied
+    Br-->>A: grant.applied → "+30 min Games — keep going!" (dismiss countdown)
+```
+
+The **authority** at every step is the dashboard, not the agent. The agent's
+local offer check is advisory (it makes the button appear instantly without a
+round-trip stall); the server re-derives balance, re-checks the activity is
+genuinely active and mapped, and re-checks the per-user redemption policy
+before it spends a single point. We never trust a client-reported balance,
+activity, or cost — consistent with the bridge's "never trusts instructions
+from the local user" rule in `client-notifications.md`.
+
+---
+
+## Design decisions to ratify (proposed ADR 0011)
+
+These shape every milestone and should be pinned in an ADR before R1 code
+lands, the same way #118 pins the inbound grant contract.
+
+1. **All NDWC traffic is server-side. The agent never holds an NDWC token.**
+   The agent talks only to the bridge; the bridge only to the dashboard; the
+   dashboard alone holds the NDWC credential and base URL. This preserves the
+   single-credential-store model, keeps the child's device free of an
+   external secret, and stays NAT-friendly (no inbound to the client).
+2. **Domain ownership: NDWC owns the points economy; this toolkit owns
+   time.** A *reward's point cost* is a property of NDWC (its currency, its
+   inflation, its catalog). Our **reward mapping** binds an NDWC reward id to
+   a time grant (`scope`/`target`/`seconds`). The dashboard reads cost from
+   NDWC at offer time; it does not store or invent prices. *(Alternative
+   considered: cost lives in our mapping. Rejected — it splits the economy
+   across two systems and drifts.)*
+3. **A redemption reuses the `Grant` ledger; it is not a new entity.**
+   `source = "integration:ndwc-redemption"`, `source_ref =` the redemption id.
+   It inherits immutability, additivity, `expires_at` (default end-of-day),
+   audit, and revoke-as-a-new-row for free.
+4. **Idempotency spans both systems via one `source_ref`.** The agent mints
+   the `source_ref` for a click; the dashboard uses it as the NDWC debit
+   idempotency key **and** the `Grant.source_ref`. The debit is committed
+   first; the `Grant` write is the commit point of the whole transaction. A
+   retried click (double-tap, reconnect replay) debits once and grants once.
+   The hard ordering question — what happens if the debit succeeds but the
+   grant write fails, or the timekpra push fails — is the core of the ADR
+   (proposal: grant write is durable and authoritative; the push rides the
+   existing offline queue #84; a debit with no matching grant is reconciled by
+   a compensating credit keyed on the same `source_ref`).
+5. **The interactive frame is capability-gated under ADR 0007.** Add a new
+   frame type (`redeem.offer`/`redeem.action`) and a capability flag the
+   client advertises in its `hello`; the server only sends offers to a client
+   that advertised support, and an old client simply never sees a redeem
+   button. Bump `eventProtocol`, keep the N-1 window.
+6. **Self-redemption is a parent-granted privilege, off by default.** A new
+   `RedemptionPolicy` (per user) decides whether the user may self-redeem at
+   all, which scopes are eligible, and a daily cap (max points or max minutes
+   redeemed per day). This keeps the household framing: the parent sets the
+   sandbox once; the child plays inside it.
+
+---
+
+## Milestones
+
+Each milestone is roughly one PR-sized slice and should become one or more
+issues on the [roadmap project](https://github.com/users/BenSeymourODB/projects/2),
+labelled against Phase 10 (or a new `phase-10b` milestone). Dependencies are
+called out so they can be sequenced against the existing build plan.
+
+### R0 — Joint API contract + ADR (coordination gate)
+
+The counterpart to #118, widened to the read/write surface. Nothing else
+starts until the wire contract with NDWC is agreed and the design decisions
+above are ratified.
+
+- Agree, with the NDWC repo, the three operations the dashboard needs:
+  **read balance**, **read reward catalog**, **idempotent debit**.
+- Pin the `source_ref` construction, the debit idempotency + reconciliation
+  contract, error envelope, and auth model.
+- Land **ADR 0011 — outbound integration boundary + redemption transaction
+  model** (the decisions above).
+- **Depends on:** #118 (reuse its `user_ref` mapping + error conventions).
+- **NDWC-side (their repo, tracked there):** expose the three endpoints;
+  see "What we need from NDWC" below.
+
+### R1 — Outbound integration client + endpoint config
+
+The reverse-direction plumbing, built once and reusable for the future
+outbound webhook (#118 stretch).
+
+- A `transport/ndwc/` REST client (or `integrations/outbound/`) — typed,
+  zod-validated responses, timeouts, retries with backoff, per-call audit.
+- An **outbound endpoint record** alongside `IntegrationToken`: base URL +
+  the credential the dashboard presents to NDWC + scopes. Managed on the
+  existing `/admin` integrations page (extends #116-era UI).
+- Preflight/health check (like AdGuard-external): can we reach NDWC and
+  authenticate?
+- **License note:** outbound REST is the same boundary as AdGuard/AW — a
+  network call to a separate service, no linkage. Add it to
+  `licensing-analysis.md`'s integration table.
+- **Depends on:** R0.
+
+### R2 — Reward-mapping model + admin UI
+
+Where an NDWC reward becomes a screen-time grant.
+
+- `RewardMapping (id, ndwc_reward_ref, scope=overall|activity|group,
+  target_id?, seconds_granted, enabled, ...)` — binds a catalog reward to a
+  grant shape. Reuses the `scope`/`target_id` vocabulary of `Budget`/`Grant`
+  and the `"scope:targetId"` keying from `buildActivityQuotas` (#307).
+- Admin UI: list NDWC's catalog (read via R1), map each reward to a scope +
+  target + seconds, enable/disable. Cost is shown read-only from NDWC.
+- Validation that `target_id` resolves to a real `Activity`/`ActivityGroup`.
+- **Depends on:** R1 (to read the catalog), #307 (quota keying).
+
+### R3 — Redemption engine (server)
+
+The transaction core. Headless — drivable from `/api` before any client UI.
+
+- `POST /api/redemptions` (and an offer/quote route, e.g.
+  `GET /api/redemptions/offer?...`) — the user/agent-facing surface, guarded
+  by the per-client bearer token (not an `IntegrationToken`; the request
+  originates on a managed client, not from NDWC).
+- Engine: re-validate (mapping enabled? activity active? self-redeem allowed
+  per R6 policy? cap not hit?) → read balance → if affordable, idempotent
+  debit → write `Grant` → hand off to the #117 recompute/push pipeline → it
+  emits `grant.applied`.
+- Affordability/quote response: `{affordable, cost, balance, shortfall,
+  label, expires_at}`.
+- Reconciliation job for debit-succeeded/grant-failed (compensating credit).
+- **Depends on:** R1, R2, #113/#117 (grant write + recompute), #108 (unlock
+  for the overall-budget case).
+
+### R4 — Interactive notification framework
+
+Make the button real and make the click reach R3.
+
+- New capability-gated frame types under ADR 0007: `redeem.offer` (server→
+  client, carries the quote) and `redeem.action` (client→server, carries the
+  click + `source_ref`). Bump `eventProtocol`; advertise the capability in
+  the bridge `hello` (#303/#288); model the client→server direction on the
+  pause-on-lock frame (#316).
+- `pct-client-agent`: render action buttons via `gdbus`
+  `org.freedesktop.Notifications` actions (it already uses `gdbus` for the
+  in-place countdown), with a `notify-send --action` fallback; wire the
+  button's invoked-action signal to send `redeem.action` over the AF_UNIX
+  socket to the bridge.
+- Bridge: forward `redeem.action` to the dashboard and route the resulting
+  `grant.applied` back to the agent (existing path).
+- **Depends on:** R3, #101/#103, #288/#303, ADR 0007.
+
+### R5 — Running-activity resolution + affordability UX
+
+Surface the *right* offer at the *right* moment.
+
+- Agent resolves the foreground/active budget (it already polls `aw-server`
+  for usage and holds the cached budget) to its mapped reward(s) using the
+  cached reward-mapping + activity matcher. Push the enabled mappings to the
+  client with policy.
+- On a low-time warning tick for a budget that has a mapping, the agent
+  requests a quote (R3/R4) and renders:
+  - **affordable** → an actionable redeem button (label + cost);
+  - **not affordable** → a non-actionable, non-punitive nudge ("Need 20 more
+    points — finish a chore to earn them"), matching the `child-status` /
+    `My Time` (#61) "earn more" tone. Never "blocked/denied".
+- Coalesce with the existing multi-budget warning coalescing so a redeem
+  offer doesn't spam.
+- **Depends on:** R4, ADR 0006, the #103 cadence.
+
+### R6 — Redemption controls, audit & edge cases
+
+Make it safe for a non-technical household (Alpha-2 bar).
+
+- `RedemptionPolicy` per user: self-redeem on/off, eligible scopes, daily
+  cap (points and/or minutes), pushed to the client with the rest of policy
+  (cap is *also* enforced server-side in R3 — the client copy is for UX only).
+- Redemption history in the `/admin` grant ledger (#116): filter
+  `source = integration:ndwc-redemption`, show points spent + balance after,
+  revocable like any grant.
+- Edge cases: bridge offline at click time (no offer shown — fail closed, the
+  user keeps cached limits; do not let an offline click promise time);
+  NDWC unreachable (offer not shown / quote errors gracefully); double-tap
+  and reconnect replay (idempotent by `source_ref`); reward disabled or
+  re-priced between offer and click (server re-validates and may decline with
+  a fresh quote); cap exhausted (decline with "you've redeemed your max for
+  today").
+- Per-token + per-user rate limiting (#115) on offers and debits.
+- **Depends on:** R3–R5.
+
+---
+
+## What we need from NDWC (their repo)
+
+Tracked in next-digital-wall-calendar; listed here so the contract is
+visible from this side. NDWC needs a small, authenticated machine API the
+dashboard can call with a per-integration credential:
+
+| Operation | Shape (illustrative, finalised in R0) | Notes |
+|---|---|---|
+| Read balance | `GET /api/points/balance?user_ref=alice` → `{ points }` | Same `user_ref` mapping as #118's inbound grants. |
+| Read reward catalog | `GET /api/rewards` → `[{ reward_ref, label, cost_points }]` | Source of truth for cost; the dashboard maps each `reward_ref` to a time grant. |
+| Debit points | `POST /api/points/debit` `{ user_ref, points, source_ref, reason }` → `{ balance }` | **Idempotent by `source_ref`.** A repeat with the same `source_ref` returns the same result, never double-debits. |
+| (Optional) Compensating credit | `POST /api/points/credit` `{ user_ref, points, source_ref }` | For R3 reconciliation when a debit committed but the grant didn't. |
+
+NDWC's own ownership of points means the toolkit never mints, prices, or
+stores point balances — it reads and spends them.
+
+---
+
+## Sequencing against the existing roadmap
+
+This work is **not** a blocker for Alpha-1 or Alpha-1.5 and sits naturally
+after the Phase 10 grant core and the Phase 8b agent are in place:
+
+- **Hard prerequisites:** Phase 10 grant pipeline (#113/#117) and Phase 8b
+  agent + bridge + ADR-0007 handshake (#101/#103/#303/#288). The grant-unlock
+  loop (#108) is needed only for the overall-budget-after-lockout path.
+- **Natural slot:** alongside or just after Phase 10 / Phase 12 ("My Time"
+  #61, whose Rewards tab is the read-only complement to this interactive
+  flow), well after the Alpha-2 gate (which already requires Phase 8b).
+- R0 (contract + ADR) can begin **now**, in parallel with Phase 10, because
+  it's coordination, not code — exactly like #118 started before #113.
+
+## License & tamper-resistance notes
+
+- **License boundary unchanged.** The outbound NDWC client is a REST call to
+  a separate service over the network — the same boundary class as AdGuard
+  and ActivityWatch (`licensing-analysis.md`). No linkage, no vendoring, no
+  new GPL surface.
+- **Tamper-resistance ceiling unchanged.** This is a feature *for* the
+  supervised user (spend earned points for time), not a hardening surface.
+  The only trust rule it adds is the standard one: the server is
+  authoritative and re-validates every redeem request; it never trusts a
+  client-reported balance, activity, cost, or cap. That is ordinary
+  client/server hygiene, not an arms race — consistent with CLAUDE.md's
+  "Tamper resistance is deliberately bounded".
+
+## Out of scope (for this roadmap)
+
+- Letting NDWC drive screen-time **schedules/rules** (allow/deny windows) —
+  that is the separate stretch #125, explicitly *not* the additive-grant
+  primitive this feature uses.
+- Earning points (chores, calendar events) — that is NDWC's domain; this
+  toolkit only spends them.
+- Parent-phone push tying into redemption — the parent-side low-time push and
+  quick-grant (#65/#111) stays the parent's lever; this feature is the
+  child's.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -283,6 +283,15 @@ so chore/calendar completions can grant screen-time rewards.
 - Stretch: outbound webhook from dashboard → calendar (e.g. "Alice has
   10 min left") to enable richer cross-app behaviour.
 
+A deeper, **user-initiated** follow-on — the supervised user redeeming NDWC
+points for a screen-time extension straight from a low-time notification — is
+planned separately in
+[`ndwc-reward-redemption-roadmap.md`](ndwc-reward-redemption-roadmap.md). It
+reuses this phase's grant pipeline (#113/#117) and the Phase 8b agent/bridge,
+and adds the reciprocal *outbound* call to NDWC (read balance, debit points)
+plus interactive notification buttons. Its contract-and-ADR milestone (R0) can
+start in parallel with this phase, exactly as #118 precedes #113.
+
 ## Phase 11 — Hardening and polish
 
 - Reverse-proxy + TLS instructions for non-LAN deployments


### PR DESCRIPTION
## What

Drafts a roadmap for a **deeper, two-way** integration between this toolkit and [next-digital-wall-calendar](https://github.com/BenSeymourODB/next-digital-wall-calendar) (NDWC): a supervised user, on receiving a low-time notification, clicks a button to **redeem earned points for a screen-time / app-time extension**.

This is the **inverse** of the Phase 10 flow already designed. Today NDWC *pushes* a grant when a chore is completed (`POST /api/integrations/grants`, #113). This feature is *user-initiated* and *pull*: the dashboard must call **out** to NDWC (read balance, debit points), and the notification channel must carry a **user action back to the server**.

## Why a new doc

Audited the issue tracker through #327. The feature builds cleanly on existing work but three things are genuinely net-new (no existing issues):
- the dashboard calling **out** to NDWC (all integration so far is inbound-only);
- **interactive notification buttons** (`pct-client-agent` #103 is render-only today);
- a **point balance / redemption** concept and a **reward → scope/activity/group mapping**.

## Contents

`docs/ndwc-reward-redemption-roadmap.md`:
- Build-on / net-new inventory against existing issues.
- End-to-end sequence diagram (low-time → quote → redeem → grant).
- Design decisions to ratify as **ADR 0011**: all NDWC traffic server-side (agent holds no NDWC token), NDWC owns the points economy / this toolkit owns time, redemption reuses the immutable `Grant` ledger, idempotent debit+grant keyed by one `source_ref`, capability-gated interactive frame under ADR 0007, off-by-default per-user self-redemption policy with daily caps.
- Milestones **R0–R6** (contract+ADR → outbound client → reward mapping → redemption engine → interactive notifications → activity-resolution UX → controls/audit/edge cases), with dependencies and proposed issues.
- The **NDWC-side API contract** (read balance, read catalog, idempotent debit) so it's visible from this side.
- Sequencing against existing phases, plus license-boundary and tamper-resistance notes (boundary unchanged — outbound REST like AdGuard; not a hardening surface).

Cross-linked from `roadmap.md` Phase 10.

## Reuse, not reinvention

Leans on the Grant pipeline (#113/#117), grant-unlock (#108), agent/bridge (#101/#103), capability gating (#288/#303, ADR 0007, with #316's client→server frame as precedent), and the activity matcher / `buildActivityQuotas` (#307, ADR 0006). No new time-accounting primitive — a redemption *is* a grant.

## Not in this PR

Docs only — no feature code. R0 (contract + ADR) is the gate before any implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sso1n2BtHakpaxho5MThhH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sso1n2BtHakpaxho5MThhH)_