### PR TITLE
feat(reapply): key the Ansible re-apply path on client platform (#325)

### DIFF
--- a/.claude/plans/issue-325-reapply-platform-keying.md
+++ b/.claude/plans/issue-325-reapply-platform-keying.md
@@ -1,0 +1,80 @@
+# Issue #325 — Key the Ansible re-apply path on platform/capability
+
+Roadmap: `docs/roadmap.md` → Phase 6 (Ansible config push / tamper-reversion).
+Follow-up to **#232** (the policy-push half), explicitly tracked in that
+issue's plan doc under "Out of scope (tracked follow-up)".
+Design source: `docs/windows-client-support.md` → "Modularity tweaks to make
+cheaply now" item 6 (names both `SSHTr` and `AnsTr`); `Client.platform` from
+#229.
+
+## Problem
+
+The periodic re-apply (tamper-reversion) scheduler (`transport/reapply`) walks
+the enrolled fleet via its injected `ClientLoader` and runs the Phase-6 Ansible
+playbooks against **every** target unconditionally — the same "every client is
+Linux" assumption #232 removed from the live policy-push path, just in the other
+runner. The scheduler is **not live-wired yet** (not started in `buildApp`; its
+start lands with the Phase-6 playbook work, #90/#91/#92), so this is a clean
+standalone change that gives Windows the seam before a real call site exists.
+
+## Decision
+
+Add the same **exact-match, skip-not-coerce** platform selection #232
+established, expressed as a **served-platforms capability gate** rather than a
+per-platform runner registry.
+
+Why a set, not a runner registry (the difference from #232): the live push has a
+genuinely *different enforcement mechanism per platform* (`timekpra`-over-SSH vs.
+a future Windows agent), so a `Platform → PlatformPolicyRunner` registry is the
+honest model there. The re-apply path is a **single Ansible reconciler** — the
+`playbooks` are inherently Linux Ansible YAML and the injected `AnsibleRunner`
+execs `ansible-playbook`. A non-Linux client is not reconciled by a *different
+Ansible runner*; it is reconciled by an *entirely different mechanism* that is
+not this scheduler at all. So the correct seam is "which platforms does this
+Ansible re-apply reconciler serve" — a client outside that set is **skipped**
+(its drift is somebody else's job), never coerced onto the Linux playbooks.
+
+Default served set is `{ linux }`. Because `Client.platform` is `NOT NULL
+DEFAULT 'linux'` (#229) — every existing and newly-enrolled client is `linux` —
+this preserves today's behaviour exactly: no real client is skipped.
+
+## Shape
+
+- `reapply/types.ts`: `ReapplyTarget` gains a required `platform: Platform`.
+  A full Drizzle `clients` select row (`ClientRow`, which carries `platform`)
+  stays assignable, so the production loader `() => listClients(db)` needs no
+  change.
+- `reapply/scheduler.ts`:
+  - Export `DEFAULT_REAPPLY_PLATFORMS: ReadonlySet<Platform> = new Set(["linux"])`.
+  - `PeriodicReapplyOptions` gains an optional `reapplyPlatforms?:
+    ReadonlySet<Platform>` (defaults to the constant).
+  - In the `tick` per-client loop, **before** the backoff/probe checks, skip a
+    client whose `platform` is not in the served set with a `debug` line
+    (`re-apply skipped: no re-apply runner for client platform`). A skipped
+    client is never probed, reconciled, or backed off.
+  - `debug` (not `warn` as #232's one-shot push uses): re-apply is a periodic
+    fleet sweep, so a warn per unsupported client every tick would be log spam.
+- `reapply/index.ts`: re-export `DEFAULT_REAPPLY_PLATFORMS`.
+
+No `WindowsAgentRunner` / Windows reconciler is implemented — seam only, same as
+#232.
+
+## Tests (unit only — pure TS, no Docker)
+
+Extend `tests/transport/reapply/scheduler.test.ts`:
+
+- Update the existing `ReapplyTarget` literals to carry `platform: "linux"`.
+- New: a `windows` client is skipped — runner never called, nothing audited,
+  never probed, `debug` skip line emitted, no backoff recorded.
+- New: mixed fleet (`linux` + `windows`) reconciles only the linux client.
+- New: a custom `reapplyPlatforms` override (adding `windows`) reconciles the
+  windows client — proves the gate is the only thing keying selection.
+- New: `DEFAULT_REAPPLY_PLATFORMS` is `{ linux }`.
+
+## License boundary
+
+Unchanged — pure in-process TypeScript dispatch/gating over the injected seams;
+the real reconciliation still execs `ansible-playbook` as a subprocess via the
+merged `transport/ansible` runner. No GPL code linked in-process, no GPL binary
+added, no new dependency, no subprocess/REST boundary collapsed
+(`CLAUDE.md` → "License boundaries").

--- a/server/src/transport/reapply/index.ts
+++ b/server/src/transport/reapply/index.ts
@@ -13,6 +13,7 @@ export const moduleName = "transport/reapply";
 export {
   DEFAULT_REAPPLY_PATTERN,
   DEFAULT_REAPPLY_BACKOFF,
+  DEFAULT_REAPPLY_PLATFORMS,
   REAPPLY_LOG_COMPONENT,
   REAPPLY_AUDIT_REASON,
   startPeriodicReapply,

--- a/server/src/transport/reapply/scheduler.ts
+++ b/server/src/transport/reapply/scheduler.ts
@@ -291,7 +291,7 @@ export function startPeriodicReapply(options: PeriodicReapplyOptions): PeriodicR
         if (!reapplyPlatforms.has(client.platform)) {
           child.debug(
             { clientId: client.id, platform: client.platform },
-            "re-apply skipped: no re-apply runner for client platform",
+            "re-apply skipped: client platform not served by the Ansible re-apply runner",
           );
           continue;
         }

--- a/server/src/transport/reapply/scheduler.ts
+++ b/server/src/transport/reapply/scheduler.ts
@@ -16,6 +16,21 @@
  * bounded", `docs/client-install.md`). A determined root user defeating it is a
  * parent-child conversation, not a defect.
  *
+ * **Platform gate (#325).** The fleet is Linux today but need not be forever
+ * (`docs/windows-client-support.md` item 6; `Client.platform`, #229). Like the
+ * live policy-push path's platform seam (#232), the pass reconciles a client
+ * only if its {@link ReapplyTarget.platform} is one this Ansible re-apply runner
+ * **serves** ({@link DEFAULT_REAPPLY_PLATFORMS}, `linux` today). Selection is
+ * exact-match: a client on an unserved platform is **skipped, not coerced** onto
+ * the Linux playbooks. This is modelled as a served-*platforms* set rather than
+ * #232's per-platform runner registry because the re-apply path is a *single*
+ * Ansible reconciler (the playbooks are Linux Ansible YAML); a non-Linux client
+ * is reconciled by an entirely different mechanism, not a second Ansible runner,
+ * so the honest question here is "does this reconciler serve that platform" —
+ * and the answer for anything but Linux is "no, somebody else does". Since
+ * `Client.platform` is `NOT NULL DEFAULT 'linux'`, every real client today is
+ * served and behaviour is unchanged.
+ *
  * The {@link ClientLoader}, {@link ReachabilityProbe}, {@link AnsibleRunner},
  * and {@link AuditSink} are all **injected** — the runner execs
  * `ansible-playbook` out of the first-run venv (#39) and the playbooks
@@ -33,7 +48,7 @@ import { performance } from "node:perf_hooks";
 import { Cron } from "croner";
 import type { FastifyBaseLogger } from "fastify";
 
-import type { AuditOutcome } from "../../policy/enums.js";
+import type { AuditOutcome, Platform } from "../../policy/enums.js";
 import {
   AnsiblePlaybookFailedError,
   AnsibleUnreachableError,
@@ -54,6 +69,16 @@ export const REAPPLY_LOG_COMPONENT = "transport/reapply";
 
 /** The `reason` recorded on every re-apply audit entry (a stable query key). */
 export const REAPPLY_AUDIT_REASON = "periodic-reapply";
+
+/**
+ * The client platforms this Ansible re-apply reconciler serves (#325). A client
+ * whose {@link ReapplyTarget.platform} is not in this set is skipped — the
+ * Phase-6 playbooks are Linux Ansible YAML, so `linux` is the only served
+ * platform today. Injectable via {@link PeriodicReapplyOptions.reapplyPlatforms}
+ * for tests / a future non-Linux reconciler; the default keeps behaviour
+ * unchanged (every real client is `linux`).
+ */
+export const DEFAULT_REAPPLY_PLATFORMS: ReadonlySet<Platform> = new Set<Platform>(["linux"]);
 
 /** Default SSH port recorded in the audit target (clients carry no port column). */
 const DEFAULT_SSH_PORT = 22;
@@ -98,6 +123,12 @@ export interface PeriodicReapplyOptions {
   readonly backoff?: ReapplyBackoff;
   /** Clock seam for backoff scheduling; defaults to `Date.now`. */
   readonly now?: () => number;
+  /**
+   * The client platforms this reconciler serves (#325). A client whose
+   * `platform` is not in the set is skipped (not coerced onto the Linux
+   * playbooks). Defaults to {@link DEFAULT_REAPPLY_PLATFORMS} (`{ linux }`).
+   */
+  readonly reapplyPlatforms?: ReadonlySet<Platform>;
 }
 
 /** A running scheduler the caller can kick manually or stop on shutdown. */
@@ -172,6 +203,7 @@ export function startPeriodicReapply(options: PeriodicReapplyOptions): PeriodicR
   const pattern = options.pattern ?? DEFAULT_REAPPLY_PATTERN;
   const backoff = options.backoff ?? DEFAULT_REAPPLY_BACKOFF;
   const now = options.now ?? Date.now;
+  const reapplyPlatforms = options.reapplyPlatforms ?? DEFAULT_REAPPLY_PLATFORMS;
   const child = log.child({ component: REAPPLY_LOG_COMPONENT });
 
   /** Per-client failure/backoff state, keyed by client id. */
@@ -251,6 +283,18 @@ export function startPeriodicReapply(options: PeriodicReapplyOptions): PeriodicR
 
     for (const client of loadClients()) {
       try {
+        // Platform gate (#325): reconcile only clients this Ansible runner
+        // serves. An unserved platform (a `windows` client today) is skipped
+        // outright — never probed, reconciled, or backed off — rather than fed
+        // to the Linux playbooks. `debug`, not `warn` like #232's one-shot push:
+        // this is a periodic fleet sweep, so a per-tick warn would be log spam.
+        if (!reapplyPlatforms.has(client.platform)) {
+          child.debug(
+            { clientId: client.id, platform: client.platform },
+            "re-apply skipped: no re-apply runner for client platform",
+          );
+          continue;
+        }
         const state = backoffByClient.get(client.id);
         if (state !== undefined && now() < state.nextEligibleAt) {
           child.debug({ clientId: client.id }, "re-apply skipped: client in backoff");

--- a/server/src/transport/reapply/types.ts
+++ b/server/src/transport/reapply/types.ts
@@ -14,18 +14,28 @@
  * still execs `ansible-playbook` as a subprocess via the merged
  * `transport/ansible` runner; this module only schedules and audits it.
  */
+import type { Platform } from "../../policy/enums.js";
 import type { AnsibleHost } from "../ansible/index.js";
 
 /**
  * The slice of a `clients` row a re-apply pass needs: the id (for audit
- * attribution and per-client backoff) plus the {@link AnsibleHost} fields the
- * runner renders into a single-host inventory. A full Drizzle `clients` select
- * row is assignable to this shape, so the production loader can return DB rows
- * directly.
+ * attribution and per-client backoff), the {@link AnsibleHost} fields the
+ * runner renders into a single-host inventory, plus the `platform`
+ * discriminator that gates whether the Ansible re-apply reconciler applies to
+ * this client (#325). A full Drizzle `clients` select row is assignable to this
+ * shape (`clients.platform` is `NOT NULL DEFAULT 'linux'`, #229), so the
+ * production loader can return DB rows directly.
  */
 export interface ReapplyTarget extends AnsibleHost {
   /** Enrolled client the playbooks are reconciled against. */
   readonly id: number;
+  /**
+   * The OS-family discriminator (`Client.platform`, #229). The scheduler
+   * reconciles only clients whose platform is served by its Ansible re-apply
+   * runner (`linux` today); any other platform is skipped, not coerced onto the
+   * Linux playbooks (#325 — the re-apply half of #232's platform seam).
+   */
+  readonly platform: Platform;
 }
 
 /**

--- a/server/tests/transport/reapply/scheduler.test.ts
+++ b/server/tests/transport/reapply/scheduler.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   DEFAULT_REAPPLY_BACKOFF,
   DEFAULT_REAPPLY_PATTERN,
+  DEFAULT_REAPPLY_PLATFORMS,
   REAPPLY_AUDIT_REASON,
   REAPPLY_LOG_COMPONENT,
   startPeriodicReapply,
@@ -55,7 +56,9 @@ function capturingSink(): { sink: AuditSink; entries: AuditEntry[] } {
   return { sink: { record: (entry) => entries.push(entry) }, entries };
 }
 
-const HOSTS: readonly ReapplyTarget[] = [{ id: 1, hostname: "mint-01", sshUser: "pct-agent" }];
+const HOSTS: readonly ReapplyTarget[] = [
+  { id: 1, hostname: "mint-01", sshUser: "pct-agent", platform: "linux" },
+];
 
 describe("startPeriodicReapply", () => {
   let log: FastifyBaseLogger;
@@ -291,8 +294,8 @@ describe("startPeriodicReapply", () => {
 
   it("isolates one client's probe failure and still re-applies the others", async () => {
     const clients: ReapplyTarget[] = [
-      { id: 1, hostname: "mint-01", sshUser: "pct-agent" },
-      { id: 2, hostname: "mint-02", sshUser: "pct-agent" },
+      { id: 1, hostname: "mint-01", sshUser: "pct-agent", platform: "linux" },
+      { id: 2, hostname: "mint-02", sshUser: "pct-agent", platform: "linux" },
     ];
     const runner = fakeRunner(ok);
     const probe = vi.fn(async (id: number) => {
@@ -314,7 +317,9 @@ describe("startPeriodicReapply", () => {
 
   it("persists a readable audit row via the real DrizzleAuditSink", async () => {
     const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
-    const clients: ReapplyTarget[] = [{ id: clientId, hostname: "mint-01", sshUser: "pct-agent" }];
+    const clients: ReapplyTarget[] = [
+      { id: clientId, hostname: "mint-01", sshUser: "pct-agent", platform: "linux" },
+    ];
 
     await start({
       loadClients: () => clients,
@@ -364,6 +369,65 @@ describe("startPeriodicReapply", () => {
     const message = entries[0]?.errorMessage ?? "";
     expect(message.length).toBeLessThan(3000);
     expect(message.endsWith("…")).toBe(true);
+  });
+
+  it("serves only linux by default", () => {
+    expect([...DEFAULT_REAPPLY_PLATFORMS]).toEqual(["linux"]);
+  });
+
+  it("skips a client on an unserved platform without probing, running, or auditing", async () => {
+    const clients: ReapplyTarget[] = [
+      { id: 7, hostname: "win-01", sshUser: "pct-agent", platform: "windows" },
+    ];
+    const runner = fakeRunner(ok);
+    const probe = vi.fn(async () => true);
+    const { sink, entries } = capturingSink();
+
+    await start({ loadClients: () => clients, probe, runner, audit: sink }).tick();
+
+    // Unserved platform → never probed, never reconciled, nothing audited, and
+    // (crucially) not coerced onto the Linux playbooks.
+    expect(probe).not.toHaveBeenCalled();
+    expect(runner.runPlaybook).not.toHaveBeenCalled();
+    expect(entries).toHaveLength(0);
+    expect(
+      lines.find((l) => l.msg === "re-apply skipped: no re-apply runner for client platform"),
+    ).toMatchObject({ component: REAPPLY_LOG_COMPONENT, clientId: 7, platform: "windows" });
+  });
+
+  it("reconciles only the served-platform clients in a mixed fleet", async () => {
+    const clients: ReapplyTarget[] = [
+      { id: 1, hostname: "mint-01", sshUser: "pct-agent", platform: "linux" },
+      { id: 2, hostname: "win-02", sshUser: "pct-agent", platform: "windows" },
+    ];
+    const runner = fakeRunner(ok);
+
+    await start({ loadClients: () => clients, runner }).tick();
+
+    expect(runner.runPlaybook).toHaveBeenCalledTimes(1);
+    expect(runner.runPlaybook).toHaveBeenCalledWith(
+      expect.objectContaining({ hosts: [clients[0]] }),
+    );
+  });
+
+  it("honours a custom served-platforms set (the gate is the only selector)", async () => {
+    const clients: ReapplyTarget[] = [
+      { id: 2, hostname: "win-02", sshUser: "pct-agent", platform: "windows" },
+    ];
+    const runner = fakeRunner(ok);
+
+    // Registering `windows` as served makes the same client reconcilable —
+    // proving the platform is gated solely by the injected set, not hard-coded.
+    await start({
+      loadClients: () => clients,
+      runner,
+      reapplyPlatforms: new Set(["windows"] as const),
+    }).tick();
+
+    expect(runner.runPlaybook).toHaveBeenCalledTimes(1);
+    expect(runner.runPlaybook).toHaveBeenCalledWith(
+      expect.objectContaining({ hosts: [clients[0]] }),
+    );
   });
 
   it("stops cleanly and exposes the default cadence", () => {

--- a/server/tests/transport/reapply/scheduler.test.ts
+++ b/server/tests/transport/reapply/scheduler.test.ts
@@ -391,7 +391,10 @@ describe("startPeriodicReapply", () => {
     expect(runner.runPlaybook).not.toHaveBeenCalled();
     expect(entries).toHaveLength(0);
     expect(
-      lines.find((l) => l.msg === "re-apply skipped: no re-apply runner for client platform"),
+      lines.find(
+        (l) =>
+          l.msg === "re-apply skipped: client platform not served by the Ansible re-apply runner",
+      ),
     ).toMatchObject({ component: REAPPLY_LOG_COMPONENT, clientId: 7, platform: "windows" });
   });
 


### PR DESCRIPTION
## Summary

- The periodic re-apply (tamper-reversion) scheduler ran the Phase-6 playbooks against **every** enrolled client unconditionally — the same "every client is Linux" assumption #232 removed from the live policy-push path, just in the other runner (`transport/reapply`). This is the follow-up #232's plan doc explicitly tracked.
- Adds the same **exact-match, skip-not-coerce** platform selection: a client whose `Client.platform` (#229) isn't served by the Ansible re-apply reconciler is skipped outright (never probed, reconciled, or backed off), not coerced onto the Linux playbooks. `ReapplyTarget` gains a required `platform`, fed straight from the `ClientRow.platform` the production loader already returns.
- Default served set is `{ linux }` and `Client.platform` is `NOT NULL DEFAULT 'linux'`, so every existing/newly-enrolled client is served and **behaviour is unchanged**. No Windows runner — seam only, same as #232.

## Design note

Modelled as a served-**platforms** capability gate (`ReadonlySet<Platform>`) rather than #232's per-platform *runner registry*. The live push has a genuinely different enforcement mechanism per platform (`timekpra`-over-SSH vs. a future Windows agent), so a `Platform → runner` registry is honest there. The re-apply path is a **single Ansible reconciler** — the `playbooks` are inherently Linux Ansible YAML — and a non-Linux client is reconciled by an *entirely different mechanism that is not this scheduler at all*, so the correct question is "does this reconciler serve that platform?". The gate is injectable (`reapplyPlatforms`) so a future non-Linux reconciler / tests can extend it without touching the scheduler. Rationale is documented in the module header and the plan.

## Plan

Linked plan: `.claude/plans/issue-325-reapply-platform-keying.md`
Roadmap: `docs/roadmap.md` → Phase 6 (Ansible config push / tamper-reversion). Follow-up to #232.

## License-boundary note

No boundary touched. Pure in-process TypeScript dispatch/gating over the injected `ClientLoader`/`ReachabilityProbe`/`AnsibleRunner` seams; the real reconciliation still execs `ansible-playbook` as a subprocess via the merged `transport/ansible` runner. No GPL code linked in-process, no GPL binary added, no new dependency, no subprocess boundary collapsed (`CLAUDE.md` → "License boundaries"). Within the bounded tamper-resistance posture — this is config reconciliation, not hardening.

## Test plan

- [x] `npm run format` / `lint` / `typecheck` clean
- [x] `npm test` green — 1675 tests pass, 98.89% overall coverage (gate 80%); `transport/reapply` at 100%
- [x] Existing `scheduler.test.ts` behaviour preserved (literals updated with `platform`)
- [x] New unit tests: unserved (`windows`) client skipped without probe/run/audit + debug line; mixed `linux`+`windows` fleet reconciles only linux; custom `reapplyPlatforms` override makes a `windows` client reconcilable (proves the gate is the sole selector); `DEFAULT_REAPPLY_PLATFORMS` is `{ linux }`
- [ ] Live Ansible round-trip — N/A: the re-apply scheduler is not live-wired yet (starts with the Phase-6 playbooks #90/#91/#92); no Docker/integration surface in this change

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gy8vtqo6gn7SYamtmAjfHE)_