### PR TITLE
fix(policy): wire group-inherited schedules/budgets into enforcement (#362)

### DIFF
--- a/.claude/plans/362-group-inherited-enforcement.md
+++ b/.claude/plans/362-group-inherited-enforcement.md
@@ -1,0 +1,83 @@
+# Plan — #362: wire group-inherited schedules/budgets into enforcement
+
+**Issue:** #362 (Phase 2, `bug`). Group-targeted schedules/budgets landed
+end-to-end (#134/#182) *except enforcement*: the resolution helpers
+`gatherUserScheduleRules` / `gatherUserBudgets` (`policy/group-resolution.ts`)
+are consumed by exactly one caller — the display endpoint
+`GET /api/users/:userId/effective`. Every path that actually enforces or
+previews reads the user's **own** rows only, so group rules are silently
+display-only.
+
+## Root cause
+
+Two composition points exist and have drifted:
+
+- **Display** (`api/policy/effective.ts`) composes via the `gather*` helpers →
+  includes group rules.
+- **Enforcement / preview / ansible renders** read own-only rows
+  (`listUserSchedules` / `listUserBudgets` / inline `db.select()`), never the
+  group layer.
+
+## Fix — one shared composition point
+
+Make `policy/group-resolution.ts` the single entry point every surface reads,
+so display, push, force-close, preview, and the ansible renders can't drift
+again (the one decision the issue asks to record).
+
+Extract merge cores that take the *own* rules explicitly, so preview can merge
+a **proposed** own-rule set with the **persisted** group rules:
+
+- `mergeScheduleRulesWithGroups(db, userId, ownRules)` — own-first, then each
+  group's rules (ascending group id), re-sequenced to dense ordinals.
+- `mergeBudgetsWithGroups(db, userId, ownBudgets)` — own-first full-replace per
+  `(scope, window, target)` slot.
+- `gatherUserScheduleRules` / `gatherUserBudgets` become thin wrappers that pass
+  the user's persisted own rows to those cores (behaviour unchanged — existing
+  tests stay green).
+
+## Phase 1 — core enforcement paths (push + force-close)
+
+1. `policy/group-resolution.ts`: extract the two merge cores; keep `gatherUser*`
+   as wrappers.
+2. `transport/policy-push/platform-runner.ts`: widen
+   `PolicyEnforcementContext.schedules` from `readonly ScheduleRow[]` to
+   `readonly ScheduleRule[]`, and `budgets` from `readonly BudgetRow[]` to
+   `readonly BudgetInput[]`. The Linux runner only forwards these to
+   `resolvePolicyPush` (which already takes those subsets), so this is a safe
+   widening; `GatheredScheduleRule`/`GatheredBudget` satisfy the subsets.
+3. `transport/policy-push/executor.ts`: read `gatherUserScheduleRules` /
+   `gatherUserBudgets` instead of `listUserSchedules` / `listUserBudgets`.
+4. `enforcement/evaluate.ts`: replace the inline own-only schedule/budget
+   `db.select()`s with the `gather*` helpers (grants stay own-only — they are a
+   per-user additive layer).
+5. Tests: a group-only schedule/budget shows up in a push's `timekpra` args and
+   drives a force-close decision; a user-level rule overrides an inherited one.
+
+## Phase 2 — preview + ansible renders
+
+6. `api/policy/preview-routes.ts`: `before` = `gatherUser*` (mirrors the push);
+   `after` = `mergeScheduleRulesWithGroups(proposedOwn)` /
+   `mergeBudgetsWithGroups(proposedOwn)` so an edit to the user's own rules is
+   diffed against the same persisted group layer the push will re-merge. Update
+   the doc comment (the old "deliberately does not use gather" note inverts).
+7. `transport/ansible/e2guardian.ts`: `resolveBannedSites` reads `gatherUser*`;
+   `isAlwaysOn` typed to the `ScheduleRule` subset so gathered rules fit.
+8. `transport/ansible/apparmor.ts`: `listUserAlwaysOnDenies` reads `gatherUser*`;
+   `isAlwaysOn` / `executablesForDeny` typed to `ScheduleRule`.
+9. Tests: an always-on group deny appears in the e2guardian banned-sites plan
+   and the AppArmor denials; the preview diff includes a group rule.
+
+## Out of scope (per issue)
+
+- Exceptions in resolution (user or group) — `resolve.ts` consumes no
+  exceptions yet (#142).
+- Weekday-varying budgets (#141); group-editor UI (#343/#363).
+- Recurring/date-scoped group denies in e2guardian/AppArmor (#216/#243) — only
+  **always-on** group denies participate in the static renders, matching the
+  own-rule behaviour those renders already have.
+
+## License boundary
+
+None touched — plain TypeScript over the policy model + Drizzle reads. Ansible
+and `timekpra` stay subprocesses; nothing linked/vendored; no GPL binary added
+to the image.

--- a/server/src/api/policy/preview-routes.ts
+++ b/server/src/api/policy/preview-routes.ts
@@ -9,13 +9,14 @@
  * pushes (`transport/policy-push/diff.ts`), and lists the user's linked clients
  * annotated with their last-seen time and current offline-queue depth.
  *
- * **Faithful to what is actually pushed.** Current policy is read with
- * `listUserSchedules` + `listUserBudgets` — the user's **own** rules, exactly
- * what the live executor (`transport/policy-push/executor.ts`) resolves and
- * pushes. It deliberately does *not* use the group-merged `gatherUserScheduleRules`
- * that the read-only `effective.ts` preview uses: group schedules are not pushed
- * over `timekpra` yet, so diffing against them would show windows the push never
- * sends.
+ * **Faithful to what is actually pushed.** Current policy is read with the
+ * group-aware `gatherUserScheduleRules` + `gatherUserBudgets` — exactly what the
+ * live executor (`transport/policy-push/executor.ts`) now resolves and pushes
+ * since group rules reach `timekpra` (#362). The *proposed* side merges the
+ * request body's own rules with the same persisted group layer
+ * (`mergeScheduleRulesWithGroups` / `mergeBudgetsWithGroups`): the admin editor
+ * only edits the user's own rules, so an accurate preview holds the group layer
+ * constant on both sides and diffs only the own-rule change the push will re-merge.
  *
  * **Side-effect-free.** Preview reads + computes only: no SSH probe, no push, no
  * queue write. The per-client push-vs-queue decision still happens at push time
@@ -35,6 +36,12 @@ import { z } from "zod";
 import type { Settings } from "../../config.js";
 import { resolveEffectiveTz } from "../../policy/budget-window.js";
 import type { PolicyDb } from "../../policy/db.js";
+import {
+  gatherUserBudgets,
+  gatherUserScheduleRules,
+  mergeBudgetsWithGroups,
+  mergeScheduleRulesWithGroups,
+} from "../../policy/group-resolution.js";
 import * as repo from "../../policy/repository.js";
 import type { BudgetInput } from "../../policy/resolve.js";
 import type { ScheduleRule } from "../../policy/schedule-precedence.js";
@@ -124,19 +131,25 @@ export function registerPreviewRoutes(scope: FastifyInstance, settings: Settings
       const tz = resolveEffectiveTz(user.tz, settings.defaultTz);
       const now = request.body.now === undefined ? new Date() : new Date(request.body.now);
 
-      // Current policy mirrors the live executor: the user's OWN schedules +
-      // budgets (group schedules are not pushed over timekpra yet), resolved at
-      // the same reference instant.
+      // Current policy mirrors the live executor: the user's effective rules —
+      // own rules merged with inherited group schedules/budgets (#362), resolved
+      // at the same reference instant.
       const before = resolvePolicyPush({
         tz,
-        schedules: repo.listUserSchedules(scope.db, userId),
-        budgets: repo.listUserBudgets(scope.db, userId),
+        schedules: gatherUserScheduleRules(scope.db, userId),
+        budgets: gatherUserBudgets(scope.db, userId),
         now,
       });
+      // The proposed side merges the edited OWN rules with the same persisted
+      // group layer, so the diff isolates the own-rule change the push re-merges.
       const after = resolvePolicyPush({
         tz,
-        schedules: request.body.schedules.map(toScheduleRule),
-        budgets: request.body.budgets.map(toBudgetInput),
+        schedules: mergeScheduleRulesWithGroups(
+          scope.db,
+          userId,
+          request.body.schedules.map(toScheduleRule),
+        ),
+        budgets: mergeBudgetsWithGroups(scope.db, userId, request.body.budgets.map(toBudgetInput)),
         now,
       });
 

--- a/server/src/enforcement/evaluate.ts
+++ b/server/src/enforcement/evaluate.ts
@@ -14,9 +14,10 @@
  * (Timekpr-nExT) concern, not per-app process-kill, so they are not enforced
  * here.
  *
- * Reads are done inline here rather than through `policy/repository.ts` — the
- * same pattern `api/policy/effective.ts` uses — so this enforcement seam stays
- * decoupled from the CRUD repository surface.
+ * Schedules and budgets are read through the shared group-aware composition
+ * helpers (`policy/group-resolution.ts`) — the same entry point the push and
+ * `api/policy/effective.ts` use — so group-inherited per-activity quotas drive
+ * force-close and the enforced answer can't drift from the displayed one (#362).
  *
  * The telemetry scheduler (#117) calls this after each rollup and holds the
  * returned cool-down state for the next pass. The decisions it returns are what
@@ -29,10 +30,10 @@ import { eq } from "drizzle-orm";
 
 import type { PolicyDb } from "../policy/db.js";
 import { localCalendarDate } from "../policy/budget-window.js";
+import { gatherUserBudgets, gatherUserScheduleRules } from "../policy/group-resolution.js";
 import { DEFAULT_GRACE_SECONDS } from "../policy/notification.js";
-import { effectivePolicy, type BudgetInput, type GrantInput } from "../policy/resolve.js";
-import type { ScheduleRule } from "../policy/schedule-precedence.js";
-import { budgets, grants, notificationPolicies, schedules } from "../policy/schema.js";
+import { effectivePolicy, type GrantInput } from "../policy/resolve.js";
+import { grants, notificationPolicies } from "../policy/schema.js";
 import { groupSecondsInWindow, usageByActivityInWindow } from "../policy/usage.js";
 
 import { decideEnforcement, type EnforcementOutcome } from "./decision.js";
@@ -74,16 +75,11 @@ export function evaluateUserEnforcement(
 ): EnforcementOutcome {
   const { userId, now, tz, cooldownSeconds } = input;
 
-  const scheduleRules: ScheduleRule[] = db
-    .select()
-    .from(schedules)
-    .where(eq(schedules.userId, userId))
-    .all();
-  const budgetRows: BudgetInput[] = db
-    .select()
-    .from(budgets)
-    .where(eq(budgets.userId, userId))
-    .all();
+  // Effective policy = the user's own rules merged with any inherited group
+  // schedules/budgets (#362), so a group per-activity quota drives force-close.
+  // Grants stay own-only — they are a per-user additive overlay, not inherited.
+  const scheduleRules = gatherUserScheduleRules(db, userId);
+  const budgetRows = gatherUserBudgets(db, userId);
   const grantRows: GrantInput[] = db.select().from(grants).where(eq(grants.userId, userId)).all();
 
   const effective = effectivePolicy({

--- a/server/src/policy/group-resolution.ts
+++ b/server/src/policy/group-resolution.ts
@@ -60,40 +60,47 @@ export interface GatheredScheduleRule extends ScheduleRule {
   readonly source: RuleSource;
 }
 
+/** Copy the {@link ScheduleRule} subset off any own-rule row (Drizzle row or proposed DTO). */
+function toScheduleRule(rule: ScheduleRule): ScheduleRule {
+  return {
+    id: rule.id,
+    ordinal: rule.ordinal,
+    targetKind: rule.targetKind,
+    targetId: rule.targetId,
+    recurrenceDays: rule.recurrenceDays,
+    recurrenceStartMinute: rule.recurrenceStartMinute,
+    recurrenceEndMinute: rule.recurrenceEndMinute,
+    effectiveFrom: rule.effectiveFrom,
+    effectiveTo: rule.effectiveTo,
+    action: rule.action,
+  };
+}
+
 /**
- * The user's effective schedule rule list — own rules first (they win), then
- * each group's rules (groups ascending by id), re-sequenced to dense ordinals
- * so the merge order is authoritative. See the file header for the full
- * precedence contract.
+ * Merge an **explicit** own-rule list with the user's inherited group schedules
+ * — own rules first (they win), then each group's rules (groups ascending by
+ * id), re-sequenced to dense ordinals so the merge order is authoritative. See
+ * the file header for the full precedence contract.
+ *
+ * The own rules are passed in rather than read here so the same composition
+ * serves both the persisted case ({@link gatherUserScheduleRules}) and the
+ * save-and-push preview, which merges a *proposed* own-rule set against the
+ * persisted group layer the push will re-merge (#362).
  */
-export function gatherUserScheduleRules(db: PolicyDb, userId: number): GatheredScheduleRule[] {
-  const own: GatheredScheduleRule[] = listUserSchedules(db, userId).map((row) => ({
-    id: row.id,
-    ordinal: row.ordinal,
-    targetKind: row.targetKind,
-    targetId: row.targetId,
-    recurrenceDays: row.recurrenceDays,
-    recurrenceStartMinute: row.recurrenceStartMinute,
-    recurrenceEndMinute: row.recurrenceEndMinute,
-    effectiveFrom: row.effectiveFrom,
-    effectiveTo: row.effectiveTo,
-    action: row.action,
+export function mergeScheduleRulesWithGroups(
+  db: PolicyDb,
+  userId: number,
+  ownRules: readonly ScheduleRule[],
+): GatheredScheduleRule[] {
+  const own: GatheredScheduleRule[] = ownRules.map((rule) => ({
+    ...toScheduleRule(rule),
     source: { kind: "user" },
   }));
 
   // `listUserGroupsForUser` already returns groups ascending by id.
   const inherited: GatheredScheduleRule[] = listUserGroupsForUser(db, userId).flatMap((group) =>
     listGroupSchedules(db, group.id).map((row) => ({
-      id: row.id,
-      ordinal: row.ordinal,
-      targetKind: row.targetKind,
-      targetId: row.targetId,
-      recurrenceDays: row.recurrenceDays,
-      recurrenceStartMinute: row.recurrenceStartMinute,
-      recurrenceEndMinute: row.recurrenceEndMinute,
-      effectiveFrom: row.effectiveFrom,
-      effectiveTo: row.effectiveTo,
-      action: row.action,
+      ...toScheduleRule(row),
       source: { kind: "group", groupId: group.id },
     })),
   );
@@ -101,6 +108,17 @@ export function gatherUserScheduleRules(db: PolicyDb, userId: number): GatheredS
   // Re-sequence dense ordinals over the user-first merge so `byOrdinal`'s id
   // tiebreak (ids collide across the two tables) can never reorder the result.
   return [...own, ...inherited].map((rule, index) => ({ ...rule, ordinal: index }));
+}
+
+/**
+ * The user's effective schedule rule list — their persisted own rules merged
+ * with inherited group rules via {@link mergeScheduleRulesWithGroups}. The
+ * single entry point every enforcement and display surface reads so the push,
+ * the force-close sweep, the preview, and `/api/.../effective` can't drift
+ * (#362).
+ */
+export function gatherUserScheduleRules(db: PolicyDb, userId: number): GatheredScheduleRule[] {
+  return mergeScheduleRulesWithGroups(db, userId, listUserSchedules(db, userId));
 }
 
 /**
@@ -124,11 +142,12 @@ function budgetSlotKey(budget: BudgetInput): string {
 }
 
 /**
- * The user's effective **budget baseline** — own budgets first (they win), then
- * each group's budgets (groups ascending by id), with **full-replace** override
- * per slot (#134, `docs/adr/0008-group-targeted-budgets.md`):
+ * Merge an **explicit** own-budget list with the user's inherited group budgets
+ * — own budgets first (they win), then each group's budgets (groups ascending
+ * by id), with **full-replace** override per slot (#134,
+ * `docs/adr/0008-group-targeted-budgets.md`):
  *
- * 1. all of the user's own budgets are included, and their slots are marked
+ * 1. all of the passed-in own budgets are included, and their slots are marked
  *    covered;
  * 2. then, for each group the user belongs to (ascending group `id`), only that
  *    group's budgets whose slot is **not yet covered** are inherited — a slot is
@@ -142,12 +161,21 @@ function budgetSlotKey(budget: BudgetInput): string {
  * user's own duplicate rows. The result is a plain `BudgetInput[]` (each tagged
  * with its {@link RuleSource}) that drops straight into
  * {@link import("./resolve.js").effectivePolicy}.
+ *
+ * The own budgets are passed in rather than read here so the same composition
+ * serves both the persisted case ({@link gatherUserBudgets}) and the
+ * save-and-push preview, which merges a *proposed* own-budget set against the
+ * persisted group layer the push will re-merge (#362).
  */
-export function gatherUserBudgets(db: PolicyDb, userId: number): GatheredBudget[] {
+export function mergeBudgetsWithGroups(
+  db: PolicyDb,
+  userId: number,
+  ownBudgets: readonly BudgetInput[],
+): GatheredBudget[] {
   const result: GatheredBudget[] = [];
   const covered = new Set<string>();
 
-  for (const row of listUserBudgets(db, userId)) {
+  for (const row of ownBudgets) {
     result.push({
       scope: row.scope,
       targetId: row.targetId,
@@ -180,4 +208,14 @@ export function gatherUserBudgets(db: PolicyDb, userId: number): GatheredBudget[
   }
 
   return result;
+}
+
+/**
+ * The user's effective budget baseline — their persisted own budgets merged
+ * with inherited group budgets via {@link mergeBudgetsWithGroups}. The single
+ * entry point every enforcement and display surface reads so the push, the
+ * force-close sweep, the preview, and `/api/.../effective` can't drift (#362).
+ */
+export function gatherUserBudgets(db: PolicyDb, userId: number): GatheredBudget[] {
+  return mergeBudgetsWithGroups(db, userId, listUserBudgets(db, userId));
 }

--- a/server/src/policy/group-resolution.ts
+++ b/server/src/policy/group-resolution.ts
@@ -43,7 +43,7 @@ import {
   listUserSchedules,
 } from "./repository.js";
 import type { BudgetInput } from "./resolve.js";
-import type { ScheduleRule } from "./schedule-precedence.js";
+import { byOrdinal, type ScheduleRule } from "./schedule-precedence.js";
 
 /** Where a gathered rule came from: the user's own list, or an inherited group. */
 export type RuleSource =
@@ -61,7 +61,7 @@ export interface GatheredScheduleRule extends ScheduleRule {
 }
 
 /** Copy the {@link ScheduleRule} subset off any own-rule row (Drizzle row or proposed DTO). */
-function toScheduleRule(rule: ScheduleRule): ScheduleRule {
+function pickScheduleRuleFields(rule: ScheduleRule): ScheduleRule {
   return {
     id: rule.id,
     ordinal: rule.ordinal,
@@ -92,15 +92,19 @@ export function mergeScheduleRulesWithGroups(
   userId: number,
   ownRules: readonly ScheduleRule[],
 ): GatheredScheduleRule[] {
-  const own: GatheredScheduleRule[] = ownRules.map((rule) => ({
-    ...toScheduleRule(rule),
-    source: { kind: "user" },
-  }));
+  // Sort the own rules into evaluation order (ascending ordinal, then id) before
+  // the merge re-sequences them. The persisted path (`listUserSchedules`) is
+  // already sorted, but a caller passing proposed rows in an arbitrary order
+  // (the save-and-push preview) must resolve by `ordinal`, not array position —
+  // matching what the eventual save + reload will yield (#362).
+  const own: GatheredScheduleRule[] = byOrdinal(
+    ownRules.map((rule) => ({ ...pickScheduleRuleFields(rule), source: { kind: "user" } })),
+  );
 
   // `listUserGroupsForUser` already returns groups ascending by id.
   const inherited: GatheredScheduleRule[] = listUserGroupsForUser(db, userId).flatMap((group) =>
     listGroupSchedules(db, group.id).map((row) => ({
-      ...toScheduleRule(row),
+      ...pickScheduleRuleFields(row),
       source: { kind: "group", groupId: group.id },
     })),
   );

--- a/server/src/transport/ansible/apparmor.ts
+++ b/server/src/transport/ansible/apparmor.ts
@@ -57,9 +57,9 @@ import {
   getClient,
   listClientLinks,
   listGroupActivities,
-  listUserSchedules,
 } from "../../policy/repository.js";
-import type { ScheduleRow } from "../../policy/repository.js";
+import { gatherUserScheduleRules } from "../../policy/group-resolution.js";
+import type { ScheduleRule } from "../../policy/schedule-precedence.js";
 import { redactArgv, type AuditContext, type AuditEntry, type AuditSink } from "../audit/index.js";
 import type { AuditOutcome } from "../../policy/enums.js";
 import type { SshTargetRef } from "../ssh/errors.js";
@@ -148,7 +148,7 @@ export function profileNameFor(executable: string): string {
 }
 
 /** A schedule is "always-on" when no recurrence or date-scoping gate is set. */
-function isAlwaysOn(rule: ScheduleRow): boolean {
+function isAlwaysOn(rule: ScheduleRule): boolean {
   return (
     rule.recurrenceDays === null &&
     rule.recurrenceStartMinute === null &&
@@ -173,7 +173,7 @@ function isMappableApp(kind: string, matchType: string, matcher: string): boolea
  * Returns absolute executable paths (possibly several, for a group), skipping
  * any non-mappable activity (non-`app`, non-`exact`, non-absolute, `app_group`).
  */
-function executablesForDeny(db: PolicyDb, rule: ScheduleRow): string[] {
+function executablesForDeny(db: PolicyDb, rule: ScheduleRule): string[] {
   if (rule.targetKind === "activity" && rule.targetId !== null) {
     const activity = getActivity(db, rule.targetId);
     if (
@@ -237,9 +237,13 @@ export function buildAppArmorPlan(db: PolicyDb, clientId: number): AppArmorPlan 
   return { clientId, hostname: client.hostname, denials };
 }
 
-/** A user's always-on `deny` schedules — the rules this mapper consumes. */
-function listUserAlwaysOnDenies(db: PolicyDb, userId: number): ScheduleRow[] {
-  return listUserSchedules(db, userId).filter((r) => r.action === "deny" && isAlwaysOn(r));
+/**
+ * A user's always-on `deny` schedules — own rules plus inherited always-on group
+ * denies (#362), so a group-targeted app block reaches the AppArmor render.
+ * Recurring/date-scoped group denies remain a #243 follow-up.
+ */
+function listUserAlwaysOnDenies(db: PolicyDb, userId: number): ScheduleRule[] {
+  return gatherUserScheduleRules(db, userId).filter((r) => r.action === "deny" && isAlwaysOn(r));
 }
 
 /** Options for {@link pushAppArmorProfiles}. */

--- a/server/src/transport/ansible/e2guardian.ts
+++ b/server/src/transport/ansible/e2guardian.ts
@@ -23,14 +23,10 @@
  */
 import { z } from "zod";
 
-import {
-  getActivity,
-  listClientLinks,
-  listGroupActivities,
-  listUserSchedules,
-} from "../../policy/repository.js";
+import { getActivity, listClientLinks, listGroupActivities } from "../../policy/repository.js";
 import type { PolicyDb } from "../../policy/db.js";
-import type { ScheduleRow } from "../../policy/repository.js";
+import { gatherUserScheduleRules } from "../../policy/group-resolution.js";
+import type { ScheduleRule } from "../../policy/schedule-precedence.js";
 import { redactArgv, type AuditEntry, type AuditSink } from "../audit/index.js";
 
 import type { AnsibleHost, AnsibleRunner, AnsibleRunResult, ExtraVarValue } from "./index.js";
@@ -105,7 +101,7 @@ export interface BuildE2guardianPlanOptions {
  * static filter group; recurring "no YouTube during homework" windows are the
  * per-website time-window swap deferred to a #90 follow-up.
  */
-function isAlwaysOn(rule: ScheduleRow): boolean {
+function isAlwaysOn(rule: ScheduleRule): boolean {
   return (
     rule.recurrenceDays === null &&
     rule.recurrenceStartMinute === null &&
@@ -123,10 +119,15 @@ function isAlwaysOn(rule: ScheduleRow): boolean {
  * `domain_group` activities (named bundles the client expands) are intentionally
  * skipped here — resolving a named bundle to concrete domains is owned by the
  * richer-matcher work (#178/#195); this slice handles concrete `domain` matchers.
+ *
+ * Reads the user's effective schedules — own rules plus inherited always-on
+ * group denies (#362) — so a group-targeted domain block reaches e2guardian.
+ * Recurring/date-scoped group denies remain a #216 follow-up (only always-on
+ * denies belong in the static filter group, matching the own-rule behaviour).
  */
 function resolveBannedSites(db: PolicyDb, userId: number): string[] {
   const sites = new Set<string>();
-  for (const rule of listUserSchedules(db, userId)) {
+  for (const rule of gatherUserScheduleRules(db, userId)) {
     if (rule.action !== "deny" || !isAlwaysOn(rule) || rule.targetId === null) continue;
     if (rule.targetKind === "activity") {
       const activity = getActivity(db, rule.targetId);

--- a/server/src/transport/policy-push/executor.ts
+++ b/server/src/transport/policy-push/executor.ts
@@ -48,13 +48,8 @@
 import { z } from "zod";
 
 import type { PolicyDb } from "../../policy/db.js";
-import {
-  getClient,
-  getUser,
-  listUserBudgets,
-  listUserLinks,
-  listUserSchedules,
-} from "../../policy/repository.js";
+import { gatherUserBudgets, gatherUserScheduleRules } from "../../policy/group-resolution.js";
+import { getClient, getUser, listUserLinks } from "../../policy/repository.js";
 import type { ActionExecutor, QueuedAction } from "../queue/types.js";
 import { policyPushPayloadSchema } from "./payload.js";
 import type { PlatformRunnerRegistry } from "./platform-runner.js";
@@ -148,8 +143,11 @@ export function createPolicyPushExecutor(options: PolicyPushExecutorOptions): Ac
     // defensive only, and a vanished user resolves to an empty-policy push.
     const user = getUser(db, userId);
     const tz = user?.tz ?? defaultTz;
-    const budgets = listUserBudgets(db, userId);
-    const schedules = listUserSchedules(db, userId);
+    // Effective policy = the user's own rules merged with any inherited group
+    // schedules/budgets (#362), so a group-targeted bedtime or budget actually
+    // reaches the client instead of being display-only.
+    const budgets = gatherUserBudgets(db, userId);
+    const schedules = gatherUserScheduleRules(db, userId);
 
     await runner.enforce({
       client,

--- a/server/src/transport/policy-push/platform-runner.ts
+++ b/server/src/transport/policy-push/platform-runner.ts
@@ -25,7 +25,9 @@
  * boundaries").
  */
 import type { Platform } from "../../policy/enums.js";
-import type { BudgetRow, ClientRow, ScheduleRow } from "../../policy/repository.js";
+import type { ClientRow } from "../../policy/repository.js";
+import type { BudgetInput } from "../../policy/resolve.js";
+import type { ScheduleRule } from "../../policy/schedule-precedence.js";
 
 /**
  * The platform-agnostic inputs for one `(client, user)` policy push, resolved by
@@ -44,10 +46,17 @@ export interface PolicyEnforcementContext {
   readonly reason: string;
   /** The user's effective timezone (`User.tz ?? PCT_DEFAULT_TZ`). */
   readonly tz: string;
-  /** The user's schedule rules (precedence order applied downstream). */
-  readonly schedules: readonly ScheduleRow[];
-  /** The user's budgets (overall + per-activity). */
-  readonly budgets: readonly BudgetRow[];
+  /**
+   * The user's effective schedule rules — own rules merged with inherited group
+   * rules in precedence order by the gatherer (#362); the runner forwards them
+   * to `resolvePolicyPush`, which applies first-match-wins.
+   */
+  readonly schedules: readonly ScheduleRule[];
+  /**
+   * The user's effective budgets — own budgets plus any inherited group budget
+   * for a slot the user has not overridden (#362), overall + per-activity.
+   */
+  readonly budgets: readonly BudgetInput[];
   /** The reference instant the week and "today" are resolved against. */
   readonly now: Date;
 }

--- a/server/tests/api/policy-preview.test.ts
+++ b/server/tests/api/policy-preview.test.ts
@@ -15,6 +15,7 @@ import { loadSettings } from "../../src/config.js";
 import {
   budgets,
   clients,
+  groupBudgets,
   groupSchedules,
   userGroupMemberships,
   userGroups,
@@ -205,11 +206,11 @@ describe("POST /api/users/:userId/policy-preview", () => {
     });
   });
 
-  it("diffs against the user's OWN rules, not inherited group schedules (#182 fidelity)", async () => {
+  it("includes inherited group schedule windows on both sides of the diff (#362)", async () => {
     const userId = await createUser("Alice"); // tz null → UTC
-    // A group deny the user inherits. The live push does NOT send group rules,
-    // so the preview must treat the *current* push as "no schedule" and show the
-    // proposed user rule as a fresh change — not diff against the group window.
+    // A group "bedtime" the child inherits: deny 22:00–24:00 every day. Since the
+    // push now sends inherited group rules (#362), the preview's *current* side
+    // must reflect it — allowed windows are 00:00–22:00, not the full day.
     const group = harness.db
       .insert(userGroups)
       .values({ name: "Kids" })
@@ -219,12 +220,18 @@ describe("POST /api/users/:userId/policy-preview", () => {
     harness.db.insert(userGroupMemberships).values({ userId, groupId: group.id }).run();
     harness.db
       .insert(groupSchedules)
-      .values({ userGroupId: group.id, targetKind: "overall", targetId: null, action: "deny" })
+      .values({
+        userGroupId: group.id,
+        targetKind: "overall",
+        targetId: null,
+        action: "deny",
+        recurrenceStartMinute: 1320, // 22:00
+        recurrenceEndMinute: 1440, // 24:00
+      })
       .run();
 
-    // Proposed: the user's own deny 22:00–24:00 (1320..1440) → allowed windows
-    // become 00:00–22:00. If the preview had diffed against the inherited group
-    // deny (fully denied), the "before" allowed windows would differ.
+    // Proposed: the child's own earlier bedtime deny 20:00–24:00 (1200..1440),
+    // which composes above the inherited group window (own rules win first).
     const res = await auth({
       method: "POST",
       url: `/api/users/${userId}/policy-preview`,
@@ -234,7 +241,7 @@ describe("POST /api/users/:userId/policy-preview", () => {
           proposedSchedule({
             userId,
             action: "deny",
-            recurrenceStartMinute: 1320,
+            recurrenceStartMinute: 1200,
             recurrenceEndMinute: 1440,
           }),
         ],
@@ -243,19 +250,63 @@ describe("POST /api/users/:userId/policy-preview", () => {
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    // The current push has no allowed-hours grid (no own rules → fully allowed
-    // is the resolver's no-schedule shape, which `resolvePolicyPush` renders as
-    // a full-week allow). The proposed deny carves out 22:00–24:00, so each day
-    // changes from full-day to 00:00–22:00.
     const allowedHoursRows = body.changes.filter(
       (c: { field: string }) => c.field === "allowed-hours",
     );
     expect(allowedHoursRows.length).toBeGreaterThan(0);
+    // before reflects the inherited group window (00:00–22:00); after tightens it
+    // to 00:00–20:00 via the proposed own rule — proving the group layer is held
+    // constant on both sides and only the own-rule change is diffed.
     expect(allowedHoursRows[0]).toMatchObject({
       field: "allowed-hours",
-      before: "00:00–24:00",
-      after: "00:00–22:00",
+      before: "00:00–22:00",
+      after: "00:00–20:00",
     });
+  });
+
+  it("uses an inherited group budget as the diff baseline a proposed own budget overrides (#362)", async () => {
+    const userId = await createUser("Alice"); // tz null → UTC
+    const group = harness.db
+      .insert(userGroups)
+      .values({ name: "Kids" })
+      .returning({ id: userGroups.id })
+      .get();
+    if (group === undefined) throw new Error("group insert returned no row");
+    harness.db.insert(userGroupMemberships).values({ userId, groupId: group.id }).run();
+    // The child has no own overall/daily budget — only the inherited group's 2h.
+    harness.db
+      .insert(groupBudgets)
+      .values({
+        userGroupId: group.id,
+        scope: "overall",
+        targetId: null,
+        window: "daily",
+        secondsAllowed: 7200,
+      })
+      .run();
+
+    // Proposed: the child's own 1h overall/daily budget fully replaces the slot.
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: {
+        budgets: [proposedBudget({ userId, secondsAllowed: 3600 })],
+        schedules: [],
+        now: "2026-06-17T12:00:00Z",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.hasChanges).toBe(true);
+    // before = inherited group 2h (not "none"), after = own 1h override.
+    expect(body.changes).toContainEqual(
+      expect.objectContaining({
+        field: "daily-overall",
+        kind: "changed",
+        before: "2h",
+        after: "1h",
+      }),
+    );
   });
 
   it("lists affected clients with hostname, lastSeen, and pending-queue depth", async () => {

--- a/server/tests/enforcement/evaluate.test.ts
+++ b/server/tests/enforcement/evaluate.test.ts
@@ -8,6 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { evaluateUserEnforcement } from "../../src/enforcement/evaluate.js";
+import { addUserToGroup, createGroupBudget, createUserGroup } from "../../src/policy/repository.js";
 import {
   activities,
   activitiesToGroups,
@@ -257,6 +258,65 @@ describe("evaluateUserEnforcement", () => {
       `activity:${codeId}`,
       `group:${groupId}`,
     ]);
+  });
+
+  it("fires on a group-inherited per-activity budget the user has not overridden (#362)", () => {
+    const group = createUserGroup(db, { name: "Kids" });
+    addUserToGroup(db, group.id, userId);
+    // The activity budget lives on the group only — the user has none of their own.
+    createGroupBudget(db, {
+      userGroupId: group.id,
+      scope: "activity",
+      targetId: firefoxId,
+      window: "daily",
+      secondsAllowed: 1800,
+    });
+    seedFirefoxUsage("2024-02-15T10:00:00.000Z", "2024-02-15T11:00:00.000Z"); // 3600s > 1800
+
+    const out = evaluateUserEnforcement(
+      db,
+      { userId, now: NOW, tz: "UTC", cooldownSeconds: 300 },
+      new Map(),
+    );
+
+    expect(out.decisions).toHaveLength(1);
+    expect(out.decisions[0]).toMatchObject({
+      scope: "activity",
+      targetId: firefoxId,
+      allowedSeconds: 1800,
+      consumedSeconds: 3600,
+    });
+  });
+
+  it("lets the user's own activity budget override the inherited group budget in enforcement (#362)", () => {
+    const group = createUserGroup(db, { name: "Kids" });
+    addUserToGroup(db, group.id, userId);
+    // The group would fire at 3600 used, but the user's own higher budget wins the slot.
+    createGroupBudget(db, {
+      userGroupId: group.id,
+      scope: "activity",
+      targetId: firefoxId,
+      window: "daily",
+      secondsAllowed: 600,
+    });
+    db.insert(budgets)
+      .values({
+        userId,
+        scope: "activity",
+        targetId: firefoxId,
+        window: "daily",
+        secondsAllowed: 7200,
+      })
+      .run();
+    seedFirefoxUsage("2024-02-15T10:00:00.000Z", "2024-02-15T11:00:00.000Z"); // 3600s < 7200
+
+    const out = evaluateUserEnforcement(
+      db,
+      { userId, now: NOW, tz: "UTC", cooldownSeconds: 300 },
+      new Map(),
+    );
+    // Own budget fully replaces the group's for the slot → under budget → no fire.
+    expect(out.decisions).toHaveLength(0);
   });
 
   it("threads cool-down state through so a recent fire is suppressed", () => {

--- a/server/tests/policy/group-resolution.test.ts
+++ b/server/tests/policy/group-resolution.test.ts
@@ -7,9 +7,13 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { gatherUserBudgets, gatherUserScheduleRules } from "../../src/policy/group-resolution.js";
+import {
+  gatherUserBudgets,
+  gatherUserScheduleRules,
+  mergeScheduleRulesWithGroups,
+} from "../../src/policy/group-resolution.js";
 import * as repo from "../../src/policy/repository.js";
-import { resolveEffectiveRule } from "../../src/policy/schedule-precedence.js";
+import { resolveEffectiveRule, type ScheduleRule } from "../../src/policy/schedule-precedence.js";
 import { testDb, type TestDb } from "../helpers/db.js";
 
 describe("gatherUserScheduleRules (#182)", () => {
@@ -115,6 +119,33 @@ describe("gatherUserScheduleRules (#182)", () => {
     const winner = resolveEffectiveRule(gatherUserScheduleRules(db, userId), () => true);
     expect(winner?.action).toBe("allow");
     expect(winner?.source).toEqual({ kind: "user" });
+  });
+
+  it("resolves passed-in own rules by ordinal, not array order (preview fidelity, #362)", () => {
+    // The save-and-push preview passes proposed own rules straight from the
+    // request body, which need not arrive in ordinal order. The merge must sort
+    // them by (ordinal, id) so precedence matches what the save + reload yields.
+    const base = {
+      targetKind: "overall" as const,
+      targetId: null,
+      recurrenceDays: null,
+      recurrenceStartMinute: null,
+      recurrenceEndMinute: null,
+      effectiveFrom: null,
+      effectiveTo: null,
+    };
+    const outOfOrder: ScheduleRule[] = [
+      { id: 2, ordinal: 1, action: "deny", ...base },
+      { id: 1, ordinal: 0, action: "allow", ...base },
+    ];
+
+    const merged = mergeScheduleRulesWithGroups(db, userId, outOfOrder);
+
+    // ordinal 0 (allow, id 1) wins the first slot despite being passed second.
+    expect(merged.map((r) => r.id)).toEqual([1, 2]);
+    expect(merged.map((r) => r.ordinal)).toEqual([0, 1]);
+    expect(merged.map((r) => r.action)).toEqual(["allow", "deny"]);
+    expect(resolveEffectiveRule(merged, () => true)?.action).toBe("allow");
   });
 
   it("falls back to the inherited group rule when the user has none", () => {

--- a/server/tests/transport/ansible/apparmor.test.ts
+++ b/server/tests/transport/ansible/apparmor.test.ts
@@ -25,11 +25,14 @@ import {
 } from "../../../src/transport/ansible/apparmor.js";
 import {
   addActivityToGroup,
+  addUserToGroup,
   createActivity,
   createActivityGroup,
   createClient,
+  createGroupSchedule,
   createSchedule,
   createUser,
+  createUserGroup,
   upsertLink,
   type ClientRow,
 } from "../../../src/policy/repository.js";
@@ -175,6 +178,31 @@ describe("buildAppArmorPlan", () => {
     const plan = buildAppArmorPlan(db, client.id);
 
     expect(plan.denials.map((d) => d.executable)).toEqual(["/usr/bin/minecraft"]);
+  });
+
+  it("maps an inherited always-on group-schedule app deny, attributed to the member (#362)", () => {
+    const db = testDb();
+    const client = seedClient(db);
+    const userId = linkUser(db, client.id, "Alice", 1001);
+    // The app deny is authored on a user-group the child belongs to.
+    const kids = createUserGroup(db, { name: "Kids" });
+    addUserToGroup(db, kids.id, userId);
+    const app = createActivity(db, { kind: "app", matcher: "/usr/bin/steam", matchType: "exact" });
+    createGroupSchedule(db, {
+      userGroupId: kids.id,
+      targetKind: "activity",
+      targetId: app.id,
+      action: "deny",
+    });
+
+    const plan = buildAppArmorPlan(db, client.id);
+
+    expect(plan.denials).toHaveLength(1);
+    expect(plan.denials[0]?.executable).toBe("/usr/bin/steam");
+    // The block is attributed to the member who inherited it, for the audit trail.
+    expect(plan.denials[0]?.blockedFor).toEqual([
+      { userId, osUsername: "alice", osUserRef: "1001" },
+    ]);
   });
 
   it("unions and sorts denials across users, deduping a shared executable", () => {

--- a/server/tests/transport/ansible/e2guardian.test.ts
+++ b/server/tests/transport/ansible/e2guardian.test.ts
@@ -8,11 +8,14 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   addActivityToGroup,
+  addUserToGroup,
   createActivity,
   createActivityGroup,
   createClient,
+  createGroupSchedule,
   createSchedule,
   createUser,
+  createUserGroup,
   upsertLink,
 } from "../../../src/policy/repository.js";
 import {
@@ -204,6 +207,37 @@ describe("buildE2guardianPlan", () => {
     expect(plan.proxyPort).toBe(9000);
     expect(plan.redirectPorts).toEqual([80]);
     expect(plan.users[0]?.listenPort).toBe(9001);
+    db.$client.close();
+  });
+
+  it("includes an inherited always-on group-schedule domain deny in the plan (#362)", () => {
+    const db = testDb();
+    const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+    const alice = addLinkedUser(db, clientId, "Alice", "alice", 1001);
+
+    // The deny is authored on a user-group the child belongs to, not on the child.
+    const kids = createUserGroup(db, { name: "Kids" });
+    addUserToGroup(db, kids.id, alice);
+    const youtube = createActivity(db, { kind: "domain", matcher: "youtube.com" });
+    createGroupSchedule(db, {
+      userGroupId: kids.id,
+      targetKind: "activity",
+      targetId: youtube.id,
+      action: "deny",
+    });
+    // Plus an own deny, to prove own + inherited denies combine (deduped + sorted).
+    const tiktok = createActivity(db, { kind: "domain", matcher: "tiktok.com" });
+    createSchedule(db, {
+      userId: alice,
+      targetKind: "activity",
+      targetId: tiktok.id,
+      action: "deny",
+    });
+
+    const plan = buildE2guardianPlan(db, clientId);
+
+    expect(plan.users).toHaveLength(1);
+    expect(plan.users[0]?.bannedSites).toEqual(["tiktok.com", "youtube.com"]);
     db.$client.close();
   });
 

--- a/server/tests/transport/policy-push/executor.test.ts
+++ b/server/tests/transport/policy-push/executor.test.ts
@@ -13,10 +13,14 @@ import { describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
 
 import {
+  addUserToGroup,
   createBudget,
   createClient,
+  createGroupBudget,
+  createGroupSchedule,
   createSchedule,
   createUser,
+  createUserGroup,
   upsertLink,
 } from "../../../src/policy/repository.js";
 import { clients } from "../../../src/policy/schema.js";
@@ -360,6 +364,82 @@ describe("createPolicyPushExecutor", () => {
 
       await executor(unlinkAction(9999, userId));
       expect(build).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("group-inherited policy reaches the push (#362)", () => {
+    it("pushes a group-inherited overall daily budget over timekpra", async () => {
+      const { userId, clientId } = setup();
+      const group = createUserGroup(db, { name: "Kids" });
+      addUserToGroup(db, group.id, userId);
+      // The budget lives on the group only — the user has none of their own.
+      createGroupBudget(db, {
+        userGroupId: group.id,
+        scope: "overall",
+        window: "daily",
+        secondsAllowed: 7200,
+      });
+
+      const rec = recordingClient();
+      const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: () => rec.client });
+
+      await executor(action(clientId, userId));
+
+      // The inherited group limit reaches the client — no longer display-only.
+      expect(rec.calls).toEqual([
+        "setTimeLimits:7200,7200,7200,7200,7200,7200,7200",
+        "setWeeklyAllowedHours:7",
+      ]);
+    });
+
+    it("lets the user's own budget override the inherited group budget in the push", async () => {
+      const { userId, clientId } = setup();
+      const group = createUserGroup(db, { name: "Kids" });
+      addUserToGroup(db, group.id, userId);
+      createGroupBudget(db, {
+        userGroupId: group.id,
+        scope: "overall",
+        window: "daily",
+        secondsAllowed: 7200,
+      });
+      // The user's own overall/daily budget fully replaces the group's for that slot.
+      createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 1800 });
+
+      const rec = recordingClient();
+      const executor = linuxExecutor({ db, defaultTz: "UTC", buildClient: () => rec.client });
+
+      await executor(action(clientId, userId));
+
+      expect(rec.calls).toEqual([
+        "setTimeLimits:1800,1800,1800,1800,1800,1800,1800",
+        "setWeeklyAllowedHours:7",
+      ]);
+    });
+
+    it("resolves a group-inherited always-on overall deny in the push (skips allowed-hours)", async () => {
+      const { userId, clientId } = setup();
+      const group = createUserGroup(db, { name: "Kids" });
+      addUserToGroup(db, group.id, userId);
+      createBudget(db, { userId, scope: "overall", window: "daily", secondsAllowed: 3600 });
+      // The deny lives on the group; it must still shape the resolved push.
+      createGroupSchedule(db, { userGroupId: group.id, targetKind: "overall", action: "deny" });
+
+      const rec = recordingClient();
+      const warn = vi.fn();
+      const executor = linuxExecutor({
+        db,
+        defaultTz: "UTC",
+        runnerLog: { warn },
+        buildClient: () => rec.client,
+      });
+
+      await executor(action(clientId, userId));
+
+      // The group deny denies all week → the unrepresentable allowed-hours push is skipped,
+      // proving the group schedule participated in the resolution.
+      expect(rec.calls).toEqual(["setTimeLimits:3600,3600,3600,3600,3600,3600,3600"]);
+      expect(rec.calls).not.toContain("setWeeklyAllowedHours:7");
+      expect(warn).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

- Group-targeted schedules/budgets (#134/#182) landed end-to-end **except enforcement**: the `gatherUserScheduleRules` / `gatherUserBudgets` resolution helpers were consumed only by the display endpoint `GET /api/users/:userId/effective`, so group rules were silently **display-only** — `/admin`'s effective view and the client's actual behaviour disagreed.
- Makes `policy/group-resolution.ts` the **single group-aware composition point** and routes every enforcement / preview / render path through it, so the enforced answer can't drift from the displayed one again.
- Group-only bedtimes/allowed-hours and group budgets now actually reach `timekpra`; group per-activity quotas now drive the force-close sweep; the save-and-push preview and the e2guardian/AppArmor renders include inherited always-on group denies — each with a user-level rule still overriding an inherited one per ADR 0004/0008 precedence.

## Plan

Linked plan: `.claude/plans/362-group-inherited-enforcement.md`
Roadmap: docs/roadmap.md → Phase 2 (policy model / group layer)

Delivered in two commits:
1. **Core enforcement** — extract `mergeScheduleRulesWithGroups` / `mergeBudgetsWithGroups` cores (own-rules passed explicitly); `gatherUser*` become thin wrappers. Route the policy-push executor + `enforcement/evaluate` through them. Widen `PolicyEnforcementContext` to the `ScheduleRule` / `BudgetInput` subsets the Linux runner already forwards to `resolvePolicyPush`.
2. **Preview + ansible renders** — preview `before` uses `gatherUser*`, `after` merges the *proposed* own rules with the persisted group layer; `e2guardian.resolveBannedSites` and `apparmor.listUserAlwaysOnDenies` read `gatherUser*`.

## License-boundary note

N/A — plain TypeScript over the policy model + Drizzle reads. Ansible and `timekpra` stay subprocesses; nothing linked/imported/vendored; no GPL binary added to the image.

## Test plan

- [x] Policy push: a group-only overall daily budget reaches `timekpra`; a user's own budget overrides it; a group always-on overall deny shapes the resolved push.
- [x] Force-close: a group-inherited per-activity budget fires; a user's own budget override suppresses it.
- [x] Preview: the diff includes an inherited group schedule window and an inherited group budget baseline on both sides (stale #182-era fidelity test rewritten to the corrected contract).
- [x] e2guardian / AppArmor: an always-on group deny appears in the banned-sites plan / the AppArmor denials.
- [x] `npm run format:check && npm run lint && npm run typecheck && npm test` — 1683 passing, coverage gate 80% held.

## Deferred (out of scope, per issue)

- Exceptions in resolution (user or group) — `resolve.ts` consumes no exceptions yet (#142).
- Weekday-varying group budgets (#141); group-editor UI (#343/#363).
- Recurring/date-scoped group denies in the static e2guardian/AppArmor renders (#216/#243) — only **always-on** group denies participate, matching the existing own-rule behaviour.

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)