### PR TITLE
feat(clients): show client version drift on the Clients page (#352)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,18 @@
 # IANA name (validated at startup). Defaults to UTC.
 # PCT_DEFAULT_TZ=UTC
 
+# The dashboard's own release version, shown on the Clients page and compared
+# against each client's reported agent version to flag drift (#352). Normally
+# stamped into the image at build time from the release tag, so you rarely set
+# it by hand; unset means the page shows reported versions without a verdict.
+# PCT_SERVER_VERSION=0.1.0-alpha.5
+
+# How many event-protocol versions below the server's own the event-stream
+# handshake still accepts (ADR 0007 §3). 1 is the historical N-1 window.
+# Widening it both stops refusing older clients and moves the threshold that
+# flags a client "update required" on the Clients page. A positive integer.
+# PCT_PROTOCOL_COMPAT_WINDOW=1
+
 # pino log level: trace | debug | info | warn | error | fatal | silent
 # PCT_LOG_LEVEL=info
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Stamp the release version into the image so the dashboard knows its
+          # own version at runtime (config.ts → the Clients-page drift badge,
+          # #352). metadata-action's `version` output is the tag without the
+          # leading `v` (e.g. 0.1.0-alpha.5).
+          build-args: |
+            PCT_SERVER_VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -80,6 +80,14 @@ RUN apt-get update \
 ENV NODE_ENV=production
 WORKDIR /app
 
+# The dashboard's own release version, stamped in at build time from the release
+# tag (release.yml passes --build-arg PCT_SERVER_VERSION=<semver>). Read at
+# runtime (config.ts) so the admin Clients page can flag clients whose reported
+# agent version has drifted from the server (#352). Empty on a plain `docker
+# build` (dev/local): the page then shows reported versions without a verdict.
+ARG PCT_SERVER_VERSION=""
+ENV PCT_SERVER_VERSION=${PCT_SERVER_VERSION}
+
 # Production dependencies and compiled backend.
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist

--- a/server/frontend/src/lib/views/ClientsView.svelte
+++ b/server/frontend/src/lib/views/ClientsView.svelte
@@ -293,6 +293,36 @@
     return Number.isNaN(date.getTime()) ? iso : date.toLocaleString();
   }
 
