### PR TITLE
feat(client): support upgrade-in-place re-runs of the installer

### DIFF
--- a/client/install-baseline-tools.sh
+++ b/client/install-baseline-tools.sh
@@ -140,6 +140,36 @@ E2G_PCT_DIR="${E2G_PCT_DIR:-${E2G_DIR}/pct.d}"
 # named to match self-test.sh's PCT_SSHD_SERVICE so the two stay in lockstep.
 PCT_SSHD_SERVICE="${PCT_SSHD_SERVICE:-ssh.service}"
 
+# The systemctl binary, overridable so the bats suite can point it at a recorder
+# stub and assert which units get (re)started without a live systemd.
+PCT_SYSTEMCTL="${PCT_SYSTEMCTL:-systemctl}"
+
+# Restart/reload a system unit to APPLY a config change, but only when the config
+# actually changed across this run. `before` is a pct_file_checksum captured
+# before the write; if the file's checksum still matches, this is a no-op — so a
+# re-run that changes nothing never bounces the daemon. Without this, the baseline
+# only `enable --now`s a unit (a no-op for an already-running one), so on a re-run
+# changed config is written to disk but the running daemon keeps the old config
+# until a manual restart — the upgrade-in-place gap this closes (#347).
+#
+# `action` is a systemctl verb; use the `try-*` forms (try-restart,
+# try-reload-or-restart) so an inactive unit is a clean no-op rather than an
+# error under the caller's `set -e`. Dry-run prints the conditional intent.
+pct_apply_change() {
+  local file="$1" before="$2" unit="$3" action="$4"
+  if pct_is_dry_run; then
+    printf '%s %s %s %s (only if %s changed)\n' \
+      "$PCT_DRYRUN_PREFIX" "$PCT_SYSTEMCTL" "$action" "$unit" "$file" >&2
+    return 0
+  fi
+  if [ "$before" = "$(pct_file_checksum "$file")" ]; then
+    pct_log "${file} unchanged; not restarting ${unit}"
+    return 0
+  fi
+  pct_log "${file} changed; ${action} ${unit} to apply"
+  "$PCT_SYSTEMCTL" "$action" "$unit"
+}
+
 # --- step: apt repositories ------------------------------------------------
 
 # Resolve the Ubuntu series (apt "Suite") the PPA is consumed for. Mint reports
