### PR TITLE
feat(admin): author recurrence + date scoping on schedule rules (#361)

### DIFF
--- a/.claude/plans/361-recurrence-authoring-ui.md
+++ b/.claude/plans/361-recurrence-authoring-ui.md
@@ -1,0 +1,91 @@
+# Plan — #361: author recurrence (day-of-week + time windows) + date scoping on schedule rules
+
+Roadmap: `docs/roadmap.md` → Phase 4 (last mile of #140). **Frontend-only.**
+The backend (DTOs, schema CHECKs, resolver, timekpra push) is already
+recurrence-aware — no server/model changes.
+
+## Problem
+
+`SchedulesView.svelte` and `GroupSchedulesView.svelte` can only create/edit
+**always-on** rules: the create form hard-codes `recurrenceDays` /
+`recurrenceStartMinute` / `recurrenceEndMinute` / `effectiveFrom` /
+`effectiveTo` to `null`, and inline edit exposes `action` only. "Allow Games
+Mon–Fri 16:00–18:00" and "deny overall after 21:00 daily" are API-only today.
+
+## Model recap (from `server/src/policy/recurrence.ts`)
+
+- `recurrenceDays`: 7-bit ISO weekday mask, bit0=Mon…bit6=Sun, `[1,127]`;
+  `null`/empty = every day.
+- `recurrenceStartMinute` / `recurrenceEndMinute`: minutes from local midnight,
+  half-open `[start,end)`, both-or-neither, `0 <= start < end <= 1440`.
+- `effectiveFrom` / `effectiveTo`: ISO-8601 UTC instants (`z.string().datetime()`),
+  `null` = open-ended; `effectiveFrom < effectiveTo` when both set.
+- Degenerate all-null row = always-on.
+- PATCH accepts all fields; cross-field invariants re-checked by storage CHECK
+  → 400. Client validation mirrors the invariants so an invalid combo can't
+  be submitted; server errors still surfaced via the existing `error` alert.
+
+## Design
+
+### 1. `src/lib/recurrence.ts` — pure helpers (unit-tested, shared, reusable by #343)
+
+- `WEEKDAY_LABELS` / `WEEKDAY_FULL` — Mon…Sun / Monday…Sunday.
+- `dayChecked(mask, i)` / `toggleDay(mask, i, checked)` — checkbox ↔ mask;
+  empty selection → `null` (every day).
+- `minutesToTimeInput(min)` / `timeInputToMinutes(value, isEnd)` — `HH:MM` ↔
+  minutes. **End-of-day convention:** an *end* time of `00:00` maps to `1440`
+  (native `<input type=time>` can't express 24:00, and end can never legitimately
+  be 0 because `start < end` with `start >= 0`); `minutesToTimeInput(1440)` → `"00:00"`.
+- `instantToDateInput(iso)` / `dateInputToInstant(value)` — ISO instant ↔
+  `YYYY-MM-DD`, using **local** midnight so the round-trip is stable in the
+  admin's browser TZ and matches the summary's `toLocaleDateString()`.
+- `validateRecurrence(value)` → `string | null` — mirrors the DTO superRefine
+  (both-or-neither minutes, `start < end`, `effectiveFrom < effectiveTo`).
+
+### 2. `src/lib/components/RecurrenceFields.svelte` — reusable picker
+
+Presentational; `$bindable` model props (`recurrenceDays`, two minutes, two
+instants), `disabled`, `error` (rendered when non-null), `idPrefix`. Renders a
+fieldset/legend with 7 weekday checkboxes (full-name aria-labels), start/end
+`type=time` inputs, from/to `type=date` inputs, and an "empty = every day / all
+day / open-ended" hint. Uses the helpers above; writes model props on input.
+
+### 3. Wire into `SchedulesView` + `GroupSchedulesView`
+
+- Create form: add `new*` recurrence state, mount `<RecurrenceFields>`,
+  send authored values (not null), reset on success. `createDisabled` gains
+  `newRecurrenceError !== null`.
+- Inline edit: add `edit*` recurrence state, populate in `startEdit`, mount
+  `<RecurrenceFields>` in the editing row, send action + all 5 recurrence
+  fields in the PATCH (full set so the stored row matches the editor). Save
+  disabled on `editRecurrenceError`.
+- Keep the existing `recurrenceSummary` / `daysLabel` / `clockLabel` collapsed
+  display untouched (distinct semantics: display shows `24:00`, input shows
+  `00:00`). Remove the "#140 pending" hint text.
+
+## Tests
+
+- `tests/components/recurrence.test.ts` — helper units: mask toggle/decode,
+  time round-trips incl. end `00:00`↔`1440` and start `00:00`, date round-trip
+  (TZ-independent), validation for each invariant + the valid degenerate.
+- `tests/components/recurrence-fields.test.ts` — component: toggling a day sets
+  the mask, entering times sets minutes (end 00:00 → end-of-day), date inputs
+  set instants, error prop renders.
+- `tests/components/schedules-view-authoring.test.ts` — create sends authored
+  recurrence; edit sends action + recurrence; invalid combo disables submit.
+- `tests/components/group-schedules-view-authoring.test.ts` — same for groups.
+
+## Acceptance criteria mapping
+
+- "Games Mon–Fri 16:00–18:00" + "deny overall after 21:00 daily", create+edit,
+  user + group → create/edit tests assert the exact payloads.
+- Date-scope authoring both editors → covered.
+- Validation blocks invalid combos → `validateRecurrence` + disabled-submit tests.
+- Reorder / in-effect / shadow unchanged → existing reorder suites still pass.
+- Quality gate green → svelte-check + frontend vitest + server gate.
+
+## Out of scope (tracked elsewhere)
+
+- Date-scoped/exception **resolution** semantics (#142).
+- Combined Policy view composition (#343) — pickers built reusable for it.
+- Timekpr sub-hour representation warnings — handled at push time.

--- a/server/frontend/src/lib/components/RecurrenceFields.svelte
+++ b/server/frontend/src/lib/components/RecurrenceFields.svelte
@@ -45,25 +45,29 @@
     error?: string | null;
   } = $props();
 
-  function onDayToggle(index: number, event: Event): void {
-    const checked = (event.currentTarget as HTMLInputElement).checked;
-    recurrenceDays = toggleDay(recurrenceDays, index, checked);
+  // The DOM event Svelte hands an input's on:change / on:input handler — typing
+  // `currentTarget` on the parameter reads the value without an unchecked `as`
+  // cast (CLAUDE.md → "no unchecked `as` casts").
+  type InputElementEvent = Event & { currentTarget: EventTarget & HTMLInputElement };
+
+  function onDayToggle(index: number, event: InputElementEvent): void {
+    recurrenceDays = toggleDay(recurrenceDays, index, event.currentTarget.checked);
   }
 
-  function onStartInput(event: Event): void {
-    recurrenceStartMinute = timeInputToMinutes((event.currentTarget as HTMLInputElement).value, false);
+  function onStartInput(event: InputElementEvent): void {
+    recurrenceStartMinute = timeInputToMinutes(event.currentTarget.value, false);
   }
 
-  function onEndInput(event: Event): void {
-    recurrenceEndMinute = timeInputToMinutes((event.currentTarget as HTMLInputElement).value, true);
+  function onEndInput(event: InputElementEvent): void {
+    recurrenceEndMinute = timeInputToMinutes(event.currentTarget.value, true);
   }
 
-  function onFromInput(event: Event): void {
-    effectiveFrom = dateInputToInstant((event.currentTarget as HTMLInputElement).value);
+  function onFromInput(event: InputElementEvent): void {
+    effectiveFrom = dateInputToInstant(event.currentTarget.value);
   }
 
-  function onToInput(event: Event): void {
-    effectiveTo = dateInputToInstant((event.currentTarget as HTMLInputElement).value);
+  function onToInput(event: InputElementEvent): void {
+    effectiveTo = dateInputToInstant(event.currentTarget.value);
   }
 </script>
 

--- a/server/frontend/src/lib/components/RecurrenceFields.svelte
+++ b/server/frontend/src/lib/components/RecurrenceFields.svelte
@@ -1,0 +1,220 @@
+<!--
+  Recurrence + date-scope picker (#361 — the frontend last mile of #140).
+
+  A reusable, presentational editor for a schedule rule's recurrence fields:
+  a 7-bit ISO weekday mask, an intra-day time window `[start, end)`, and an
+  open-ended effective-date range. Bindable model props carry the canonical
+  values (mask / minutes-from-midnight / ISO instants); this component only maps
+  them to/from native inputs via the pure helpers in `$lib/recurrence`, so both
+  `SchedulesView` and `GroupSchedulesView` (and later the combined Policy view,
+  #343) can compose it without re-deriving anything.
+
+  Validation lives in the parent (it owns submit gating) via
+  `validateRecurrence`; the resulting message is passed back in as `error` and
+  rendered here beside the fields.
+-->
+<script lang="ts">
+  import {
+    WEEKDAY_LABELS,
+    WEEKDAY_FULL,
+    dayChecked,
+    toggleDay,
+    minutesToTimeInput,
+    timeInputToMinutes,
+    instantToDateInput,
+    dateInputToInstant,
+  } from "$lib/recurrence.js";
+
+  let {
+    recurrenceDays = $bindable(),
+    recurrenceStartMinute = $bindable(),
+    recurrenceEndMinute = $bindable(),
+    effectiveFrom = $bindable(),
+    effectiveTo = $bindable(),
+    disabled = false,
+    idPrefix,
+    error = null,
+  }: {
+    recurrenceDays: number | null;
+    recurrenceStartMinute: number | null;
+    recurrenceEndMinute: number | null;
+    effectiveFrom: string | null;
+    effectiveTo: string | null;
+    disabled?: boolean;
+    idPrefix: string;
+    error?: string | null;
+  } = $props();
+
+  function onDayToggle(index: number, event: Event): void {
+    const checked = (event.currentTarget as HTMLInputElement).checked;
+    recurrenceDays = toggleDay(recurrenceDays, index, checked);
+  }
+
+  function onStartInput(event: Event): void {
+    recurrenceStartMinute = timeInputToMinutes((event.currentTarget as HTMLInputElement).value, false);
+  }
+
+  function onEndInput(event: Event): void {
+    recurrenceEndMinute = timeInputToMinutes((event.currentTarget as HTMLInputElement).value, true);
+  }
+
+  function onFromInput(event: Event): void {
+    effectiveFrom = dateInputToInstant((event.currentTarget as HTMLInputElement).value);
+  }
+
+  function onToInput(event: Event): void {
+    effectiveTo = dateInputToInstant((event.currentTarget as HTMLInputElement).value);
+  }
+</script>
+
+<fieldset class="recurrence" {disabled}>
+  <legend>Recurrence</legend>
+
+  <div class="field">
+    <span class="label" id="{idPrefix}-days-label">Days</span>
+    <div class="days" role="group" aria-labelledby="{idPrefix}-days-label">
+      {#each WEEKDAY_LABELS as label, index (label)}
+        <label class="day">
+          <input
+            type="checkbox"
+            checked={dayChecked(recurrenceDays, index)}
+            onchange={(event) => onDayToggle(index, event)}
+            aria-label={WEEKDAY_FULL[index]}
+          />
+          <span>{label}</span>
+        </label>
+      {/each}
+    </div>
+    <p class="hint">No days selected = every day.</p>
+  </div>
+
+  <div class="field">
+    <span class="label">Time window</span>
+    <div class="row">
+      <label class="inline">
+        <span class="sub">From</span>
+        <input
+          type="time"
+          value={minutesToTimeInput(recurrenceStartMinute)}
+          oninput={onStartInput}
+          aria-label="Start time"
+        />
+      </label>
+      <label class="inline">
+        <span class="sub">To</span>
+        <input
+          type="time"
+          value={minutesToTimeInput(recurrenceEndMinute)}
+          oninput={onEndInput}
+          aria-label="End time"
+        />
+      </label>
+    </div>
+    <p class="hint">Leave both empty = all day. An end of 00:00 means end of day.</p>
+  </div>
+
+  <div class="field">
+    <span class="label">Active dates</span>
+    <div class="row">
+      <label class="inline">
+        <span class="sub">From</span>
+        <input
+          type="date"
+          value={instantToDateInput(effectiveFrom)}
+          oninput={onFromInput}
+          aria-label="Active from date"
+        />
+      </label>
+      <label class="inline">
+        <span class="sub">Until</span>
+        <input
+          type="date"
+          value={instantToDateInput(effectiveTo)}
+          oninput={onToInput}
+          aria-label="Active until date"
+        />
+      </label>
+    </div>
+    <p class="hint">Leave empty = open-ended.</p>
+  </div>
+
+  {#if error !== null}
+    <p class="field-error" role="alert">{error}</p>
+  {/if}
+</fieldset>
+
+<style>
+  .recurrence {
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 0.75rem 0.9rem 0.9rem;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  legend {
+    padding: 0 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #374151;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #374151;
+  }
+  .days {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+  }
+  .day {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    color: #374151;
+  }
+  .row {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .inline {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: #374151;
+  }
+  .sub {
+    color: #6b7280;
+  }
+  input[type="time"],
+  input[type="date"] {
+    padding: 0.4rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    background: #fff;
+    font: inherit;
+  }
+  .hint {
+    margin: 0;
+    font-size: 0.75rem;
+    color: #6b7280;
+  }
+  .field-error {
+    margin: 0;
+    font-size: 0.8rem;
+    color: #b91c1c;
+  }
+  fieldset:disabled {
+    opacity: 0.6;
+  }
+</style>

--- a/server/frontend/src/lib/recurrence.ts
+++ b/server/frontend/src/lib/recurrence.ts
@@ -1,0 +1,177 @@
+/**
+ * Recurrence authoring helpers (#361 — the frontend last mile of #140).
+ *
+ * Pure conversions and validation shared by {@link ./components/RecurrenceFields.svelte}
+ * and the schedule editors (`SchedulesView`, `GroupSchedulesView`), and reusable
+ * by the future combined Policy view (#343). These mirror the server's
+ * single-source recurrence rules in `server/src/policy/recurrence.ts` (the same
+ * bounds the zod DTOs and the storage `CHECK`s enforce) so the editor can never
+ * submit a combination the API will reject — while the server stays the
+ * authority (its errors still surface through the view's error alert).
+ *
+ * Model recap:
+ * - `recurrenceDays` — 7-bit ISO weekday mask, bit0=Mon … bit6=Sun, `[1,127]`;
+ *   `null` (no bits set) = every day.
+ * - `recurrenceStartMinute` / `recurrenceEndMinute` — minutes from local
+ *   midnight on the half-open interval `[start,end)`, both-or-neither,
+ *   `0 <= start < end <= 1440`.
+ * - `effectiveFrom` / `effectiveTo` — ISO-8601 UTC instants; `null` = open-ended.
+ *
+ * License boundary: none — plain TypeScript, no backend coupling.
+ */
+
+/** Minutes in a full day — the exclusive end of the intra-day window space. */
+export const MINUTES_PER_DAY = 1440;
+
+/** Short ISO-weekday labels in mask-bit order (bit0=Mon … bit6=Sun). */
+export const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+/** Full ISO-weekday names in mask-bit order, for accessible labels. */
+export const WEEKDAY_FULL = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;
+
+/** The five recurrence + date-scope fields as authored on a schedule rule. */
+export interface RecurrenceValue {
+  recurrenceDays: number | null;
+  recurrenceStartMinute: number | null;
+  recurrenceEndMinute: number | null;
+  effectiveFrom: string | null;
+  effectiveTo: string | null;
+}
+
+/** Whether weekday bit `index` (0=Mon … 6=Sun) is set in `mask`. */
+export function dayChecked(mask: number | null, index: number): boolean {
+  return mask !== null && (mask & (1 << index)) !== 0;
+}
+
+/**
+ * Set/clear weekday bit `index` in `mask`, returning the new mask. A result of
+ * no bits set collapses to `null` — the "every day" degenerate the DTO expects
+ * (an empty selection is not a stored `0`).
+ */
+export function toggleDay(mask: number | null, index: number, checked: boolean): number | null {
+  const base = mask ?? 0;
+  const next = checked ? base | (1 << index) : base & ~(1 << index);
+  return next === 0 ? null : next;
+}
+
+/**
+ * Minutes-from-midnight → an `<input type="time">` value (`HH:MM`). `null`
+ * renders as empty. The end-of-day sentinel `1440` (24:00, which a native time
+ * input can't express) renders as `00:00` — see {@link timeInputToMinutes}.
+ */
+export function minutesToTimeInput(minutes: number | null): string {
+  if (minutes === null) {
+    return "";
+  }
+  const wrapped = minutes === MINUTES_PER_DAY ? 0 : minutes;
+  const h = Math.floor(wrapped / 60);
+  const m = wrapped % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+/**
+ * An `<input type="time">` value (`HH:MM`) → minutes from midnight. Empty → `null`.
+ *
+ * Native time inputs top out at `23:59`, so "until end of day" (24:00 = 1440)
+ * is expressed by entering `00:00` in the **end** field: when `isEnd` and the
+ * parsed value is `0`, it maps to `1440`. This is unambiguous because a valid
+ * window has `start < end` with `start >= 0`, so an end of `0` can never be
+ * legitimate.
+ */
+export function timeInputToMinutes(value: string, isEnd: boolean): number | null {
+  if (value === "") {
+    return null;
+  }
+  const [hStr, mStr] = value.split(":");
+  const h = Number(hStr);
+  const m = Number(mStr);
+  if (!Number.isInteger(h) || !Number.isInteger(m)) {
+    return null;
+  }
+  const minutes = h * 60 + m;
+  return isEnd && minutes === 0 ? MINUTES_PER_DAY : minutes;
+}
+
+/**
+ * An ISO-8601 instant → an `<input type="date">` value (`YYYY-MM-DD`) in the
+ * viewer's local timezone. `null` renders as empty. Paired with
+ * {@link dateInputToInstant} so a date authored, stored, and re-opened for edit
+ * round-trips to the same calendar day in the admin's browser, matching the
+ * summary's `toLocaleDateString()` rendering.
+ */
+export function instantToDateInput(iso: string | null): string {
+  if (iso === null) {
+    return "";
+  }
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return "";
+  }
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * An `<input type="date">` value (`YYYY-MM-DD`) → an ISO-8601 UTC instant at
+ * local midnight of that day. Empty → `null`. Local midnight (not UTC) keeps
+ * the round-trip with {@link instantToDateInput} stable in the admin's TZ.
+ */
+export function dateInputToInstant(value: string): string | null {
+  if (value === "") {
+    return null;
+  }
+  const [yStr, mStr, dStr] = value.split("-");
+  const y = Number(yStr);
+  const m = Number(mStr);
+  const d = Number(dStr);
+  if (!Number.isInteger(y) || !Number.isInteger(m) || !Number.isInteger(d)) {
+    return null;
+  }
+  return new Date(y, m - 1, d).toISOString();
+}
+
+/**
+ * Validate a recurrence combination against the DTO's cross-field invariants,
+ * returning a human message or `null` when valid. Mirrors the `superRefine` in
+ * `server/src/policy/recurrence.ts`:
+ * - the two minute bounds are both set or both empty;
+ * - when set, `start < end`;
+ * - when both effective bounds are set, `effectiveFrom < effectiveTo`.
+ *
+ * Per-field bounds (mask `[1,127]`, minutes `[0,1440]`) are guaranteed by the
+ * inputs themselves (checkboxes, native time pickers), so only the cross-field
+ * rules need re-checking here.
+ */
+export function validateRecurrence(value: RecurrenceValue): string | null {
+  const startSet = value.recurrenceStartMinute !== null;
+  const endSet = value.recurrenceEndMinute !== null;
+
+  if (startSet !== endSet) {
+    return "Set both a start and end time, or leave both empty for all day.";
+  }
+  if (
+    value.recurrenceStartMinute !== null &&
+    value.recurrenceEndMinute !== null &&
+    value.recurrenceStartMinute >= value.recurrenceEndMinute
+  ) {
+    return "The end time must be after the start time.";
+  }
+  if (
+    value.effectiveFrom !== null &&
+    value.effectiveTo !== null &&
+    Date.parse(value.effectiveFrom) >= Date.parse(value.effectiveTo)
+  ) {
+    return "The end date must be after the start date.";
+  }
+  return null;
+}

--- a/server/frontend/src/lib/views/GroupSchedulesView.svelte
+++ b/server/frontend/src/lib/views/GroupSchedulesView.svelte
@@ -20,8 +20,10 @@
 
   A group `Schedule` allow/deny/extends a `targetKind` (`overall`, an `activity`,
   or an activity `group`). Scope/target are fixed at create time; inline edit
-  exposes `action` only. Recurrence is rendered read-only ("Always" for the
-  degenerate always-on rule); authoring day/time windows is #140.
+  exposes `action` plus the rule's recurrence (day-of-week + time window) and
+  effective-date scope, authored via the reusable `RecurrenceFields` picker
+  (#361). The collapsed row keeps the read-only `recurrenceSummary` ("Always"
+  for the degenerate always-on rule).
 -->
 <script lang="ts">
   import { onMount } from "svelte";
@@ -45,6 +47,8 @@
   import { listUserGroups } from "$lib/api/user-groups.js";
   import { listActivities } from "$lib/api/activities.js";
   import { listActivityGroups } from "$lib/api/activity-groups.js";
+  import RecurrenceFields from "$lib/components/RecurrenceFields.svelte";
+  import { validateRecurrence } from "$lib/recurrence.js";
 
   const SCOPE_OPTIONS: ReadonlyArray<{ value: Scope; label: string }> = [
     { value: "overall", label: "Overall" },
@@ -73,16 +77,46 @@
   let orderLoading = $state(false);
   let reordering = $state(false);
 
-  // Create form (the group is the selected one; only scope/target/action here).
+  // Create form (the group is the selected one; scope/target/action + recurrence).
   let newScope = $state<Scope>("overall");
   let newTargetId = $state<number | null>(null);
   let newAction = $state<ScheduleAction>("deny");
+  let newRecurrenceDays = $state<number | null>(null);
+  let newRecurrenceStartMinute = $state<number | null>(null);
+  let newRecurrenceEndMinute = $state<number | null>(null);
+  let newEffectiveFrom = $state<string | null>(null);
+  let newEffectiveTo = $state<string | null>(null);
   let creating = $state(false);
 
-  // Inline edit (action only).
+  // Inline edit (action + recurrence).
   let editingId = $state<number | null>(null);
   let editAction = $state<ScheduleAction>("deny");
+  let editRecurrenceDays = $state<number | null>(null);
+  let editRecurrenceStartMinute = $state<number | null>(null);
+  let editRecurrenceEndMinute = $state<number | null>(null);
+  let editEffectiveFrom = $state<string | null>(null);
+  let editEffectiveTo = $state<string | null>(null);
   let saving = $state(false);
+
+  // Client-side recurrence validation, mirroring the DTO cross-field invariants.
+  let newRecurrenceError = $derived(
+    validateRecurrence({
+      recurrenceDays: newRecurrenceDays,
+      recurrenceStartMinute: newRecurrenceStartMinute,
+      recurrenceEndMinute: newRecurrenceEndMinute,
+      effectiveFrom: newEffectiveFrom,
+      effectiveTo: newEffectiveTo,
+    }),
+  );
+  let editRecurrenceError = $derived(
+    validateRecurrence({
+      recurrenceDays: editRecurrenceDays,
+      recurrenceStartMinute: editRecurrenceStartMinute,
+      recurrenceEndMinute: editRecurrenceEndMinute,
+      effectiveFrom: editEffectiveFrom,
+      effectiveTo: editEffectiveTo,
+    }),
+  );
 
   // The rule being dragged (index into the current order), or null.
   let dragIndex = $state<number | null>(null);
@@ -209,12 +243,15 @@
   }
 
   let createDisabled = $derived(
-    creating || selectedGroupId === null || (newScope !== "overall" && newTargetId === null),
+    creating ||
+      selectedGroupId === null ||
+      (newScope !== "overall" && newTargetId === null) ||
+      newRecurrenceError !== null,
   );
 
   async function handleCreate(event: SubmitEvent): Promise<void> {
     event.preventDefault();
-    if (selectedGroupId === null) {
+    if (selectedGroupId === null || newRecurrenceError !== null) {
       return;
     }
     creating = true;
@@ -229,15 +266,20 @@
         targetId: newScope === "overall" ? null : newTargetId,
         action: newAction,
         ordinal: appendOrdinal,
-        recurrenceDays: null,
-        recurrenceStartMinute: null,
-        recurrenceEndMinute: null,
-        effectiveFrom: null,
-        effectiveTo: null,
+        recurrenceDays: newRecurrenceDays,
+        recurrenceStartMinute: newRecurrenceStartMinute,
+        recurrenceEndMinute: newRecurrenceEndMinute,
+        effectiveFrom: newEffectiveFrom,
+        effectiveTo: newEffectiveTo,
       });
       newScope = "overall";
       newTargetId = null;
       newAction = "deny";
+      newRecurrenceDays = null;
+      newRecurrenceStartMinute = null;
+      newRecurrenceEndMinute = null;
+      newEffectiveFrom = null;
+      newEffectiveTo = null;
       await loadOrder();
     } catch (err) {
       error = messageOf(err);
@@ -249,6 +291,11 @@
   function startEdit(schedule: GroupScheduleResponse): void {
     editingId = schedule.id;
     editAction = schedule.action;
+    editRecurrenceDays = schedule.recurrenceDays;
+    editRecurrenceStartMinute = schedule.recurrenceStartMinute;
+    editRecurrenceEndMinute = schedule.recurrenceEndMinute;
+    editEffectiveFrom = schedule.effectiveFrom;
+    editEffectiveTo = schedule.effectiveTo;
     error = null;
   }
 
@@ -257,10 +304,23 @@
   }
 
   async function saveEdit(id: number): Promise<void> {
+    if (editRecurrenceError !== null) {
+      return;
+    }
     saving = true;
     error = null;
     try {
-      await updateGroupSchedule(id, { action: editAction });
+      // Send the full recurrence set alongside the action so the persisted row
+      // matches exactly what the editor shows (a PATCH merges, and the storage
+      // CHECKs re-validate the merged row).
+      await updateGroupSchedule(id, {
+        action: editAction,
+        recurrenceDays: editRecurrenceDays,
+        recurrenceStartMinute: editRecurrenceStartMinute,
+        recurrenceEndMinute: editRecurrenceEndMinute,
+        effectiveFrom: editEffectiveFrom,
+        effectiveTo: editEffectiveTo,
+      });
       editingId = null;
       await loadOrder();
     } catch (err) {
@@ -353,8 +413,8 @@
       are evaluated top to bottom and the first matching rule wins, so drag (or
       use Move up / Move down) to set precedence. Because a group's members can
       span timezones, "in effect now" is shown per user on their own status, not
-      here. New rules apply at all times; day-of-week and time-of-day windows
-      come later (#140).
+      here. Each rule can be scoped to particular days, a time window, and a date
+      range — leave those empty for an always-on rule.
     </p>
   </header>
 
@@ -386,36 +446,53 @@
       <p class="muted">Choose a group to view and order its schedule rules.</p>
     {:else}
       <form class="create" onsubmit={handleCreate}>
-        <select
-          bind:value={newScope}
-          onchange={onScopeChange}
+        <div class="create-row">
+          <select
+            bind:value={newScope}
+            onchange={onScopeChange}
+            disabled={creating}
+            aria-label="Schedule scope"
+          >
+            {#each SCOPE_OPTIONS as option (option.value)}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
+          {#if newScope === "activity"}
+            <select
+              bind:value={newTargetId}
+              disabled={creating}
+              aria-label="Target activity"
+              required
+            >
+              <option value={null} disabled selected>Choose an activity…</option>
+              {#each activities as activity (activity.id)}
+                <option value={activity.id}>{activity.matcher} ({activity.kind})</option>
+              {/each}
+            </select>
+          {:else if newScope === "group"}
+            <select bind:value={newTargetId} disabled={creating} aria-label="Target group" required>
+              <option value={null} disabled selected>Choose a group…</option>
+              {#each activityGroups as group (group.id)}
+                <option value={group.id}>{group.name}</option>
+              {/each}
+            </select>
+          {/if}
+          <select bind:value={newAction} disabled={creating} aria-label="Schedule action">
+            {#each ACTION_OPTIONS as option (option.value)}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
+        </div>
+        <RecurrenceFields
+          idPrefix="create"
           disabled={creating}
-          aria-label="Schedule scope"
-        >
-          {#each SCOPE_OPTIONS as option (option.value)}
-            <option value={option.value}>{option.label}</option>
-          {/each}
-        </select>
-        {#if newScope === "activity"}
-          <select bind:value={newTargetId} disabled={creating} aria-label="Target activity" required>
-            <option value={null} disabled selected>Choose an activity…</option>
-            {#each activities as activity (activity.id)}
-              <option value={activity.id}>{activity.matcher} ({activity.kind})</option>
-            {/each}
-          </select>
-        {:else if newScope === "group"}
-          <select bind:value={newTargetId} disabled={creating} aria-label="Target group" required>
-            <option value={null} disabled selected>Choose a group…</option>
-            {#each activityGroups as group (group.id)}
-              <option value={group.id}>{group.name}</option>
-            {/each}
-          </select>
-        {/if}
-        <select bind:value={newAction} disabled={creating} aria-label="Schedule action">
-          {#each ACTION_OPTIONS as option (option.value)}
-            <option value={option.value}>{option.label}</option>
-          {/each}
-        </select>
+          error={newRecurrenceError}
+          bind:recurrenceDays={newRecurrenceDays}
+          bind:recurrenceStartMinute={newRecurrenceStartMinute}
+          bind:recurrenceEndMinute={newRecurrenceEndMinute}
+          bind:effectiveFrom={newEffectiveFrom}
+          bind:effectiveTo={newEffectiveTo}
+        />
         <button type="submit" disabled={createDisabled}>
           {creating ? "Adding…" : "Add schedule"}
         </button>
@@ -459,7 +536,20 @@
                     >
                   {/if}
                 </div>
-                <div class="when muted">{recurrenceSummary(schedule)}</div>
+                {#if editingId === schedule.id}
+                  <RecurrenceFields
+                    idPrefix={`edit-${schedule.id}`}
+                    disabled={saving}
+                    error={editRecurrenceError}
+                    bind:recurrenceDays={editRecurrenceDays}
+                    bind:recurrenceStartMinute={editRecurrenceStartMinute}
+                    bind:recurrenceEndMinute={editRecurrenceEndMinute}
+                    bind:effectiveFrom={editEffectiveFrom}
+                    bind:effectiveTo={editEffectiveTo}
+                  />
+                {:else}
+                  <div class="when muted">{recurrenceSummary(schedule)}</div>
+                {/if}
                 {#if shadower !== null}
                   <p class="warn" role="note">
                     Never applies — rule #{shadower} above always wins for this target.
@@ -481,7 +571,10 @@
                   onclick={() => move(index, 1)}>↓</button
                 >
                 {#if editingId === schedule.id}
-                  <button onclick={() => saveEdit(schedule.id)} disabled={saving}>
+                  <button
+                    onclick={() => saveEdit(schedule.id)}
+                    disabled={saving || editRecurrenceError !== null}
+                  >
                     {saving ? "Saving…" : "Save"}
                   </button>
                   <button class="ghost" onclick={cancelEdit} disabled={saving}>Cancel</button>
@@ -518,8 +611,14 @@
   }
   .create {
     display: flex;
-    gap: 0.5rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
     margin-bottom: 1.25rem;
+  }
+  .create-row {
+    display: flex;
+    gap: 0.5rem;
     flex-wrap: wrap;
   }
   select {

--- a/server/frontend/src/lib/views/SchedulesView.svelte
+++ b/server/frontend/src/lib/views/SchedulesView.svelte
@@ -15,8 +15,10 @@
 
   A `Schedule` allow/deny/extends a `targetKind` (`overall`, an `activity`, or a
   `group`). Scope/target are fixed at create time; inline edit exposes `action`
-  only. Recurrence is rendered read-only ("Always" for the degenerate always-on
-  rule); authoring day/time windows is #140.
+  plus the rule's recurrence (day-of-week + time window) and effective-date
+  scope, authored via the reusable `RecurrenceFields` picker (#361). The
+  collapsed row keeps the read-only `recurrenceSummary` ("Always" for the
+  degenerate always-on rule).
 -->
 <script lang="ts">
   import { onMount } from "svelte";
@@ -40,6 +42,8 @@
   import { listUsers } from "$lib/api/users.js";
   import { listActivities } from "$lib/api/activities.js";
   import { listActivityGroups } from "$lib/api/activity-groups.js";
+  import RecurrenceFields from "$lib/components/RecurrenceFields.svelte";
+  import { validateRecurrence } from "$lib/recurrence.js";
 
   const SCOPE_OPTIONS: ReadonlyArray<{ value: Scope; label: string }> = [
     { value: "overall", label: "Overall" },
@@ -68,16 +72,46 @@
   let orderLoading = $state(false);
   let reordering = $state(false);
 
-  // Create form (the user is the selected one; only scope/target/action here).
+  // Create form (the user is the selected one; scope/target/action + recurrence).
   let newScope = $state<Scope>("overall");
   let newTargetId = $state<number | null>(null);
   let newAction = $state<ScheduleAction>("deny");
+  let newRecurrenceDays = $state<number | null>(null);
+  let newRecurrenceStartMinute = $state<number | null>(null);
+  let newRecurrenceEndMinute = $state<number | null>(null);
+  let newEffectiveFrom = $state<string | null>(null);
+  let newEffectiveTo = $state<string | null>(null);
   let creating = $state(false);
 
-  // Inline edit (action only).
+  // Inline edit (action + recurrence).
   let editingId = $state<number | null>(null);
   let editAction = $state<ScheduleAction>("deny");
+  let editRecurrenceDays = $state<number | null>(null);
+  let editRecurrenceStartMinute = $state<number | null>(null);
+  let editRecurrenceEndMinute = $state<number | null>(null);
+  let editEffectiveFrom = $state<string | null>(null);
+  let editEffectiveTo = $state<string | null>(null);
   let saving = $state(false);
+
+  // Client-side recurrence validation, mirroring the DTO cross-field invariants.
+  let newRecurrenceError = $derived(
+    validateRecurrence({
+      recurrenceDays: newRecurrenceDays,
+      recurrenceStartMinute: newRecurrenceStartMinute,
+      recurrenceEndMinute: newRecurrenceEndMinute,
+      effectiveFrom: newEffectiveFrom,
+      effectiveTo: newEffectiveTo,
+    }),
+  );
+  let editRecurrenceError = $derived(
+    validateRecurrence({
+      recurrenceDays: editRecurrenceDays,
+      recurrenceStartMinute: editRecurrenceStartMinute,
+      recurrenceEndMinute: editRecurrenceEndMinute,
+      effectiveFrom: editEffectiveFrom,
+      effectiveTo: editEffectiveTo,
+    }),
+  );
 
   // The rule being dragged (index into the current order), or null.
   let dragIndex = $state<number | null>(null);
@@ -203,12 +237,15 @@
   }
 
   let createDisabled = $derived(
-    creating || selectedUserId === null || (newScope !== "overall" && newTargetId === null),
+    creating ||
+      selectedUserId === null ||
+      (newScope !== "overall" && newTargetId === null) ||
+      newRecurrenceError !== null,
   );
 
   async function handleCreate(event: SubmitEvent): Promise<void> {
     event.preventDefault();
-    if (selectedUserId === null) {
+    if (selectedUserId === null || newRecurrenceError !== null) {
       return;
     }
     creating = true;
@@ -224,15 +261,20 @@
         targetId: newScope === "overall" ? null : newTargetId,
         action: newAction,
         ordinal: appendOrdinal,
-        recurrenceDays: null,
-        recurrenceStartMinute: null,
-        recurrenceEndMinute: null,
-        effectiveFrom: null,
-        effectiveTo: null,
+        recurrenceDays: newRecurrenceDays,
+        recurrenceStartMinute: newRecurrenceStartMinute,
+        recurrenceEndMinute: newRecurrenceEndMinute,
+        effectiveFrom: newEffectiveFrom,
+        effectiveTo: newEffectiveTo,
       });
       newScope = "overall";
       newTargetId = null;
       newAction = "deny";
+      newRecurrenceDays = null;
+      newRecurrenceStartMinute = null;
+      newRecurrenceEndMinute = null;
+      newEffectiveFrom = null;
+      newEffectiveTo = null;
       await loadOrder();
     } catch (err) {
       error = messageOf(err);
@@ -244,6 +286,11 @@
   function startEdit(schedule: ScheduleResponse): void {
     editingId = schedule.id;
     editAction = schedule.action;
+    editRecurrenceDays = schedule.recurrenceDays;
+    editRecurrenceStartMinute = schedule.recurrenceStartMinute;
+    editRecurrenceEndMinute = schedule.recurrenceEndMinute;
+    editEffectiveFrom = schedule.effectiveFrom;
+    editEffectiveTo = schedule.effectiveTo;
     error = null;
   }
 
@@ -252,10 +299,23 @@
   }
 
   async function saveEdit(id: number): Promise<void> {
+    if (editRecurrenceError !== null) {
+      return;
+    }
     saving = true;
     error = null;
     try {
-      await updateSchedule(id, { action: editAction });
+      // Send the full recurrence set alongside the action so the persisted row
+      // matches exactly what the editor shows (a PATCH merges, and the storage
+      // CHECKs re-validate the merged row).
+      await updateSchedule(id, {
+        action: editAction,
+        recurrenceDays: editRecurrenceDays,
+        recurrenceStartMinute: editRecurrenceStartMinute,
+        recurrenceEndMinute: editRecurrenceEndMinute,
+        effectiveFrom: editEffectiveFrom,
+        effectiveTo: editEffectiveTo,
+      });
       editingId = null;
       await loadOrder();
     } catch (err) {
@@ -346,8 +406,8 @@
       Recurring rules that allow, deny, or extend access — overall or for a
       specific activity or activity group. Rules are evaluated top to bottom and
       the first matching rule wins, so drag (or use Move up / Move down) to set
-      precedence. New rules apply at all times; day-of-week and time-of-day
-      windows come later (#140).
+      precedence. Each rule can be scoped to particular days, a time window, and
+      a date range — leave those empty for an always-on rule.
     </p>
   </header>
 
@@ -379,36 +439,53 @@
       <p class="muted">Choose a user to view and order their schedule rules.</p>
     {:else}
       <form class="create" onsubmit={handleCreate}>
-        <select
-          bind:value={newScope}
-          onchange={onScopeChange}
+        <div class="create-row">
+          <select
+            bind:value={newScope}
+            onchange={onScopeChange}
+            disabled={creating}
+            aria-label="Schedule scope"
+          >
+            {#each SCOPE_OPTIONS as option (option.value)}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
+          {#if newScope === "activity"}
+            <select
+              bind:value={newTargetId}
+              disabled={creating}
+              aria-label="Target activity"
+              required
+            >
+              <option value={null} disabled selected>Choose an activity…</option>
+              {#each activities as activity (activity.id)}
+                <option value={activity.id}>{activity.matcher} ({activity.kind})</option>
+              {/each}
+            </select>
+          {:else if newScope === "group"}
+            <select bind:value={newTargetId} disabled={creating} aria-label="Target group" required>
+              <option value={null} disabled selected>Choose a group…</option>
+              {#each groups as group (group.id)}
+                <option value={group.id}>{group.name}</option>
+              {/each}
+            </select>
+          {/if}
+          <select bind:value={newAction} disabled={creating} aria-label="Schedule action">
+            {#each ACTION_OPTIONS as option (option.value)}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
+        </div>
+        <RecurrenceFields
+          idPrefix="create"
           disabled={creating}
-          aria-label="Schedule scope"
-        >
-          {#each SCOPE_OPTIONS as option (option.value)}
-            <option value={option.value}>{option.label}</option>
-          {/each}
-        </select>
-        {#if newScope === "activity"}
-          <select bind:value={newTargetId} disabled={creating} aria-label="Target activity" required>
-            <option value={null} disabled selected>Choose an activity…</option>
-            {#each activities as activity (activity.id)}
-              <option value={activity.id}>{activity.matcher} ({activity.kind})</option>
-            {/each}
-          </select>
-        {:else if newScope === "group"}
-          <select bind:value={newTargetId} disabled={creating} aria-label="Target group" required>
-            <option value={null} disabled selected>Choose a group…</option>
-            {#each groups as group (group.id)}
-              <option value={group.id}>{group.name}</option>
-            {/each}
-          </select>
-        {/if}
-        <select bind:value={newAction} disabled={creating} aria-label="Schedule action">
-          {#each ACTION_OPTIONS as option (option.value)}
-            <option value={option.value}>{option.label}</option>
-          {/each}
-        </select>
+          error={newRecurrenceError}
+          bind:recurrenceDays={newRecurrenceDays}
+          bind:recurrenceStartMinute={newRecurrenceStartMinute}
+          bind:recurrenceEndMinute={newRecurrenceEndMinute}
+          bind:effectiveFrom={newEffectiveFrom}
+          bind:effectiveTo={newEffectiveTo}
+        />
         <button type="submit" disabled={createDisabled}>
           {creating ? "Adding…" : "Add schedule"}
         </button>
@@ -455,7 +532,20 @@
                     <span class="badge effect">In effect now</span>
                   {/if}
                 </div>
-                <div class="when muted">{recurrenceSummary(schedule)}</div>
+                {#if editingId === schedule.id}
+                  <RecurrenceFields
+                    idPrefix={`edit-${schedule.id}`}
+                    disabled={saving}
+                    error={editRecurrenceError}
+                    bind:recurrenceDays={editRecurrenceDays}
+                    bind:recurrenceStartMinute={editRecurrenceStartMinute}
+                    bind:recurrenceEndMinute={editRecurrenceEndMinute}
+                    bind:effectiveFrom={editEffectiveFrom}
+                    bind:effectiveTo={editEffectiveTo}
+                  />
+                {:else}
+                  <div class="when muted">{recurrenceSummary(schedule)}</div>
+                {/if}
                 {#if shadower !== null}
                   <p class="warn" role="note">
                     Never applies — rule #{shadower} above always wins for this target.
@@ -477,7 +567,10 @@
                   onclick={() => move(index, 1)}>↓</button
                 >
                 {#if editingId === schedule.id}
-                  <button onclick={() => saveEdit(schedule.id)} disabled={saving}>
+                  <button
+                    onclick={() => saveEdit(schedule.id)}
+                    disabled={saving || editRecurrenceError !== null}
+                  >
                     {saving ? "Saving…" : "Save"}
                   </button>
                   <button class="ghost" onclick={cancelEdit} disabled={saving}>Cancel</button>
@@ -514,8 +607,14 @@
   }
   .create {
     display: flex;
-    gap: 0.5rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
     margin-bottom: 1.25rem;
+  }
+  .create-row {
+    display: flex;
+    gap: 0.5rem;
     flex-wrap: wrap;
   }
   select {

--- a/server/frontend/tests/components/group-schedules-view-authoring.test.ts
+++ b/server/frontend/tests/components/group-schedules-view-authoring.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Recurrence authoring flow for `GroupSchedulesView` (#361) — the group
+ * counterpart of `schedules-view-authoring.test.ts`. Drives the real
+ * `<RecurrenceFields>` binding in the group create form and inline edit and
+ * asserts the exact `/api` payload (create is keyed by the path `groupId`, so
+ * the body carries no `userId`), plus the client-side validation gating.
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ActivityResponse,
+  GroupScheduleOrderView,
+  GroupScheduleResponse,
+  UserGroupResponse,
+} from "../../src/lib/api/contract.js";
+
+const listUserGroups = vi.fn<() => Promise<UserGroupResponse[]>>();
+const listActivities = vi.fn<() => Promise<ActivityResponse[]>>();
+const listActivityGroups = vi.fn<() => Promise<unknown[]>>();
+const getGroupScheduleOrder = vi.fn<(groupId: number) => Promise<GroupScheduleOrderView>>();
+const reorderGroupSchedules =
+  vi.fn<(groupId: number, ids: number[]) => Promise<GroupScheduleOrderView>>();
+const createGroupSchedule =
+  vi.fn<(groupId: number, input: unknown) => Promise<GroupScheduleResponse>>();
+const updateGroupSchedule = vi.fn<(id: number, input: unknown) => Promise<GroupScheduleResponse>>();
+const deleteGroupSchedule = vi.fn<(id: number) => Promise<void>>();
+
+vi.mock("$lib/api/user-groups", () => ({ listUserGroups: () => listUserGroups() }));
+vi.mock("$lib/api/activities", () => ({ listActivities: () => listActivities() }));
+vi.mock("$lib/api/activity-groups", () => ({ listActivityGroups: () => listActivityGroups() }));
+vi.mock("$lib/api/schedules", () => ({
+  getGroupScheduleOrder: (groupId: number) => getGroupScheduleOrder(groupId),
+  reorderGroupSchedules: (groupId: number, ids: number[]) => reorderGroupSchedules(groupId, ids),
+  createGroupSchedule: (groupId: number, input: unknown) => createGroupSchedule(groupId, input),
+  updateGroupSchedule: (id: number, input: unknown) => updateGroupSchedule(id, input),
+  deleteGroupSchedule: (id: number) => deleteGroupSchedule(id),
+}));
+
+const { default: GroupSchedulesView } = await import(
+  "../../src/lib/views/GroupSchedulesView.svelte"
+);
+
+function schedule(overrides: Partial<GroupScheduleResponse> & Pick<GroupScheduleResponse, "id">) {
+  return {
+    userGroupId: 1,
+    targetKind: "overall",
+    targetId: null,
+    action: "deny",
+    recurrenceDays: null,
+    recurrenceStartMinute: null,
+    recurrenceEndMinute: null,
+    effectiveFrom: null,
+    effectiveTo: null,
+    ordinal: 0,
+    ...overrides,
+  } as GroupScheduleResponse;
+}
+
+function orderView(schedules: GroupScheduleResponse[]): GroupScheduleOrderView {
+  return { schedules, shadows: [] };
+}
+
+async function selectGroup(name: string): Promise<void> {
+  const select = (await screen.findByLabelText("Manage schedules for group")) as HTMLSelectElement;
+  const index = Array.from(select.options).findIndex((o) => o.textContent?.trim() === name);
+  expect(index).toBeGreaterThanOrEqual(0);
+  select.selectedIndex = index;
+  await fireEvent.change(select);
+}
+
+beforeEach(() => {
+  listUserGroups
+    .mockReset()
+    .mockResolvedValue([
+      { id: 1, name: "Kids", createdAt: "2026-01-01T00:00:00.000Z" },
+    ] as UserGroupResponse[]);
+  listActivities
+    .mockReset()
+    .mockResolvedValue([{ id: 5, matcher: "youtube.com", kind: "domain" }] as ActivityResponse[]);
+  listActivityGroups.mockReset().mockResolvedValue([]);
+  getGroupScheduleOrder.mockReset().mockResolvedValue(orderView([schedule({ id: 1 })]));
+  reorderGroupSchedules.mockReset();
+  createGroupSchedule.mockReset().mockResolvedValue(schedule({ id: 2 }));
+  updateGroupSchedule.mockReset().mockResolvedValue(schedule({ id: 1 }));
+  deleteGroupSchedule.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GroupSchedulesView create with recurrence", () => {
+  it("creates 'deny Mon–Fri 21:00–end-of-day' for the group, keyed by groupId, no userId", async () => {
+    render(GroupSchedulesView);
+    await selectGroup("Kids");
+    await screen.findAllByRole("listitem");
+
+    for (const day of ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]) {
+      await fireEvent.click(screen.getByLabelText(day));
+    }
+    await fireEvent.input(screen.getByLabelText("Start time"), { target: { value: "21:00" } });
+    await fireEvent.input(screen.getByLabelText("End time"), { target: { value: "00:00" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Add schedule" }));
+
+    await waitFor(() => expect(createGroupSchedule).toHaveBeenCalledTimes(1));
+    const [groupId, body] = createGroupSchedule.mock.calls[0]!;
+    expect(groupId).toBe(1);
+    expect(body).toEqual(
+      expect.objectContaining({
+        targetKind: "overall",
+        action: "deny",
+        recurrenceDays: 0b0011111,
+        recurrenceStartMinute: 1260,
+        recurrenceEndMinute: 1440,
+        effectiveFrom: null,
+        effectiveTo: null,
+      }),
+    );
+    expect(body).not.toHaveProperty("userId");
+  });
+
+  it("blocks Add for an invalid window (end only) and never calls the API", async () => {
+    render(GroupSchedulesView);
+    await selectGroup("Kids");
+    await screen.findAllByRole("listitem");
+
+    await fireEvent.input(screen.getByLabelText("End time"), { target: { value: "18:00" } });
+
+    const addButton = screen.getByRole("button", { name: "Add schedule" });
+    expect(addButton).toBeDisabled();
+    await fireEvent.click(addButton);
+    expect(createGroupSchedule).not.toHaveBeenCalled();
+  });
+});
+
+describe("GroupSchedulesView edit with recurrence", () => {
+  it("prefills the picker and PATCHes the full recurrence set on save", async () => {
+    getGroupScheduleOrder.mockResolvedValue(
+      orderView([schedule({ id: 1, recurrenceDays: 0b1000000, action: "allow" })]),
+    );
+    render(GroupSchedulesView);
+    await selectGroup("Kids");
+
+    const item = (await screen.findAllByRole("listitem"))[0]!;
+    await fireEvent.click(within(item).getByRole("button", { name: "Edit" }));
+
+    expect(within(item).getByLabelText("Sunday")).toBeChecked();
+
+    // Add a Saturday window scope by also checking Saturday.
+    await fireEvent.click(within(item).getByLabelText("Saturday"));
+    await fireEvent.click(within(item).getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(updateGroupSchedule).toHaveBeenCalledWith(1, {
+        action: "allow",
+        recurrenceDays: 0b1100000, // Sat + Sun
+        recurrenceStartMinute: null,
+        recurrenceEndMinute: null,
+        effectiveFrom: null,
+        effectiveTo: null,
+      }),
+    );
+  });
+});

--- a/server/frontend/tests/components/group-schedules-view-authoring.test.ts
+++ b/server/frontend/tests/components/group-schedules-view-authoring.test.ts
@@ -14,6 +14,7 @@ import type {
   GroupScheduleResponse,
   UserGroupResponse,
 } from "../../src/lib/api/contract.js";
+import { dateInputToInstant } from "../../src/lib/recurrence.js";
 
 const listUserGroups = vi.fn<() => Promise<UserGroupResponse[]>>();
 const listActivities = vi.fn<() => Promise<ActivityResponse[]>>();
@@ -120,6 +121,30 @@ describe("GroupSchedulesView create with recurrence", () => {
     expect(body).not.toHaveProperty("userId");
   });
 
+  it("creates a date-scoped group rule from the effective-date pickers", async () => {
+    render(GroupSchedulesView);
+    await selectGroup("Kids");
+    await screen.findAllByRole("listitem");
+
+    await fireEvent.input(screen.getByLabelText("Active from date"), {
+      target: { value: "2026-03-01" },
+    });
+    await fireEvent.input(screen.getByLabelText("Active until date"), {
+      target: { value: "2026-09-01" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Add schedule" }));
+
+    await waitFor(() => expect(createGroupSchedule).toHaveBeenCalledTimes(1));
+    const [groupId, body] = createGroupSchedule.mock.calls[0]!;
+    expect(groupId).toBe(1);
+    expect(body).toEqual(
+      expect.objectContaining({
+        effectiveFrom: dateInputToInstant("2026-03-01"),
+        effectiveTo: dateInputToInstant("2026-09-01"),
+      }),
+    );
+  });
+
   it("blocks Add for an invalid window (end only) and never calls the API", async () => {
     render(GroupSchedulesView);
     await selectGroup("Kids");
@@ -161,5 +186,24 @@ describe("GroupSchedulesView edit with recurrence", () => {
         effectiveTo: null,
       }),
     );
+  });
+
+  it("disables Save and does not PATCH when the edited window is invalid", async () => {
+    getGroupScheduleOrder.mockResolvedValue(
+      orderView([schedule({ id: 1, recurrenceStartMinute: 960, recurrenceEndMinute: 1080 })]),
+    );
+    render(GroupSchedulesView);
+    await selectGroup("Kids");
+
+    const item = (await screen.findAllByRole("listitem"))[0]!;
+    await fireEvent.click(within(item).getByRole("button", { name: "Edit" }));
+
+    // End before start → invalid.
+    await fireEvent.input(within(item).getByLabelText("End time"), { target: { value: "08:00" } });
+
+    const saveButton = within(item).getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+    await fireEvent.click(saveButton);
+    expect(updateGroupSchedule).not.toHaveBeenCalled();
   });
 });

--- a/server/frontend/tests/components/recurrence-fields.test.ts
+++ b/server/frontend/tests/components/recurrence-fields.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Component test for the reusable `RecurrenceFields` picker (#361).
+ *
+ * Covers the presentational contract — inputs reflect the bound model, the
+ * end-of-day sentinel renders as 00:00, `disabled` disables the group, and the
+ * `error` prop surfaces as an alert. The write path (toggling a day / typing a
+ * time updates the *submitted* payload through real `bind:`) is exercised
+ * end-to-end in the view authoring suites, which assert the resulting API call.
+ */
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+
+import RecurrenceFields from "../../src/lib/components/RecurrenceFields.svelte";
+import { MINUTES_PER_DAY } from "../../src/lib/recurrence.js";
+
+/** Render with a full, always-on default prop set; override at will. */
+function renderFields(overrides: Record<string, unknown> = {}) {
+  return render(RecurrenceFields, {
+    idPrefix: "test",
+    recurrenceDays: null,
+    recurrenceStartMinute: null,
+    recurrenceEndMinute: null,
+    effectiveFrom: null,
+    effectiveTo: null,
+    ...overrides,
+  });
+}
+
+describe("RecurrenceFields presentation", () => {
+  it("renders seven weekday checkboxes with full-name accessible labels", () => {
+    renderFields();
+    for (const day of [
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+      "Sunday",
+    ]) {
+      expect(screen.getByLabelText(day)).toBeInTheDocument();
+    }
+  });
+
+  it("checks exactly the weekdays set in the mask (Mon–Fri)", () => {
+    renderFields({ recurrenceDays: 0b0011111 });
+    for (const day of ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]) {
+      expect(screen.getByLabelText(day)).toBeChecked();
+    }
+    for (const day of ["Saturday", "Sunday"]) {
+      expect(screen.getByLabelText(day)).not.toBeChecked();
+    }
+  });
+
+  it("checks no weekday for the null (every-day) mask", () => {
+    renderFields({ recurrenceDays: null });
+    for (const day of ["Monday", "Sunday"]) {
+      expect(screen.getByLabelText(day)).not.toBeChecked();
+    }
+  });
+
+  it("reflects the time window in the start/end inputs", () => {
+    renderFields({ recurrenceStartMinute: 960, recurrenceEndMinute: 1080 });
+    expect(screen.getByLabelText("Start time")).toHaveValue("16:00");
+    expect(screen.getByLabelText("End time")).toHaveValue("18:00");
+  });
+
+  it("renders the end-of-day sentinel (1440) as 00:00 in the end input", () => {
+    renderFields({ recurrenceStartMinute: 1260, recurrenceEndMinute: MINUTES_PER_DAY });
+    expect(screen.getByLabelText("Start time")).toHaveValue("21:00");
+    expect(screen.getByLabelText("End time")).toHaveValue("00:00");
+  });
+
+  it("reflects the effective-date scope in the date inputs", () => {
+    // Local-midnight round-trip: an instant authored from a day shows that day.
+    const from = new Date(2026, 2, 1).toISOString(); // 2026-03-01 local
+    renderFields({ effectiveFrom: from });
+    expect(screen.getByLabelText("Active from date")).toHaveValue("2026-03-01");
+    expect(screen.getByLabelText("Active until date")).toHaveValue("");
+  });
+
+  it("surfaces the error prop as an alert, and none when null", () => {
+    const { rerender } = renderFields({ error: "The end time must be after the start time." });
+    expect(screen.getByRole("alert")).toHaveTextContent(/end time must be after/i);
+
+    // The alert clears when the error is resolved.
+    void rerender({
+      idPrefix: "test",
+      recurrenceDays: null,
+      recurrenceStartMinute: null,
+      recurrenceEndMinute: null,
+      effectiveFrom: null,
+      effectiveTo: null,
+      error: null,
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("disables the whole group when disabled", () => {
+    renderFields({ disabled: true });
+    // The <fieldset disabled> disables its descendant controls; toBeDisabled()
+    // honours the ancestor-fieldset inheritance the plain `.disabled` prop misses.
+    expect(screen.getByLabelText("Monday")).toBeDisabled();
+    expect(screen.getByLabelText("Start time")).toBeDisabled();
+  });
+});

--- a/server/frontend/tests/components/recurrence.test.ts
+++ b/server/frontend/tests/components/recurrence.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for the pure recurrence authoring helpers (#361), the frontend
+ * mirror of `server/src/policy/recurrence.ts`. These are plain functions (no
+ * DOM), but they live under `tests/components/` so the `components` project's
+ * SvelteKit `$lib` alias resolves the import; the jsdom environment is a
+ * harmless superset for pure code.
+ *
+ * Date conversions are asserted as **round-trips** rather than against a fixed
+ * offset, so they hold in any timezone the runner happens to use.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  MINUTES_PER_DAY,
+  dayChecked,
+  dateInputToInstant,
+  instantToDateInput,
+  minutesToTimeInput,
+  timeInputToMinutes,
+  toggleDay,
+  validateRecurrence,
+  type RecurrenceValue,
+} from "../../src/lib/recurrence.js";
+
+/** A valid, always-on (degenerate) recurrence value; override at will. */
+function value(overrides: Partial<RecurrenceValue> = {}): RecurrenceValue {
+  return {
+    recurrenceDays: null,
+    recurrenceStartMinute: null,
+    recurrenceEndMinute: null,
+    effectiveFrom: null,
+    effectiveTo: null,
+    ...overrides,
+  };
+}
+
+describe("weekday mask helpers", () => {
+  it("reports no day checked for the null (every-day) mask", () => {
+    for (let i = 0; i < 7; i++) {
+      expect(dayChecked(null, i)).toBe(false);
+    }
+  });
+
+  it("decodes bit 0 = Monday and bit 6 = Sunday", () => {
+    expect(dayChecked(0b0000001, 0)).toBe(true); // Mon
+    expect(dayChecked(0b0000001, 1)).toBe(false); // Tue
+    expect(dayChecked(0b1000000, 6)).toBe(true); // Sun
+  });
+
+  it("sets a bit, building the Mon–Fri mask incrementally", () => {
+    let mask: number | null = null;
+    for (let i = 0; i < 5; i++) {
+      mask = toggleDay(mask, i, true);
+    }
+    expect(mask).toBe(0b0011111); // 31 = Mon–Fri
+  });
+
+  it("collapses to null (every day) when the last bit is cleared", () => {
+    expect(toggleDay(0b0000001, 0, false)).toBeNull();
+  });
+
+  it("clears one bit of many without collapsing", () => {
+    // Mon–Fri (31) minus Wednesday (bit 2) → 0b0011011 = 27.
+    expect(toggleDay(0b0011111, 2, false)).toBe(0b0011011);
+  });
+});
+
+describe("time-window <-> minutes", () => {
+  it("formats minutes as zero-padded HH:MM and null as empty", () => {
+    expect(minutesToTimeInput(null)).toBe("");
+    expect(minutesToTimeInput(0)).toBe("00:00");
+    expect(minutesToTimeInput(540)).toBe("09:00");
+    expect(minutesToTimeInput(1290)).toBe("21:30");
+    expect(minutesToTimeInput(1439)).toBe("23:59");
+  });
+
+  it("renders the end-of-day sentinel 1440 as 00:00", () => {
+    expect(minutesToTimeInput(MINUTES_PER_DAY)).toBe("00:00");
+  });
+
+  it("parses HH:MM to minutes and empty to null", () => {
+    expect(timeInputToMinutes("", false)).toBeNull();
+    expect(timeInputToMinutes("09:00", false)).toBe(540);
+    expect(timeInputToMinutes("21:30", false)).toBe(1290);
+  });
+
+  it("maps an end of 00:00 to 1440 (end of day) but a start of 00:00 to 0", () => {
+    expect(timeInputToMinutes("00:00", true)).toBe(MINUTES_PER_DAY);
+    expect(timeInputToMinutes("00:00", false)).toBe(0);
+  });
+
+  it("rejects a malformed value as null", () => {
+    expect(timeInputToMinutes("not-a-time", false)).toBeNull();
+  });
+
+  it("round-trips a normal window and the end-of-day case", () => {
+    expect(timeInputToMinutes(minutesToTimeInput(960), false)).toBe(960); // 16:00
+    // 21:00 → "21:00" → 1260; and 1440 → "00:00" → 1440 (as an end).
+    expect(timeInputToMinutes(minutesToTimeInput(1260), false)).toBe(1260);
+    expect(timeInputToMinutes(minutesToTimeInput(MINUTES_PER_DAY), true)).toBe(MINUTES_PER_DAY);
+  });
+});
+
+describe("date-scope <-> instant", () => {
+  it("maps null to empty and back", () => {
+    expect(instantToDateInput(null)).toBe("");
+    expect(dateInputToInstant("")).toBeNull();
+  });
+
+  it("round-trips a calendar day regardless of the runner timezone", () => {
+    // Local-midnight conversion means author → store → re-open is stable.
+    for (const day of ["2026-01-01", "2026-07-02", "2026-12-31"]) {
+      const instant = dateInputToInstant(day);
+      expect(instant).not.toBeNull();
+      expect(instantToDateInput(instant)).toBe(day);
+    }
+  });
+
+  it("produces a Zod .datetime()-compatible instant (UTC, with Z)", () => {
+    const instant = dateInputToInstant("2026-07-02");
+    expect(instant).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it("treats a malformed date as null", () => {
+    expect(dateInputToInstant("nope")).toBeNull();
+  });
+});
+
+describe("validateRecurrence (mirrors the DTO cross-field invariants)", () => {
+  it("accepts the always-on degenerate value", () => {
+    expect(validateRecurrence(value())).toBeNull();
+  });
+
+  it("accepts a full, valid window + date scope", () => {
+    expect(
+      validateRecurrence(
+        value({
+          recurrenceDays: 0b0011111,
+          recurrenceStartMinute: 960,
+          recurrenceEndMinute: 1080,
+          effectiveFrom: "2026-03-01T00:00:00.000Z",
+          effectiveTo: "2026-09-01T00:00:00.000Z",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects only one half of the minute pair", () => {
+    expect(validateRecurrence(value({ recurrenceStartMinute: 540 }))).toMatch(/both a start and end/i);
+    expect(validateRecurrence(value({ recurrenceEndMinute: 540 }))).toMatch(/both a start and end/i);
+  });
+
+  it("rejects end <= start", () => {
+    expect(
+      validateRecurrence(value({ recurrenceStartMinute: 1080, recurrenceEndMinute: 1080 })),
+    ).toMatch(/end time must be after/i);
+    expect(
+      validateRecurrence(value({ recurrenceStartMinute: 1080, recurrenceEndMinute: 960 })),
+    ).toMatch(/end time must be after/i);
+  });
+
+  it("rejects effectiveTo <= effectiveFrom", () => {
+    expect(
+      validateRecurrence(
+        value({
+          effectiveFrom: "2026-09-01T00:00:00.000Z",
+          effectiveTo: "2026-03-01T00:00:00.000Z",
+        }),
+      ),
+    ).toMatch(/end date must be after/i);
+  });
+
+  it("accepts an open-ended date scope (one side null)", () => {
+    expect(validateRecurrence(value({ effectiveFrom: "2026-03-01T00:00:00.000Z" }))).toBeNull();
+    expect(validateRecurrence(value({ effectiveTo: "2026-09-01T00:00:00.000Z" }))).toBeNull();
+  });
+});

--- a/server/frontend/tests/components/schedules-view-authoring.test.ts
+++ b/server/frontend/tests/components/schedules-view-authoring.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Recurrence authoring flow for `SchedulesView` (#361) — the write path the
+ * presentational `recurrence-fields` suite doesn't cover. Drives the real
+ * `<RecurrenceFields>` binding in the create form and inline edit, and asserts
+ * the exact `/api` payload, plus the client-side validation gating.
+ *
+ * The `/api` wrappers are mocked; no live backend. Mirrors the mock setup in
+ * `schedules-view.test.ts`.
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ActivityGroupResponse,
+  ActivityResponse,
+  ScheduleOrderView,
+  ScheduleResponse,
+  UserResponse,
+} from "../../src/lib/api/contract.js";
+import { dateInputToInstant } from "../../src/lib/recurrence.js";
+
+const listUsers = vi.fn<() => Promise<UserResponse[]>>();
+const listActivities = vi.fn<() => Promise<ActivityResponse[]>>();
+const listActivityGroups = vi.fn<() => Promise<ActivityGroupResponse[]>>();
+const getScheduleOrder = vi.fn<(userId: number) => Promise<ScheduleOrderView>>();
+const reorderSchedules = vi.fn<(userId: number, ids: number[]) => Promise<ScheduleOrderView>>();
+const createSchedule = vi.fn<(input: unknown) => Promise<ScheduleResponse>>();
+const updateSchedule = vi.fn<(id: number, input: unknown) => Promise<ScheduleResponse>>();
+const deleteSchedule = vi.fn<(id: number) => Promise<void>>();
+
+vi.mock("$lib/api/users", () => ({ listUsers: () => listUsers() }));
+vi.mock("$lib/api/activities", () => ({ listActivities: () => listActivities() }));
+vi.mock("$lib/api/activity-groups", () => ({ listActivityGroups: () => listActivityGroups() }));
+vi.mock("$lib/api/schedules", () => ({
+  getScheduleOrder: (userId: number) => getScheduleOrder(userId),
+  reorderSchedules: (userId: number, ids: number[]) => reorderSchedules(userId, ids),
+  createSchedule: (input: unknown) => createSchedule(input),
+  updateSchedule: (id: number, input: unknown) => updateSchedule(id, input),
+  deleteSchedule: (id: number) => deleteSchedule(id),
+}));
+
+const { default: SchedulesView } = await import("../../src/lib/views/SchedulesView.svelte");
+
+function schedule(overrides: Partial<ScheduleResponse> & Pick<ScheduleResponse, "id">) {
+  return {
+    userId: 1,
+    targetKind: "overall",
+    targetId: null,
+    action: "deny",
+    recurrenceDays: null,
+    recurrenceStartMinute: null,
+    recurrenceEndMinute: null,
+    effectiveFrom: null,
+    effectiveTo: null,
+    ordinal: 0,
+    ...overrides,
+  } as ScheduleResponse;
+}
+
+function orderView(schedules: ScheduleResponse[]): ScheduleOrderView {
+  return { schedules, shadows: [], effectiveIds: [] };
+}
+
+async function selectUser(name: string): Promise<void> {
+  const select = (await screen.findByLabelText("Manage schedules for user")) as HTMLSelectElement;
+  const index = Array.from(select.options).findIndex((o) => o.textContent?.trim() === name);
+  expect(index).toBeGreaterThanOrEqual(0);
+  select.selectedIndex = index;
+  await fireEvent.change(select);
+}
+
+async function selectOptionContaining(label: string, text: string): Promise<void> {
+  const select = (await screen.findByLabelText(label)) as HTMLSelectElement;
+  const index = Array.from(select.options).findIndex((o) => o.textContent?.includes(text));
+  expect(index).toBeGreaterThanOrEqual(0);
+  select.selectedIndex = index;
+  await fireEvent.change(select);
+}
+
+beforeEach(() => {
+  listUsers.mockReset().mockResolvedValue([
+    { id: 1, displayName: "Alice", tz: "UTC", createdAt: "2026-01-01T00:00:00.000Z" },
+  ] as UserResponse[]);
+  listActivities
+    .mockReset()
+    .mockResolvedValue([{ id: 5, matcher: "youtube.com", kind: "domain" }] as ActivityResponse[]);
+  listActivityGroups
+    .mockReset()
+    .mockResolvedValue([{ id: 9, name: "Social media" }] as ActivityGroupResponse[]);
+  getScheduleOrder.mockReset().mockResolvedValue(orderView([schedule({ id: 1 })]));
+  reorderSchedules.mockReset();
+  createSchedule.mockReset().mockResolvedValue(schedule({ id: 2 }));
+  updateSchedule.mockReset().mockResolvedValue(schedule({ id: 1 }));
+  deleteSchedule.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SchedulesView create with recurrence", () => {
+  it("creates 'allow Mon–Fri 16:00–18:00' with the authored recurrence", async () => {
+    render(SchedulesView);
+    await selectUser("Alice");
+    await screen.findAllByRole("listitem");
+
+    for (const day of ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]) {
+      await fireEvent.click(screen.getByLabelText(day));
+    }
+    await fireEvent.input(screen.getByLabelText("Start time"), { target: { value: "16:00" } });
+    await fireEvent.input(screen.getByLabelText("End time"), { target: { value: "18:00" } });
+    await selectOptionContaining("Schedule action", "Allow");
+    await fireEvent.click(screen.getByRole("button", { name: "Add schedule" }));
+
+    await waitFor(() =>
+      expect(createSchedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 1,
+          targetKind: "overall",
+          action: "allow",
+          recurrenceDays: 0b0011111, // Mon–Fri = 31
+          recurrenceStartMinute: 960,
+          recurrenceEndMinute: 1080,
+          effectiveFrom: null,
+          effectiveTo: null,
+        }),
+      ),
+    );
+  });
+
+  it("creates 'deny after 21:00 daily' with end 00:00 mapped to end-of-day (1440)", async () => {
+    render(SchedulesView);
+    await selectUser("Alice");
+    await screen.findAllByRole("listitem");
+
+    await fireEvent.input(screen.getByLabelText("Start time"), { target: { value: "21:00" } });
+    await fireEvent.input(screen.getByLabelText("End time"), { target: { value: "00:00" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Add schedule" }));
+
+    await waitFor(() =>
+      expect(createSchedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recurrenceDays: null, // no weekday restriction = every day
+          recurrenceStartMinute: 1260,
+          recurrenceEndMinute: 1440,
+        }),
+      ),
+    );
+  });
+
+  it("creates a date-scoped rule from the effective-date pickers", async () => {
+    render(SchedulesView);
+    await selectUser("Alice");
+    await screen.findAllByRole("listitem");
+
+    await fireEvent.input(screen.getByLabelText("Active from date"), {
+      target: { value: "2026-03-01" },
+    });
+    await fireEvent.input(screen.getByLabelText("Active until date"), {
+      target: { value: "2026-09-01" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Add schedule" }));
+
+    await waitFor(() =>
+      expect(createSchedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          effectiveFrom: dateInputToInstant("2026-03-01"),
+          effectiveTo: dateInputToInstant("2026-09-01"),
+        }),
+      ),
+    );
+  });
+
+  it("blocks Add and never calls the API for an invalid window (start only)", async () => {
+    render(SchedulesView);
+    await selectUser("Alice");
+    await screen.findAllByRole("listitem");
+
+    await fireEvent.input(screen.getByLabelText("Start time"), { target: { value: "16:00" } });
+
+    const addButton = screen.getByRole("button", { name: "Add schedule" });
+    expect(addButton).toBeDisabled();
+    expect(await screen.findByText(/both a start and end time/i)).toBeInTheDocument();
+
+    await fireEvent.click(addButton);
+    expect(createSchedule).not.toHaveBeenCalled();
+  });
+});
+
+describe("SchedulesView edit with recurrence", () => {
+  it("prefills the picker and PATCHes the full recurrence set on save", async () => {
+    getScheduleOrder.mockResolvedValue(
+      orderView([
+        schedule({
+          id: 1,
+          recurrenceDays: 0b0011111,
+          recurrenceStartMinute: 960,
+          recurrenceEndMinute: 1080,
+        }),
+      ]),
+    );
+    render(SchedulesView);
+    await selectUser("Alice");
+
+    const item = (await screen.findAllByRole("listitem"))[0]!;
+    await fireEvent.click(within(item).getByRole("button", { name: "Edit" }));
+
+    // Prefilled from the row.
+    expect(within(item).getByLabelText("Monday")).toBeChecked();
+    expect(within(item).getByLabelText("Start time")).toHaveValue("16:00");
+
+    // Widen the window to 15:00 and save.
+    await fireEvent.input(within(item).getByLabelText("Start time"), {
+      target: { value: "15:00" },
+    });
+    await fireEvent.click(within(item).getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(updateSchedule).toHaveBeenCalledWith(1, {
+        action: "deny",
+        recurrenceDays: 0b0011111,
+        recurrenceStartMinute: 900,
+        recurrenceEndMinute: 1080,
+        effectiveFrom: null,
+        effectiveTo: null,
+      }),
+    );
+  });
+
+  it("disables Save and does not PATCH when the edited window is invalid", async () => {
+    getScheduleOrder.mockResolvedValue(
+      orderView([
+        schedule({ id: 1, recurrenceStartMinute: 960, recurrenceEndMinute: 1080 }),
+      ]),
+    );
+    render(SchedulesView);
+    await selectUser("Alice");
+
+    const item = (await screen.findAllByRole("listitem"))[0]!;
+    await fireEvent.click(within(item).getByRole("button", { name: "Edit" }));
+
+    // End before start → invalid.
+    await fireEvent.input(within(item).getByLabelText("End time"), { target: { value: "08:00" } });
+
+    const saveButton = within(item).getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+    await fireEvent.click(saveButton);
+    expect(updateSchedule).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- The schedule editors could only create/edit **always-on** rules — the create form hard-coded recurrence to `null` and inline edit exposed `action` only, so "allow Games Mon–Fri 16:00–18:00" and "deny overall after 21:00 daily" were **API-only**. This ships the frontend last mile of #140; the backend (DTOs, schema CHECKs, resolver, timekpra push) is already recurrence-aware, so **no server/model change**.
- New reusable pure helpers (`src/lib/recurrence.ts`) + a reusable `RecurrenceFields.svelte` picker (day-of-week checkboxes, time-window inputs, effective-date pickers), wired into **create and inline edit** in both `SchedulesView` and `GroupSchedulesView`.
- Client-side validation mirrors the DTO cross-field invariants (both-or-neither minutes, `start < end`, `effectiveFrom < effectiveTo`) so invalid combos can't be submitted; server errors still surface via the existing alert.

## Plan

Linked plan: `.claude/plans/361-recurrence-authoring-ui.md`
Roadmap: `docs/roadmap.md` → Phase 4 (last mile of #140)

## Design notes

- **Helpers are pure and shared** (`recurrence.ts`), mirroring the single-source rules in `server/src/policy/recurrence.ts` so the editor can't submit what the API will reject.
- **End-of-day convention:** a native `<input type=time>` can't express 24:00, so an *end* time of `00:00` maps to the `1440` sentinel (unambiguous — a valid window has `start < end` with `start >= 0`, so an end of 0 can never be legitimate). This is what makes "deny after 21:00 daily" authorable.
- **Date scope** converts `YYYY-MM-DD` ↔ ISO instant at **local** midnight, so author → store → re-open round-trips to the same calendar day in the admin's browser and matches the existing summary's `toLocaleDateString()`. Resolution semantics for date-scoped rules stay #142.
- **Edit PATCHes the full recurrence set** alongside `action`, so the persisted row matches exactly what the editor shows (a PATCH merges; the storage CHECKs re-validate the merged row).
- `RecurrenceFields` is built to be composed by the future combined Policy view (#343).

## License-boundary note

N/A — plain TypeScript + Svelte over the existing `/api` JSON contract. No GPL import, no subprocess/REST boundary touched, no image change, no new dependency.

## Test plan

- [x] `recurrence.test.ts` — helper units: weekday-mask toggle/decode, time round-trips incl. end `00:00`↔`1440` and start `00:00`, TZ-independent date round-trip, validation for each invariant + the valid degenerate.
- [x] `recurrence-fields.test.ts` — the picker's presentational contract (inputs reflect the model, end-of-day renders as 00:00, `disabled`/`error`).
- [x] `schedules-view-authoring.test.ts` — create "allow Mon–Fri 16:00–18:00" and "deny after 21:00 daily", date-scope create, edit PATCH, and disabled-on-invalid.
- [x] `group-schedules-view-authoring.test.ts` — same for group-targeted rules (payload keyed by `groupId`, no `userId`).
- [x] Frontend gate green: `npm run check` (svelte-check, 0 errors), `npm test` (45 files / 292 pass), `npm run build`.
- [x] Existing reorder / "in effect now" / shadow-warning suites unchanged and passing.

## Out of scope (tracked)

- Date-scoped rule / exception **resolution** semantics — #142.
- Combined Policy view composition — #343 (the pickers are built reusable for it).
- Timekpr sub-hour representation warnings — handled at push time.

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WF54KGziwsrLvRBQoL3As6)_