+  /** Badge label + pill class + hover detail for a client's version-drift verdict (#352). */
+  function versionStatusMeta(status: ClientHealthResponse["versionStatus"] | undefined): {
+    label: string;
+    cls: string;
+    title: string;
+  } {
+    switch (status) {
+      case "up_to_date":
+        return { label: "up to date", cls: "ok", title: "Reported agent version matches or is newer than the server." };
+      case "outdated":
+        return {
+          label: "update available",
+          cls: "warn",
+          title: "This client's reported agent version is behind the server. It still works; re-run the installer to update it.",
+        };
+      case "update_required":
+        return {
+          label: "update required",
+          cls: "bad",
+          title: "The event-stream handshake refused this client for running an out-of-window protocol (ADR 0007). It must be updated before it can reconnect.",
+        };
+      default:
+        return {
+          label: "version unknown",
+          cls: "unknown",
+          title: "No version to compare — the client hasn't reported one, the server build stamped none, or the version string couldn't be parsed.",
+        };
+    }
+  }
+
   function reachabilityClass(reachability: ClientHealthResponse["reachability"]): string {
     if (reachability === "online") {
       return "ok";
@@ -343,6 +373,7 @@
       {#each merged as entry (entry.client.id)}
         {@const client = entry.client}
         {@const h = entry.health}
+        {@const vsm = versionStatusMeta(h?.versionStatus)}
         <article class="card">
           <div class="card-top">
             <div>
@@ -367,9 +398,12 @@
                 {formatDateTime(client.enrolledAt)}
               </div>
             </div>
-            <span class="pill {reachabilityClass(h?.reachability ?? 'unknown')}">
-              {h?.reachability ?? "unknown"}
-            </span>
+            <div class="status-pills">
+              <span class="pill {reachabilityClass(h?.reachability ?? 'unknown')}">
+                {h?.reachability ?? "unknown"}
+              </span>
+              <span class="pill {vsm.cls}" title={vsm.title}>{vsm.label}</span>
+            </div>
           </div>
 
           <dl class="kv">
@@ -384,6 +418,29 @@
               </dd>
             </div>
             <div><dt>Last seen</dt><dd>{formatDateTime(client.lastSeen)}</dd></div>
+            <div>
+              <dt>Agent version</dt>
+              <dd>
+                {#if h?.agentVersion}
+                  {h.agentVersion}
+                  {#if h.serverVersion}
+                    <span class="muted small">· server {h.serverVersion}</span>
+                  {/if}
+                {:else}
+                  <span class="muted">not reported</span>
+                {/if}
+              </dd>
+            </div>
+            <div>
+              <dt>Version reported</dt>
+              <dd>
+                {#if h?.versionsReportedAt}
+                  {formatDateTime(h.versionsReportedAt)}
+                {:else}
+                  <span class="muted">—</span>
+                {/if}
+              </dd>
+            </div>
             <div>
               <dt>Last probe</dt>
               <dd>
@@ -692,6 +749,12 @@
     gap: 0.4rem;
     border-top: 1px solid #f3f4f6;
     padding-top: 0.5rem;
+  }
+  .status-pills {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.3rem;
   }
   .pill {
     display: inline-flex;

--- a/server/frontend/src/lib/views/ClientsView.svelte
+++ b/server/frontend/src/lib/views/ClientsView.svelte
@@ -423,11 +423,11 @@
               <dd>
                 {#if h?.agentVersion}
                   {h.agentVersion}
-                  {#if h.serverVersion}
-                    <span class="muted small">· server {h.serverVersion}</span>
-                  {/if}
                 {:else}
                   <span class="muted">not reported</span>
+                {/if}
+                {#if h?.serverVersion}
+                  <span class="muted small">· server {h.serverVersion}</span>
                 {/if}
               </dd>
             </div>

--- a/server/frontend/tests/components/clients-view-health.test.ts
+++ b/server/frontend/tests/components/clients-view-health.test.ts
@@ -71,6 +71,10 @@ function health(overrides: Partial<ClientHealthResponse> = {}): ClientHealthResp
     enrolledAt: "2026-06-01T00:00:00.000Z",
     probedAt: "2026-06-20T10:00:00.000Z",
     updateRequired: false,
+    agentVersion: "0.1.0-alpha.5",
+    versionsReportedAt: "2026-06-20T10:00:00.000Z",
+    serverVersion: "0.1.0-alpha.5",
+    versionStatus: "up_to_date",
     components: [{ component: "timekpr-next", status: "ok", detail: "active" }],
     queue: { pending: 0, failed: 0, actions: [] },
     ...overrides,
@@ -161,6 +165,44 @@ describe("ClientsView health list + queue", () => {
     render(ClientsView);
 
     expect(await screen.findByText("No clients yet. Enrol one below.")).toBeInTheDocument();
+  });
+
+  it("badges version drift and shows the reported vs server version (#352)", async () => {
+    listClients.mockResolvedValue([client()]);
+    listClientHealth.mockResolvedValue([
+      health({ agentVersion: "0.1.0-alpha.4", serverVersion: "0.1.0-alpha.5", versionStatus: "outdated" }),
+    ]);
+
+    render(ClientsView);
+    await screen.findByText("mint-box");
+
+    expect(screen.getByText("update available")).toBeInTheDocument();
+    // The reported version and the server version both surface on the card.
+    expect(screen.getByText("0.1.0-alpha.4")).toBeInTheDocument();
+    expect(screen.getByText(/server 0\.1\.0-alpha\.5/)).toBeInTheDocument();
+  });
+
+  it("shows 'update required' when the handshake flagged the client (#352)", async () => {
+    listClients.mockResolvedValue([client()]);
+    listClientHealth.mockResolvedValue([health({ updateRequired: true, versionStatus: "update_required" })]);
+
+    render(ClientsView);
+    await screen.findByText("mint-box");
+
+    expect(screen.getByText("update required")).toBeInTheDocument();
+  });
+
+  it("shows 'version unknown' for a client that never reported one (#352)", async () => {
+    listClients.mockResolvedValue([client()]);
+    listClientHealth.mockResolvedValue([
+      health({ agentVersion: null, versionsReportedAt: null, versionStatus: "unknown" }),
+    ]);
+
+    render(ClientsView);
+    await screen.findByText("mint-box");
+
+    expect(screen.getByText("version unknown")).toBeInTheDocument();
+    expect(screen.getByText("not reported")).toBeInTheDocument();
   });
 });
 

--- a/server/src/api/clients/health-dtos.ts
+++ b/server/src/api/clients/health-dtos.ts
@@ -21,6 +21,7 @@ import {
   componentHealthStatusValues,
   clientReachabilityValues,
 } from "../../transport/health/index.js";
+import { clientVersionStatusValues } from "./version-status.js";
 
 /** Health of one supervised component on a client. */
 export const componentHealthSchema = z.object({
@@ -72,6 +73,24 @@ export const clientHealthSchema = z.object({
    * client needs a `pct-client` agent update before it can reconnect.
    */
   updateRequired: z.boolean(),
+  /** The agent version the client last reported (enrol or handshake), or null (#164). */
+  agentVersion: z.string().nullable(),
+  /** When that version was last reported (ISO), or null if never (#164). */
+  versionsReportedAt: z.string().nullable(),
+  /**
+   * The dashboard's own release version, or null when the build didn't stamp
+   * one (dev/test). Echoed per row so the card can show "client X vs server Y"
+   * and the admin has one place to read the server version (#352).
+   */
+  serverVersion: z.string().nullable(),
+  /**
+   * The version-drift verdict the card badges on (#352): `update_required` (the
+   * protocol handshake refused it), `outdated` (behind the server), `up_to_date`
+   * (equal or newer), or `unknown` (nothing to compare). Computed server-side
+   * from {@link updateRequired} + agent/server versions so the frontend never
+   * reimplements the comparison.
+   */
+  versionStatus: z.enum(clientVersionStatusValues),
   components: z.array(componentHealthSchema),
   queue: clientQueueSchema,
 });

--- a/server/src/api/clients/health-routes.ts
+++ b/server/src/api/clients/health-routes.ts
@@ -44,6 +44,13 @@ export interface ClientHealthRoutesDeps {
    * {@link listClientHealth}. Inert until `prober` is wired (#39).
    */
   probeDeadlineMs?: number;
+  /**
+   * The dashboard's own release version (#352), threaded from
+   * `settings.serverVersion`. Echoed into each health row and used to classify
+   * version drift; absent (dev/test build) → clients show a reported version
+   * without a drift verdict.
+   */
+  serverVersion?: string;
 }
 
 /**
@@ -64,6 +71,7 @@ export function registerClientHealthRoutes(
       listClientHealth(scope.db, deps.prober, {
         concurrency: deps.probeConcurrency,
         deadlineMs: deps.probeDeadlineMs,
+        serverVersion: deps.serverVersion ?? null,
       }),
   );
 
@@ -71,7 +79,12 @@ export function registerClientHealthRoutes(
     "/clients/:id/health",
     { ...guard, schema: { params: idParamsSchema } },
     async (request): Promise<ClientHealthResponse> => {
-      const health = await getClientHealth(scope.db, request.params.id, deps.prober);
+      const health = await getClientHealth(
+        scope.db,
+        request.params.id,
+        deps.prober,
+        deps.serverVersion ?? null,
+      );
       if (health === undefined) {
         throw new ApiError(404, "not_found", `Client ${request.params.id} not found`);
       }

--- a/server/src/api/clients/health-service.ts
+++ b/server/src/api/clients/health-service.ts
@@ -32,6 +32,7 @@ import {
   type ClientHealthResponse,
   type ComponentHealthDto,
 } from "./health-dtos.js";
+import { classifyVersionStatus } from "./version-status.js";
 
 /** Detail shown for every component when no live prober is configured (pre-#39). */
 const PROBE_UNCONFIGURED_DETAIL = "SSH probing not yet configured (#39)";
@@ -77,6 +78,7 @@ function assemble(
   db: PolicyDb,
   client: ClientRow,
   probe: ClientProbeResult | undefined,
+  serverVersion: string | null,
   unknownDetail = PROBE_UNCONFIGURED_DETAIL,
 ): ClientHealthResponse {
   const queueRows = listForClient(db, client.id);
@@ -97,6 +99,15 @@ function assemble(
     enrolledAt: client.enrolledAt.toISOString(),
     probedAt: probe === undefined ? null : probe.at.toISOString(),
     updateRequired: client.updateRequired,
+    agentVersion: client.agentVersion,
+    versionsReportedAt:
+      client.versionsReportedAt === null ? null : client.versionsReportedAt.toISOString(),
+    serverVersion,
+    versionStatus: classifyVersionStatus({
+      clientVersion: client.agentVersion,
+      serverVersion,
+      updateRequired: client.updateRequired,
+    }),
     components,
     queue: {
       pending: queueRows.filter((row) => row.status === "pending").length,
@@ -114,11 +125,12 @@ export async function getClientHealth(
   db: PolicyDb,
   clientId: number,
   prober?: ClientProber,
+  serverVersion: string | null = null,
 ): Promise<ClientHealthResponse | undefined> {
   const client = repo.getClient(db, clientId);
   if (client === undefined) return undefined;
   const probe = prober === undefined ? undefined : await prober.probe(client);
-  return assemble(db, refreshLastSeen(db, client, probe), probe);
+  return assemble(db, refreshLastSeen(db, client, probe), probe, serverVersion);
 }
 
 /** Options bounding the live-probe fan-out of {@link listClientHealth} (#198). */
@@ -136,6 +148,12 @@ export interface ListClientHealthOptions {
   deadlineMs?: number | undefined;
   /** Test seam for the deadline timer; defaults to a real `setTimeout` timer. */
   deadlineFactory?: DeadlineFactory;
+  /**
+   * The dashboard's own version, echoed into each row and used to classify
+   * version drift (#352). `null` (the default) when the build stamped none — the
+   * card then reports each client's reported version without a drift verdict.
+   */
+  serverVersion?: string | null;
 }
 
 /** The settled outcome of racing one client's probe against the list deadline. */
@@ -161,6 +179,7 @@ async function probeClient(
   prober: ClientProber,
   client: ClientRow,
   deadlineReached: Promise<void> | undefined,
+  serverVersion: string | null,
 ): Promise<ClientHealthResponse> {
   const probed: Promise<ProbeOutcome> = prober.probe(client).then(
     (probe) => ({ kind: "ok", probe }),
@@ -171,11 +190,13 @@ async function probeClient(
       ? await probed
       : await Promise.race([probed, deadlineReached.then(() => ({ kind: "timeout" }) as const)]);
 
-  if (outcome.kind === "timeout") return assemble(db, client, undefined, PROBE_DEADLINE_DETAIL);
-  if (outcome.kind === "ok") {
-    return assemble(db, refreshLastSeen(db, client, outcome.probe), outcome.probe);
+  if (outcome.kind === "timeout") {
+    return assemble(db, client, undefined, serverVersion, PROBE_DEADLINE_DETAIL);
   }
-  return assemble(db, client, undefined, probeErrorDetail(outcome.error));
+  if (outcome.kind === "ok") {
+    return assemble(db, refreshLastSeen(db, client, outcome.probe), outcome.probe, serverVersion);
+  }
+  return assemble(db, client, undefined, serverVersion, probeErrorDetail(outcome.error));
 }
 
 /**
@@ -197,8 +218,11 @@ export async function listClientHealth(
   options: ListClientHealthOptions = {},
 ): Promise<ClientHealthResponse[]> {
   const clients = repo.listClients(db);
+  const serverVersion = options.serverVersion ?? null;
   if (prober === undefined) {
-    return clients.map((client) => assemble(db, client, undefined, PROBE_UNCONFIGURED_DETAIL));
+    return clients.map((client) =>
+      assemble(db, client, undefined, serverVersion, PROBE_UNCONFIGURED_DETAIL),
+    );
   }
 
   const concurrency = options.concurrency ?? DEFAULT_PROBE_CONCURRENCY;
@@ -207,7 +231,7 @@ export async function listClientHealth(
     deadlineMs > 0 ? (options.deadlineFactory ?? timerDeadline)(deadlineMs) : undefined;
   try {
     return await mapWithConcurrency(clients, concurrency, (client) =>
-      probeClient(db, prober, client, deadline?.reached),
+      probeClient(db, prober, client, deadline?.reached, serverVersion),
     );
   } finally {
     deadline?.cancel();

--- a/server/src/api/clients/version-status.ts
+++ b/server/src/api/clients/version-status.ts
@@ -1,0 +1,171 @@
+/**
+ * Client version-drift classification (#352): the pure, I/O-free core that
+ * decides how a client's reported agent version compares to the dashboard's own
+ * release, for the badge the admin "Clients" page renders.
+ *
+ * Two axes feed the verdict, and they are deliberately kept separate:
+ *
+ *  - **`update_required` (the red state)** is authoritative and comes from the
+ *    event-stream protocol handshake (ADR 0007 §5), governed by the configurable
+ *    compatibility window (`PCT_PROTOCOL_COMPAT_WINDOW` → {@link negotiate}). If
+ *    the server refused the client for speaking an out-of-window protocol, it
+ *    *must* update regardless of what its version string says.
+ *  - **version drift (green / amber / grey)** compares the reported
+ *    `agentVersion` *string* against the server's own version string. This is
+ *    the only signal available for a client that has never connected the event
+ *    stream (exactly the case that motivated this issue), which reports only its
+ *    enrol-time version and never reaches the protocol handshake.
+ *
+ * Isolated here — mirroring `events/protocol.ts`, `policy/budget-window.ts` — so
+ * the comparison is unit-testable with zero I/O and the frontend never
+ * reimplements it.
+ *
+ * License boundary: none touched — plain TypeScript.
+ */
+
+/** The per-client version verdict the Clients page badges on. */
+export const clientVersionStatusValues = [
+  /** Reported version equals or is newer than the server's. */
+  "up_to_date",
+  /** Reported version is older than the server's, but still protocol-compatible. */
+  "outdated",
+  /** The protocol handshake refused this client as too old (ADR 0007 §5). */
+  "update_required",
+  /** No reported version, no server version, or an unparseable version string. */
+  "unknown",
+] as const;
+
+/** One of {@link clientVersionStatusValues}. */
+export type ClientVersionStatus = (typeof clientVersionStatusValues)[number];
+
+/** A version split into its numeric release identifiers and prerelease tag. */
+interface ParsedVersion {
+  /** Dot-separated numeric release identifiers, e.g. `[0, 1, 0]`. */
+  release: number[];
+  /**
+   * Dot-separated prerelease identifiers (`["alpha", "5"]`) or `null` for a
+   * final release. A prerelease sorts *before* the same release with no tag
+   * (semver §11), matching Debian's `~` ordering.
+   */
+  prerelease: string[] | null;
+}
+
+/**
+ * Parse a version string into {@link ParsedVersion}, or `null` when the release
+ * component is not purely numeric-dotted (so callers report `unknown` rather
+ * than guess an order).
+ *
+ * Handles the two forms this project emits: a semver tag (`0.1.0-alpha.5`, the
+ * release-workflow / git-tag form) and a Debian package version (`0.1.0~alpha.5`,
+ * the `dpkg --showformat '${Version}'` the client reports at enrol). A leading
+ * `v` and either prerelease separator (`-` or `~`) are normalised away. The
+ * Debian `epoch:` prefix and `-revision` suffix are out of scope — this project
+ * versions its own artifacts as plain semver — so a `-<numeric>` Debian revision
+ * would be read as a prerelease; documented rather than handled.
+ */
+function parseVersion(raw: string): ParsedVersion | null {
+  const trimmed = raw.trim().replace(/^[vV]/, "");
+  if (trimmed === "") return null;
+
+  // The first `-` or `~` starts the prerelease tag; `~` is Debian's marker and
+  // `-` is semver's, and both sort the tail before a final release.
+  const sepIndex = trimmed.search(/[-~]/);
+  const releasePart = sepIndex === -1 ? trimmed : trimmed.slice(0, sepIndex);
+  const prereleasePart = sepIndex === -1 ? null : trimmed.slice(sepIndex + 1);
+
+  const release = releasePart.split(".").map((id) => Number(id));
+  if (release.length === 0 || release.some((n) => !Number.isInteger(n) || n < 0)) {
+    return null;
+  }
+
+  const prerelease =
+    prereleasePart === null || prereleasePart === "" ? null : prereleasePart.split(".");
+  return { release, prerelease };
+}
+
+/** Compare two dot-separated numeric release id lists; missing fields are `0`. */
+function compareRelease(a: number[], b: number[]): -1 | 0 | 1 {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    if (ai < bi) return -1;
+    if (ai > bi) return 1;
+  }
+  return 0;
+}
+
+/** Compare a single prerelease identifier pair per semver §11 (numeric < alnum). */
+function comparePreId(a: string, b: string): -1 | 0 | 1 {
+  const aNum = /^\d+$/.test(a);
+  const bNum = /^\d+$/.test(b);
+  if (aNum && bNum) {
+    const an = Number(a);
+    const bn = Number(b);
+    return an < bn ? -1 : an > bn ? 1 : 0;
+  }
+  // Numeric identifiers always have lower precedence than alphanumeric ones.
+  if (aNum) return -1;
+  if (bNum) return 1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Compare two prerelease tag lists per semver §11 (a longer tag wins on a tie). */
+function comparePrerelease(a: string[], b: string[]): -1 | 0 | 1 {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    // Both indices are within bounds of the shared prefix.
+    const cmp = comparePreId(a[i] as string, b[i] as string);
+    if (cmp !== 0) return cmp;
+  }
+  return a.length < b.length ? -1 : a.length > b.length ? 1 : 0;
+}
+
+/**
+ * Order two version strings: `-1` if `a` is older, `1` if newer, `0` if equal,
+ * or `null` if either is unparseable (the caller then reports `unknown`).
+ * Follows semver precedence, including "a prerelease sorts before its release".
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 | null {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (pa === null || pb === null) return null;
+
+  const releaseCmp = compareRelease(pa.release, pb.release);
+  if (releaseCmp !== 0) return releaseCmp;
+
+  // Same release: a version with a prerelease tag is older than one without.
+  if (pa.prerelease === null && pb.prerelease === null) return 0;
+  if (pa.prerelease === null) return 1;
+  if (pb.prerelease === null) return -1;
+  return comparePrerelease(pa.prerelease, pb.prerelease);
+}
+
+/** Inputs to {@link classifyVersionStatus}. */
+export interface VersionStatusInput {
+  /** The client's reported agent version, or `null` if none reported. */
+  clientVersion: string | null;
+  /** The dashboard's own version, or `null` if the build didn't stamp one. */
+  serverVersion: string | null;
+  /** Whether the protocol handshake has flagged this client as too old. */
+  updateRequired: boolean;
+}
+
+/**
+ * Classify a client's version drift into the badge the Clients page renders.
+ *
+ * `update_required` (the protocol handshake's verdict, governed by the
+ * configurable compatibility window) always wins — it is the authoritative
+ * "must update". Otherwise the reported version string is compared to the
+ * server's: equal-or-newer is `up_to_date`, older is `outdated`, and anything we
+ * can't compare (missing or unparseable version) is `unknown` rather than a
+ * misleading verdict.
+ */
+export function classifyVersionStatus(input: VersionStatusInput): ClientVersionStatus {
+  if (input.updateRequired) return "update_required";
+  if (input.clientVersion === null || input.serverVersion === null) return "unknown";
+
+  const cmp = compareVersions(input.clientVersion, input.serverVersion);
+  if (cmp === null) return "unknown";
+  return cmp < 0 ? "outdated" : "up_to_date";
+}

--- a/server/src/api/clients/version-status.ts
+++ b/server/src/api/clients/version-status.ts
@@ -73,10 +73,15 @@ function parseVersion(raw: string): ParsedVersion | null {
   const releasePart = sepIndex === -1 ? trimmed : trimmed.slice(0, sepIndex);
   const prereleasePart = sepIndex === -1 ? null : trimmed.slice(sepIndex + 1);
 
-  const release = releasePart.split(".").map((id) => Number(id));
-  if (release.length === 0 || release.some((n) => !Number.isInteger(n) || n < 0)) {
+  // Require each release identifier to be a plain non-negative decimal integer.
+  // `Number` alone would accept `3e2`/`0x0` and coerce `""`→0, admitting version
+  // strings this project never emits; a strict per-identifier check matches the
+  // "numeric-dotted" contract and returns `null` (→ `unknown`) for anything else.
+  const releaseIds = releasePart.split(".");
+  if (releaseIds.length === 0 || releaseIds.some((id) => !/^\d+$/.test(id))) {
     return null;
   }
+  const release = releaseIds.map((id) => Number(id));
 
   const prerelease =
     prereleasePart === null || prereleasePart === "" ? null : prereleasePart.split(".");

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -113,7 +113,12 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   // Event stream (#100): GET /api/events/stream WebSocket, per-client bearer
   // auth. Registered against the shared event hub so producers publish onto
   // the same registry. Async because it registers @fastify/websocket.
-  await registerEventStream(scope, opts.eventHub, opts.eventStream ?? {});
+  // The compatibility window is threaded from settings (the single source of
+  // truth, #352) unless a test injects a full `eventStream` override.
+  await registerEventStream(scope, opts.eventHub, {
+    compatWindow: opts.settings.protocolCompatWindow,
+    ...(opts.eventStream ?? {}),
+  });
   // Client health/status (#81): the read-only Clients-page reads. The live SSH
   // prober is injected from buildApp when the SSH-key bootstrap (#39) has run
   // and the policy-push transport is live; without it (dev/CI/tests, or a
@@ -124,6 +129,9 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
     ...(opts.prober !== undefined ? { prober: opts.prober } : {}),
     probeConcurrency: opts.settings.clientHealth.probeConcurrency,
     probeDeadlineMs: opts.settings.clientHealth.probeDeadlineMs,
+    ...(opts.settings.serverVersion !== undefined
+      ? { serverVersion: opts.settings.serverVersion }
+      : {}),
   });
   // Transport audit log (#85): admin-only read of every command issued to a client.
   registerAuditRoutes(scope);

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -171,8 +171,17 @@ const settingsSchema = z
      * each client's reported agent version without a drift verdict (there is
      * nothing authoritative to compare against). Used only for display/drift
      * classification — never for behaviour — so an absent value degrades safely.
+     *
+     * The `preprocess` maps an empty/whitespace-only value to `undefined` before
+     * validation: the `server/Dockerfile` sets `ENV PCT_SERVER_VERSION=` from an
+     * empty build arg on a plain `docker build` (no `--build-arg`), so the var is
+     * *present but empty* rather than unset. Without this, `.min(1)` would reject
+     * `""` and crash startup — the opposite of the "degrade safely" contract.
      */
-    serverVersion: z.string().min(1).optional(),
+    serverVersion: z.preprocess(
+      (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
+      z.string().min(1).optional(),
+    ),
     /**
      * How many event-protocol versions below the server's own the handshake
      * still accepts (`PCT_PROTOCOL_COMPAT_WINDOW`, ADR 0007 §3). `1` is the

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import { isValidTimeZone } from "./policy/budget-window.js";
 import { DEFAULT_RETENTION_DAYS, MAX_RETENTION_DAYS } from "./policy/retention.js";
 import { isValidCronPattern } from "./transport/activitywatch/telemetry.js";
+import { DEFAULT_COMPAT_WINDOW } from "./events/protocol.js";
 
 /** pino log levels, in increasing severity, plus `silent`. */
 const LOG_LEVELS = ["trace", "debug", "info", "warn", "error", "fatal", "silent"] as const;
@@ -162,6 +163,25 @@ const settingsSchema = z
     defaultTz: z.string().min(1).default("UTC").refine(isValidTimeZone, {
       message: "must be a valid IANA timezone (e.g. America/New_York)",
     }),
+    /**
+     * The dashboard's own release version (`PCT_SERVER_VERSION`, e.g.
+     * `0.1.0-alpha.5`), injected at image-build time from the release tag
+     * (`server/Dockerfile` build arg, set by `release.yml`). Optional: a local
+     * dev/test build leaves it unset, in which case the admin Clients page shows
+     * each client's reported agent version without a drift verdict (there is
+     * nothing authoritative to compare against). Used only for display/drift
+     * classification — never for behaviour — so an absent value degrades safely.
+     */
+    serverVersion: z.string().min(1).optional(),
+    /**
+     * How many event-protocol versions below the server's own the handshake
+     * still accepts (`PCT_PROTOCOL_COMPAT_WINDOW`, ADR 0007 §3). `1` is the
+     * historical N-1 window. This is the single source of truth for the window:
+     * it threads into {@link negotiate} via the event-stream route, so widening
+     * it both stops refusing older clients *and* moves the threshold that flags
+     * `update_required` on the Clients page. A positive integer.
+     */
+    protocolCompatWindow: z.coerce.number().int().positive().default(DEFAULT_COMPAT_WINDOW),
     /** Drives pino's level (see #11). */
     logLevel: z.enum(LOG_LEVELS).default("info"),
     /**
@@ -437,6 +457,8 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
     databaseUrl: env.DATABASE_URL,
     frontendRoot: env.PCT_FRONTEND_ROOT,
     defaultTz: env.PCT_DEFAULT_TZ,
+    serverVersion: env.PCT_SERVER_VERSION,
+    protocolCompatWindow: env.PCT_PROTOCOL_COMPAT_WINDOW,
     logLevel: env.PCT_LOG_LEVEL,
     logPretty: env.PCT_LOG_PRETTY,
     trustProxy: env.PCT_TRUST_PROXY,

--- a/server/src/events/protocol.ts
+++ b/server/src/events/protocol.ts
@@ -30,6 +30,16 @@ import { API_VERSION } from "../api/version.js";
 export const EVENT_PROTOCOL = 1;
 
 /**
+ * Default backward-compatibility window: how many protocol versions *below* the
+ * server's own the handshake still accepts (ADR 0007 §3). `1` is the historical
+ * N-1 window. Operators can widen it via `PCT_PROTOCOL_COMPAT_WINDOW`
+ * (`config.ts`), which threads through {@link negotiate} — the single source of
+ * truth for when a client is refused as `client_too_old` (and thereby flagged
+ * `update_required`, the admin-facing "must update" signal).
+ */
+export const DEFAULT_COMPAT_WINDOW = 1;
+
+/**
  * Client → server opening frame, sent first on every (re)connect (ADR 0007 §2).
  * `capabilities` is an order-independent, additively-extensible flag set naming
  * the optional frame types / enforcement primitives the client supports.
@@ -105,17 +115,22 @@ function refuse(reason: RefusalReason, message: string): NegotiationResult {
 }
 
 /**
- * Decide whether to accept a client `hello` and in which dialect, per the N-1
- * window (ADR 0007 §3), against the given server protocol (defaults to
- * {@link EVENT_PROTOCOL}; injectable for tests).
+ * Decide whether to accept a client `hello` and in which dialect, per the
+ * backward-compatibility window (ADR 0007 §3), against the given server protocol
+ * (defaults to {@link EVENT_PROTOCOL}; injectable for tests). `compatWindow` is
+ * how many versions below the server the window reaches (defaults to
+ * {@link DEFAULT_COMPAT_WINDOW}; the deployment sets it from
+ * `PCT_PROTOCOL_COMPAT_WINDOW`).
  *
  * - `hello` is `null`/unparseable → refuse `malformed_hello` (never assume a
  *   dialect).
  * - `eventProtocol === P` → accept, current dialect.
- * - `eventProtocol === P − 1` → accept, N-1 dialect (the server withholds frame
- *   types introduced by the bump to `P`; that withholding is the stream's job,
- *   this returns the agreed dialect integer).
- * - `eventProtocol < P − 1` → refuse `client_too_old` (→ `update_required`).
+ * - `P − compatWindow ≤ eventProtocol < P` → accept in the client's (older)
+ *   dialect (the server withholds frame types introduced by the newer bumps;
+ *   that withholding is the stream's job, this returns the agreed dialect
+ *   integer).
+ * - `eventProtocol < P − compatWindow` → refuse `client_too_old` (→
+ *   `update_required`).
  * - `eventProtocol > P` → refuse `server_too_old`.
  *
  * Total and pure: it never throws and performs no I/O.
@@ -124,27 +139,34 @@ export function negotiate(
   hello: HelloFrame | null,
   serverProtocol: number = EVENT_PROTOCOL,
   apiVersion: number = API_VERSION,
+  compatWindow: number = DEFAULT_COMPAT_WINDOW,
 ): NegotiationResult {
   if (hello === null) {
     return refuse("malformed_hello", "Missing or unparseable hello frame");
   }
 
+  // A window narrower than 1 would be meaningless (it could refuse a client
+  // speaking the server's own protocol); clamp defensively even though the
+  // config schema already enforces a positive integer.
+  const window = Math.max(1, Math.trunc(compatWindow));
+  const oldestAccepted = serverProtocol - window;
   const client = hello.eventProtocol;
-  if (client === serverProtocol || client === serverProtocol - 1) {
-    return {
-      kind: "accept",
-      frame: { type: "accept", eventProtocol: client, apiVersion },
-    };
-  }
+
   if (client > serverProtocol) {
     return refuse(
       "server_too_old",
       `Server speaks eventProtocol ${serverProtocol}; client requires ${client}. Upgrade the server.`,
     );
   }
+  if (client >= oldestAccepted) {
+    return {
+      kind: "accept",
+      frame: { type: "accept", eventProtocol: client, apiVersion },
+    };
+  }
   return refuse(
     "client_too_old",
-    `Client eventProtocol ${client} is older than the supported window (${serverProtocol - 1}–${serverProtocol}); update the client.`,
+    `Client eventProtocol ${client} is older than the supported window (${oldestAccepted}–${serverProtocol}); update the client.`,
   );
 }
 

--- a/server/src/events/stream.ts
+++ b/server/src/events/stream.ts
@@ -45,7 +45,7 @@ import {
 import { authenticateEventClient } from "./auth.js";
 import type { EventHub } from "./hub.js";
 import { DEFAULT_HEARTBEAT_INTERVAL_MS, startHeartbeat } from "./heartbeat.js";
-import { EVENT_PROTOCOL, negotiate, parseHello } from "./protocol.js";
+import { DEFAULT_COMPAT_WINDOW, EVENT_PROTOCOL, negotiate, parseHello } from "./protocol.js";
 
 /** WebSocket close code for a refused/abandoned handshake (RFC 6455 "policy violation"). */
 const HANDSHAKE_CLOSE_CODE = 1008;
@@ -83,11 +83,19 @@ export interface EventStreamOptions {
   helloTimeoutMs?: number;
   /**
    * The server's event-protocol version to negotiate against. Defaults to
-   * {@link EVENT_PROTOCOL}; overridable so a test can exercise the N-1 window's
+   * {@link EVENT_PROTOCOL}; overridable so a test can exercise the window's
    * refusal branches (which, at the shipped `EVENT_PROTOCOL`, no valid client
    * `hello` can reach).
    */
   serverProtocol?: number;
+  /**
+   * How many protocol versions below {@link serverProtocol} the handshake still
+   * accepts (ADR 0007 §3). Defaults to {@link DEFAULT_COMPAT_WINDOW}; production
+   * threads it from `PCT_PROTOCOL_COMPAT_WINDOW` (see `config.ts` /
+   * `api/plugin.ts`) so the refusal that flags `update_required` and the admin
+   * Clients page share one configured window.
+   */
+  compatWindow?: number;
 }
 
 /**
@@ -104,6 +112,7 @@ export async function registerEventStream(
   const heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
   const helloTimeoutMs = options.helloTimeoutMs ?? DEFAULT_HELLO_TIMEOUT_MS;
   const serverProtocol = options.serverProtocol ?? EVENT_PROTOCOL;
+  const compatWindow = options.compatWindow ?? DEFAULT_COMPAT_WINDOW;
 
   await scope.register(async (events) => {
     await events.register(fastifyWebsocket);
@@ -144,7 +153,7 @@ export async function registerEventStream(
         const helloTimer = setTimeout(() => {
           if (settled) return;
           settled = true;
-          const refusal = negotiate(null, serverProtocol);
+          const refusal = negotiate(null, serverProtocol, undefined, compatWindow);
           socket.send(JSON.stringify(refusal.frame));
           log.warn(
             { event: "event_stream_refused", clientId, reason: "hello_timeout" },
@@ -162,7 +171,7 @@ export async function registerEventStream(
           settled = true;
           clearTimeout(helloTimer);
           const hello = parseHello(String(data));
-          const result = negotiate(hello, serverProtocol);
+          const result = negotiate(hello, serverProtocol, undefined, compatWindow);
 
           if (result.kind === "refuse") {
             socket.send(JSON.stringify(result.frame));

--- a/server/tests/api/clients/health-dtos.test.ts
+++ b/server/tests/api/clients/health-dtos.test.ts
@@ -70,13 +70,17 @@ describe("health DTO contract", () => {
       enrolledAt: "2026-06-01T00:00:00.000Z",
       probedAt: "2026-06-19T12:00:00.000Z",
       updateRequired: false,
+      agentVersion: "0.1.0-alpha.5",
+      versionsReportedAt: "2026-06-19T12:00:00.000Z",
+      serverVersion: "0.1.0-alpha.5",
+      versionStatus: "up_to_date",
       components: [{ component: "timekpr-next", status: "ok", detail: "active" }],
       queue: { pending: 1, failed: 0, actions: [toQueuedActionSummary(row)] },
     });
     expect(parsed.success).toBe(true);
   });
 
-  it("allows null lastSeen / probedAt (never-seen, un-probed client)", () => {
+  it("allows null lastSeen / probedAt / versions (never-seen, un-probed client)", () => {
     const parsed = clientHealthSchema.safeParse({
       clientId: 3,
       hostname: "alice-pc.local",
@@ -85,9 +89,32 @@ describe("health DTO contract", () => {
       enrolledAt: "2026-06-01T00:00:00.000Z",
       probedAt: null,
       updateRequired: true,
+      agentVersion: null,
+      versionsReportedAt: null,
+      serverVersion: null,
+      versionStatus: "unknown",
       components: [],
       queue: { pending: 0, failed: 0, actions: [] },
     });
     expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a versionStatus outside the enum", () => {
+    const parsed = clientHealthSchema.safeParse({
+      clientId: 3,
+      hostname: "alice-pc.local",
+      reachability: "unknown",
+      lastSeen: null,
+      enrolledAt: "2026-06-01T00:00:00.000Z",
+      probedAt: null,
+      updateRequired: false,
+      agentVersion: null,
+      versionsReportedAt: null,
+      serverVersion: null,
+      versionStatus: "ancient",
+      components: [],
+      queue: { pending: 0, failed: 0, actions: [] },
+    });
+    expect(parsed.success).toBe(false);
   });
 });

--- a/server/tests/api/clients/health-service.test.ts
+++ b/server/tests/api/clients/health-service.test.ts
@@ -128,6 +128,59 @@ describe("getClientHealth", () => {
   });
 });
 
+describe("version drift (#352)", () => {
+  it("reports the reported agent version + reported-at, echoing the server version", async () => {
+    repo.recordClientAgentVersion(db, client.id, "0.1.0-alpha.4", PROBE_AT);
+
+    const health = await getClientHealth(db, client.id, undefined, "0.1.0-alpha.5");
+    expect(health?.agentVersion).toBe("0.1.0-alpha.4");
+    expect(health?.versionsReportedAt).toBe(PROBE_AT.toISOString());
+    expect(health?.serverVersion).toBe("0.1.0-alpha.5");
+    // Behind the server but still protocol-compatible → amber "outdated".
+    expect(health?.versionStatus).toBe("outdated");
+  });
+
+  it("is up_to_date when the reported version matches the server", async () => {
+    repo.recordClientAgentVersion(db, client.id, "0.1.0-alpha.5", PROBE_AT);
+    const health = await getClientHealth(db, client.id, undefined, "0.1.0-alpha.5");
+    expect(health?.versionStatus).toBe("up_to_date");
+  });
+
+  it("is update_required when the handshake flagged the client, over any version", async () => {
+    repo.recordClientAgentVersion(db, client.id, "0.1.0-alpha.5", PROBE_AT);
+    repo.setClientUpdateRequired(db, client.id, true);
+    const health = await getClientHealth(db, client.id, undefined, "0.1.0-alpha.5");
+    expect(health?.updateRequired).toBe(true);
+    expect(health?.versionStatus).toBe("update_required");
+  });
+
+  it("is unknown when the client never reported a version (never-connected case)", async () => {
+    const health = await getClientHealth(db, client.id, undefined, "0.1.0-alpha.5");
+    expect(health?.agentVersion).toBeNull();
+    expect(health?.versionsReportedAt).toBeNull();
+    expect(health?.versionStatus).toBe("unknown");
+  });
+
+  it("is unknown (no verdict) when the build stamped no server version", async () => {
+    repo.recordClientAgentVersion(db, client.id, "0.1.0-alpha.4", PROBE_AT);
+    // No serverVersion argument → the dev/test default (null).
+    const health = await getClientHealth(db, client.id);
+    expect(health?.serverVersion).toBeNull();
+    expect(health?.versionStatus).toBe("unknown");
+  });
+
+  it("classifies each client in the list against the server version", async () => {
+    repo.recordClientAgentVersion(db, client.id, "0.1.0-alpha.4", PROBE_AT);
+    const ahead = repo.createClient(db, { hostname: "bob-pc.local", sshUser: "pct-agent" });
+    repo.recordClientAgentVersion(db, ahead.id, "0.2.0", PROBE_AT);
+
+    const list = await listClientHealth(db, undefined, { serverVersion: "0.1.0-alpha.5" });
+    const byId = new Map(list.map((h) => [h.clientId, h]));
+    expect(byId.get(client.id)?.versionStatus).toBe("outdated");
+    expect(byId.get(ahead.id)?.versionStatus).toBe("up_to_date");
+  });
+});
+
 describe("listClientHealth", () => {
   it("returns one record per client, ascending by id, probing each", async () => {
     const second = repo.createClient(db, { hostname: "bob-pc.local", sshUser: "pct-agent" });

--- a/server/tests/api/clients/version-status.test.ts
+++ b/server/tests/api/clients/version-status.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the client version-drift classification (#352): the pure
+ * `compareVersions` ordering and the `classifyVersionStatus` verdict the admin
+ * Clients page badges on.
+ */
+import { describe, expect, it } from "vitest";
+
+import { classifyVersionStatus, compareVersions } from "../../../src/api/clients/version-status.js";
+
+describe("compareVersions", () => {
+  it("orders by numeric release identifiers", () => {
+    expect(compareVersions("0.1.0", "0.2.0")).toBe(-1);
+    expect(compareVersions("1.0.0", "0.9.9")).toBe(1);
+    expect(compareVersions("0.1.0", "0.1.0")).toBe(0);
+  });
+
+  it("treats missing release fields as zero", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+    expect(compareVersions("1.2.1", "1.2")).toBe(1);
+  });
+
+  it("sorts a prerelease before its final release (semver §11)", () => {
+    expect(compareVersions("0.1.0-alpha.1", "0.1.0")).toBe(-1);
+    expect(compareVersions("0.1.0", "0.1.0-alpha.1")).toBe(1);
+  });
+
+  it("orders prerelease tags: numeric numerically, and by length on a tie", () => {
+    expect(compareVersions("0.1.0-alpha.2", "0.1.0-alpha.10")).toBe(-1);
+    expect(compareVersions("0.1.0-alpha", "0.1.0-alpha.1")).toBe(-1);
+    expect(compareVersions("0.1.0-alpha.5", "0.1.0-alpha.5")).toBe(0);
+  });
+
+  it("ranks numeric prerelease identifiers below alphanumeric ones", () => {
+    expect(compareVersions("1.0.0-1", "1.0.0-alpha")).toBe(-1);
+  });
+
+  it("strips a leading v and treats Debian ~ as the prerelease separator", () => {
+    expect(compareVersions("v0.1.0", "0.1.0")).toBe(0);
+    // The tilde form (dpkg) and the dash form (git tag) compare equal.
+    expect(compareVersions("0.1.0~alpha.5", "0.1.0-alpha.5")).toBe(0);
+    expect(compareVersions("0.1.0~alpha.4", "0.1.0-alpha.5")).toBe(-1);
+  });
+
+  it("returns null when either release component is unparseable", () => {
+    expect(compareVersions("nightly", "0.1.0")).toBeNull();
+    expect(compareVersions("0.1.0", "")).toBeNull();
+    expect(compareVersions("1.x.0", "1.0.0")).toBeNull();
+  });
+});
+
+describe("classifyVersionStatus", () => {
+  it("returns update_required whenever the flag is set, regardless of versions", () => {
+    expect(
+      classifyVersionStatus({
+        clientVersion: "0.1.0-alpha.5",
+        serverVersion: "0.1.0-alpha.5",
+        updateRequired: true,
+      }),
+    ).toBe("update_required");
+    // Even a newer client is "update_required" if the handshake refused it.
+    expect(
+      classifyVersionStatus({
+        clientVersion: "9.9.9",
+        serverVersion: "0.1.0",
+        updateRequired: true,
+      }),
+    ).toBe("update_required");
+  });
+
+  it("is up_to_date when the client equals or leads the server", () => {
+    expect(
+      classifyVersionStatus({
+        clientVersion: "0.1.0-alpha.5",
+        serverVersion: "0.1.0-alpha.5",
+        updateRequired: false,
+      }),
+    ).toBe("up_to_date");
+    expect(
+      classifyVersionStatus({
+        clientVersion: "0.2.0",
+        serverVersion: "0.1.0",
+        updateRequired: false,
+      }),
+    ).toBe("up_to_date");
+  });
+
+  it("is outdated when the client trails the server (the incident case)", () => {
+    expect(
+      classifyVersionStatus({
+        clientVersion: "0.1.0-alpha.4",
+        serverVersion: "0.1.0-alpha.5",
+        updateRequired: false,
+      }),
+    ).toBe("outdated");
+  });
+
+  it("is unknown when either version is missing or unparseable", () => {
+    expect(
+      classifyVersionStatus({
+        clientVersion: null,
+        serverVersion: "0.1.0-alpha.5",
+        updateRequired: false,
+      }),
+    ).toBe("unknown");
+    expect(
+      classifyVersionStatus({
+        clientVersion: "0.1.0-alpha.5",
+        serverVersion: null,
+        updateRequired: false,
+      }),
+    ).toBe("unknown");
+    expect(
+      classifyVersionStatus({
+        clientVersion: "nightly-build",
+        serverVersion: "0.1.0",
+        updateRequired: false,
+      }),
+    ).toBe("unknown");
+  });
+});

--- a/server/tests/api/clients/version-status.test.ts
+++ b/server/tests/api/clients/version-status.test.ts
@@ -46,6 +46,14 @@ describe("compareVersions", () => {
     expect(compareVersions("0.1.0", "")).toBeNull();
     expect(compareVersions("1.x.0", "1.0.0")).toBeNull();
   });
+
+  it("rejects non-decimal release identifiers rather than coercing them", () => {
+    // `Number("1.2.3e2")` would silently become 1.2.300; the strict parse refuses it.
+    expect(compareVersions("1.2.3e2", "1.2.3")).toBeNull();
+    expect(compareVersions("1.0.0x0", "1.0.0")).toBeNull();
+    // A trailing-dot empty identifier is not treated as 0.
+    expect(compareVersions("1.2.", "1.2.0")).toBeNull();
+  });
 });
 
 describe("classifyVersionStatus", () => {

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -38,6 +38,13 @@ describe("loadSettings", () => {
       );
     });
 
+    it("treats an empty/whitespace PCT_SERVER_VERSION as unset (the no-build-arg image)", () => {
+      // `docker build` with no --build-arg sets ENV PCT_SERVER_VERSION="" — present
+      // but empty. It must degrade to "no verdict", not crash startup on .min(1).
+      expect(loadSettings({ PCT_SERVER_VERSION: "" }).serverVersion).toBeUndefined();
+      expect(loadSettings({ PCT_SERVER_VERSION: "   " }).serverVersion).toBeUndefined();
+    });
+
     it("coerces PCT_PROTOCOL_COMPAT_WINDOW and rejects non-positive / non-integer values", () => {
       expect(loadSettings({ PCT_PROTOCOL_COMPAT_WINDOW: "2" }).protocolCompatWindow).toBe(2);
       expect(() => loadSettings({ PCT_PROTOCOL_COMPAT_WINDOW: "0" })).toThrow(SettingsError);

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -27,6 +27,23 @@ describe("loadSettings", () => {
     expect(settings.reapply).toEqual({ cron: "0 * * * *", playbooks: [] });
     expect(settings.clientHealth).toEqual({ probeConcurrency: 4, probeDeadlineMs: 15000 });
     expect(settings.preMigrationBackup).toEqual({ enabled: true, retain: 5 });
+    expect(settings.serverVersion).toBeUndefined();
+    expect(settings.protocolCompatWindow).toBe(1);
+  });
+
+  describe("version drift settings (#352)", () => {
+    it("reads PCT_SERVER_VERSION verbatim", () => {
+      expect(loadSettings({ PCT_SERVER_VERSION: "0.1.0-alpha.5" }).serverVersion).toBe(
+        "0.1.0-alpha.5",
+      );
+    });
+
+    it("coerces PCT_PROTOCOL_COMPAT_WINDOW and rejects non-positive / non-integer values", () => {
+      expect(loadSettings({ PCT_PROTOCOL_COMPAT_WINDOW: "2" }).protocolCompatWindow).toBe(2);
+      expect(() => loadSettings({ PCT_PROTOCOL_COMPAT_WINDOW: "0" })).toThrow(SettingsError);
+      expect(() => loadSettings({ PCT_PROTOCOL_COMPAT_WINDOW: "-1" })).toThrow(SettingsError);
+      expect(() => loadSettings({ PCT_PROTOCOL_COMPAT_WINDOW: "1.5" })).toThrow(SettingsError);
+    });
   });
 
   describe("pre-migration backup (#166)", () => {

--- a/server/tests/events/protocol.test.ts
+++ b/server/tests/events/protocol.test.ts
@@ -85,6 +85,41 @@ describe("negotiate — N-1 window (ADR 0007 §3)", () => {
   });
 });
 
+describe("negotiate — configurable compatibility window (#352)", () => {
+  const P = 5;
+
+  it("widening the window accepts a client the default window would refuse", () => {
+    // P-2 is outside the default N-1 window...
+    expect(negotiate(hello(P - 2), P).kind).toBe("refuse");
+    // ...but accepted (in its own dialect) with a window of 2.
+    const result = negotiate(hello(P - 2), P, undefined, 2);
+    expect(result.kind).toBe("accept");
+    if (result.kind !== "accept") throw new Error("expected accept");
+    expect(result.frame.eventProtocol).toBe(P - 2);
+  });
+
+  it("still refuses a client just beyond the widened window as client_too_old", () => {
+    const result = negotiate(hello(P - 3), P, undefined, 2);
+    expect(result.kind).toBe("refuse");
+    if (result.kind !== "refuse") throw new Error("expected refuse");
+    expect(result.reason).toBe("client_too_old");
+    // The refusal message reports the widened floor (P - window).
+    expect(result.frame.error.message).toContain(`${P - 2}`);
+  });
+
+  it("a window below 1 is clamped so a client speaking P is never refused", () => {
+    const result = negotiate(hello(P), P, undefined, 0);
+    expect(result.kind).toBe("accept");
+  });
+
+  it("never accepts a client newer than the server, whatever the window", () => {
+    const result = negotiate(hello(P + 1), P, undefined, 5);
+    expect(result.kind).toBe("refuse");
+    if (result.kind !== "refuse") throw new Error("expected refuse");
+    expect(result.reason).toBe("server_too_old");
+  });
+});
+
 describe("parseHello", () => {
   it("parses a well-formed hello, defaulting capabilities to []", () => {
     const raw = JSON.stringify({ type: "hello", agentVersion: "2.0.0", eventProtocol: 3 });


### PR DESCRIPTION
Closes #352.

## What

Makes an out-of-date supervised client obvious on the admin **Clients** page — the gap surfaced by the v0.1.0-alpha.5 "all clients unreachable" incident, where the affected boxes ran a pre-alpha.5 installer but nothing in the UI showed their version.

Each client card now shows its **reported agent version** and **when it was reported**, plus a drift badge:

| Badge | Colour | Meaning |
|---|---|---|
| `up to date` | green | reported version ≥ the server's |
| `update available` | amber | reported version is behind the server |
| `update required` | red | the event-stream handshake refused it as out-of-window (ADR 0007 §5) |
| `version unknown` | grey | no reported/server version, or an unparseable string |

## The two axes, kept honest

The issue frames drift as "client version vs server version", but the codebase had **no runtime server version string** (`package.json` is `0.0.0`; real versions live only in git tags) and the compatibility "window" is defined on the integer `eventProtocol`, not the version string. So the two signals are kept separate and reconciled on the card:

- **Red (`update_required`)** is the authoritative protocol-handshake verdict, now governed by a **configurable window**: `PCT_PROTOCOL_COMPAT_WINDOW` (default `1`, the historical N-1) threads through `negotiate()` as the single source of truth for when a client is refused and flagged `update_required`.
- **Amber / green / grey drift** compares the reported agent version *string* against the dashboard's **own version**, newly stamped into the image at build time from the release tag (`PCT_SERVER_VERSION`, wired via a `Dockerfile` build arg set in `release.yml`). When the build stamps none (local/dev), the card shows reported versions **without a verdict** rather than guessing (`0.0.0` would otherwise make every client look "ahead").

The version comparison + classification live in a pure, unit-tested module (`api/clients/version-status.ts`); the verdict is computed **server-side** into the client-health DTO so the frontend never reimplements the ordering.

## Changes

- **config** — `PCT_SERVER_VERSION` (optional) and `PCT_PROTOCOL_COMPAT_WINDOW` (positive int, default 1).
- **events/protocol** — `negotiate()` takes a `compatWindow` (defaulted, clamped ≥ 1); `stream.ts` + `api/plugin.ts` thread it from settings.
- **api/clients** — new `version-status.ts`; health DTO gains `agentVersion`, `versionsReportedAt`, `serverVersion`, `versionStatus`; service + routes thread the server version through.
- **frontend** — Clients card renders the drift badge and the version rows.
- **build/docs** — Dockerfile build arg, `release.yml` `build-args`, `.env.example`.

## Testing

- New: `version-status.test.ts` (ordering incl. semver prerelease + Debian `~`, and the classifier).
- Extended: `protocol.test.ts` (window widening/clamping), `health-service.test.ts` (drift incl. the never-connected case), `health-dtos.test.ts`, `config.test.ts`, and the `ClientsView` component test (badges).
- Full gate green: `format:check`, `lint`, `typecheck`, backend `vitest` (1669 tests, 98.88% coverage), frontend `svelte-check` + `vite build` + `vitest` (254 tests).

## Notes / follow-ups

- At the shipped `EVENT_PROTOCOL = 1` the red `update_required` state is not yet reachable (a client can't speak a protocol < 1), so today the visible signal is the amber/green version-string drift — which is exactly what the incident needed. The window plumbing is forward-looking infrastructure for the first protocol bump.
- Agent version only refreshes at enrol and event-stream `hello`, so a never-connected client shows its enrol-time version; the card shows `versionsReportedAt` so staleness is visible. Letting the SSH health probe refresh the inventory is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbWXzTfF5rFpNmH4gkeA7q

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbWXzTfF5rFpNmH4gkeA7q)_