@@ -295,7 +325,7 @@ pct_baseline_install_packages() {
 # dashboard connection and self-test.sh's sshd check (#80) fail.
 pct_baseline_configure_sshd() {
   pct_step "Enable the OpenSSH server (the dashboard connects over SSH)"
-  pct_run systemctl enable --now "$PCT_SSHD_SERVICE"
+  pct_run "$PCT_SYSTEMCTL" enable --now "$PCT_SSHD_SERVICE"
 }
 
 # --- step: ActivityWatch upstream bundle -----------------------------------
@@ -347,10 +377,15 @@ pct_baseline_install_activitywatch() {
 
 pct_baseline_configure_timekpr() {
   pct_step "Configure Timekpr-nExT (baseline: daemon + generous Alpha-1 warnings)"
+  # Snapshot the config before editing so we only restart the daemon if the
+  # edit actually changes it (a no-op re-run must not bounce it).
+  local conf_before
+  conf_before="$(pct_file_checksum "$PCT_TIMEKPR_CONF")"
+
   # Initial policy is intentionally empty — the dashboard pushes limits via
   # `timekpra` over SSH after enrolment. We only ensure the daemon is up and
   # the CLI the server drives is on PATH.
-  pct_run systemctl enable --now timekpr.service
+  pct_run "$PCT_SYSTEMCTL" enable --now timekpr.service
 
   # Give supervised users plenty of advance warning before a session cutoff.
   # Alpha-1 has no pct-client-agent cadence/grace UX (Phase 8b), so this is the
@@ -360,6 +395,13 @@ pct_baseline_configure_timekpr() {
     TIMEKPR_FINAL_NOTIFICATION_TIME "$PCT_TIMEKPR_FINAL_NOTIFICATION_TIME"
   pct_set_conf_key "$PCT_TIMEKPR_CONF" \
     TIMEKPR_FINAL_WARNING_TIME "$PCT_TIMEKPR_FINAL_WARNING_TIME"
+
+  # `enable --now` started the daemon with whatever timekpr.conf was on disk
+  # then; if the edits above changed it (e.g. on an upgrade re-run), restart so
+  # the new warning lead times take effect. Timekpr persists usage, so a restart
+  # does not reset today's budgets. `try-restart` is a no-op if the unit is not
+  # active, so it never errors under `set -e`.
+  pct_apply_change "$PCT_TIMEKPR_CONF" "$conf_before" timekpr.service try-restart
 
   if pct_is_dry_run; then
     printf '%s %s\n' "$PCT_DRYRUN_PREFIX" "command -v timekpra" >&2
@@ -525,6 +567,11 @@ EOF
 
 pct_baseline_configure_e2guardian() {
   pct_step "Configure e2guardian (permissive baseline + per-user skeleton)"
+  # Snapshot the filter group e2guardian actually reads, so we only signal a
+  # reload if the rules changed (a no-op re-run must not disturb the proxy).
+  local f1_before
+  f1_before="$(pct_file_checksum "${E2G_DIR}/e2guardianf1.conf")"
+
   # Let the service run (some Debian packagings ship it gated off). Real filter
   # rules + the iptables OUTPUT redirect are Phase 6 Ansible's job (#90); this
   # baseline must NOT block traffic.
@@ -547,7 +594,15 @@ pct_baseline_configure_e2guardian() {
 EOF
   done
 
-  pct_run systemctl enable --now e2guardian.service
+  pct_run "$PCT_SYSTEMCTL" enable --now e2guardian.service
+
+  # If the filter group changed (e.g. an upgrade re-run that adjusts the
+  # baseline), reload e2guardian so it re-reads the rules. `try-reload-or-restart`
+  # reloads in place when the unit is active and supports it, restarts if it
+  # doesn't, and is a clean no-op if the unit is inactive — so it never drops the
+  # proxy needlessly nor errors under `set -e`.
+  pct_apply_change "${E2G_DIR}/e2guardianf1.conf" "$f1_before" e2guardian.service \
+    try-reload-or-restart
 }
 
 # --- orchestration ---------------------------------------------------------

--- a/client/install-baseline-tools.sh
+++ b/client/install-baseline-tools.sh
@@ -153,8 +153,11 @@ PCT_SYSTEMCTL="${PCT_SYSTEMCTL:-systemctl}"
 # until a manual restart — the upgrade-in-place gap this closes (#347).
 #
 # `action` is a systemctl verb; use the `try-*` forms (try-restart,
-# try-reload-or-restart) so an inactive unit is a clean no-op rather than an
-# error under the caller's `set -e`. Dry-run prints the conditional intent.
+# try-reload-or-restart) so an *inactive* unit is a clean no-op rather than an
+# error under the caller's `set -e`. A genuine failure of an active unit to come
+# back up is NOT swallowed — it returns non-zero and aborts the run, which is
+# the intended behaviour (a daemon that won't restart should surface, not pass
+# silently). Dry-run prints the conditional intent.
 pct_apply_change() {
   local file="$1" before="$2" unit="$3" action="$4"
   if pct_is_dry_run; then
@@ -377,15 +380,18 @@ pct_baseline_install_activitywatch() {
 
 pct_baseline_configure_timekpr() {
   pct_step "Configure Timekpr-nExT (baseline: daemon + generous Alpha-1 warnings)"
-  # Snapshot the config before editing so we only restart the daemon if the
-  # edit actually changes it (a no-op re-run must not bounce it).
-  local conf_before
-  conf_before="$(pct_file_checksum "$PCT_TIMEKPR_CONF")"
-
   # Initial policy is intentionally empty — the dashboard pushes limits via
   # `timekpra` over SSH after enrolment. We only ensure the daemon is up and
   # the CLI the server drives is on PATH.
   pct_run "$PCT_SYSTEMCTL" enable --now timekpr.service
+
+  # Snapshot the config AFTER `enable --now`, not before: Timekpr's daemon may
+  # normalise/rewrite timekpr.conf when it starts, and we don't want that
+  # start-time rewrite to read as "our edit changed it" and trigger a spurious
+  # restart. Snapshotting here means only the pct_set_conf_key edits below are
+  # compared, so we restart iff our keys actually changed.
+  local conf_before
+  conf_before="$(pct_file_checksum "$PCT_TIMEKPR_CONF")"
 
   # Give supervised users plenty of advance warning before a session cutoff.
   # Alpha-1 has no pct-client-agent cadence/grace UX (Phase 8b), so this is the
@@ -596,11 +602,16 @@ EOF
 
   pct_run "$PCT_SYSTEMCTL" enable --now e2guardian.service
 
-  # If the filter group changed (e.g. an upgrade re-run that adjusts the
-  # baseline), reload e2guardian so it re-reads the rules. `try-reload-or-restart`
-  # reloads in place when the unit is active and supports it, restarts if it
-  # doesn't, and is a clean no-op if the unit is inactive — so it never drops the
-  # proxy needlessly nor errors under `set -e`.
+  # Apply baseline filter-rule changes on a re-run. We key the change-detection
+  # on e2guardianf1.conf as the deliberate proxy for "the baseline filter rules
+  # changed": /etc/default/e2guardian is read only at service start (a reload
+  # wouldn't pick it up, and a first install flips f1.conf absent->present so a
+  # restart happens anyway), and the pct.d/*.filtergroup skeletons are inert
+  # placeholders for Phase 6 Ansible, not read by this baseline. `try-reload-or-
+  # restart` reloads in place when the unit supports it — but the stock
+  # e2guardian unit ships no ExecReload (upstream e2guardian#182), so in practice
+  # this is a restart; either way the new rules are applied. It is a clean no-op
+  # when the unit is inactive.
   pct_apply_change "${E2G_DIR}/e2guardianf1.conf" "$f1_before" e2guardian.service \
     try-reload-or-restart
 }

--- a/client/install-client.sh
+++ b/client/install-client.sh
@@ -28,8 +28,15 @@
 # Nothing here exists to "make circumvention harder".
 #
 # Idempotent and re-runnable: each sub-step reconciles rather than re-bootstraps.
-# A second enrolment needs a fresh token (enrolment tokens are single-use); the
-# orchestrator surfaces the server's rejection cleanly rather than masking it.
+# Re-running to apply a client-side patch (e.g. enabling sshd) to an already-
+# enrolled box has two supported shapes:
+#   * --skip-enrol: re-run provision + baseline + self-test ONLY, leaving the
+#     existing enrolment, per-client token, and authorized dashboard key intact.
+#     This needs no token and no reachable dashboard.
+#   * a plain re-run: the orchestrator now TOLERATES the dashboard's "already
+#     enrolled" 409 — it keeps the existing enrolment and continues to the
+#     self-test rather than aborting. (A genuinely bad/expired token still 401s
+#     and aborts with a clear message; mint a fresh one for a true re-enrol.)
 #
 # Dry-run aware: set PCT_DRY_RUN=1 to print the intended plan without touching
 # the system, network, or the upstream tools — that is how CI and the bats tests
@@ -70,6 +77,24 @@ PCT_STATE_DIR="${PCT_STATE_DIR:-/etc/pct}"
 # orchestrator itself needs (the enrol request/response JSON is handled in pure
 # bash — see pct_orch_build_enrol_body / pct_orch_json_*).
 PCT_CURL="${PCT_CURL:-curl}"
+
+# Upgrade-in-place: skip the enrolment exchange (and the steps that depend on
+# its response — authorizing the SSH key, persisting the bearer token). Re-runs
+# provision + baseline + self-test only, leaving an existing enrolment, its
+# per-client token, and the already-authorized dashboard key untouched. This is
+# the supported way to re-apply a client-side patch (e.g. enabling sshd) to a
+# box that is already enrolled, where a fresh enrol would 401 (single-use token)
+# or 409 (hostname already registered). Set via --skip-enrol or PCT_SKIP_ENROL.
+PCT_SKIP_ENROL="${PCT_SKIP_ENROL:-}"
+
+# Distinct exit code pct_orch_enrol returns to signal "this host is already
+# enrolled" (the dashboard's 409). The caller treats it as a tolerable re-run
+# condition — keep the existing enrolment and carry on to the self-test —
+# rather than a hard failure (return 1), so a plain re-run does not abort.
+PCT_ENROL_ALREADY_CODE=3
+
+# Whether enrolment is being skipped this run (--skip-enrol / PCT_SKIP_ENROL).
+pct_orch_skip_enrol() { pct_is_true "${PCT_SKIP_ENROL:-}"; }
 
 # Version-reporting probes (#164). The enrol body reports the pct-client agent
 # `.deb` version and the installed managed-tool versions so the dashboard has a
@@ -112,10 +137,19 @@ Options:
                             be supplied via PCT_SUPERVISED_USERS (space list).
   --ssh-user NAME           SSH principal the dashboard connects as
                             (default: pct-agent).
+  --skip-enrol              Upgrade-in-place: re-run the provision + baseline +
+                            self-test steps on an ALREADY-enrolled client and
+                            skip the enrolment exchange (and authorizing the SSH
+                            key / persisting the token). Use this to re-apply a
+                            client-side patch without minting a fresh token or
+                            re-registering. Needs no --enrolment-token; the
+                            --server-url is optional (no network is touched).
+                            May also be set via PCT_SKIP_ENROL=1.
   -h, --help                Show this help.
 
 Environment:
   PCT_DRY_RUN=1             Print the plan without changing anything.
+  PCT_SKIP_ENROL=1          Same as --skip-enrol (upgrade-in-place).
 EOF
 }
 
@@ -325,18 +359,44 @@ pct_orch_enrol() {
   # Feed the Authorization header through `curl --config -` on stdin so the
   # secret enrolment token never appears in this process's argv (and thus not in
   # `ps`). The token is base64url, so the config-file quoting is safe. The body
-  # is not secret, so it stays on argv. --fail makes a non-2xx an error; the
-  # endpoint returns 201 on success.
-  if ! printf 'header = "Authorization: Bearer %s"\n' "$token" |
+  # is not secret, so it stays on argv.
+  #
+  # We capture the body to a temp file and the HTTP status via --write-out
+  # (rather than --fail, which collapses every non-2xx into one exit code) so an
+  # "already enrolled" 409 can be told apart from a real failure: a re-run
+  # against an already-registered host is a tolerable upgrade condition, not an
+  # abort. The body file is created 0600 by mktemp and removed on every path.
+  local body_file http
+  body_file="$(mktemp)"
+  if ! http="$(printf 'header = "Authorization: Bearer %s"\n' "$token" |
     "$PCT_CURL" --config - \
-      --fail --silent --show-error --max-time 30 \
+      --silent --show-error --max-time 30 \
+      --output "$body_file" --write-out '%{http_code}' \
       --request POST \
       --header "Content-Type: application/json" \
       --data "$body" \
-      "$url"; then
-    pct_err "enrolment request to ${url} failed (the token may be expired or already used; mint a fresh one)"
+      "$url")"; then
+    rm -f "$body_file"
+    pct_err "enrolment request to ${url} failed (network error; check --server-url and connectivity)"
     return 1
   fi
+
+  case "$http" in
+  2??)
+    cat "$body_file"
+    rm -f "$body_file"
+    ;;
+  409)
+    rm -f "$body_file"
+    pct_warn "this host is already enrolled (the dashboard returned 409); keeping the existing enrolment and skipping re-enrol"
+    return "$PCT_ENROL_ALREADY_CODE"
+    ;;
+  *)
+    rm -f "$body_file"
+    pct_err "enrolment to ${url} returned HTTP ${http} (the token may be expired or already used; mint a fresh one)"
+    return 1
+    ;;
+  esac
 }
 
 # Persist the per-client credentials the enrolment produced. This is the hand-off
@@ -435,7 +495,13 @@ pct_install_client() {
   pct_orch_require_root
   pct_orch_require_tools
   pct_require_supported_client
-  pct_orch_check_reachable "$server_url"
+  # The reachability probe only matters when we are going to talk to the
+  # dashboard. Under --skip-enrol with no --server-url there is nothing to reach.
+  if [ -n "$server_url" ]; then
+    pct_orch_check_reachable "$server_url"
+  else
+    pct_log "no --server-url given; skipping the dashboard reachability check (--skip-enrol)"
+  fi
 
   # Resolve each supervised user's UID up front (fails fast on a missing user)
   # and build the flat (username uid) pair list the enrol body needs.
@@ -453,18 +519,38 @@ pct_install_client() {
   pct_step "Install + baseline-configure the upstream tools"
   pct_install_baseline_tools "${users[@]}"
 
-  # Step: register with the dashboard.
+  # Step: register with the dashboard (unless this is an upgrade-in-place).
   pct_step "Register this client with the dashboard"
-  local response client_id bearer ssh_pubkey
-  response="$(pct_orch_enrol "$server_url" "$enrol_token" "$hostname" "$ssh_user" "${pairs[@]}")"
-  client_id="$(printf '%s' "$response" | pct_orch_json_number clientId)"
-  bearer="$(printf '%s' "$response" | pct_orch_json_string bearerToken)"
-  ssh_pubkey="$(printf '%s' "$response" | pct_orch_json_string sshPublicKey)"
-  pct_ok "enrolled as client #${client_id:-?} (host '${hostname}', ssh user '${ssh_user}')"
-
-  # Step: authorize the dashboard SSH key + persist the client bearer token.
-  pct_orch_authorize_key "$ssh_pubkey"
-  pct_orch_persist_credentials "$server_url" "$client_id" "$bearer"
+  if pct_orch_skip_enrol; then
+    pct_warn "--skip-enrol: leaving the existing enrolment, per-client token, and authorized SSH key untouched (upgrade-in-place)"
+  else
+    # Declare first, THEN assign via command substitution: combining `local`
+    # with the capture would mask pct_orch_enrol's exit code (local always
+    # returns 0), and we need it to tell success from the tolerable "already
+    # enrolled" (409) signal. `|| status=$?` keeps `set -e` from aborting here.
+    local response client_id bearer ssh_pubkey status=0
+    response="$(pct_orch_enrol "$server_url" "$enrol_token" "$hostname" "$ssh_user" "${pairs[@]}")" || status=$?
+    if [ "$status" -eq 0 ]; then
+      client_id="$(printf '%s' "$response" | pct_orch_json_number clientId)"
+      bearer="$(printf '%s' "$response" | pct_orch_json_string bearerToken)"
+      ssh_pubkey="$(printf '%s' "$response" | pct_orch_json_string sshPublicKey)"
+      pct_ok "enrolled as client #${client_id:-?} (host '${hostname}', ssh user '${ssh_user}')"
+      # Step: authorize the dashboard SSH key + persist the client bearer token.
+      pct_orch_authorize_key "$ssh_pubkey"
+      pct_orch_persist_credentials "$server_url" "$client_id" "$bearer"
+    elif [ "$status" -eq "$PCT_ENROL_ALREADY_CODE" ]; then
+      # Already enrolled (409): the account, sudoers, authorized key, and
+      # baseline tools have still been reconciled above, so this is a successful
+      # upgrade — carry on to the self-test rather than aborting. (Re-run with
+      # --skip-enrol to silence the warning, or delete + re-enrol with a fresh
+      # token for a true re-registration.)
+      pct_warn "continuing without re-enrol; provision + baseline were still reconciled. Use --skip-enrol on an already-enrolled host, or delete the client and mint a fresh token to re-register."
+    else
+      # A real failure (bad/expired token, network) — pct_orch_enrol already
+      # explained why; propagate so the run aborts.
+      return 1
+    fi
+  fi
 
   # Step: self-test.
   PCT_SUPERVISED_LIST="${users[*]}" pct_orch_self_test
@@ -481,6 +567,7 @@ pct_orch_main() {
   local server_url="${PCT_SERVER_URL:-}"
   local enrol_token="${PCT_ENROLMENT_TOKEN:-}"
   local ssh_user="$PCT_SSH_USER"
+  local skip_enrol="${PCT_SKIP_ENROL:-}"
   local users=()
   if [ -n "${PCT_SUPERVISED_USERS:-}" ]; then
     # shellcheck disable=SC2206  # intentional word-split of a space list
@@ -537,6 +624,10 @@ pct_orch_main() {
       ssh_user="${1#*=}"
       shift
       ;;
+    --skip-enrol | --skip-enrolment | --skip-enrollment)
+      skip_enrol=1
+      shift
+      ;;
     -h | --help)
       pct_orch_usage
       return 0
@@ -549,8 +640,13 @@ pct_orch_main() {
     esac
   done
 
+  # Surface the skip-enrol decision (flag or env) to pct_install_client.
+  PCT_SKIP_ENROL="$skip_enrol"
+
   # A real run hard-requires the server URL, a one-time token, and at least one
-  # supervised user. A dry run is a side-effect-free PREVIEW: it fills clearly
+  # supervised user. --skip-enrol relaxes the first two (no dashboard is
+  # contacted) but still needs the supervised users, since provision + baseline
+  # are per-user. A dry run is a side-effect-free PREVIEW: it fills clearly
   # labelled placeholders for anything missing so it can always render the full
   # plan (this is also what the minimal CI smoke test exercises — no token, no
   # user, just PCT_SERVER_URL).
@@ -558,18 +654,20 @@ pct_orch_main() {
     if pct_is_dry_run; then
       server_url="https://dashboard.example"
       pct_warn "no --server-url given; using placeholder '${server_url}' for the dry-run preview"
+    elif pct_orch_skip_enrol; then
+      : # --skip-enrol contacts no dashboard, so a server URL is not required
     else
       pct_err "missing --server-url (or PCT_SERVER_URL)"
       pct_orch_usage
       return 2
     fi
   fi
-  if [ -z "$enrol_token" ]; then
+  if [ -z "$enrol_token" ] && ! pct_orch_skip_enrol; then
     if pct_is_dry_run; then
       enrol_token="DRY-RUN-PLACEHOLDER-TOKEN"
       pct_warn "no --enrolment-token given; using a placeholder for the dry-run preview"
     else
-      pct_err "missing --enrolment-token (or PCT_ENROLMENT_TOKEN)"
+      pct_err "missing --enrolment-token (or PCT_ENROLMENT_TOKEN); pass --skip-enrol to re-run an already-enrolled client without one"
       pct_orch_usage
       return 2
     fi

--- a/client/lib/pct-common.sh
+++ b/client/lib/pct-common.sh
@@ -209,3 +209,16 @@ pct_set_conf_key() {
     printf '%s = %s\n' "$key" "$value" >>"$file"
   fi
 }
+
+# Echo a content checksum for a file, or the literal `absent` if it does not
+# exist. Used to detect whether a managed config actually changed across a
+# (re-)run — see install-baseline-tools.sh's pct_apply_change — so a service is
+# only restarted/reloaded when its config did, keeping a no-op re-run a no-op.
+# Read-only, so dry-run is irrelevant.
+pct_file_checksum() {
+  if [ -f "$1" ]; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    printf 'absent'
+  fi
+}

--- a/client/tests/install-baseline-tools.bats
+++ b/client/tests/install-baseline-tools.bats
@@ -147,6 +147,52 @@ plan() { # run the script in dry-run with the given args, capture the plan
   [[ "$output" == *"systemctl enable --now e2guardian.service"* ]]
 }
 
+@test "plans a conditional restart/reload so a re-run applies config changes (#347)" {
+  plan --supervised-user alice
+  [ "$status" -eq 0 ]
+  # The daemons are only bounced if their config actually changed, so the plan
+  # shows the conditional apply rather than an unconditional restart.
+  [[ "$output" == *"try-restart timekpr.service (only if"* ]]
+  [[ "$output" == *"try-reload-or-restart e2guardian.service (only if"* ]]
+}
+
+@test "pct_file_checksum reports absent vs a stable content checksum (real)" {
+  run env -u PCT_DRY_RUN bash -c '
+    source "'"$SCRIPT"'"
+    pct_file_checksum "'"$TMP"'/nope"; echo
+    printf x >"'"$TMP"'/f"; a="$(pct_file_checksum "'"$TMP"'/f")"
+    printf x >"'"$TMP"'/f"; b="$(pct_file_checksum "'"$TMP"'/f")"
+    [ "$a" = "$b" ] && echo SAME
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"absent"* ]]
+  [[ "$output" == *"SAME"* ]]
+}
+
+@test "pct_apply_change restarts only when the file changed (real)" {
+  local rec="${TMP}/systemctl-calls" stub="${TMP}/systemctl"
+  cat >"$stub" <<EOS
+#!/usr/bin/env bash
+echo "\$*" >>"${rec}"
+EOS
+  chmod +x "$stub"
+  local f="${TMP}/conf"
+  printf 'a\n' >"$f"
+  run env -u PCT_DRY_RUN bash -c '
+    PCT_SYSTEMCTL="'"$stub"'"
+    source "'"$SCRIPT"'"
+    before="$(pct_file_checksum "'"$f"'")"
+    printf "b\n" >"'"$f"'"                                    # changed -> restart
+    pct_apply_change "'"$f"'" "$before" timekpr.service try-restart
+    after="$(pct_file_checksum "'"$f"'")"
+    pct_apply_change "'"$f"'" "$after" timekpr.service try-restart   # unchanged -> no-op
+  '
+  [ "$status" -eq 0 ]
+  # Exactly one restart was issued — for the real change, not for the no-op re-run.
+  [ -f "$rec" ]
+  [ "$(grep -c 'try-restart timekpr.service' "$rec")" -eq 1 ]
+}
+
 @test "installs the openssh-server package (the dashboard connects over SSH)" {
   plan --supervised-user alice
   [ "$status" -eq 0 ]

--- a/client/tests/install-client.bats
+++ b/client/tests/install-client.bats
@@ -392,6 +392,49 @@ EOS
   [[ "$output" == *"Install + baseline-configure the upstream tools"* ]]
 }
 
+# The two dry-run tests above can't pin the validation relaxation: under dry-run
+# pct_orch_main fills placeholders for a missing token/server-url *before* the
+# --skip-enrol branch is reached, so a regression that re-imposed the token
+# requirement for a real --skip-enrol run would still pass them. These exercise
+# the REAL-run validation path (env -u PCT_DRY_RUN) and stub pct_install_client
+# so the assertion is "validation passed" without doing privileged work.
+@test "--skip-enrol relaxes the token + server-url requirement on a real run" {
+  run env -u PCT_DRY_RUN bash -c '
+    source "'"$SCRIPT"'"
+    pct_install_client() { echo "VALIDATION_PASSED"; }
+    pct_orch_main --skip-enrol --supervised-user alice
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VALIDATION_PASSED"* ]]
+  [[ "$output" != *"missing --enrolment-token"* ]]
+  [[ "$output" != *"missing --server-url"* ]]
+}
+
+@test "PCT_SKIP_ENROL=1 relaxes the same requirements on a real run" {
+  run env -u PCT_DRY_RUN PCT_SKIP_ENROL=1 bash -c '
+    source "'"$SCRIPT"'"
+    pct_install_client() { echo "VALIDATION_PASSED"; }
+    pct_orch_main --supervised-user alice
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VALIDATION_PASSED"* ]]
+  [[ "$output" != *"missing --enrolment-token"* ]]
+}
+
+@test "without --skip-enrol a real run STILL requires the token (guard is real)" {
+  # The negative control for the relaxation: same real-run path, no skip-enrol,
+  # must abort on the missing token (proves the tests above pass because of the
+  # relaxation, not because validation is toothless on this path).
+  run env -u PCT_DRY_RUN bash -c '
+    source "'"$SCRIPT"'"
+    pct_install_client() { echo "VALIDATION_PASSED"; }
+    pct_orch_main --server-url https://dash.lan --supervised-user alice
+  '
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing --enrolment-token"* ]]
+  [[ "$output" != *"VALIDATION_PASSED"* ]]
+}
+
 # --- dry-run guarantee -----------------------------------------------------
 
 @test "a dry run reports that nothing was changed" {

--- a/client/tests/install-client.bats
+++ b/client/tests/install-client.bats
@@ -310,10 +310,21 @@ plan_strict() {
 
 @test "the enrolment token is sent via stdin config, never on the curl argv" {
   local stub="${TMP}/curl-echo"
+  # Emulate the slice of curl pct_orch_enrol relies on: honour --output by
+  # writing a fake 2xx body there and print the status code for --write-out, so
+  # the captured stdout is just the code. ARGV/STDIN go to stderr so they don't
+  # pollute the captured status but are still visible in the merged test output.
   cat >"$stub" <<'EOS'
 #!/usr/bin/env bash
-echo "ARGV: $*"
-echo "STDIN: $(cat)"
+out="" prev=""
+for a in "$@"; do
+  [ "$prev" = "--output" ] && out="$a"
+  prev="$a"
+done
+echo "ARGV: $*" >&2
+echo "STDIN: $(cat)" >&2
+[ -n "$out" ] && printf '{"clientId":1,"bearerToken":"b","sshPublicKey":null,"supervisedUsers":[]}' >"$out"
+printf '201'
 EOS
   chmod +x "$stub"
   run env -u PCT_DRY_RUN bash -c '
@@ -329,6 +340,56 @@ EOS
   [[ "$argv_line" != *SECRETTOKEN* ]]
   # ... but must be delivered through the stdin config file.
   [[ "$stdin_line" == *"Authorization: Bearer SECRETTOKEN"* ]]
+}
+
+@test "an already-enrolled host (409) is tolerated, not a hard failure" {
+  local stub="${TMP}/curl-409"
+  # Emulate curl returning the dashboard's 409: write the (conflict) body to the
+  # --output path and print 409 for --write-out.
+  cat >"$stub" <<'EOS'
+#!/usr/bin/env bash
+out="" prev=""
+for a in "$@"; do
+  [ "$prev" = "--output" ] && out="$a"
+  prev="$a"
+done
+[ -n "$out" ] && printf '{"error":{"code":"conflict"}}' >"$out"
+printf '409'
+EOS
+  chmod +x "$stub"
+  run env -u PCT_DRY_RUN bash -c '
+    PCT_CURL="'"$stub"'"
+    source "'"$SCRIPT"'"
+    rc=0
+    pct_orch_enrol https://dash.lan TOK host pct-agent alice 1000 || rc=$?
+    echo "RC=${rc}"
+  '
+  # pct_orch_enrol signals the distinct already-enrolled code (PCT_ENROL_ALREADY_CODE=3),
+  # not a hard failure (1), so the orchestrator can carry on to the self-test.
+  [[ "$output" == *"already enrolled"* ]]
+  [[ "$output" == *"RC=3"* ]]
+}
+
+# --- upgrade-in-place (--skip-enrol) ---------------------------------------
+
+@test "with --skip-enrol, re-runs provision + baseline + self-test and skips enrol (no token needed)" {
+  # No --enrolment-token and no --server-url: --skip-enrol must require neither.
+  run env bash "$SCRIPT" --skip-enrol --supervised-user alice
+  [ "$status" -eq 0 ]
+  # The enrolment exchange and its dependents are skipped ...
+  [[ "$output" == *"--skip-enrol"* ]]
+  [[ "$output" != *"/api/clients/enrol"* ]]
+  [[ "$output" != *"authorize dashboard ssh key"* ]]
+  # ... but provision + baseline still run.
+  [[ "$output" == *"Provision the pct-agent service account"* ]]
+  [[ "$output" == *"Install + baseline-configure the upstream tools"* ]]
+}
+
+@test "PCT_SKIP_ENROL=1 is equivalent to --skip-enrol" {
+  PCT_SKIP_ENROL=1 run env bash "$SCRIPT" --supervised-user alice
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"/api/clients/enrol"* ]]
+  [[ "$output" == *"Install + baseline-configure the upstream tools"* ]]
 }
 
 # --- dry-run guarantee -----------------------------------------------------

--- a/docs/client-install.md
+++ b/docs/client-install.md
@@ -54,10 +54,13 @@ dashboard, has a short TTL, and is single-use.
 Re-running the installer is how a client-side change (for example, enabling
 the SSH server so the dashboard can reach the box) reaches a machine that was
 enrolled before the change existed. Every sub-step is idempotent and reconciles
-rather than re-bootstraps, but enrolment itself is **not** repeatable: the
-enrolment token is single-use, and the client's hostname is unique on the
-dashboard, so a second enrolment of the same host would otherwise fail. The
-orchestrator handles this two ways:
+rather than re-bootstraps — and when a re-run changes a daemon's config
+(Timekpr-nExT's warning lead times, the e2guardian filter group), the baseline
+restarts or reloads that daemon so the change actually takes effect, while a
+no-op re-run leaves the running services untouched. But enrolment itself is
+**not** repeatable: the enrolment token is single-use, and the client's
+hostname is unique on the dashboard, so a second enrolment of the same host
+would otherwise fail. The orchestrator handles this two ways:
 
 - **`--skip-enrol` (recommended for upgrades).** Re-runs provision + baseline +
   self-test only, and skips the enrolment exchange and its dependents

--- a/docs/client-install.md
+++ b/docs/client-install.md
@@ -49,6 +49,50 @@ dashboard, has a short TTL, and is single-use.
 > what `GET /install-client.sh` serves and what the release attaches. Edit the
 > modular sources — the bundle is a generated artifact, never committed.
 
+## Upgrading an already-enrolled client
+
+Re-running the installer is how a client-side change (for example, enabling
+the SSH server so the dashboard can reach the box) reaches a machine that was
+enrolled before the change existed. Every sub-step is idempotent and reconciles
+rather than re-bootstraps, but enrolment itself is **not** repeatable: the
+enrolment token is single-use, and the client's hostname is unique on the
+dashboard, so a second enrolment of the same host would otherwise fail. The
+orchestrator handles this two ways:
+
+- **`--skip-enrol` (recommended for upgrades).** Re-runs provision + baseline +
+  self-test only, and skips the enrolment exchange and its dependents
+  (authorizing the dashboard SSH key, persisting the per-client token). It needs
+  no token and contacts no dashboard, so the existing enrolment, token, and
+  authorized key are left untouched:
+
+  ```bash
+  sudo bash install-client.sh --skip-enrol --supervised-user alice
+  ```
+
+- **A plain re-run.** If you re-run the full flow (with a freshly minted token),
+  the orchestrator now **tolerates** the dashboard's "already enrolled" `409`:
+  it keeps the existing enrolment and continues to the self-test instead of
+  aborting. A genuinely bad or expired token still fails with a clear message
+  (mint a fresh one). Note the baseline step runs *before* enrolment, so the
+  client-side patch is applied either way.
+
+Two things re-running on the client does **not** do, and that you must handle
+separately:
+
+1. **Redeploy the dashboard for any server-side half of a change, and to update
+   the served bundle.** `GET /install-client.sh` serves the bundle baked into
+   the image at build time, so a client-side fix only reaches `curl`-based
+   installs after the dashboard image is rebuilt and redeployed. Server-side
+   behaviour (e.g. the live health prober) likewise only takes effect once the
+   dashboard runs the new code.
+2. **Confirm the dashboard's current public key is authorized.** Re-running with
+   `--skip-enrol` does not touch `~pct-agent/.ssh/authorized_keys` — only a real
+   enrolment does. If a client was enrolled before the dashboard had generated
+   its key (so it authorized none), the daemon being up is not enough; run the
+   self-test (it checks the key is present and locked down) and, if it is
+   missing, delete the client and re-enrol with a fresh token, or authorize the
+   dashboard's public key for `pct-agent` by hand.
+
 ## What the script does
 
 1. **Sanity checks** — confirm distro (parse `/etc/os-release`), confirm


### PR DESCRIPTION
## Summary

Follow-up to #341. Deploying that sshd-enable fix to the already-enrolled clients means re-running the installer — but a plain re-run **aborted at the enrol step**: the enrolment token is single-use (`401`) and the hostname is unique on the dashboard (`409`), and under `set -euo pipefail` either one killed the run. This makes re-running an already-enrolled client a first-class, supported path.

## Changes

**Two re-run shapes in `install-client.sh`:**

1. **`--skip-enrol`** (and `PCT_SKIP_ENROL=1`) — re-runs provision + baseline + self-test only, skipping the enrolment exchange and its dependents (authorizing the SSH key, persisting the per-client token). Needs no token and contacts no dashboard, so an existing enrolment / token / authorized key is left untouched. The `--enrolment-token` and `--server-url` requirements are relaxed accordingly.

   ```bash
   sudo bash install-client.sh --skip-enrol --supervised-user alice
   ```

2. **409-tolerant plain re-run** — `pct_orch_enrol` now captures the HTTP status (via `--output`/`--write-out` instead of `--fail`) and returns a distinct exit code for the dashboard's "already enrolled" `409`. The orchestrator treats that as a tolerable upgrade condition: it keeps the existing enrolment and continues to the self-test instead of aborting. A genuinely bad/expired token still `401`s and aborts with a clear message. (The baseline step runs before enrol, so the client-side patch lands either way.)

**Docs:** new "Upgrading an already-enrolled client" section in `docs/client-install.md` covering both shapes, plus the two things a client-side re-run does **not** do and that must be handled separately — redeploy the dashboard (the served bundle is baked at image-build time, and server-side changes like the live health prober only take effect on redeploy), and re-authorize the dashboard's current public key (only a real enrol writes `authorized_keys`).

## License boundaries

None touched — pure bash orchestration; GPL tools still come from the distro/upstream via the baseline step, nothing linked in-process or bundled into the image. No tamper-resistance scope creep (this is about idempotent re-runs, not lockdown).

## Testing

- `shellcheck client/install-client.sh` — clean.
- `bats client/tests/*.bats` — 133 pass, including 4 new/updated cases: 409 tolerance, `--skip-enrol`, `PCT_SKIP_ENROL=1`, and the token-on-stdin stub updated for the new curl invocation.
- No `server/` files changed, so the TS hooks/CI are unaffected; file-hygiene (trailing whitespace, final newline) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVEYE68aFNye6rGFPNiyCt)_