### PR TITLE
refactor(policy): extract budget resolvers from effectivePolicy (#307)

### DIFF
--- a/.claude/plans/307-extract-build-activity-quotas.md
+++ b/.claude/plans/307-extract-build-activity-quotas.md
@@ -1,0 +1,51 @@
+# Plan — #307: extract `buildActivityQuotas` from `effectivePolicy`
+
+**Issue:** #307 (code-review, complexity, Effort S). `effectivePolicy`
+(`server/src/policy/resolve.ts`, ~`:280-353`) resolves a user's effective
+policy for a day. The per-activity/per-group quota-accumulation loop
+(~`:318-343`) builds a `Map` from budgets + grants across scopes with nested
+iteration — correct and tested, but dense, and #141 (weekday-varying budgets)
+would make it worse.
+
+**Unblocked:** the ticket states `resolve.ts` is in no open PR's footprint;
+verified against the current backlog (PR #365 does its group work in
+`group-resolution.ts`; #359/#366/#367/#368/#370/#371 touch
+ansible/frontend/transport). No open PR closes #307.
+
+## Change (pure refactor — behaviour unchanged)
+
+Extract two module-private helpers so `effectivePolicy` reads as a clear
+orchestrator (gather day → gather rules → resolve windows → resolve budgets →
+return):
+
+- `buildActivityQuotas(budgets, grants, dayBounds) -> ActivityQuota[]` — the
+  per-activity/per-group daily quota map, keyed `"scope:targetId"`, folding in
+  active same-scope grants, grant-only targets skipped, emitted ascending by
+  `(scope, targetId)`. JSDoc documents the key format (the ticket's companion
+  ask).
+- `resolveOverallSeconds(budgets, grants, dayBounds) -> number | null` — the
+  overall daily baseline + active overall grants, `null` when no daily overall
+  budget exists. Extracted as a sibling so the orchestrator's "resolve budgets"
+  step reads symmetrically.
+
+`dayBounds` is the `{ start, end }` from `localDayBounds` — it already encodes
+the effective timezone, so `tz` is **not** re-passed into the quota helpers
+(passing an unused `tz` would be dead + lint-flagged). The ticket's suggested
+`(…, tz)` signature is satisfied in substance by `dayBounds`; a JSDoc note
+records why `tz` is redundant here.
+
+No public export surface changes: `effectivePolicy`, `isRuleActiveAt`,
+`ruleActiveAt`, and the exported types stay identical. The new helpers stay
+private, mirroring the existing private helpers (`resolveAllowedWindows`,
+`appliesOnDay`, …); they are fully exercised by the existing
+`effectivePolicy` tests, so coverage holds.
+
+## Validation
+
+- `npm run format` / `lint:fix` / `typecheck` clean.
+- `npm test` — existing `resolve.test.ts` (overall-budget + per-activity-quota
+  suites) stays green with no test changes; coverage gate 80% held.
+
+## License boundary
+
+None touched — pure TypeScript over the policy model, single file.

--- a/server/src/policy/resolve.ts
+++ b/server/src/policy/resolve.ts
@@ -272,6 +272,83 @@ function grantOverlapsDay(grant: GrantInput, dayStart: Date, dayEnd: Date): bool
 }
 
 /**
+ * The day's UTC `[start, end)` bounds, as returned by
+ * {@link import("./budget-window.js").localDayBounds}. These already encode the
+ * user's effective timezone, so the budget resolvers below take them directly
+ * and never need the `tz` string again — grant overlap is a UTC-instant test.
+ */
+interface DayBounds {
+  readonly start: Date;
+  readonly end: Date;
+}
+
+/**
+ * The effective overall daily allowance in seconds: the sum of the user's
+ * `overall`/`daily` budgets plus any active overall grants overlapping the day.
+ * Returns `null` when no daily overall budget is defined (no daily limit — a
+ * grant on an unlimited base is moot).
+ */
+function resolveOverallSeconds(
+  budgets: readonly BudgetInput[],
+  grants: readonly GrantInput[],
+  dayBounds: DayBounds,
+): number | null {
+  const dailyOverall = budgets.filter((b) => b.scope === "overall" && b.window === "daily");
+  if (dailyOverall.length === 0) return null;
+
+  let seconds = dailyOverall.reduce((sum, b) => sum + b.secondsAllowed, 0);
+  for (const grant of grants) {
+    if (grant.scope === "overall" && grantOverlapsDay(grant, dayBounds.start, dayBounds.end)) {
+      seconds += grant.secondsGranted;
+    }
+  }
+  return seconds;
+}
+
+/**
+ * The effective per-activity / per-group daily quotas: every `(scope, target)`
+ * with a `daily` budget, folding in that target's active same-scope grants.
+ *
+ * Quotas are accumulated in a `Map` keyed `"scope:targetId"` (e.g.
+ * `"activity:2"`, `"group:1"`) so multiple budget rows and grants for the same
+ * target sum onto one slot. A grant on a target with **no** daily budget is
+ * skipped — an unlimited base stays unlimited. The result is emitted ascending
+ * by `(scope, targetId)`.
+ */
+function buildActivityQuotas(
+  budgets: readonly BudgetInput[],
+  grants: readonly GrantInput[],
+  dayBounds: DayBounds,
+): ActivityQuota[] {
+  const quotas = new Map<string, ActivityQuota>();
+  for (const b of budgets) {
+    if (b.window !== "daily") continue;
+    if ((b.scope !== "activity" && b.scope !== "group") || b.targetId === null) continue;
+    const key = `${b.scope}:${b.targetId}`;
+    const existing = quotas.get(key);
+    quotas.set(key, {
+      scope: b.scope,
+      targetId: b.targetId,
+      seconds: (existing?.seconds ?? 0) + b.secondsAllowed,
+    });
+  }
+  for (const grant of grants) {
+    if (grant.scope !== "activity" && grant.scope !== "group") continue;
+    if (grant.targetId === null || !grantOverlapsDay(grant, dayBounds.start, dayBounds.end)) {
+      continue;
+    }
+    const key = `${grant.scope}:${grant.targetId}`;
+    const existing = quotas.get(key);
+    // Grant-only targets (no daily budget) leave the base unlimited → skip.
+    if (existing === undefined) continue;
+    quotas.set(key, { ...existing, seconds: existing.seconds + grant.secondsGranted });
+  }
+  return [...quotas.values()].sort(
+    (a, b) => a.scope.localeCompare(b.scope) || a.targetId - b.targetId,
+  );
+}
+
+/**
  * Resolve the effective policy for user *U* on day *D* — the core computation
  * documented at the top of this module. Pure: every input row is supplied by
  * the caller (the `/api/.../effective` route loads them), so this is fully
@@ -302,45 +379,12 @@ export function effectivePolicy(input: EffectivePolicyInput): EffectivePolicy {
     activeRules.filter((rule) => rule.targetKind === "overall"),
   );
 
-  // Overall budget: daily baseline + active overall grants. Null when no daily
-  // overall budget exists (no daily limit; a grant on an unlimited base is moot).
-  const dailyOverall = input.budgets.filter((b) => b.scope === "overall" && b.window === "daily");
-  let overallSeconds: number | null = null;
-  if (dailyOverall.length > 0) {
-    overallSeconds = dailyOverall.reduce((sum, b) => sum + b.secondsAllowed, 0);
-    for (const grant of input.grants) {
-      if (grant.scope === "overall" && grantOverlapsDay(grant, dayStart, dayEnd)) {
-        overallSeconds += grant.secondsGranted;
-      }
-    }
-  }
-
-  // Per-activity / per-group quotas: each (scope, target) with a daily budget,
-  // plus its active grants. Keyed `scope:targetId`, emitted ascending.
-  const quotas = new Map<string, ActivityQuota>();
-  for (const b of input.budgets) {
-    if (b.window !== "daily") continue;
-    if ((b.scope !== "activity" && b.scope !== "group") || b.targetId === null) continue;
-    const key = `${b.scope}:${b.targetId}`;
-    const existing = quotas.get(key);
-    quotas.set(key, {
-      scope: b.scope,
-      targetId: b.targetId,
-      seconds: (existing?.seconds ?? 0) + b.secondsAllowed,
-    });
-  }
-  for (const grant of input.grants) {
-    if (grant.scope !== "activity" && grant.scope !== "group") continue;
-    if (grant.targetId === null || !grantOverlapsDay(grant, dayStart, dayEnd)) continue;
-    const key = `${grant.scope}:${grant.targetId}`;
-    const existing = quotas.get(key);
-    // Grant-only targets (no daily budget) leave the base unlimited → skip.
-    if (existing === undefined) continue;
-    quotas.set(key, { ...existing, seconds: existing.seconds + grant.secondsGranted });
-  }
-  const perActivitySeconds = [...quotas.values()].sort(
-    (a, b) => a.scope.localeCompare(b.scope) || a.targetId - b.targetId,
-  );
+  // Budgets: the overall daily allowance and the per-activity/per-group quotas,
+  // each folding in active grants overlapping the day (`dayBounds` carries the
+  // effective-tz day edges the grant-overlap test needs).
+  const dayBounds: DayBounds = { start: dayStart, end: dayEnd };
+  const overallSeconds = resolveOverallSeconds(input.budgets, input.grants, dayBounds);
+  const perActivitySeconds = buildActivityQuotas(input.budgets, input.grants, dayBounds);
 
   return {
     date: `${year}-${pad2(month)}-${pad2(day)}`,


### PR DESCRIPTION
## Summary

- `effectivePolicy` (`server/src/policy/resolve.ts`) interleaved its day/rule/window resolution with two dense inline budget-accumulation blocks. Extracts them into module-private `resolveOverallSeconds` and `buildActivityQuotas(budgets, grants, dayBounds)` so the function reads as a clear orchestrator: **gather day → gather rules → resolve windows → resolve budgets → return** (the ticket's stated goal).
- `buildActivityQuotas`' JSDoc documents the `"scope:targetId"` `Map` key format (the ticket's companion ask). A new `DayBounds` type carries the `localDayBounds` edges the grant-overlap test needs — these already encode the effective timezone, so `tz` is deliberately **not** re-threaded into the helpers (a JSDoc note records why, avoiding a dead/lint-flagged param vs. the ticket's suggested `(…, tz)` shape).

## Plan

Linked plan: `.claude/plans/307-extract-build-activity-quotas.md`
Roadmap: code-review complexity cleanup under tracking epic #308 (`resolve.ts` was explicitly called out as *not* in any open PR's footprint — safe to do now).

## License-boundary note

N/A — pure TypeScript over the policy model, single file. No GPL import, no subprocess/REST boundary touched, no image change, no new dependency.

## Test plan

- [x] Pure refactor: behaviour and the public export surface (`effectivePolicy`, `isRuleActiveAt`, `ruleActiveAt`, exported types) are unchanged; the new helpers stay module-private, mirroring the existing private helpers, and are fully exercised by the existing `resolve.test.ts` overall-budget + per-activity-quota suites.
- [x] `npm run format:check && npm run lint && npm run typecheck` — clean.
- [x] `npm test` — 1675 passing, no test edits; `resolve.ts` 98.68% lines (uncovered 338–339 is the identical grant-only-target skip already uncovered on `main`), coverage gate 80% held.

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6cTXZk7B7CqCU9cFBMLTv)_