### PR TITLE
fix(client): close child→root symlink privesc in activitywatch.yml (#351)

### DIFF
--- a/.claude/plans/351-activitywatch-symlink-privesc.md
+++ b/.claude/plans/351-activitywatch-symlink-privesc.md
@@ -1,0 +1,65 @@
+# Plan — #351: symlink-following privesc (child → root) in `activitywatch.yml`
+
+## Problem
+
+`client/ansible/playbooks/activitywatch.yml` runs `hosts: all`, `become: true`
+(as root). Its "Reconcile per-user ActivityWatch configuration and units" block
+creates directories and renders templates **inside each supervised user's home**
+(`{{ ansible_facts.getent_passwd[item][4] }}/.config/...`). The child owns that
+home, so it is fully writable by them.
+
+`ansible.builtin.file`'s `follow` parameter **defaults to `yes`**. For
+`state: directory`, when the leaf path is a symlink the module resolves it
+(`realpath`) and applies `owner`/`group`/`mode` to the **target**. A child who
+replaces `~/.config/systemd/user` with a symlink to `/etc` gets `/etc` chowned to
+themselves on the next root-run re-apply (Phase-6 periodic re-apply, #93) — a
+concrete unprivileged → root escalation.
+
+In scope per `CLAUDE.md`: this is a genuine privesc defect in our own code, not a
+tamper-*evasion* arms-race feature.
+
+## Affected tasks (the per-user block, lines ~140–178)
+
+1. `file` `state: directory` → `.config/activitywatch/aw-server-rust` (loop: `aw_supervised_users`, item = user)
+2. `file` `state: directory` → `.config/systemd/user` (loop: `aw_supervised_users`, item = user)
+3. `template` → `.config/activitywatch/aw-server-rust/config.toml` (loop: `aw_supervised_users`, item = user)
+4. `template` → `.config/systemd/user/{{ item.1.name }}.service` (loop: `product(...)`, item.0 = user)
+
+## Fix (combine the issue's option 1 + option 2)
+
+- **`become_user: "{{ item }}"`** (or `"{{ item.0 }}"` for task 4) on all four
+  tasks — the robust fix: root never touches a child-owned path, so a hostile
+  symlink can only ever reach files the child already owns (no escalation).
+  Mirrors the play's own later `systemd_service` tasks (already `become_user`).
+- **`follow: false`** on all four — directly neutralises the documented
+  `follow: yes` root cause and documents intent.
+- `owner`/`group` (set to the same user) stay: harmless no-ops when running as
+  that user, and they keep intent explicit.
+- Add a comment block above the block referencing #351.
+
+## Sibling playbooks — audited, no change
+
+`e2guardian-filtering.yml` and `apparmor-profiles.yml` write only into root-owned
+`/etc` trees (`pct_e2g_dir`, `pct_e2g_managed_dir`, `pct_apparmor_dir`, all
+`owner: root`). The supervised user cannot plant a symlink there, so the vector
+does not exist. Note this in the PR.
+
+## Tests
+
+- New Vitest guard `server/tests/ansible/activitywatch-privesc.test.ts`: parse the
+  playbook YAML (`yaml` dep, already present) and assert every home-writing
+  `ansible.builtin.file`/`ansible.builtin.template` task (path/dest references
+  `getent_passwd`) carries `become_user` resolving to the loop user **and**
+  `follow: false`. Regression guard so the vector cannot silently reopen. Mirrors
+  the static-analysis approach of `dockerfile-playbooks.test.ts`.
+- Live Molecule symlink-planting assertion (plant `~/.config/systemd/user →
+  /etc`, converge, assert `/etc` still root-owned) belongs to the Molecule
+  harness (#242); note as fast-follow, do not stand up live infra in this PR.
+
+## License boundary
+
+N/A — no transport/packaging change; Ansible stays a subprocess, nothing linked.
+
+## Quality gate
+
+`cd server && npm run format && npm run lint:fix && npm run typecheck && npm test`.

--- a/client/ansible/playbooks/activitywatch.yml
+++ b/client/ansible/playbooks/activitywatch.yml
@@ -134,6 +134,21 @@
 
     # --- per-user configuration + units (drift reconciled every run) --------
 
+    # SECURITY (#351): these tasks write into each supervised user's own home
+    # directory, which that (untrusted, child) user can fully control. Two
+    # defences, applied together, keep a root-run re-apply from being tricked
+    # into a child → root privilege escalation via a planted symlink:
+    #   1. `become_user: "{{ item }}"` — do the home writes AS the target user,
+    #      never as root. A hostile symlink can then only ever reach files the
+    #      child already owns, so there is nothing to escalate to. (Mirrors the
+    #      `systemd_service` tasks below, which already drop privileges.)
+    #   2. `follow: false` — neutralise `ansible.builtin.file`'s `follow: yes`
+    #      default, under which a leaf symlink (e.g. `~/.config/systemd/user`
+    #      → `/etc`) would have its *target* chowned/chmod'd. This is the
+    #      documented root cause; keep it pinned even though defence 1 already
+    #      contains it.
+    # The `owner`/`group` set to the same user are harmless no-ops under
+    # `become_user` and are kept to document intent.
     - name: Reconcile per-user ActivityWatch configuration and units
       when: aw_supervised_users | length > 0
       block:
@@ -144,6 +159,8 @@
             owner: "{{ item }}"
             group: "{{ item }}"
             mode: "0755"
+            follow: false
+          become_user: "{{ item }}"
           loop: "{{ aw_supervised_users }}"
 
         - name: Ensure the systemd --user unit directory exists
@@ -153,6 +170,8 @@
             owner: "{{ item }}"
             group: "{{ item }}"
             mode: "0755"
+            follow: false
+          become_user: "{{ item }}"
           loop: "{{ aw_supervised_users }}"
 
         - name: Render the loopback-only aw-server config
@@ -162,6 +181,8 @@
             owner: "{{ item }}"
             group: "{{ item }}"
             mode: "0644"
+            follow: false
+          become_user: "{{ item }}"
           loop: "{{ aw_supervised_users }}"
 
         - name: Render the per-user systemd --user units
@@ -171,6 +192,8 @@
             owner: "{{ item.0 }}"
             group: "{{ item.0 }}"
             mode: "0644"
+            follow: false
+          become_user: "{{ item.0 }}"
           vars:
             unit: "{{ item.1 }}"
           loop: "{{ aw_supervised_users | product(aw_units) | list }}"

--- a/client/ansible/playbooks/activitywatch.yml
+++ b/client/ansible/playbooks/activitywatch.yml
@@ -160,6 +160,7 @@
             group: "{{ item }}"
             mode: "0755"
             follow: false
+          become: true
           become_user: "{{ item }}"
           loop: "{{ aw_supervised_users }}"
 
@@ -171,6 +172,7 @@
             group: "{{ item }}"
             mode: "0755"
             follow: false
+          become: true
           become_user: "{{ item }}"
           loop: "{{ aw_supervised_users }}"
 
@@ -182,6 +184,7 @@
             group: "{{ item }}"
             mode: "0644"
             follow: false
+          become: true
           become_user: "{{ item }}"
           loop: "{{ aw_supervised_users }}"
 
@@ -193,6 +196,7 @@
             group: "{{ item.0 }}"
             mode: "0644"
             follow: false
+          become: true
           become_user: "{{ item.0 }}"
           vars:
             unit: "{{ item.1 }}"

--- a/server/tests/ansible/activitywatch-privesc.test.ts
+++ b/server/tests/ansible/activitywatch-privesc.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression guard for the child → root symlink-following privilege escalation
+ * in `client/ansible/playbooks/activitywatch.yml` (#351).
+ *
+ * The per-user reconciliation block writes directories and templates INTO each
+ * supervised (untrusted, child) user's home. `ansible.builtin.file`'s `follow`
+ * defaults to `yes`, so a leaf symlink planted by the child (e.g.
+ * `~/.config/systemd/user` → `/etc`) would have its TARGET chowned by the
+ * root-run re-apply — a concrete privilege escalation.
+ *
+ * The fix pins two defences on every home-writing task:
+ *   - `become_user: "{{ item }}"` (or `"{{ item.0 }}"`) — the write runs as the
+ *     child, so a hostile symlink can only reach files they already own.
+ *   - `follow: false` — neutralises the `follow: yes` default (the root cause).
+ *
+ * This static guard parses the playbook and asserts both defences are present
+ * on every task that writes into a user home, so the vector cannot silently
+ * reopen. The live symlink-planting assertion belongs to the Molecule harness
+ * (#242). Mirrors the static-analysis approach of `dockerfile-playbooks.test.ts`.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { z } from "zod";
+
+const playbookPath = fileURLToPath(
+  new URL("../../../client/ansible/playbooks/activitywatch.yml", import.meta.url),
+);
+
+// Validate the slice of the playbook schema this test asserts on, rather than
+// casting `parse()`'s `unknown` output — keeps the repo's "validate external
+// input with zod / no unchecked `as`" convention (CLAUDE.md → "Code conventions").
+const moduleParamsSchema = z
+  .object({
+    path: z.string().optional(),
+    dest: z.string().optional(),
+    state: z.string().optional(),
+    follow: z.boolean().optional(),
+  })
+  .passthrough();
+
+// Fields spell out `| undefined` so this matches the shape zod's `.optional()`
+// produces under `exactOptionalPropertyTypes` (a present-but-undefined property,
+// not just an absent one), letting the recursive `z.lazy` annotation line up.
+interface PlaybookTask {
+  name?: string | undefined;
+  block?: PlaybookTask[] | undefined;
+  become_user?: string | undefined;
+  "ansible.builtin.file"?: z.infer<typeof moduleParamsSchema> | undefined;
+  "ansible.builtin.template"?: z.infer<typeof moduleParamsSchema> | undefined;
+}
+
+const taskSchema: z.ZodType<PlaybookTask> = z.lazy(() =>
+  z
+    .object({
+      name: z.string().optional(),
+      block: z.array(taskSchema).optional(),
+      become_user: z.string().optional(),
+      "ansible.builtin.file": moduleParamsSchema.optional(),
+      "ansible.builtin.template": moduleParamsSchema.optional(),
+    })
+    .passthrough(),
+);
+
+const playSchema = z
+  .object({
+    name: z.string().optional(),
+    tasks: z.array(taskSchema).optional(),
+  })
+  .passthrough();
+
+const playbookSchema = z.array(playSchema);
+
+function loadPlaybook(): z.infer<typeof playbookSchema> {
+  return playbookSchema.parse(parse(readFileSync(playbookPath, "utf8")));
+}
+
+/** Flatten a play's task list, descending into `block:` groups. */
+function flattenTasks(tasks: PlaybookTask[]): PlaybookTask[] {
+  return tasks.flatMap((task) => [task, ...(task.block ? flattenTasks(task.block) : [])]);
+}
+
+/** The `file`/`template` module params on a task, whichever is present. */
+function fileOrTemplateParams(task: PlaybookTask): z.infer<typeof moduleParamsSchema> | undefined {
+  return task["ansible.builtin.file"] ?? task["ansible.builtin.template"];
+}
+
+/**
+ * A task writes into a supervised user's home iff its `file`/`template` target
+ * is derived from `getent_passwd[...]` — the child's real, writable home dir.
+ */
+function writesIntoUserHome(task: PlaybookTask): boolean {
+  const params = fileOrTemplateParams(task);
+  if (params === undefined) return false;
+  const target = params.path ?? params.dest ?? "";
+  return target.includes("getent_passwd");
+}
+
+describe("activitywatch.yml — child→root symlink privesc guard (#351)", () => {
+  const allTasks = loadPlaybook().flatMap((play) => flattenTasks(play.tasks ?? []));
+  const homeWritingTasks = allTasks.filter(writesIntoUserHome);
+
+  it("still contains the per-user home-writing tasks this guard protects", () => {
+    // If these tasks are renamed/removed the guard must not silently pass over
+    // nothing. The block writes two directories + two templates per user.
+    expect(homeWritingTasks.length).toBe(4);
+  });
+
+  it("runs every home-write as the target user (become_user), never as root", () => {
+    for (const task of homeWritingTasks) {
+      expect(
+        task.become_user,
+        `task "${task.name ?? "<unnamed>"}" writes into a user home but is missing become_user`,
+      ).toBeDefined();
+      // The loop var is the username: `{{ item }}` for the plain loops, or
+      // `{{ item.0 }}` for the product() loop. Either localises the write to
+      // the child, so a hostile symlink can only reach files they own.
+      expect(task.become_user).toMatch(/^\{\{\s*item(\.0)?\s*\}\}$/);
+    }
+  });
+
+  it("pins follow: false on every home-write (neutralises the follow: yes default)", () => {
+    for (const task of homeWritingTasks) {
+      const params = fileOrTemplateParams(task);
+      expect(
+        params?.follow,
+        `task "${task.name ?? "<unnamed>"}" writes into a user home but does not pin follow: false`,
+      ).toBe(false);
+    }
+  });
+});

--- a/server/tests/ansible/activitywatch-privesc.test.ts
+++ b/server/tests/ansible/activitywatch-privesc.test.ts
@@ -87,15 +87,28 @@ function fileOrTemplateParams(task: PlaybookTask): z.infer<typeof moduleParamsSc
   return task["ansible.builtin.file"] ?? task["ansible.builtin.template"];
 }
 
+/** The `file`/`template` target path/dest, whichever is present. */
+function homeTarget(task: PlaybookTask): string {
+  const params = fileOrTemplateParams(task);
+  return params?.path ?? params?.dest ?? "";
+}
+
 /**
  * A task writes into a supervised user's home iff its `file`/`template` target
  * is derived from `getent_passwd[...]` — the child's real, writable home dir.
  */
 function writesIntoUserHome(task: PlaybookTask): boolean {
-  const params = fileOrTemplateParams(task);
-  if (params === undefined) return false;
-  const target = params.path ?? params.dest ?? "";
-  return target.includes("getent_passwd");
+  return fileOrTemplateParams(task) !== undefined && homeTarget(task).includes("getent_passwd");
+}
+
+/**
+ * The loop variable a home-write must drop to. The username is `item.0` when the
+ * task loops over `product(users, units)` (its target reads `getent_passwd[item.0]`)
+ * and plain `item` otherwise — so `become_user` must reference the *same* index,
+ * or it would drop to the wrong (or a malformed) principal.
+ */
+function expectedLoopVar(task: PlaybookTask): "item.0" | "item" {
+  return /getent_passwd\[\s*item\.0\s*\]/.test(homeTarget(task)) ? "item.0" : "item";
 }
 
 describe("activitywatch.yml — child→root symlink privesc guard (#351)", () => {
@@ -114,10 +127,15 @@ describe("activitywatch.yml — child→root symlink privesc guard (#351)", () =
         task.become_user,
         `task "${task.name ?? "<unnamed>"}" writes into a user home but is missing become_user`,
       ).toBeDefined();
-      // The loop var is the username: `{{ item }}` for the plain loops, or
-      // `{{ item.0 }}` for the product() loop. Either localises the write to
-      // the child, so a hostile symlink can only reach files they own.
-      expect(task.become_user).toMatch(/^\{\{\s*item(\.0)?\s*\}\}$/);
+      // Drop to the child — a hostile symlink can then only reach files they
+      // own. The `become_user` index must match the one the task's path uses
+      // (`item.0` for the product() loop, `item` otherwise): dropping to the
+      // wrong index would target the wrong principal or a malformed one.
+      const loopVar = expectedLoopVar(task);
+      expect(
+        task.become_user,
+        `task "${task.name ?? "<unnamed>"}" targets ${loopVar} but its become_user does not`,
+      ).toMatch(new RegExp(`^\\{\\{\\s*${loopVar.replace(".", "\\.")}\\s*\\}\\}$`));
     }
   });
 


### PR DESCRIPTION
## Summary

- Close the child→root privilege escalation in `client/ansible/playbooks/activitywatch.yml`: the per-user reconciliation block writes into each supervised (untrusted, child) user's home while running as root, and `ansible.builtin.file`'s `follow` defaults to `yes`, so a child-planted symlink (e.g. `~/.config/systemd/user` → `/etc`) has its **target** chowned on the next root-run re-apply (#93) — an unprivileged → root escalation.
- Pin two defences on all four home-writing tasks: **`become: true` + `become_user: "{{ item }}"`** (`{{ item.0 }}` for the `product()` loop) so the writes run *as the child* — a hostile symlink can then only reach files they already own — and **`follow: false`** to neutralise the `follow: yes` default (the documented root cause). This mirrors the play's own later `systemd_service` tasks, which already carry both `become` keys.
- Add a CI-runnable Vitest guard that parses the playbook and asserts every home-writing `file`/`template` task keeps both defences, so the vector can't silently reopen.

## Sibling-playbook audit (no change)

`e2guardian-filtering.yml` and `apparmor-profiles.yml` write only into root-owned `/etc` trees (`pct_e2g_dir`, `pct_e2g_managed_dir`, `pct_apparmor_dir`, all `owner: root`), where the supervised user cannot plant a symlink — so the escalation vector does not exist there. Left unchanged.

## Plan

Linked plan: `.claude/plans/351-activitywatch-symlink-privesc.md`
Roadmap: `docs/roadmap.md` → Phase 6 (managed ActivityWatch deploy / periodic re-apply)

## License-boundary note

N/A — no transport or packaging change. Ansible stays a subprocess (`transport/ansible` runner); nothing is linked, imported, or vendored, and no GPL binary is added to the image.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1674 passing, coverage 98.88% (gate 80%)
- [x] `ansible-lint client/ansible/` — passes (production profile, 0 failures)
- [x] New guard `server/tests/ansible/activitywatch-privesc.test.ts` finds all 4 home-writing tasks and asserts `become_user` + `follow: false` on each
- [ ] **Fast-follow (deferred, tracked by #360):** live Molecule assertion — plant `~/.config/systemd/user → /etc`, converge, assert `/etc` is still root-owned. Belongs to the live Molecule harness (gated on Molecule-in-CI #219) rather than standing up live infra in this security fix.

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)