### PR TITLE
feat(client): pct-client-agent per-user notification daemon core (#103)

### DIFF
--- a/.claude/plans/issue-103-pct-client-agent.md
+++ b/.claude/plans/issue-103-pct-client-agent.md
@@ -1,0 +1,107 @@
+# Plan — #103 `pct-client-agent` core (Phase 8b)
+
+The per-user notification daemon (`systemd --user`) that renders the
+supervised-user-facing experience in
+[`docs/client-notifications.md`](../../docs/client-notifications.md)
+§Components/2: it connects to the `pct-client-bridge`'s per-user `AF_UNIX`
+socket, keeps a locally-cached budget + `NotificationPolicy`, computes the
+warning cadence and grace/force-close locally, and renders toasts + sound
+through the desktop's own CLI tools.
+
+Authoritative design: `docs/client-notifications.md` (Goals, Components/2,
+Event channel, "Notification cadence — exact rules", "Sound design", "Grace
+period and force-close", "Configuration knobs", "Failure modes").
+
+## Why implementable end-to-end now
+
+Everything the agent consumes is already on `main`:
+
+- The **bridge** (#101) owns and *listens* on `/run/pct/<uid>.sock` and writes
+  **newline-delimited JSON `EventFrame`s** to the connected agent
+  (`client/agent/src/bridge/dispatch.ts`). The agent is the connecting reader.
+- The **frame/event contract** (`{ seq, at, event }` + the 5-member
+  `ServerEvent` union) is mirrored client-side in
+  `client/agent/src/bridge/protocol.ts` with `decodeFrame` — the agent reuses it.
+- Reusable pure utilities already in the package: `bridge/backoff.ts`
+  (full-jitter exponential backoff) and `bridge/logger.ts` (`StreamLogger`).
+- `NotificationPolicy` vocabulary/defaults are fixed in
+  `server/src/policy/notification.ts` (`enabled`, `soundProfile`
+  `off`/`subtle`/`prominent`, `graceSeconds` 0–60, loose `cadenceOverrides`).
+
+`client/agent/src/agent/` is greenfield → no merge-conflict surface against the
+open PRs (all server-side transport-health / group-UI / dashboard / ansible).
+
+## Scope of this PR (agent core), under `client/agent/src/agent/`
+
+Same package as the bridge; reuses `../bridge/{protocol,backoff,logger}.js`.
+
+1. **`config.ts`** — zod-validated `AgentConfig` (own `userId`, `socketPath`,
+   `awBaseUrl`, backoff knobs, kill-signal grace/escalation) + `NotificationPrefs`
+   mirror of `NotificationPolicyValues`. `loadConfigFromEnv()`.
+2. **`cadence.ts`** — **pure** warning-cadence engine implementing the exact
+   15/5/1-minute boundary rules. Threshold set = every 15-min multiple ≥ 15min,
+   plus 10, 5, 4, 3, 2, 1 min, bounded by the budget total. A `CadenceTracker`
+   per budget remembers the last-announced threshold (monotonic) so a warning
+   fires once per boundary as remaining ticks down; `0` → the final "time's up".
+   A `coalesce()` groups budgets that crossed within the same tick into one toast.
+3. **`budget.ts`** — the locally cached budgets: `{ key, label, totalSeconds,
+   activityId|null }` + remaining = `max(0, total − used)`. `grant.applied`
+   adds seconds to the matching budget; `policy.changed` marks stale (re-pull).
+4. **`effects.ts`** — desktop-integration seams as **subprocess** calls behind
+   an injected `Spawn`: `Notifier` (`gdbus call … Notify`, falling back to
+   `notify-send`, supporting in-place countdown updates via the returned id),
+   `SoundPlayer` (`canberra-gtk-play`, `off`/`subtle`/`prominent` → sound-name
+   map), `ProcessSignaller` (`process.kill`). No native bindings (license rule).
+5. **`force-close.ts`** — grace-countdown state machine: on 0:00 / a per-app
+   `enforce.force_close`, show the countdown toast updating each second (injected
+   clock), cancel + "keep going" toast if a grant tops the budget back up, else
+   after grace `SIGTERM`→(5s)→`SIGKILL` the resolved PIDs.
+6. **`usage.ts`** — `UsageSource` interface + `AwUsageSource` polling
+   `aw-server` on `http://127.0.0.1:5600` over REST (injected `fetch`), per the
+   doc ("Polls aw-server on localhost:5600 … render warnings locally").
+7. **`agent.ts`** — orchestrator: socket intake (reconnecting reader over the
+   bridge socket, reusing `decodeFrame` + `backoff`) → cache updates + toasts;
+   a tick loop (injected clock + `UsageSource`) → cadence → notifier;
+   `enforce.force_close` → the force-close state machine.
+8. **`main.ts`** — thin bootstrap (load config, build logger + agent, SIGTERM).
+   Coverage-excluded like `bridge`/`main.ts`.
+
+Tooling already exists (the package is shared with the bridge): the CI
+`client-agent` job, `package.json`, `tsconfig`, eslint, vitest 80% gate.
+
+## Deferred (tracked follow-ups, linked from the PR)
+
+- **Activity-matcher → PID resolution for force-close.** Needs the activity
+  matchers pushed to the *client* as part of policy distribution (a transport
+  concern not yet built). The kill state machine ships fully; PID resolution is
+  behind an injected `resolvePids(activityId)` seam that returns `[]` (logged
+  degraded) until a **new follow-up issue** wires client-side matchers.
+- **`enforce.session_lock` / lockout `timekpra --kill-session`** — the bridge's
+  privileged Phase-8c surface (#107/#108); the agent only toasts around it.
+- **Interactive toast action buttons + client→server action frame** — #337
+  (buttons stay inert here).
+- **`.deb` packaging, `systemd --user` unit, `/run/pct` tmpfiles** — #106.
+- **Structured `cadence_overrides` semantics** — #302 (the agent honours a
+  simple per-budget mute; the rich override schema is that issue's).
+- **ADR-0007 version handshake** — follow-up gated on the #165 server side.
+
+## Phasing (commit + push per phase; first push opens the draft PR)
+
+- **Phase 1** — `config.ts` + `cadence.ts` + `budget.ts` (pure cores) + tests.
+- **Phase 2** — `effects.ts` + `force-close.ts` + `usage.ts` + tests.
+- **Phase 3** — `agent.ts` orchestrator (socket intake + tick loop) + `main.ts`
+  + an integration-style test (bridge `Dispatcher` → real socket → agent
+  receives + renders); quality gate, follow-ups filed, mark ready, review pass.
+
+## License boundary
+
+No GPL linkage: the agent talks to the bridge over a local JSON `AF_UNIX`
+socket, to `aw-server` over REST, and renders via the desktop's own CLI tools
+(`gdbus`/`notify-send`/`canberra-gtk-play`) as **subprocesses**. `timekpra`
+session-kill is the bridge's job (Phase 8c), not this PR. No GPL binaries added
+to any image; the `.deb` (deferred, #106) bundles its own Node runtime.
+
+## Tamper resistance
+
+Within bounds — a notification/relay daemon acting on the user's *own*
+processes only. No anti-tamper, obfuscation, or `/etc`/`/usr` lockdown.

--- a/client/agent/src/agent/agent.ts
+++ b/client/agent/src/agent/agent.ts
@@ -29,17 +29,14 @@ import { budgetKey, remainingSeconds, type BudgetCache, type CachedBudget } from
 import {
   CadenceTracker,
   coalesceWarnings,
+  formatCadenceMessage,
   type CadenceWarning,
   type CoalescedWarning,
 } from "./cadence.js";
 import type { AgentConfig, NotificationPrefs } from "./config.js";
 import { soundNameForEvent, type Notifier, type SoundEvent, type SoundPlayer } from "./effects.js";
-import {
-  ForceCloseController,
-  type ForceClose,
-  type Scheduler,
-  type TimerHandle,
-} from "./force-close.js";
+import type { ForceClose } from "./force-close.js";
+import type { Scheduler, TimerHandle } from "./scheduler.js";
 import { AgentSocketClient, type SocketFactory } from "./socket-client.js";
 import type { UsageSource } from "./usage.js";
 
@@ -129,24 +126,37 @@ export class Agent {
   }
 
   async #render(group: CoalescedWarning): Promise<void> {
-    const isTimesUp = group.kind === "timesUp";
+    if (group.kind === "timesUp") {
+      await this.#renderTimesUp(group);
+      return;
+    }
     if (this.#prefs.enabled) {
       await this.#opts.notifier.notify({
-        title: isTimesUp ? "Time's up" : "Time remaining",
+        title: "Time remaining",
         body: group.message,
-        urgency:
-          isTimesUp || group.thresholdSeconds <= FINAL_WARNING_SECONDS ? "critical" : "normal",
+        urgency: group.thresholdSeconds <= FINAL_WARNING_SECONDS ? "critical" : "normal",
       });
       await this.#playSound(this.#soundEventFor(group));
     }
-    // Local force-close fallback: a per-app budget that hit zero.
-    if (isTimesUp) {
-      for (const b of group.budgets) {
-        const activityId = this.#activityIdForKey(b.key);
-        if (activityId !== null) {
-          await this.#opts.forceClose.begin({ activityId, label: b.label });
-        }
-      }
+  }
+
+  async #renderTimesUp(group: CoalescedWarning): Promise<void> {
+    // A per-app budget at zero begins the local grace countdown — whose own
+    // countdown toast IS the "time's up" toast, so the agent does not also
+    // toast those budgets (that would double up). Only the overall budget,
+    // which has no force-close (Timekpr handles the session lock), is toasted.
+    const overall = group.budgets.filter((b) => this.#activityIdForKey(b.key) === null);
+    for (const b of group.budgets) {
+      const activityId = this.#activityIdForKey(b.key);
+      if (activityId !== null) await this.#opts.forceClose.begin({ activityId, label: b.label });
+    }
+    if (overall.length > 0 && this.#prefs.enabled) {
+      await this.#opts.notifier.notify({
+        title: "Time's up",
+        body: formatCadenceMessage({ kind: "timesUp", thresholdSeconds: 0, budgets: overall }),
+        urgency: "critical",
+      });
+      await this.#playSound("timesUp");
     }
   }
 
@@ -169,8 +179,10 @@ export class Agent {
         );
         break;
       case "enforce.force_close": {
+        // The server fires this only after the grace period has already
+        // elapsed, so kill straight away rather than starting a fresh countdown.
         const label = this.#opts.budgets.get(budgetKey(event.activityId))?.label ?? "This app";
-        await this.#opts.forceClose.begin({ activityId: event.activityId, label });
+        await this.#opts.forceClose.forceCloseNow({ activityId: event.activityId, label });
         break;
       }
       case "enforce.session_lock":
@@ -225,10 +237,10 @@ export class Agent {
   }
 }
 
-/** Whole minutes for a granted-seconds figure, for the toast copy. */
+/**
+ * Whole minutes for a granted-seconds figure, for the toast copy. A positive
+ * sub-minute grant rounds up to 1 so it never reads as "+0 min granted".
+ */
 function minutes(seconds: number): number {
-  return Math.round(seconds / 60);
+  return Math.max(1, Math.round(seconds / 60));
 }
-
-/** Re-export so `main.ts` can build the controller alongside the agent. */
-export { ForceCloseController };

--- a/client/agent/src/agent/agent.ts
+++ b/client/agent/src/agent/agent.ts
@@ -1,0 +1,234 @@
+/**
+ * The per-user agent orchestrator (#103, Phase 8b).
+ *
+ * Wires the pieces of `docs/client-notifications.md` → Components/2 together:
+ * it reads server events off the bridge socket ({@link AgentSocketClient}) and
+ * renders them, and runs a local tick loop that polls the {@link UsageSource},
+ * computes each budget's remaining time against the cached totals, and fires the
+ * warning cadence + per-app force-close **locally** so warnings tick between
+ * server pulls and while briefly offline.
+ *
+ * Division of labour with the rest of the system:
+ * - `grant.applied` / `policy.changed` / `lockout.cleared` render toasts and
+ *   (for grants) top up the cached budget + cancel any in-flight countdown.
+ * - `enforce.force_close` starts the grace countdown for that activity; the tick
+ *   loop starts the *same* countdown as a local fallback when a per-app budget
+ *   reaches zero (both idempotent per activity).
+ * - `enforce.session_lock` is only announced here — Timekpr-nExT (via the
+ *   bridge, Phase 8c) performs the actual session kill; the agent never does.
+ *
+ * All timers are the injected {@link Scheduler} and every effect is an injected
+ * seam, so the whole orchestrator unit-tests deterministically with no clock,
+ * sockets, or desktop processes.
+ *
+ * License boundary: none touched — local socket + REST + subprocess seams only.
+ */
+import type { Logger } from "../bridge/logger.js";
+import type { ServerEvent } from "../bridge/protocol.js";
+import { budgetKey, remainingSeconds, type BudgetCache, type CachedBudget } from "./budget.js";
+import {
+  CadenceTracker,
+  coalesceWarnings,
+  type CadenceWarning,
+  type CoalescedWarning,
+} from "./cadence.js";
+import type { AgentConfig, NotificationPrefs } from "./config.js";
+import { soundNameForEvent, type Notifier, type SoundEvent, type SoundPlayer } from "./effects.js";
+import {
+  ForceCloseController,
+  type ForceClose,
+  type Scheduler,
+  type TimerHandle,
+} from "./force-close.js";
+import { AgentSocketClient, type SocketFactory } from "./socket-client.js";
+import type { UsageSource } from "./usage.js";
+
+/** A warning at or below this threshold uses the sharper "final-warning" sound. */
+const FINAL_WARNING_SECONDS = 60;
+
+/** Everything the {@link Agent} orchestrates through (all injectable). */
+export interface AgentOptions {
+  config: AgentConfig;
+  budgets: BudgetCache;
+  usage: UsageSource;
+  notifier: Notifier;
+  soundPlayer: SoundPlayer;
+  forceClose: ForceClose;
+  scheduler: Scheduler;
+  logger: Logger;
+  /** Passed through to the socket client (tests inject a fake socket). */
+  socketFactory?: SocketFactory;
+  rng?: () => number;
+}
+
+/** The running per-user agent: event intake + the local cadence tick loop. */
+export class Agent {
+  readonly #opts: AgentOptions;
+  readonly #prefs: NotificationPrefs;
+  readonly #socket: AgentSocketClient;
+  readonly #trackers = new Map<string, CadenceTracker>();
+  #tickTimer: TimerHandle | null = null;
+
+  constructor(opts: AgentOptions) {
+    this.#opts = opts;
+    this.#prefs = opts.config.notifications;
+    this.#socket = new AgentSocketClient({
+      socketPath: opts.config.socketPath,
+      onEvent: (event) => void this.#onEvent(event),
+      backoff: opts.config.backoff,
+      scheduler: opts.scheduler,
+      logger: opts.logger,
+      ...(opts.socketFactory !== undefined ? { factory: opts.socketFactory } : {}),
+      ...(opts.rng !== undefined ? { rng: opts.rng } : {}),
+    });
+  }
+
+  /** Connect to the bridge and start the cadence tick loop. */
+  start(): void {
+    this.#socket.start();
+    this.#tickTimer = this.#opts.scheduler.interval(() => {
+      void this.tick();
+    }, this.#opts.config.tickIntervalMs);
+    this.#opts.logger.info({ userId: this.#opts.config.userId }, "pct-client-agent started");
+  }
+
+  /** Stop the socket, the tick loop, and any in-flight force-close. */
+  stop(): void {
+    this.#socket.stop();
+    if (this.#tickTimer !== null) {
+      this.#opts.scheduler.cancel(this.#tickTimer);
+      this.#tickTimer = null;
+    }
+    this.#opts.forceClose.stop();
+  }
+
+  /**
+   * One cadence tick: read usage, recompute each budget's remaining time, fire
+   * the coalesced warnings, and start a local force-close for any per-app
+   * budget that reached zero. Exposed for the tick loop and tests.
+   */
+  async tick(): Promise<void> {
+    const usedByKey = await this.#opts.usage.usedSeconds();
+    const warnings: CadenceWarning[] = [];
+    for (const budget of this.#opts.budgets.list()) {
+      const used = usedByKey.get(budget.key) ?? 0;
+      const remaining = remainingSeconds(budget.totalSeconds, used);
+      const warning = this.#trackerFor(budget).observe(remaining);
+      if (warning !== null) warnings.push(warning);
+    }
+    for (const group of coalesceWarnings(warnings)) await this.#render(group);
+  }
+
+  #trackerFor(budget: CachedBudget): CadenceTracker {
+    let tracker = this.#trackers.get(budget.key);
+    if (tracker === undefined) {
+      tracker = new CadenceTracker(budget.key, budget.label, budget.totalSeconds);
+      this.#trackers.set(budget.key, tracker);
+    }
+    return tracker;
+  }
+
+  async #render(group: CoalescedWarning): Promise<void> {
+    const isTimesUp = group.kind === "timesUp";
+    if (this.#prefs.enabled) {
+      await this.#opts.notifier.notify({
+        title: isTimesUp ? "Time's up" : "Time remaining",
+        body: group.message,
+        urgency:
+          isTimesUp || group.thresholdSeconds <= FINAL_WARNING_SECONDS ? "critical" : "normal",
+      });
+      await this.#playSound(this.#soundEventFor(group));
+    }
+    // Local force-close fallback: a per-app budget that hit zero.
+    if (isTimesUp) {
+      for (const b of group.budgets) {
+        const activityId = this.#activityIdForKey(b.key);
+        if (activityId !== null) {
+          await this.#opts.forceClose.begin({ activityId, label: b.label });
+        }
+      }
+    }
+  }
+
+  #soundEventFor(group: CoalescedWarning): SoundEvent {
+    if (group.kind === "timesUp") return "timesUp";
+    return group.thresholdSeconds <= FINAL_WARNING_SECONDS ? "final-warning" : "warning";
+  }
+
+  async #onEvent(event: ServerEvent): Promise<void> {
+    switch (event.type) {
+      case "grant.applied":
+        await this.#onGrant(event.activityId, event.grantedSeconds, event.reason);
+        break;
+      case "policy.changed":
+        if (event.summary !== undefined)
+          await this.#toast("Limit updated", event.summary, "normal");
+        this.#opts.logger.info(
+          { userId: event.userId },
+          "policy changed; awaiting SSH policy pull",
+        );
+        break;
+      case "enforce.force_close": {
+        const label = this.#opts.budgets.get(budgetKey(event.activityId))?.label ?? "This app";
+        await this.#opts.forceClose.begin({ activityId: event.activityId, label });
+        break;
+      }
+      case "enforce.session_lock":
+        await this.#toast("Time's up", "You're out of screen time for now.", "critical");
+        break;
+      case "lockout.cleared":
+        await this.#toast("More time!", "You can log back in.", "normal");
+        break;
+    }
+  }
+
+  async #onGrant(activityId: number | null, grantedSeconds: number, reason: string): Promise<void> {
+    const updated = this.#opts.budgets.applyGrant(activityId, grantedSeconds);
+    if (updated !== null) {
+      // Re-arm the cadence for the new total so warnings fire again later.
+      this.#trackers.set(
+        updated.key,
+        new CadenceTracker(updated.key, updated.label, updated.totalSeconds),
+      );
+    } else {
+      this.#opts.logger.warn({ activityId }, "grant for an uncached budget; awaiting policy pull");
+    }
+    // A per-app grant cancels that activity's in-flight force-close countdown.
+    if (activityId !== null) {
+      await this.#opts.forceClose.cancel(
+        activityId,
+        `+${minutes(grantedSeconds)} min — keep going`,
+      );
+    }
+    await this.#toast(
+      "More time!",
+      `+${minutes(grantedSeconds)} min granted · ${reason}`,
+      "normal",
+    );
+    await this.#playSound("grant");
+  }
+
+  async #toast(title: string, body: string, urgency: "low" | "normal" | "critical"): Promise<void> {
+    if (!this.#prefs.enabled) return;
+    await this.#opts.notifier.notify({ title, body, urgency });
+  }
+
+  async #playSound(event: SoundEvent): Promise<void> {
+    if (!this.#prefs.enabled || this.#prefs.soundProfile === "off") return;
+    await this.#opts.soundPlayer.play(soundNameForEvent(event));
+  }
+
+  /** The `Activity.id` a budget key targets, or `null` for the overall budget. */
+  #activityIdForKey(key: string): number | null {
+    const match = /^activity:(\d+)$/.exec(key);
+    return match?.[1] !== undefined ? Number(match[1]) : null;
+  }
+}
+
+/** Whole minutes for a granted-seconds figure, for the toast copy. */
+function minutes(seconds: number): number {
+  return Math.round(seconds / 60);
+}
+
+/** Re-export so `main.ts` can build the controller alongside the agent. */
+export { ForceCloseController };

--- a/client/agent/src/agent/budget.ts
+++ b/client/agent/src/agent/budget.ts
@@ -1,0 +1,91 @@
+/**
+ * The agent's locally-cached budgets (#103, Phase 8b).
+ *
+ * `docs/client-notifications.md` → Components/2: the agent "holds the locally
+ * cached budget + `NotificationPolicy`" and uses "the locally cached budget
+ * total (last pushed by the server) plus the local usage stream from
+ * `aw-server` to compute 'time remaining' without needing the server to be
+ * reachable." This module is the cache half of that: the per-budget totals the
+ * agent warns against, mutated additively by grants.
+ *
+ * The authoritative totals are pushed over the SSH policy transport (a
+ * `policy.changed` event is only a nudge to re-pull); a `grant.applied` event
+ * carries its own delta and is applied here immediately so the countdown reacts
+ * without waiting for the next policy pull. Both keep the cache the single local
+ * source of "how much time does this budget have".
+ *
+ * License boundary: none touched — plain TypeScript.
+ */
+
+/** The overall device screen-time budget's stable cache key. */
+export const OVERALL_BUDGET_KEY = "overall";
+
+/** Stable per-budget key: `overall` for screen time, `activity:<id>` otherwise. */
+export function budgetKey(activityId: number | null): string {
+  return activityId === null ? OVERALL_BUDGET_KEY : `activity:${activityId}`;
+}
+
+/** One cached budget the agent tracks a countdown for. */
+export interface CachedBudget {
+  /** {@link budgetKey} of this budget. */
+  key: string;
+  /** Human label for toasts ("overall screen time", "YouTube"). */
+  label: string;
+  /** The targeted activity, or `null` for the overall screen-time budget. */
+  activityId: number | null;
+  /** Effective total for the current window in seconds (policy + grants). */
+  totalSeconds: number;
+}
+
+/** Remaining seconds for a budget given usage so far, clamped to `≥ 0`. */
+export function remainingSeconds(totalSeconds: number, usedSeconds: number): number {
+  return Math.max(0, Math.floor(totalSeconds) - Math.floor(usedSeconds));
+}
+
+/**
+ * The set of budgets the agent is currently warning against, keyed by
+ * {@link budgetKey}. Replaced wholesale on a policy pull ({@link replace}) and
+ * mutated additively by grants ({@link applyGrant}).
+ */
+export class BudgetCache {
+  readonly #byKey = new Map<string, CachedBudget>();
+
+  constructor(initial: readonly CachedBudget[] = []) {
+    this.replace(initial);
+  }
+
+  /** Replace the whole set (a fresh policy snapshot). */
+  replace(budgets: readonly CachedBudget[]): void {
+    this.#byKey.clear();
+    for (const budget of budgets) this.#byKey.set(budget.key, { ...budget });
+  }
+
+  /** The current budgets, in insertion order. */
+  list(): CachedBudget[] {
+    return [...this.#byKey.values()].map((b) => ({ ...b }));
+  }
+
+  /** The budget for a key, or `undefined` if not cached. */
+  get(key: string): CachedBudget | undefined {
+    const budget = this.#byKey.get(key);
+    return budget ? { ...budget } : undefined;
+  }
+
+  /**
+   * Add `grantedSeconds` to the budget targeted by `activityId` (or the overall
+   * budget when `null`). Returns the updated budget, or `null` if that budget
+   * is not cached — a grant for a budget the agent doesn't know about is a
+   * no-op the caller logs (the next policy pull reconciles it).
+   */
+  applyGrant(activityId: number | null, grantedSeconds: number): CachedBudget | null {
+    const key = budgetKey(activityId);
+    const budget = this.#byKey.get(key);
+    if (budget === undefined) return null;
+    const updated: CachedBudget = {
+      ...budget,
+      totalSeconds: budget.totalSeconds + Math.max(0, Math.floor(grantedSeconds)),
+    };
+    this.#byKey.set(key, updated);
+    return { ...updated };
+  }
+}

--- a/client/agent/src/agent/cadence.ts
+++ b/client/agent/src/agent/cadence.ts
@@ -1,0 +1,202 @@
+/**
+ * Local time-remaining warning cadence for the per-user agent (#103, Phase 8b).
+ *
+ * `docs/client-notifications.md` → "Notification cadence — exact rules": for
+ * every active budget the agent tracks remaining time and fires escalating
+ * warnings that line up with **round numbers of minutes remaining**, regardless
+ * of when in real time the budget started:
+ *
+ * | remaining | interval | warnings fire at (minutes remaining)              |
+ * |-----------|----------|---------------------------------------------------|
+ * | > 15 min  | 15 min   | every 15-minute boundary (…, 45, 30, 15)          |
+ * | 6–15 min  | 5 min    | 15, 10                                             |
+ * | 1–5 min   | 1 min    | 5, 4, 3, 2, 1                                      |
+ * | 0:00      | —        | the final "time's up — save and quit!"            |
+ *
+ * The union of those boundaries is the {@link warningThresholdsSeconds} set:
+ * every 15-minute multiple, plus 10, plus 5/4/3/2/1 minutes — each **strictly
+ * below** the budget total, so a fresh budget never warns at t=0.
+ *
+ * This module is **pure** (no timers, no I/O): a {@link CadenceTracker} takes
+ * successive `remaining` readings and returns the warning to render, if any, so
+ * the schedule is unit-testable without a clock — the same discipline
+ * `bridge/backoff.ts` uses for the reconnect delay. The agent owns one tracker
+ * per budget and drives it from the tick loop.
+ *
+ * License boundary: none touched — plain TypeScript.
+ */
+
+/** Seconds in a minute — the cadence is expressed entirely in whole minutes. */
+const SECONDS_PER_MINUTE = 60;
+/** The coarse interval: a warning at every 15-minute boundary while > 15 min. */
+const COARSE_INTERVAL_MINUTES = 15;
+/** The single mid-tier boundary between the 15- and 5-minute cadences. */
+const MID_TIER_MINUTES = 10;
+/** The fine tier: a warning at each of the last five whole minutes. */
+const FINE_TIER_MINUTES: readonly number[] = [5, 4, 3, 2, 1];
+
+/** What a fired warning is: a routine boundary, or the final zero. */
+export type CadenceKind = "warning" | "timesUp";
+
+/** A single budget's warning to render this tick. */
+export interface CadenceWarning {
+  /** Stable per-budget key (e.g. `overall` or `activity:7`). */
+  budgetKey: string;
+  /** Human label for the toast ("YouTube", "overall screen time"). */
+  budgetLabel: string;
+  kind: CadenceKind;
+  /** Remaining seconds at the moment the warning fired (clamped to ≥ 0). */
+  remainingSeconds: number;
+  /** The minute-boundary that triggered it, in seconds; `0` for `timesUp`. */
+  thresholdSeconds: number;
+}
+
+/**
+ * The set of warning boundaries for a budget of `totalSeconds`, in seconds,
+ * sorted **descending**. Every entry is strictly less than the total so the
+ * first tick of a fresh budget is silent. A budget of a minute or less has no
+ * boundaries — it only ever fires the final `timesUp`.
+ */
+export function warningThresholdsSeconds(totalSeconds: number): number[] {
+  const total = Math.max(0, Math.floor(totalSeconds));
+  const minutes = new Set<number>();
+
+  // Every 15-minute multiple below the total (…, 45, 30, 15).
+  for (
+    let m = COARSE_INTERVAL_MINUTES;
+    m * SECONDS_PER_MINUTE < total;
+    m += COARSE_INTERVAL_MINUTES
+  ) {
+    minutes.add(m);
+  }
+  // The mid-tier and fine-tier boundaries, each kept only if below the total.
+  for (const m of [MID_TIER_MINUTES, ...FINE_TIER_MINUTES]) {
+    if (m * SECONDS_PER_MINUTE < total) minutes.add(m);
+  }
+
+  return [...minutes].map((m) => m * SECONDS_PER_MINUTE).sort((a, b) => b - a);
+}
+
+/**
+ * Tracks one budget's descent toward zero and decides when to warn.
+ *
+ * `observe(remaining)` is called each tick with the current remaining seconds;
+ * it returns a {@link CadenceWarning} the first time remaining reaches a
+ * not-yet-announced boundary (the **deepest** boundary reached that tick, so a
+ * large jump announces the most urgent state rather than a stale higher one),
+ * a `timesUp` warning the first time remaining hits `0`, and `null` otherwise.
+ *
+ * A tracker is single-use per budget total: when a grant tops the budget back
+ * up, the agent builds a fresh tracker for the new total, which re-arms the
+ * boundaries so warnings fire again as it drains a second time.
+ */
+export class CadenceTracker {
+  readonly #thresholds: readonly number[];
+  #lastAnnounced = Number.POSITIVE_INFINITY;
+  #finalAnnounced = false;
+
+  constructor(
+    private readonly budgetKey: string,
+    private readonly budgetLabel: string,
+    totalSeconds: number,
+  ) {
+    this.#thresholds = warningThresholdsSeconds(totalSeconds);
+  }
+
+  /** Feed the current remaining seconds; get the warning to render, if any. */
+  observe(remainingSeconds: number): CadenceWarning | null {
+    const remaining = Math.max(0, Math.floor(remainingSeconds));
+
+    if (remaining <= 0) {
+      if (this.#finalAnnounced) return null;
+      this.#finalAnnounced = true;
+      this.#lastAnnounced = 0;
+      return this.#warning("timesUp", 0, 0);
+    }
+
+    // Boundaries reached this tick and not yet announced. `#thresholds` is
+    // descending, so the last match is the smallest — the deepest boundary
+    // reached, i.e. the most urgent one to announce.
+    let deepest: number | null = null;
+    for (const threshold of this.#thresholds) {
+      if (threshold < this.#lastAnnounced && remaining <= threshold) deepest = threshold;
+    }
+    if (deepest === null) return null;
+
+    this.#lastAnnounced = deepest;
+    return this.#warning("warning", remaining, deepest);
+  }
+
+  #warning(kind: CadenceKind, remainingSeconds: number, thresholdSeconds: number): CadenceWarning {
+    return {
+      budgetKey: this.budgetKey,
+      budgetLabel: this.budgetLabel,
+      kind,
+      remainingSeconds,
+      thresholdSeconds,
+    };
+  }
+}
+
+/** One rendered notification covering one or more budgets at the same boundary. */
+export interface CoalescedWarning {
+  kind: CadenceKind;
+  thresholdSeconds: number;
+  /** The budgets that crossed this boundary together, in input order. */
+  budgets: { key: string; label: string }[];
+  /** A ready-to-render toast body. */
+  message: string;
+}
+
+/**
+ * Coalesce the warnings produced across all budgets in a single tick into one
+ * notification per (kind, boundary) pair, so several budgets crossing the same
+ * boundary in the same ~5-second window become one toast rather than a burst
+ * (`docs/client-notifications.md`: "coalesces them into one toast").
+ *
+ * Grouping order follows first appearance so the output is deterministic.
+ */
+export function coalesceWarnings(warnings: readonly CadenceWarning[]): CoalescedWarning[] {
+  const groups = new Map<string, CoalescedWarning>();
+  for (const w of warnings) {
+    const groupKey = `${w.kind}:${w.thresholdSeconds}`;
+    const existing = groups.get(groupKey);
+    if (existing) {
+      existing.budgets.push({ key: w.budgetKey, label: w.budgetLabel });
+    } else {
+      groups.set(groupKey, {
+        kind: w.kind,
+        thresholdSeconds: w.thresholdSeconds,
+        budgets: [{ key: w.budgetKey, label: w.budgetLabel }],
+        message: "",
+      });
+    }
+  }
+  for (const group of groups.values()) group.message = formatCadenceMessage(group);
+  return [...groups.values()];
+}
+
+/** Format the toast body for a coalesced warning, non-punitive per the design. */
+export function formatCadenceMessage(group: {
+  kind: CadenceKind;
+  thresholdSeconds: number;
+  budgets: readonly { label: string }[];
+}): string {
+  const labels = group.budgets.map((b) => b.label);
+  const subject = joinLabels(labels);
+  if (group.kind === "timesUp") {
+    const verb = labels.length > 1 ? "are" : "is";
+    return `Time's up — save and quit! ${subject} ${verb} out of time.`;
+  }
+  const minutes = Math.round(group.thresholdSeconds / SECONDS_PER_MINUTE);
+  const unit = minutes === 1 ? "minute" : "minutes";
+  const verb = labels.length > 1 ? "have" : "has";
+  return `${subject} ${verb} ${minutes} ${unit} left.`;
+}
+
+/** Join labels as a natural-language list: "A", "A and B", "A, B and C". */
+function joinLabels(labels: readonly string[]): string {
+  if (labels.length <= 1) return labels[0] ?? "";
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
+}

--- a/client/agent/src/agent/config.ts
+++ b/client/agent/src/agent/config.ts
@@ -1,0 +1,142 @@
+/**
+ * Configuration for the per-user agent (#103, Phase 8b).
+ *
+ * The agent is one `systemd --user` process per supervised user; its config is
+ * provisioned by the install script (#106) and read from the environment at
+ * start. Everything external is zod-validated before it crosses into typed code
+ * (`CLAUDE.md` → "Validate all external input"), the same posture as
+ * `bridge/config.ts`.
+ *
+ * The {@link NotificationPrefs} block mirrors the server's
+ * `NotificationPolicyValues` (`server/src/policy/notification.ts` /
+ * `enums.ts` — `enabled`, `soundProfile` `off`/`subtle`/`prominent`,
+ * `graceSeconds` 0–60, loose `cadenceOverrides`). It is redeclared here rather
+ * than imported because the agent ships in the `.deb` with its own bundled Node
+ * runtime and no workspace to reach `server/src` across — the same
+ * generated-client shape the bridge uses for the event contract. The
+ * authoritative per-user values are pushed with policy; the config carries the
+ * documented defaults so the agent has a sane policy before the first pull.
+ *
+ * License boundary: none touched — plain TypeScript + zod (MIT).
+ */
+import { z } from "zod";
+
+/** Sound themes, mirroring `server/src/policy/enums.ts` `SoundProfile`. */
+export const SOUND_PROFILES = ["off", "subtle", "prominent"] as const;
+export type SoundProfile = (typeof SOUND_PROFILES)[number];
+
+/** Grace-period bounds, mirroring `server/src/policy/notification.ts`. */
+export const GRACE_SECONDS_MIN = 0;
+export const GRACE_SECONDS_MAX = 60;
+export const DEFAULT_GRACE_SECONDS = 15;
+export const DEFAULT_SOUND_PROFILE: SoundProfile = "subtle";
+export const DEFAULT_NOTIFICATION_ENABLED = true;
+
+/** How long to wait after `SIGTERM` before escalating to `SIGKILL` (doc: 5 s). */
+export const DEFAULT_SIGKILL_ESCALATION_MS = 5_000;
+/** Cadence tick interval — how often the agent recomputes remaining time. */
+export const DEFAULT_TICK_INTERVAL_MS = 1_000;
+/** Default `aw-server` REST base (loopback only; never network-exposed). */
+export const DEFAULT_AW_BASE_URL = "http://127.0.0.1:5600";
+
+/** The per-user notification preferences the agent renders under. */
+export const notificationPrefsSchema = z.object({
+  enabled: z.boolean().default(DEFAULT_NOTIFICATION_ENABLED),
+  soundProfile: z.enum(SOUND_PROFILES).default(DEFAULT_SOUND_PROFILE),
+  graceSeconds: z
+    .number()
+    .int()
+    .min(GRACE_SECONDS_MIN)
+    .max(GRACE_SECONDS_MAX)
+    .default(DEFAULT_GRACE_SECONDS),
+  /** Loose per-budget overrides (structured shape is #302); `null` ⇒ defaults. */
+  cadenceOverrides: z.record(z.string(), z.unknown()).nullable().default(null),
+});
+export type NotificationPrefs = z.infer<typeof notificationPrefsSchema>;
+
+/** The documented default preferences (used until policy is pulled). */
+export function defaultNotificationPrefs(): NotificationPrefs {
+  return notificationPrefsSchema.parse({});
+}
+
+/** Reconnect-backoff knobs for the socket reader (mirrors `bridge/backoff.ts`). */
+const backoffSchema = z.object({
+  baseMs: z.number().int().positive().default(1_000),
+  maxMs: z.number().int().positive().default(60_000),
+});
+
+/** The validated agent configuration. */
+export const agentConfigSchema = z
+  .object({
+    /** The policy `User.id` this agent serves — events are addressed to it. */
+    userId: z.number().int().positive(),
+    /** AF_UNIX path the bridge listens on for this user (`/run/pct/<uid>.sock`). */
+    socketPath: z.string().min(1),
+    /** `aw-server` REST base for local usage polling. */
+    awBaseUrl: z.url().default(DEFAULT_AW_BASE_URL),
+    backoff: backoffSchema.default({ baseMs: 1_000, maxMs: 60_000 }),
+    tickIntervalMs: z.number().int().positive().default(DEFAULT_TICK_INTERVAL_MS),
+    sigkillEscalationMs: z.number().int().positive().default(DEFAULT_SIGKILL_ESCALATION_MS),
+    notifications: notificationPrefsSchema.default({
+      enabled: DEFAULT_NOTIFICATION_ENABLED,
+      soundProfile: DEFAULT_SOUND_PROFILE,
+      graceSeconds: DEFAULT_GRACE_SECONDS,
+      cadenceOverrides: null,
+    }),
+  })
+  .refine((c) => c.backoff.maxMs >= c.backoff.baseMs, {
+    message: "backoff.maxMs must be >= backoff.baseMs",
+    path: ["backoff", "maxMs"],
+  });
+export type AgentConfig = z.infer<typeof agentConfigSchema>;
+
+/** Raised when the environment does not describe a valid {@link AgentConfig}. */
+export class AgentConfigError extends Error {
+  constructor(
+    message: string,
+    override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AgentConfigError";
+  }
+}
+
+/**
+ * Build an {@link AgentConfig} from environment variables. Required:
+ * `PCT_AGENT_USER_ID` and `PCT_AGENT_SOCKET`. Optional overrides:
+ * `PCT_AGENT_AW_URL`, `PCT_AGENT_TICK_MS`, `PCT_AGENT_BACKOFF_BASE_MS`,
+ * `PCT_AGENT_BACKOFF_MAX_MS`, `PCT_AGENT_SIGKILL_MS`. Notification prefs default
+ * to the documented values; the authoritative per-user policy is pushed later.
+ */
+export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): AgentConfig {
+  const parsed = agentConfigSchema.safeParse({
+    userId: numberOrUndefined(env.PCT_AGENT_USER_ID),
+    socketPath: env.PCT_AGENT_SOCKET,
+    ...optional("awBaseUrl", env.PCT_AGENT_AW_URL),
+    ...optional("tickIntervalMs", numberOrUndefined(env.PCT_AGENT_TICK_MS)),
+    ...optional("sigkillEscalationMs", numberOrUndefined(env.PCT_AGENT_SIGKILL_MS)),
+    backoff: {
+      ...optional("baseMs", numberOrUndefined(env.PCT_AGENT_BACKOFF_BASE_MS)),
+      ...optional("maxMs", numberOrUndefined(env.PCT_AGENT_BACKOFF_MAX_MS)),
+    },
+  });
+  if (!parsed.success) {
+    throw new AgentConfigError("invalid agent configuration from environment", parsed.error);
+  }
+  return parsed.data;
+}
+
+/** Parse a decimal env var to a number, or `undefined` if unset/blank. */
+function numberOrUndefined(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : Number.NaN; // NaN → zod rejects with a clear path
+}
+
+/** Spread helper: include `{ [key]: value }` only when `value` is defined. */
+function optional<K extends string, V>(
+  key: K,
+  value: V | undefined,
+): Record<K, V> | Record<never, never> {
+  return value === undefined ? {} : ({ [key]: value } as Record<K, V>);
+}

--- a/client/agent/src/agent/effects.ts
+++ b/client/agent/src/agent/effects.ts
@@ -1,0 +1,248 @@
+/**
+ * Desktop-integration effect seams for the per-user agent (#103, Phase 8b).
+ *
+ * `docs/client-notifications.md` → Components/2: the agent renders toasts via
+ * the desktop notification stack (`gdbus call` against
+ * `org.freedesktop.Notifications`, falling back to `notify-send`), plays sounds
+ * via `libcanberra`'s `canberra-gtk-play`, and force-closes the user's **own**
+ * processes with `SIGTERM`→`SIGKILL`. All of it runs the desktop's own CLI
+ * tools as **subprocesses** — "no native D-Bus bindings" — which keeps the
+ * agent off any GPL in-process linkage (`CLAUDE.md` → "License boundaries").
+ *
+ * Every side effect goes through a small injected {@link CommandRunner} (or
+ * {@link ProcessSignaller}) seam so the orchestrator and its tests exercise the
+ * rendering logic without spawning real desktop processes — the same
+ * inject-the-boundary discipline the bridge uses for its WebSocket and timers.
+ *
+ * License boundary: none touched — `node:child_process` subprocesses only.
+ */
+import { spawn } from "node:child_process";
+
+import type { Logger } from "../bridge/logger.js";
+
+/** The result of running a command: its exit code and captured output. */
+export interface CommandResult {
+  /** Process exit code, or `null` if it was terminated by a signal. */
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Runs a command and resolves with its {@link CommandResult}. A non-zero exit
+ * **resolves** (the caller inspects `code`); the promise only **rejects** when
+ * the process could not be spawned at all (e.g. the binary is missing), so a
+ * caller can fall back to an alternative renderer.
+ */
+export interface CommandRunner {
+  run(command: string, args: readonly string[]): Promise<CommandResult>;
+}
+
+/** The default {@link CommandRunner}, backed by `node:child_process` `spawn`. */
+export class SpawnCommandRunner implements CommandRunner {
+  run(command: string, args: readonly string[]): Promise<CommandResult> {
+    return new Promise<CommandResult>((resolve, reject) => {
+      const child = spawn(command, [...args], { stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      child.stdout?.on("data", (chunk: Buffer) => (stdout += chunk.toString("utf8")));
+      child.stderr?.on("data", (chunk: Buffer) => (stderr += chunk.toString("utf8")));
+      child.on("error", reject);
+      child.on("close", (code) => resolve({ code, stdout, stderr }));
+    });
+  }
+}
+
+/** Notification urgency, mapped to the freedesktop `urgency` byte hint. */
+export type Urgency = "low" | "normal" | "critical";
+const URGENCY_BYTE: Record<Urgency, number> = { low: 0, normal: 1, critical: 2 };
+
+/** What to render in a toast. */
+export interface NotifyOptions {
+  title: string;
+  body: string;
+  urgency?: Urgency;
+}
+
+/**
+ * A handle to a shown notification. `id` is the freedesktop notification id
+ * (from `gdbus`) used to replace the toast in place for the grace countdown, or
+ * `null` when the fallback path (which cannot update in place) was used.
+ */
+export interface NotificationHandle {
+  id: number | null;
+}
+
+/** Renders toasts, optionally replacing one in place (the grace countdown). */
+export interface Notifier {
+  /** Show a new toast; resolve with a handle usable by {@link update}. */
+  notify(options: NotifyOptions): Promise<NotificationHandle>;
+  /** Replace an existing toast in place; falls back to a fresh toast. */
+  update(handle: NotificationHandle, options: NotifyOptions): Promise<NotificationHandle>;
+}
+
+const NOTIFY_DEST = "org.freedesktop.Notifications";
+const NOTIFY_PATH = "/org/freedesktop/Notifications";
+const NOTIFY_METHOD = "org.freedesktop.Notifications.Notify";
+/** freedesktop `expire_timeout`: `-1` lets the server pick a default timeout. */
+const DEFAULT_EXPIRE_TIMEOUT = -1;
+
+/**
+ * The desktop notifier: `gdbus call … Notify` (which returns a numeric id we
+ * can later reuse as `replaces_id` to update the countdown toast in place),
+ * falling back to `notify-send` when `gdbus` is unavailable or errors.
+ */
+export class DesktopNotifier implements Notifier {
+  readonly #runner: CommandRunner;
+  readonly #appName: string;
+  readonly #logger: Logger | undefined;
+
+  constructor(options: { runner: CommandRunner; appName?: string; logger?: Logger }) {
+    this.#runner = options.runner;
+    this.#appName = options.appName ?? "pct-client-agent";
+    this.#logger = options.logger;
+  }
+
+  notify(options: NotifyOptions): Promise<NotificationHandle> {
+    return this.#send(0, options);
+  }
+
+  update(handle: NotificationHandle, options: NotifyOptions): Promise<NotificationHandle> {
+    // `replaces_id` 0 means "new toast"; a real id replaces that toast in place.
+    return this.#send(handle.id ?? 0, options);
+  }
+
+  async #send(replacesId: number, options: NotifyOptions): Promise<NotificationHandle> {
+    const hints =
+      options.urgency !== undefined ? `{'urgency': <byte ${URGENCY_BYTE[options.urgency]}>}` : "{}";
+    const args = [
+      "call",
+      "--session",
+      "--dest",
+      NOTIFY_DEST,
+      "--object-path",
+      NOTIFY_PATH,
+      "--method",
+      NOTIFY_METHOD,
+      this.#appName,
+      String(replacesId),
+      "", // app_icon
+      options.title,
+      options.body,
+      "[]", // actions (inert here; interactive buttons are #337)
+      hints,
+      String(DEFAULT_EXPIRE_TIMEOUT),
+    ];
+
+    try {
+      const result = await this.#runner.run("gdbus", args);
+      if (result.code === 0) {
+        return { id: parseNotificationId(result.stdout) };
+      }
+      this.#logger?.warn({ code: result.code, stderr: result.stderr }, "gdbus notify failed");
+    } catch (err) {
+      this.#logger?.warn({ err }, "gdbus unavailable; falling back to notify-send");
+    }
+    return this.#fallback(options);
+  }
+
+  async #fallback(options: NotifyOptions): Promise<NotificationHandle> {
+    const args = [
+      ...(options.urgency !== undefined ? ["--urgency", options.urgency] : []),
+      options.title,
+      options.body,
+    ];
+    try {
+      await this.#runner.run("notify-send", args);
+    } catch (err) {
+      // Headless / no notification stack: log and continue (a documented
+      // degraded mode) — enforcement still happens regardless of the toast.
+      this.#logger?.warn({ err }, "notify-send unavailable; dropping toast");
+    }
+    return { id: null };
+  }
+}
+
+/** Extract the `uint32 <n>` id `gdbus` prints for a `Notify` call. */
+export function parseNotificationId(stdout: string): number | null {
+  const match = /uint32\s+(\d+)/.exec(stdout);
+  return match?.[1] !== undefined ? Number(match[1]) : null;
+}
+
+/** The desktop-sound events the agent plays, from `docs/…` → "Sound design". */
+export type SoundEvent = "warning" | "final-warning" | "grant" | "timesUp";
+
+/**
+ * The freedesktop sound name for an event. The `subtle`/`prominent` profiles
+ * use the same *names* (the doc: "the same set"); the profile only decides
+ * on/off and, for `prominent`, louder packaged files + channel (that packaging
+ * is #106). The `off` profile is handled by the caller, which simply does not
+ * play.
+ */
+export function soundNameForEvent(event: SoundEvent): string {
+  switch (event) {
+    case "warning":
+      return "message-new-instant";
+    case "final-warning":
+      return "dialog-warning";
+    case "grant":
+      return "complete";
+    case "timesUp":
+      return "bell";
+  }
+}
+
+/** Plays a named desktop sound (a no-op when passed `null`). */
+export interface SoundPlayer {
+  play(soundName: string | null): Promise<void>;
+}
+
+/** Plays sounds through `canberra-gtk-play -i <name>`. */
+export class CanberraSoundPlayer implements SoundPlayer {
+  readonly #runner: CommandRunner;
+  readonly #logger: Logger | undefined;
+
+  constructor(options: { runner: CommandRunner; logger?: Logger }) {
+    this.#runner = options.runner;
+    this.#logger = options.logger;
+  }
+
+  async play(soundName: string | null): Promise<void> {
+    if (soundName === null) return;
+    try {
+      await this.#runner.run("canberra-gtk-play", ["-i", soundName]);
+    } catch (err) {
+      this.#logger?.warn({ err, soundName }, "canberra-gtk-play unavailable; dropping sound");
+    }
+  }
+}
+
+/** Sends a signal to a process; the seam the force-close state machine kills through. */
+export interface ProcessSignaller {
+  /** Deliver `signal` to `pid`. Returns `false` if the process is already gone. */
+  signal(pid: number, signal: NodeJS.Signals): boolean;
+}
+
+/** The default {@link ProcessSignaller}, using `process.kill` on the user's own PIDs. */
+export class OsProcessSignaller implements ProcessSignaller {
+  signal(pid: number, signal: NodeJS.Signals): boolean {
+    try {
+      process.kill(pid, signal);
+      return true;
+    } catch (err) {
+      // ESRCH — the process already exited; treat as delivered-enough.
+      if (isNoSuchProcess(err)) return false;
+      throw err;
+    }
+  }
+}
+
+/** True if `err` is an `ESRCH` ("no such process") errno error. */
+function isNoSuchProcess(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "ESRCH"
+  );
+}

--- a/client/agent/src/agent/effects.ts
+++ b/client/agent/src/agent/effects.ts
@@ -239,10 +239,5 @@ export class OsProcessSignaller implements ProcessSignaller {
 
 /** True if `err` is an `ESRCH` ("no such process") errno error. */
 function isNoSuchProcess(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code?: unknown }).code === "ESRCH"
-  );
+  return typeof err === "object" && err !== null && "code" in err && err.code === "ESRCH";
 }

--- a/client/agent/src/agent/force-close.ts
+++ b/client/agent/src/agent/force-close.ts
@@ -2,20 +2,26 @@
  * Grace-period + per-app force-close state machine (#103, Phase 8b).
  *
  * `docs/client-notifications.md` → "Grace period and force-close": when a
- * per-app budget reaches 0:00 (or an `enforce.force_close` arrives), the agent
- * shows the "time's up" toast **immediately** with a visible countdown of the
- * grace period (default 15 s, `policy.grace_seconds`, 0–60), updating the toast
- * each second. If a grant tops the budget back up during the countdown, it is
- * cancelled with a "keep going" toast. After the grace period the agent
- * `SIGTERM`s the activity's processes, waits 5 s, then `SIGKILL`s survivors —
- * always the user's **own** processes, so no privilege escalation.
+ * per-app budget reaches 0:00 **locally** the agent shows the "time's up" toast
+ * immediately with a visible countdown of the grace period (default 15 s,
+ * `policy.grace_seconds`, 0–60), updating the toast each second; if a grant tops
+ * the budget back up during the countdown it is cancelled with a "keep going"
+ * toast. After the grace period the agent `SIGTERM`s the activity's processes,
+ * waits 5 s, then `SIGKILL`s survivors — always the user's **own** processes.
+ * A server `enforce.force_close` means the grace period has *already* elapsed
+ * server-side, so {@link ForceCloseController.forceCloseNow} skips the countdown
+ * and kills straight away.
+ *
+ * Toasts and sound respect the per-user {@link ForceCloseDeps.renderToasts}
+ * master switch and the injected sound player (which `main.ts` omits when the
+ * profile is `off`) — enforcement runs regardless, but the *UX* around it obeys
+ * the notification policy, matching what `agent.ts` does for its own toasts.
  *
  * The countdown/kill schedule is driven by an injected {@link Scheduler} so the
- * whole state machine is unit-testable with no real time, matching the bridge's
- * injected-timer discipline. PID resolution is itself an injected seam
- * ({@link ForceCloseDeps.resolvePids}); wiring it to the activity matchers the
- * server pushes to the client is a tracked follow-up, so the kill machinery
- * ships complete while resolution stays degraded (`[]`) until then.
+ * whole state machine is unit-testable with no real time. PID resolution is an
+ * injected seam ({@link ForceCloseDeps.resolvePids}); wiring it to the activity
+ * matchers the server pushes to the client is a tracked follow-up (#381), so the
+ * kill machinery ships complete while resolution stays degraded (`[]`).
  *
  * License boundary: none touched — signals go through the {@link ProcessSignaller}
  * seam (`process.kill`), never a GPL binary.
@@ -23,38 +29,7 @@
 import type { Logger } from "../bridge/logger.js";
 import type { Notifier, NotificationHandle, ProcessSignaller, SoundPlayer } from "./effects.js";
 import { soundNameForEvent } from "./effects.js";
-
-/** An opaque cancellable timer handle from a {@link Scheduler}. */
-export interface TimerHandle {
-  readonly token: unknown;
-}
-
-/** Timer seam: a repeating tick and a one-shot delay, injectable for tests. */
-export interface Scheduler {
-  interval(callback: () => void, ms: number): TimerHandle;
-  timeout(callback: () => void, ms: number): TimerHandle;
-  cancel(handle: TimerHandle): void;
-}
-
-/** The default {@link Scheduler}, backed by `node:timers` (unref'd). */
-export class SystemScheduler implements Scheduler {
-  interval(callback: () => void, ms: number): TimerHandle {
-    const token = setInterval(callback, ms);
-    token.unref?.();
-    return { token };
-  }
-  timeout(callback: () => void, ms: number): TimerHandle {
-    const token = setTimeout(callback, ms);
-    token.unref?.();
-    return { token };
-  }
-  cancel(handle: TimerHandle): void {
-    const token = handle.token;
-    // Both clearInterval and clearTimeout accept the same timer object.
-    clearInterval(token as ReturnType<typeof setInterval>);
-    clearTimeout(token as ReturnType<typeof setTimeout>);
-  }
-}
+import type { Scheduler, TimerHandle } from "./scheduler.js";
 
 /** The budget whose exhaustion triggers a force-close. */
 export interface ForceCloseTarget {
@@ -69,13 +44,15 @@ export interface ForceCloseDeps {
   notifier: Notifier;
   signaller: ProcessSignaller;
   scheduler: Scheduler;
-  /** Resolve the PIDs to close for an activity (degraded `[]` until #wired). */
+  /** Resolve the PIDs to close for an activity (degraded `[]` until #381). */
   resolvePids: (activityId: number) => Promise<number[]>;
   /** Grace-period length in seconds (0 skips the countdown). */
   graceSeconds: number;
   /** Delay between `SIGTERM` and the `SIGKILL` escalation, in ms. */
   sigkillEscalationMs: number;
-  /** Optional sound player; a `null` play (or omission) is silent. */
+  /** Whether to render countdown/keep-going toasts (the `enabled` master switch). */
+  renderToasts: boolean;
+  /** Optional sound player; omitted when the sound profile is `off`. */
   soundPlayer?: SoundPlayer;
   logger?: Logger;
 }
@@ -83,6 +60,7 @@ export interface ForceCloseDeps {
 /** The force-close surface the agent orchestrator drives (injectable in tests). */
 export interface ForceClose {
   begin(target: ForceCloseTarget): Promise<void>;
+  forceCloseNow(target: ForceCloseTarget): Promise<void>;
   cancel(activityId: number, message: string): Promise<void>;
   stop(): void;
 }
@@ -92,13 +70,16 @@ interface Countdown {
   target: ForceCloseTarget;
   remaining: number;
   handle: NotificationHandle;
+  /** The 1 Hz countdown interval (null once the countdown has elapsed). */
   timer: TimerHandle | null;
+  /** The pending SIGTERM→SIGKILL escalation timeout (null until SIGTERM sent). */
+  escalation: TimerHandle | null;
 }
 
 /**
  * Drives the grace countdown and force-close for each per-app budget that
- * exhausts. One countdown per `activityId` at a time; a repeat `begin` for an
- * activity already counting down is ignored.
+ * exhausts. One countdown per `activityId` at a time; a repeat `begin` /
+ * `forceCloseNow` for an activity already in flight is ignored.
  */
 export class ForceCloseController implements ForceClose {
   readonly #deps: ForceCloseDeps;
@@ -108,28 +89,46 @@ export class ForceCloseController implements ForceClose {
     this.#deps = deps;
   }
 
-  /** Whether a countdown is currently running for an activity (for tests). */
+  /** Whether a countdown or escalation is in flight for an activity (for tests). */
   isCountingDown(activityId: number): boolean {
     return this.#active.has(activityId);
   }
 
   /**
-   * Begin the grace countdown for `target`. Shows the "time's up" toast with
-   * the grace countdown, plays the times-up sound, and — after the grace period
-   * (immediately if `graceSeconds` is 0) — force-closes the activity.
+   * Begin the local grace countdown for `target`: the "time's up" toast + the
+   * per-second countdown, then force-close after the grace period (immediately
+   * if `graceSeconds` is 0). Used for the local pre-zero decision.
    */
-  async begin(target: ForceCloseTarget): Promise<void> {
+  begin(target: ForceCloseTarget): Promise<void> {
+    return this.#start(target, Math.max(0, Math.floor(this.#deps.graceSeconds)));
+  }
+
+  /**
+   * Force-close `target` immediately, with no grace countdown — the server's
+   * `enforce.force_close` fires only after the grace period has already elapsed
+   * server-side, so a fresh countdown would double the wait.
+   */
+  forceCloseNow(target: ForceCloseTarget): Promise<void> {
+    return this.#start(target, 0);
+  }
+
+  async #start(target: ForceCloseTarget, grace: number): Promise<void> {
     if (this.#active.has(target.activityId)) return;
 
-    const grace = Math.max(0, Math.floor(this.#deps.graceSeconds));
-    const handle = await this.#deps.notifier.notify({
+    const handle = await this.#notify({
       title: "Time's up",
       body: this.#countdownBody(target.label, grace),
       urgency: "critical",
     });
-    await this.#deps.soundPlayer?.play(soundNameForEvent("timesUp"));
+    await this.#playTimesUp();
 
-    const countdown: Countdown = { target, remaining: grace, handle, timer: null };
+    const countdown: Countdown = {
+      target,
+      remaining: grace,
+      handle,
+      timer: null,
+      escalation: null,
+    };
     this.#active.set(target.activityId, countdown);
 
     if (grace <= 0) {
@@ -140,27 +139,22 @@ export class ForceCloseController implements ForceClose {
   }
 
   /**
-   * Cancel an in-flight countdown because time was restored (a grant top-up),
-   * dismissing the countdown with a "keep going" toast. No-op if the activity
-   * is not counting down.
+   * Cancel an in-flight force-close because time was restored (a grant top-up),
+   * dismissing it with a "keep going" toast. Cancels both the countdown and any
+   * pending SIGKILL escalation, so a grant that lands in the escalation window
+   * truly spares the process. No-op if the activity is not in flight.
    */
   async cancel(activityId: number, message: string): Promise<void> {
     const countdown = this.#active.get(activityId);
     if (countdown === undefined) return;
-    if (countdown.timer !== null) this.#deps.scheduler.cancel(countdown.timer);
+    this.#clearTimers(countdown);
     this.#active.delete(activityId);
-    await this.#deps.notifier.update(countdown.handle, {
-      title: "More time!",
-      body: message,
-      urgency: "normal",
-    });
+    await this.#update(countdown.handle, { title: "More time!", body: message, urgency: "normal" });
   }
 
-  /** Stop all countdowns and their timers (shutdown). */
+  /** Stop all in-flight countdowns and escalations (shutdown). */
   stop(): void {
-    for (const countdown of this.#active.values()) {
-      if (countdown.timer !== null) this.#deps.scheduler.cancel(countdown.timer);
-    }
+    for (const countdown of this.#active.values()) this.#clearTimers(countdown);
     this.#active.clear();
   }
 
@@ -169,15 +163,13 @@ export class ForceCloseController implements ForceClose {
     if (countdown === undefined) return;
     countdown.remaining -= 1;
     if (countdown.remaining > 0) {
-      void this.#deps.notifier
-        .update(countdown.handle, {
-          title: "Time's up",
-          body: this.#countdownBody(countdown.target.label, countdown.remaining),
-          urgency: "critical",
-        })
-        .then((h) => {
-          countdown.handle = h;
-        });
+      void this.#update(countdown.handle, {
+        title: "Time's up",
+        body: this.#countdownBody(countdown.target.label, countdown.remaining),
+        urgency: "critical",
+      }).then((h) => {
+        countdown.handle = h;
+      });
       return;
     }
     if (countdown.timer !== null) this.#deps.scheduler.cancel(countdown.timer);
@@ -193,7 +185,7 @@ export class ForceCloseController implements ForceClose {
     if (pids.length === 0) {
       this.#deps.logger?.warn(
         { activityId },
-        "force-close: no processes resolved for activity (degraded until client-side matchers land)",
+        "force-close: no processes resolved for activity (degraded until client-side matchers land, #381)",
       );
       this.#active.delete(activityId);
       return;
@@ -202,11 +194,34 @@ export class ForceCloseController implements ForceClose {
     for (const pid of pids) this.#deps.signaller.signal(pid, "SIGTERM");
     this.#deps.logger?.info({ activityId, pids, signal: "SIGTERM" }, "force-close: SIGTERM sent");
 
-    this.#deps.scheduler.timeout(() => {
+    countdown.escalation = this.#deps.scheduler.timeout(() => {
       for (const pid of pids) this.#deps.signaller.signal(pid, "SIGKILL");
       this.#deps.logger?.info({ activityId, pids, signal: "SIGKILL" }, "force-close: SIGKILL sent");
       this.#active.delete(activityId);
     }, this.#deps.sigkillEscalationMs);
+  }
+
+  #clearTimers(countdown: Countdown): void {
+    if (countdown.timer !== null) this.#deps.scheduler.cancel(countdown.timer);
+    if (countdown.escalation !== null) this.#deps.scheduler.cancel(countdown.escalation);
+  }
+
+  #notify(options: Parameters<Notifier["notify"]>[0]): Promise<NotificationHandle> {
+    if (!this.#deps.renderToasts) return Promise.resolve({ id: null });
+    return this.#deps.notifier.notify(options);
+  }
+
+  #update(
+    handle: NotificationHandle,
+    options: Parameters<Notifier["notify"]>[0],
+  ): Promise<NotificationHandle> {
+    if (!this.#deps.renderToasts) return Promise.resolve(handle);
+    return this.#deps.notifier.update(handle, options);
+  }
+
+  async #playTimesUp(): Promise<void> {
+    if (!this.#deps.renderToasts) return;
+    await this.#deps.soundPlayer?.play(soundNameForEvent("timesUp"));
   }
 
   #countdownBody(label: string, secondsLeft: number): string {

--- a/client/agent/src/agent/force-close.ts
+++ b/client/agent/src/agent/force-close.ts
@@ -80,6 +80,13 @@ export interface ForceCloseDeps {
   logger?: Logger;
 }
 
+/** The force-close surface the agent orchestrator drives (injectable in tests). */
+export interface ForceClose {
+  begin(target: ForceCloseTarget): Promise<void>;
+  cancel(activityId: number, message: string): Promise<void>;
+  stop(): void;
+}
+
 /** Per-activity countdown state. */
 interface Countdown {
   target: ForceCloseTarget;
@@ -93,7 +100,7 @@ interface Countdown {
  * exhausts. One countdown per `activityId` at a time; a repeat `begin` for an
  * activity already counting down is ignored.
  */
-export class ForceCloseController {
+export class ForceCloseController implements ForceClose {
   readonly #deps: ForceCloseDeps;
   readonly #active = new Map<number, Countdown>();
 

--- a/client/agent/src/agent/force-close.ts
+++ b/client/agent/src/agent/force-close.ts
@@ -1,0 +1,210 @@
+/**
+ * Grace-period + per-app force-close state machine (#103, Phase 8b).
+ *
+ * `docs/client-notifications.md` → "Grace period and force-close": when a
+ * per-app budget reaches 0:00 (or an `enforce.force_close` arrives), the agent
+ * shows the "time's up" toast **immediately** with a visible countdown of the
+ * grace period (default 15 s, `policy.grace_seconds`, 0–60), updating the toast
+ * each second. If a grant tops the budget back up during the countdown, it is
+ * cancelled with a "keep going" toast. After the grace period the agent
+ * `SIGTERM`s the activity's processes, waits 5 s, then `SIGKILL`s survivors —
+ * always the user's **own** processes, so no privilege escalation.
+ *
+ * The countdown/kill schedule is driven by an injected {@link Scheduler} so the
+ * whole state machine is unit-testable with no real time, matching the bridge's
+ * injected-timer discipline. PID resolution is itself an injected seam
+ * ({@link ForceCloseDeps.resolvePids}); wiring it to the activity matchers the
+ * server pushes to the client is a tracked follow-up, so the kill machinery
+ * ships complete while resolution stays degraded (`[]`) until then.
+ *
+ * License boundary: none touched — signals go through the {@link ProcessSignaller}
+ * seam (`process.kill`), never a GPL binary.
+ */
+import type { Logger } from "../bridge/logger.js";
+import type { Notifier, NotificationHandle, ProcessSignaller, SoundPlayer } from "./effects.js";
+import { soundNameForEvent } from "./effects.js";
+
+/** An opaque cancellable timer handle from a {@link Scheduler}. */
+export interface TimerHandle {
+  readonly token: unknown;
+}
+
+/** Timer seam: a repeating tick and a one-shot delay, injectable for tests. */
+export interface Scheduler {
+  interval(callback: () => void, ms: number): TimerHandle;
+  timeout(callback: () => void, ms: number): TimerHandle;
+  cancel(handle: TimerHandle): void;
+}
+
+/** The default {@link Scheduler}, backed by `node:timers` (unref'd). */
+export class SystemScheduler implements Scheduler {
+  interval(callback: () => void, ms: number): TimerHandle {
+    const token = setInterval(callback, ms);
+    token.unref?.();
+    return { token };
+  }
+  timeout(callback: () => void, ms: number): TimerHandle {
+    const token = setTimeout(callback, ms);
+    token.unref?.();
+    return { token };
+  }
+  cancel(handle: TimerHandle): void {
+    const token = handle.token;
+    // Both clearInterval and clearTimeout accept the same timer object.
+    clearInterval(token as ReturnType<typeof setInterval>);
+    clearTimeout(token as ReturnType<typeof setTimeout>);
+  }
+}
+
+/** The budget whose exhaustion triggers a force-close. */
+export interface ForceCloseTarget {
+  /** The `Activity.id` whose processes to close. */
+  activityId: number;
+  /** Human label for the countdown toast ("YouTube"). */
+  label: string;
+}
+
+/** Collaborators the {@link ForceCloseController} acts through. */
+export interface ForceCloseDeps {
+  notifier: Notifier;
+  signaller: ProcessSignaller;
+  scheduler: Scheduler;
+  /** Resolve the PIDs to close for an activity (degraded `[]` until #wired). */
+  resolvePids: (activityId: number) => Promise<number[]>;
+  /** Grace-period length in seconds (0 skips the countdown). */
+  graceSeconds: number;
+  /** Delay between `SIGTERM` and the `SIGKILL` escalation, in ms. */
+  sigkillEscalationMs: number;
+  /** Optional sound player; a `null` play (or omission) is silent. */
+  soundPlayer?: SoundPlayer;
+  logger?: Logger;
+}
+
+/** Per-activity countdown state. */
+interface Countdown {
+  target: ForceCloseTarget;
+  remaining: number;
+  handle: NotificationHandle;
+  timer: TimerHandle | null;
+}
+
+/**
+ * Drives the grace countdown and force-close for each per-app budget that
+ * exhausts. One countdown per `activityId` at a time; a repeat `begin` for an
+ * activity already counting down is ignored.
+ */
+export class ForceCloseController {
+  readonly #deps: ForceCloseDeps;
+  readonly #active = new Map<number, Countdown>();
+
+  constructor(deps: ForceCloseDeps) {
+    this.#deps = deps;
+  }
+
+  /** Whether a countdown is currently running for an activity (for tests). */
+  isCountingDown(activityId: number): boolean {
+    return this.#active.has(activityId);
+  }
+
+  /**
+   * Begin the grace countdown for `target`. Shows the "time's up" toast with
+   * the grace countdown, plays the times-up sound, and — after the grace period
+   * (immediately if `graceSeconds` is 0) — force-closes the activity.
+   */
+  async begin(target: ForceCloseTarget): Promise<void> {
+    if (this.#active.has(target.activityId)) return;
+
+    const grace = Math.max(0, Math.floor(this.#deps.graceSeconds));
+    const handle = await this.#deps.notifier.notify({
+      title: "Time's up",
+      body: this.#countdownBody(target.label, grace),
+      urgency: "critical",
+    });
+    await this.#deps.soundPlayer?.play(soundNameForEvent("timesUp"));
+
+    const countdown: Countdown = { target, remaining: grace, handle, timer: null };
+    this.#active.set(target.activityId, countdown);
+
+    if (grace <= 0) {
+      await this.#forceClose(target.activityId);
+      return;
+    }
+    countdown.timer = this.#deps.scheduler.interval(() => this.#tick(target.activityId), 1_000);
+  }
+
+  /**
+   * Cancel an in-flight countdown because time was restored (a grant top-up),
+   * dismissing the countdown with a "keep going" toast. No-op if the activity
+   * is not counting down.
+   */
+  async cancel(activityId: number, message: string): Promise<void> {
+    const countdown = this.#active.get(activityId);
+    if (countdown === undefined) return;
+    if (countdown.timer !== null) this.#deps.scheduler.cancel(countdown.timer);
+    this.#active.delete(activityId);
+    await this.#deps.notifier.update(countdown.handle, {
+      title: "More time!",
+      body: message,
+      urgency: "normal",
+    });
+  }
+
+  /** Stop all countdowns and their timers (shutdown). */
+  stop(): void {
+    for (const countdown of this.#active.values()) {
+      if (countdown.timer !== null) this.#deps.scheduler.cancel(countdown.timer);
+    }
+    this.#active.clear();
+  }
+
+  #tick(activityId: number): void {
+    const countdown = this.#active.get(activityId);
+    if (countdown === undefined) return;
+    countdown.remaining -= 1;
+    if (countdown.remaining > 0) {
+      void this.#deps.notifier
+        .update(countdown.handle, {
+          title: "Time's up",
+          body: this.#countdownBody(countdown.target.label, countdown.remaining),
+          urgency: "critical",
+        })
+        .then((h) => {
+          countdown.handle = h;
+        });
+      return;
+    }
+    if (countdown.timer !== null) this.#deps.scheduler.cancel(countdown.timer);
+    countdown.timer = null;
+    void this.#forceClose(activityId);
+  }
+
+  async #forceClose(activityId: number): Promise<void> {
+    const countdown = this.#active.get(activityId);
+    if (countdown === undefined) return;
+
+    const pids = await this.#deps.resolvePids(activityId);
+    if (pids.length === 0) {
+      this.#deps.logger?.warn(
+        { activityId },
+        "force-close: no processes resolved for activity (degraded until client-side matchers land)",
+      );
+      this.#active.delete(activityId);
+      return;
+    }
+
+    for (const pid of pids) this.#deps.signaller.signal(pid, "SIGTERM");
+    this.#deps.logger?.info({ activityId, pids, signal: "SIGTERM" }, "force-close: SIGTERM sent");
+
+    this.#deps.scheduler.timeout(() => {
+      for (const pid of pids) this.#deps.signaller.signal(pid, "SIGKILL");
+      this.#deps.logger?.info({ activityId, pids, signal: "SIGKILL" }, "force-close: SIGKILL sent");
+      this.#active.delete(activityId);
+    }, this.#deps.sigkillEscalationMs);
+  }
+
+  #countdownBody(label: string, secondsLeft: number): string {
+    if (secondsLeft <= 0) return `${label} is out of time — closing now.`;
+    const unit = secondsLeft === 1 ? "second" : "seconds";
+    return `${label} is out of time. Save now — closing in ${secondsLeft} ${unit}.`;
+  }
+}

--- a/client/agent/src/agent/main.ts
+++ b/client/agent/src/agent/main.ts
@@ -31,7 +31,8 @@ import {
   OsProcessSignaller,
   SpawnCommandRunner,
 } from "./effects.js";
-import { ForceCloseController, SystemScheduler } from "./force-close.js";
+import { ForceCloseController } from "./force-close.js";
+import { SystemScheduler } from "./scheduler.js";
 import { AwUsageSource } from "./usage.js";
 
 function main(): void {
@@ -44,15 +45,19 @@ function main(): void {
     const runner = new SpawnCommandRunner();
     const notifier = new DesktopNotifier({ runner, logger });
     const soundPlayer = new CanberraSoundPlayer({ runner, logger });
+    // The sound player is omitted entirely when the profile is `off`, so the
+    // force-close path can't play a bell against an opted-out policy.
+    const soundEnabled = config.notifications.soundProfile !== "off";
     const forceClose = new ForceCloseController({
       notifier,
       signaller: new OsProcessSignaller(),
       scheduler,
-      // Degraded until client-side activity matchers land (tracked follow-up).
+      // Degraded until client-side activity matchers land (tracked follow-up, #381).
       resolvePids: () => Promise.resolve([]),
       graceSeconds: config.notifications.graceSeconds,
       sigkillEscalationMs: config.sigkillEscalationMs,
-      soundPlayer,
+      renderToasts: config.notifications.enabled,
+      ...(soundEnabled ? { soundPlayer } : {}),
       logger,
     });
     agent = new Agent({

--- a/client/agent/src/agent/main.ts
+++ b/client/agent/src/agent/main.ts
@@ -1,0 +1,96 @@
+/**
+ * `pct-client-agent` entry point (#103, Phase 8b).
+ *
+ * The thin per-user process bootstrap (`systemd --user`): read the
+ * configuration from the environment, build the logger + effect implementations
+ * + the {@link Agent}, start it, and wire a graceful shutdown on
+ * `SIGTERM`/`SIGINT`. An {@link AgentConfigError} on a misconfigured unit exits
+ * non-zero with a readable message.
+ *
+ * Untested by design (excluded from the coverage gate, like the bridge's
+ * `src/main.ts`): its only logic is process-lifecycle wiring. Everything it
+ * composes — config, cadence, budgets, effects, force-close, socket intake — is
+ * covered through {@link Agent} and the module tests.
+ *
+ * The budget cache seeds empty and force-close PID resolution is degraded
+ * (`[]`) here: both are fed by the server's client-side policy push, which is a
+ * tracked follow-up. The agent still renders every server event and runs the
+ * local cadence/force-close machinery against whatever budgets it is given.
+ *
+ * License boundary: none touched — composes the agent modules + `node:process`.
+ */
+import process from "node:process";
+
+import { StreamLogger } from "../bridge/logger.js";
+import { Agent } from "./agent.js";
+import { BudgetCache } from "./budget.js";
+import { AgentConfigError, loadConfigFromEnv } from "./config.js";
+import {
+  CanberraSoundPlayer,
+  DesktopNotifier,
+  OsProcessSignaller,
+  SpawnCommandRunner,
+} from "./effects.js";
+import { ForceCloseController, SystemScheduler } from "./force-close.js";
+import { AwUsageSource } from "./usage.js";
+
+function main(): void {
+  const logger = new StreamLogger({ component: "pct-client-agent" });
+
+  let agent: Agent;
+  try {
+    const config = loadConfigFromEnv();
+    const scheduler = new SystemScheduler();
+    const runner = new SpawnCommandRunner();
+    const notifier = new DesktopNotifier({ runner, logger });
+    const soundPlayer = new CanberraSoundPlayer({ runner, logger });
+    const forceClose = new ForceCloseController({
+      notifier,
+      signaller: new OsProcessSignaller(),
+      scheduler,
+      // Degraded until client-side activity matchers land (tracked follow-up).
+      resolvePids: () => Promise.resolve([]),
+      graceSeconds: config.notifications.graceSeconds,
+      sigkillEscalationMs: config.sigkillEscalationMs,
+      soundPlayer,
+      logger,
+    });
+    agent = new Agent({
+      config,
+      budgets: new BudgetCache(),
+      usage: new AwUsageSource({ baseUrl: config.awBaseUrl, logger }),
+      notifier,
+      soundPlayer,
+      forceClose,
+      scheduler,
+      logger,
+    });
+  } catch (err) {
+    if (err instanceof AgentConfigError) {
+      logger.error({ err }, "invalid configuration; refusing to start");
+      process.exitCode = 78; // EX_CONFIG
+      return;
+    }
+    throw err;
+  }
+
+  let stopping = false;
+  const shutdown = (signal: string): void => {
+    if (stopping) return;
+    stopping = true;
+    logger.info({ signal }, "shutting down");
+    agent.stop();
+    process.exit(0);
+  };
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+
+  agent.start();
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`pct-client-agent: fatal: ${String(err)}\n`);
+  process.exit(1);
+}

--- a/client/agent/src/agent/scheduler.ts
+++ b/client/agent/src/agent/scheduler.ts
@@ -1,0 +1,45 @@
+/**
+ * The agent's timer seam (#103, Phase 8b).
+ *
+ * A minimal repeating-tick / one-shot-delay abstraction the agent's modules
+ * (`force-close.ts`, `socket-client.ts`, `agent.ts`) drive their timers
+ * through, so the countdown, the reconnect backoff, and the cadence tick loop
+ * all unit-test deterministically with an injected fake — the same
+ * inject-the-clock discipline the bridge uses in `ws-client.ts`. The concrete
+ * {@link SystemScheduler} is the only place `node:timers` is touched.
+ *
+ * License boundary: none touched — `node:timers` globals only.
+ */
+
+/** An opaque cancellable timer handle from a {@link Scheduler}. */
+export interface TimerHandle {
+  readonly token: unknown;
+}
+
+/** Timer seam: a repeating tick and a one-shot delay, injectable for tests. */
+export interface Scheduler {
+  interval(callback: () => void, ms: number): TimerHandle;
+  timeout(callback: () => void, ms: number): TimerHandle;
+  cancel(handle: TimerHandle): void;
+}
+
+/** The default {@link Scheduler}, backed by `node:timers` (unref'd). */
+export class SystemScheduler implements Scheduler {
+  interval(callback: () => void, ms: number): TimerHandle {
+    const token = setInterval(callback, ms);
+    token.unref?.();
+    return { token };
+  }
+  timeout(callback: () => void, ms: number): TimerHandle {
+    const token = setTimeout(callback, ms);
+    token.unref?.();
+    return { token };
+  }
+  cancel(handle: TimerHandle): void {
+    // `token` is opaque (a `NodeJS.Timeout`); both clears accept the same
+    // object, so route it through both rather than tracking which kind it is.
+    const token = handle.token as ReturnType<typeof setInterval>;
+    clearInterval(token);
+    clearTimeout(token);
+  }
+}

--- a/client/agent/src/agent/socket-client.ts
+++ b/client/agent/src/agent/socket-client.ts
@@ -23,7 +23,7 @@ import net from "node:net";
 import { computeBackoffDelayMs, type BackoffOptions } from "../bridge/backoff.js";
 import type { Logger } from "../bridge/logger.js";
 import { decodeFrame, FrameDecodeError, type ServerEvent } from "../bridge/protocol.js";
-import type { Scheduler, TimerHandle } from "./force-close.js";
+import type { Scheduler, TimerHandle } from "./scheduler.js";
 
 /** The minimal slice of a connected socket {@link AgentSocketClient} drives. */
 export interface SocketLike {

--- a/client/agent/src/agent/socket-client.ts
+++ b/client/agent/src/agent/socket-client.ts
@@ -1,0 +1,155 @@
+/**
+ * The agent's inbound AF_UNIX reader (#103, Phase 8b).
+ *
+ * `docs/client-notifications.md`: the per-user agent "Subscribes to its own
+ * socket from the bridge (`/run/pct/<uid>.sock`) for server-pushed events." The
+ * bridge is the socket **owner/listener** (`bridge/dispatch.ts`) and writes
+ * **newline-delimited JSON `EventFrame`s**; this client connects in, splits the
+ * stream on newlines, validates each frame with the shared `decodeFrame`, and
+ * hands the decoded {@link ServerEvent} to a callback. It reconnects with the
+ * package's full-jitter backoff whenever the bridge restarts or the socket
+ * drops — the mirror of the bridge's own outbound `ws-client.ts`.
+ *
+ * The socket is created through an injected {@link SocketFactory} and timers
+ * through the injected {@link Scheduler}, so the connect → frames → close →
+ * reconnect lifecycle unit-tests with a fake socket and, end-to-end, against a
+ * real in-process bridge `Dispatcher`. A malformed frame is logged and dropped
+ * so one poison line never tears down the connection.
+ *
+ * License boundary: none touched — `node:net` + the shared zod frame decoder.
+ */
+import net from "node:net";
+
+import { computeBackoffDelayMs, type BackoffOptions } from "../bridge/backoff.js";
+import type { Logger } from "../bridge/logger.js";
+import { decodeFrame, FrameDecodeError, type ServerEvent } from "../bridge/protocol.js";
+import type { Scheduler, TimerHandle } from "./force-close.js";
+
+/** The minimal slice of a connected socket {@link AgentSocketClient} drives. */
+export interface SocketLike {
+  on(event: "connect" | "close", listener: () => void): unknown;
+  on(event: "data", listener: (chunk: Buffer) => void): unknown;
+  on(event: "error", listener: (err: Error) => void): unknown;
+  /** Drop the socket (used on stop and before a reconnect). */
+  destroy(): void;
+}
+
+/** Opens a connection to the given AF_UNIX path. */
+export type SocketFactory = (path: string) => SocketLike;
+
+const defaultFactory: SocketFactory = (path) => net.connect(path);
+
+/** Options for {@link AgentSocketClient}. */
+export interface AgentSocketClientOptions {
+  /** AF_UNIX path the bridge listens on for this user. */
+  socketPath: string;
+  /** Called with each decoded, validated server event. */
+  onEvent: (event: ServerEvent) => void;
+  backoff: BackoffOptions;
+  scheduler: Scheduler;
+  logger: Logger;
+  /** Override the socket constructor (tests inject a fake). */
+  factory?: SocketFactory;
+  /** Override the jitter RNG (tests inject a deterministic one). */
+  rng?: () => number;
+}
+
+/** Newline that delimits frames on the bridge socket (see `bridge/dispatch.ts`). */
+const FRAME_DELIMITER = "\n";
+
+/**
+ * Connects to the bridge's per-user socket, decodes newline-delimited frames,
+ * and reconnects with backoff on every drop until {@link stop} is called.
+ */
+export class AgentSocketClient {
+  readonly #options: AgentSocketClientOptions;
+  readonly #factory: SocketFactory;
+  readonly #rng: () => number;
+
+  #socket: SocketLike | null = null;
+  #reconnectTimer: TimerHandle | null = null;
+  #buffer = "";
+  #attempt = 0;
+  #stopped = false;
+
+  constructor(options: AgentSocketClientOptions) {
+    this.#options = options;
+    this.#factory = options.factory ?? defaultFactory;
+    this.#rng = options.rng ?? Math.random;
+  }
+
+  /** Open the connection. Subsequent drops reconnect automatically. */
+  start(): void {
+    this.#stopped = false;
+    this.#connect();
+  }
+
+  /** Stop reconnecting and drop the current socket. Idempotent. */
+  stop(): void {
+    this.#stopped = true;
+    if (this.#reconnectTimer !== null) {
+      this.#options.scheduler.cancel(this.#reconnectTimer);
+      this.#reconnectTimer = null;
+    }
+    this.#socket?.destroy();
+    this.#socket = null;
+    this.#buffer = "";
+  }
+
+  #connect(): void {
+    this.#reconnectTimer = null;
+    this.#buffer = "";
+    const socket = this.#factory(this.#options.socketPath);
+    this.#socket = socket;
+
+    socket.on("connect", () => {
+      this.#attempt = 0;
+      this.#options.logger.info({ path: this.#options.socketPath }, "bridge socket connected");
+    });
+    socket.on("data", (chunk) => this.#onData(chunk));
+    socket.on("error", (err) => {
+      this.#options.logger.warn({ err }, "bridge socket error");
+    });
+    socket.on("close", () => {
+      this.#socket = null;
+      if (this.#stopped) return;
+      this.#scheduleReconnect();
+    });
+  }
+
+  #onData(chunk: Buffer): void {
+    this.#buffer += chunk.toString("utf8");
+    let index = this.#buffer.indexOf(FRAME_DELIMITER);
+    while (index !== -1) {
+      const line = this.#buffer.slice(0, index);
+      this.#buffer = this.#buffer.slice(index + 1);
+      if (line.trim() !== "") this.#handleLine(line);
+      index = this.#buffer.indexOf(FRAME_DELIMITER);
+    }
+  }
+
+  #handleLine(line: string): void {
+    try {
+      const frame = decodeFrame(line);
+      this.#options.onEvent(frame.event);
+    } catch (err) {
+      if (err instanceof FrameDecodeError) {
+        this.#options.logger.warn({ err }, "dropping undecodable frame");
+        return;
+      }
+      throw err;
+    }
+  }
+
+  #scheduleReconnect(): void {
+    const delay = computeBackoffDelayMs(this.#attempt, this.#options.backoff, this.#rng);
+    this.#attempt += 1;
+    this.#options.logger.info(
+      { attempt: this.#attempt, delayMs: delay },
+      "scheduling bridge socket reconnect",
+    );
+    this.#reconnectTimer = this.#options.scheduler.timeout(() => {
+      if (!this.#stopped) this.#connect();
+    }, delay);
+  }
+}

--- a/client/agent/src/agent/usage.ts
+++ b/client/agent/src/agent/usage.ts
@@ -1,0 +1,119 @@
+/**
+ * Local usage source for the per-user agent (#103, Phase 8b).
+ *
+ * `docs/client-notifications.md` → Components/2: the agent "Polls `aw-server` on
+ * `localhost:5600` for current usage so it can render warnings locally without
+ * round-tripping the server", combining that with the server-pushed budget
+ * totals to compute time remaining even while briefly offline. This module is
+ * the poll side: a {@link UsageSource} the tick loop reads used-seconds from.
+ *
+ * ActivityWatch is reached **over its REST API only** (`CLAUDE.md` → rule 4) —
+ * here the query2 endpoint (`POST /api/0/query/`) summing the not-afk durations
+ * of the local afk watcher for the current day. The response is zod-validated
+ * before it crosses into typed code. An unreachable/erroring `aw-server` yields
+ * an empty map (a documented degraded mode: the agent keeps warning on the last
+ * cached figures), never a throw.
+ *
+ * **Overall only, for now.** This returns used-seconds for the `overall`
+ * screen-time budget (whole-session active time). Per-activity usage needs the
+ * activity matchers the server pushes to the client, which is not yet built —
+ * so per-activity budgets have no local usage here and read as full until that
+ * lands (the same follow-up that wires force-close PID resolution).
+ *
+ * License boundary: none touched — `aw-server` REST via an injected `fetch`.
+ */
+import { z } from "zod";
+
+import type { Logger } from "../bridge/logger.js";
+import { OVERALL_BUDGET_KEY } from "./budget.js";
+
+/** Used-seconds per {@link ../agent/budget.js budgetKey}, read each tick. */
+export interface UsageSource {
+  usedSeconds(): Promise<Map<string, number>>;
+}
+
+/** The minimal slice of `fetch` this module uses (injectable in tests). */
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
+
+/** The query2 response: one summed-duration number per requested timeperiod. */
+const queryResponseSchema = z.array(z.number());
+
+/** Options for an {@link AwUsageSource}. */
+export interface AwUsageSourceOptions {
+  /** `aw-server` REST base, e.g. `http://127.0.0.1:5600`. */
+  baseUrl: string;
+  /** Injectable `fetch` (defaults to the global). */
+  fetchFn?: FetchLike;
+  /** Injectable clock for the day window (defaults to `() => new Date()`). */
+  now?: () => Date;
+  logger?: Logger;
+}
+
+/**
+ * A {@link UsageSource} backed by `aw-server`'s query2 API: it sums the local
+ * afk watcher's `not-afk` durations for the current local day into the
+ * `overall` budget's used-seconds.
+ */
+export class AwUsageSource implements UsageSource {
+  readonly #baseUrl: string;
+  readonly #fetch: FetchLike;
+  readonly #now: () => Date;
+  readonly #logger: Logger | undefined;
+
+  constructor(options: AwUsageSourceOptions) {
+    this.#baseUrl = options.baseUrl.endsWith("/") ? options.baseUrl.slice(0, -1) : options.baseUrl;
+    this.#fetch = options.fetchFn ?? ((url, init) => fetch(url, init));
+    this.#now = options.now ?? (() => new Date());
+    this.#logger = options.logger;
+  }
+
+  async usedSeconds(): Promise<Map<string, number>> {
+    const result = new Map<string, number>();
+    try {
+      const response = await this.#fetch(`${this.#baseUrl}/api/0/query/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          timeperiods: [dayTimeperiod(this.#now())],
+          query: [OVERALL_ACTIVE_QUERY],
+        }),
+      });
+      if (!response.ok) {
+        this.#logger?.warn({ status: response.status }, "aw-server query returned non-2xx");
+        return result;
+      }
+      const parsed = queryResponseSchema.safeParse(await response.json());
+      if (!parsed.success) {
+        this.#logger?.warn({ err: parsed.error }, "aw-server query response failed validation");
+        return result;
+      }
+      const seconds = parsed.data[0];
+      if (seconds !== undefined) result.set(OVERALL_BUDGET_KEY, Math.max(0, Math.floor(seconds)));
+    } catch (err) {
+      // Unreachable aw-server is a normal transient (boot ordering, restart):
+      // keep the agent on its last cached figures rather than throwing.
+      this.#logger?.warn({ err }, "aw-server unreachable; using cached usage");
+    }
+    return result;
+  }
+}
+
+/**
+ * The query2 program summing today's not-afk durations. `find_bucket` matches
+ * the local afk watcher by prefix so no hostname discovery is needed.
+ */
+const OVERALL_ACTIVE_QUERY = [
+  "afk = query_bucket(find_bucket('aw-watcher-afk_'));",
+  "not_afk = filter_keyvals(afk, 'status', ['not-afk']);",
+  "RETURN = sum_durations(not_afk);",
+].join(" ");
+
+/** The `start/end` ISO timeperiod for the local calendar day containing `at`. */
+export function dayTimeperiod(at: Date): string {
+  const start = new Date(at.getFullYear(), at.getMonth(), at.getDate(), 0, 0, 0, 0);
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  return `${start.toISOString()}/${end.toISOString()}`;
+}

--- a/client/agent/tests/agent/agent.test.ts
+++ b/client/agent/tests/agent/agent.test.ts
@@ -11,12 +11,8 @@ import type {
   NotificationHandle,
   SoundPlayer,
 } from "../../src/agent/effects.js";
-import type {
-  ForceClose,
-  ForceCloseTarget,
-  Scheduler,
-  TimerHandle,
-} from "../../src/agent/force-close.js";
+import type { ForceClose, ForceCloseTarget } from "../../src/agent/force-close.js";
+import type { Scheduler, TimerHandle } from "../../src/agent/scheduler.js";
 import type { SocketFactory, SocketLike } from "../../src/agent/socket-client.js";
 import type { UsageSource } from "../../src/agent/usage.js";
 
@@ -47,10 +43,15 @@ class FakeSound implements SoundPlayer {
 
 class FakeForceClose implements ForceClose {
   begun: ForceCloseTarget[] = [];
+  forcedNow: ForceCloseTarget[] = [];
   cancelled: { activityId: number; message: string }[] = [];
   stopped = 0;
   begin(target: ForceCloseTarget): Promise<void> {
     this.begun.push(target);
+    return Promise.resolve();
+  }
+  forceCloseNow(target: ForceCloseTarget): Promise<void> {
+    this.forcedNow.push(target);
     return Promise.resolve();
   }
   cancel(activityId: number, message: string): Promise<void> {
@@ -258,11 +259,13 @@ describe("Agent event handling", () => {
     expect(h.sound.played.at(-1)).toBe("complete");
   });
 
-  it("a per-app grant cancels that activity's in-flight countdown", async () => {
+  it("a server force_close kills immediately, and a later per-app grant cancels it", async () => {
     const h = build([activity(7, 5 * MIN)]);
     h.agent.start();
     await emit(h, { type: "enforce.force_close", userId: 42, activityId: 7 });
-    expect(h.forceClose.begun).toEqual([{ activityId: 7, label: "YouTube" }]);
+    // The server already waited out the grace period → immediate, not a countdown.
+    expect(h.forceClose.forcedNow).toEqual([{ activityId: 7, label: "YouTube" }]);
+    expect(h.forceClose.begun).toHaveLength(0);
     await emit(h, {
       type: "grant.applied",
       userId: 42,
@@ -273,11 +276,11 @@ describe("Agent event handling", () => {
     expect(h.forceClose.cancelled[0]?.activityId).toBe(7);
   });
 
-  it("force_close for an uncached activity still begins with a fallback label", async () => {
+  it("force_close for an uncached activity uses a fallback label", async () => {
     const h = build([]);
     h.agent.start();
     await emit(h, { type: "enforce.force_close", userId: 42, activityId: 9 });
-    expect(h.forceClose.begun).toEqual([{ activityId: 9, label: "This app" }]);
+    expect(h.forceClose.forcedNow).toEqual([{ activityId: 9, label: "This app" }]);
   });
 
   it("toasts a policy summary, a session lock, and a cleared lockout", async () => {

--- a/client/agent/tests/agent/agent.test.ts
+++ b/client/agent/tests/agent/agent.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+
+import type { Logger } from "../../src/bridge/logger.js";
+import type { EventFrame, ServerEvent } from "../../src/bridge/protocol.js";
+import { Agent, type AgentOptions } from "../../src/agent/agent.js";
+import { BudgetCache, type CachedBudget } from "../../src/agent/budget.js";
+import { agentConfigSchema } from "../../src/agent/config.js";
+import type {
+  NotifyOptions,
+  Notifier,
+  NotificationHandle,
+  SoundPlayer,
+} from "../../src/agent/effects.js";
+import type {
+  ForceClose,
+  ForceCloseTarget,
+  Scheduler,
+  TimerHandle,
+} from "../../src/agent/force-close.js";
+import type { SocketFactory, SocketLike } from "../../src/agent/socket-client.js";
+import type { UsageSource } from "../../src/agent/usage.js";
+
+const MIN = 60;
+const noop = (): void => undefined;
+const silentLogger: Logger = { debug: noop, info: noop, warn: noop, error: noop };
+const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+class FakeNotifier implements Notifier {
+  calls: NotifyOptions[] = [];
+  notify(o: NotifyOptions): Promise<NotificationHandle> {
+    this.calls.push(o);
+    return Promise.resolve({ id: 1 });
+  }
+  update(_h: NotificationHandle, o: NotifyOptions): Promise<NotificationHandle> {
+    this.calls.push(o);
+    return Promise.resolve({ id: 1 });
+  }
+}
+
+class FakeSound implements SoundPlayer {
+  played: (string | null)[] = [];
+  play(soundName: string | null): Promise<void> {
+    this.played.push(soundName);
+    return Promise.resolve();
+  }
+}
+
+class FakeForceClose implements ForceClose {
+  begun: ForceCloseTarget[] = [];
+  cancelled: { activityId: number; message: string }[] = [];
+  stopped = 0;
+  begin(target: ForceCloseTarget): Promise<void> {
+    this.begun.push(target);
+    return Promise.resolve();
+  }
+  cancel(activityId: number, message: string): Promise<void> {
+    this.cancelled.push({ activityId, message });
+    return Promise.resolve();
+  }
+  stop(): void {
+    this.stopped += 1;
+  }
+}
+
+class FakeUsage implements UsageSource {
+  map = new Map<string, number>();
+  usedSeconds(): Promise<Map<string, number>> {
+    return Promise.resolve(new Map(this.map));
+  }
+}
+
+class FakeScheduler implements Scheduler {
+  intervals: (() => void)[] = [];
+  cancelled = 0;
+  interval(callback: () => void): TimerHandle {
+    this.intervals.push(callback);
+    return { token: Symbol() };
+  }
+  timeout(): TimerHandle {
+    return { token: Symbol() };
+  }
+  cancel(): void {
+    this.cancelled += 1;
+  }
+}
+
+class FakeSocket implements SocketLike {
+  #connect?: () => void;
+  #data?: (chunk: Buffer) => void;
+  destroyed = false;
+
+  on(event: "connect" | "close", listener: () => void): this;
+  on(event: "data", listener: (chunk: Buffer) => void): this;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(
+    event: "connect" | "close" | "data" | "error",
+    listener: (() => void) | ((chunk: Buffer) => void) | ((err: Error) => void),
+  ): this {
+    if (event === "connect") this.#connect = listener as () => void;
+    else if (event === "data") this.#data = listener as (chunk: Buffer) => void;
+    // close/error are unused in these orchestrator tests.
+    return this;
+  }
+  destroy(): void {
+    this.destroyed = true;
+  }
+  emitConnect(): void {
+    this.#connect?.();
+  }
+  emitData(chunk: Buffer): void {
+    this.#data?.(chunk);
+  }
+}
+
+interface Harness {
+  agent: Agent;
+  notifier: FakeNotifier;
+  sound: FakeSound;
+  forceClose: FakeForceClose;
+  usage: FakeUsage;
+  budgets: BudgetCache;
+  scheduler: FakeScheduler;
+  socketRef: { socket?: FakeSocket };
+}
+
+function build(
+  budgets: CachedBudget[],
+  prefs: { enabled?: boolean; soundProfile?: "off" | "subtle" | "prominent" } = {},
+): Harness {
+  const notifier = new FakeNotifier();
+  const sound = new FakeSound();
+  const forceClose = new FakeForceClose();
+  const usage = new FakeUsage();
+  const scheduler = new FakeScheduler();
+  const cache = new BudgetCache(budgets);
+  const socketRef: { socket?: FakeSocket } = {};
+  const factory: SocketFactory = () => (socketRef.socket = new FakeSocket());
+  const config = agentConfigSchema.parse({
+    userId: 42,
+    socketPath: "/run/pct/1001.sock",
+    notifications: {
+      enabled: prefs.enabled ?? true,
+      soundProfile: prefs.soundProfile ?? "subtle",
+      graceSeconds: 15,
+      cadenceOverrides: null,
+    },
+  });
+  const opts: AgentOptions = {
+    config,
+    budgets: cache,
+    usage,
+    notifier,
+    soundPlayer: sound,
+    forceClose,
+    scheduler,
+    logger: silentLogger,
+    socketFactory: factory,
+  };
+  return {
+    agent: new Agent(opts),
+    notifier,
+    sound,
+    forceClose,
+    usage,
+    budgets: cache,
+    scheduler,
+    socketRef,
+  };
+}
+
+const overall = (totalSeconds: number): CachedBudget => ({
+  key: "overall",
+  label: "overall screen time",
+  activityId: null,
+  totalSeconds,
+});
+const activity = (id: number, totalSeconds: number): CachedBudget => ({
+  key: `activity:${id}`,
+  label: "YouTube",
+  activityId: id,
+  totalSeconds,
+});
+
+const emit = async (h: Harness, event: ServerEvent): Promise<void> => {
+  h.socketRef.socket?.emitConnect();
+  const frame: EventFrame = { seq: 1, at: "2026-07-03T12:00:00.000Z", event };
+  h.socketRef.socket?.emitData(Buffer.from(JSON.stringify(frame) + "\n"));
+  await flush();
+};
+
+describe("Agent cadence tick loop", () => {
+  it("renders coalesced warnings with the right urgency and sound", async () => {
+    const h = build([overall(20 * MIN)]);
+    h.usage.map.set("overall", 5 * MIN); // remaining 15 min
+    await h.agent.tick();
+    expect(h.notifier.calls[0]).toMatchObject({ title: "Time remaining", urgency: "normal" });
+    expect(h.notifier.calls[0]?.body).toContain("15 minutes left");
+    expect(h.sound.played).toEqual(["message-new-instant"]);
+
+    h.usage.map.set("overall", 19 * MIN); // remaining 1 min → critical + final-warning sound
+    await h.agent.tick();
+    expect(h.notifier.calls.at(-1)).toMatchObject({ urgency: "critical" });
+    expect(h.sound.played.at(-1)).toBe("dialog-warning");
+  });
+
+  it("times up the overall budget without a force-close", async () => {
+    const h = build([overall(5 * MIN)]);
+    h.usage.map.set("overall", 5 * MIN);
+    await h.agent.tick();
+    expect(h.notifier.calls.at(-1)).toMatchObject({ title: "Time's up" });
+    expect(h.forceClose.begun).toHaveLength(0);
+  });
+
+  it("starts a local force-close when a per-app budget hits zero", async () => {
+    const h = build([activity(7, 5 * MIN)]);
+    h.usage.map.set("activity:7", 5 * MIN);
+    await h.agent.tick();
+    expect(h.forceClose.begun).toEqual([{ activityId: 7, label: "YouTube" }]);
+  });
+
+  it("still force-closes with notifications disabled, but shows no toast", async () => {
+    const h = build([activity(7, 5 * MIN)], { enabled: false });
+    h.usage.map.set("activity:7", 5 * MIN);
+    await h.agent.tick();
+    expect(h.notifier.calls).toHaveLength(0);
+    expect(h.forceClose.begun).toHaveLength(1);
+  });
+
+  it("shows a toast but plays no sound when the profile is off", async () => {
+    const h = build([overall(20 * MIN)], { soundProfile: "off" });
+    h.usage.map.set("overall", 5 * MIN);
+    await h.agent.tick();
+    expect(h.notifier.calls).toHaveLength(1);
+    expect(h.sound.played).toHaveLength(0);
+  });
+
+  it("treats a budget with no usage sample as full (silent)", async () => {
+    const h = build([activity(7, 5 * MIN)]);
+    await h.agent.tick(); // no usage entry → remaining full → no warning
+    expect(h.notifier.calls).toHaveLength(0);
+  });
+});
+
+describe("Agent event handling", () => {
+  it("applies a grant: tops up the budget, toasts, plays the grant sound", async () => {
+    const h = build([overall(20 * MIN)]);
+    h.agent.start();
+    await emit(h, {
+      type: "grant.applied",
+      userId: 42,
+      grantedSeconds: 600,
+      reason: "chores done",
+      activityId: null,
+    });
+    expect(h.budgets.get("overall")?.totalSeconds).toBe(20 * MIN + 600);
+    expect(h.notifier.calls.at(-1)).toMatchObject({ title: "More time!" });
+    expect(h.notifier.calls.at(-1)?.body).toBe("+10 min granted · chores done");
+    expect(h.sound.played.at(-1)).toBe("complete");
+  });
+
+  it("a per-app grant cancels that activity's in-flight countdown", async () => {
+    const h = build([activity(7, 5 * MIN)]);
+    h.agent.start();
+    await emit(h, { type: "enforce.force_close", userId: 42, activityId: 7 });
+    expect(h.forceClose.begun).toEqual([{ activityId: 7, label: "YouTube" }]);
+    await emit(h, {
+      type: "grant.applied",
+      userId: 42,
+      grantedSeconds: 300,
+      reason: "bonus",
+      activityId: 7,
+    });
+    expect(h.forceClose.cancelled[0]?.activityId).toBe(7);
+  });
+
+  it("force_close for an uncached activity still begins with a fallback label", async () => {
+    const h = build([]);
+    h.agent.start();
+    await emit(h, { type: "enforce.force_close", userId: 42, activityId: 9 });
+    expect(h.forceClose.begun).toEqual([{ activityId: 9, label: "This app" }]);
+  });
+
+  it("toasts a policy summary, a session lock, and a cleared lockout", async () => {
+    const h = build([]);
+    h.agent.start();
+    await emit(h, { type: "policy.changed", userId: 42, summary: "YouTube is now 1h" });
+    expect(h.notifier.calls.at(-1)).toMatchObject({
+      title: "Limit updated",
+      body: "YouTube is now 1h",
+    });
+    await emit(h, { type: "enforce.session_lock", userId: 42 });
+    expect(h.notifier.calls.at(-1)).toMatchObject({ title: "Time's up", urgency: "critical" });
+    await emit(h, { type: "lockout.cleared", userId: 42 });
+    expect(h.notifier.calls.at(-1)).toMatchObject({ title: "More time!" });
+  });
+
+  it("logs (no throw) a grant for an uncached budget", async () => {
+    const h = build([]);
+    h.agent.start();
+    await emit(h, {
+      type: "grant.applied",
+      userId: 42,
+      grantedSeconds: 120,
+      reason: "x",
+      activityId: null,
+    });
+    // Toast still fires; no budget to top up.
+    expect(h.notifier.calls.at(-1)?.title).toBe("More time!");
+  });
+});
+
+describe("Agent lifecycle", () => {
+  it("start wires the tick interval; stop cancels it and stops force-close", () => {
+    const h = build([]);
+    h.agent.start();
+    expect(h.scheduler.intervals).toHaveLength(1);
+    expect(h.socketRef.socket).toBeDefined();
+    h.agent.stop();
+    expect(h.scheduler.cancelled).toBeGreaterThanOrEqual(1);
+    expect(h.forceClose.stopped).toBe(1);
+    expect(h.socketRef.socket?.destroyed).toBe(true);
+  });
+
+  it("the interval callback runs a tick", async () => {
+    const h = build([overall(20 * MIN)]);
+    h.usage.map.set("overall", 5 * MIN);
+    h.agent.start();
+    h.scheduler.intervals[0]?.(); // fire the tick loop once
+    await flush();
+    expect(h.notifier.calls.at(-1)?.body).toContain("15 minutes left");
+  });
+});

--- a/client/agent/tests/agent/budget.test.ts
+++ b/client/agent/tests/agent/budget.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BudgetCache,
+  budgetKey,
+  OVERALL_BUDGET_KEY,
+  remainingSeconds,
+  type CachedBudget,
+} from "../../src/agent/budget.js";
+
+const overall: CachedBudget = {
+  key: OVERALL_BUDGET_KEY,
+  label: "overall screen time",
+  activityId: null,
+  totalSeconds: 3600,
+};
+const youtube: CachedBudget = {
+  key: "activity:7",
+  label: "YouTube",
+  activityId: 7,
+  totalSeconds: 1800,
+};
+
+describe("budgetKey", () => {
+  it("maps null to the overall key and an id to activity:<id>", () => {
+    expect(budgetKey(null)).toBe(OVERALL_BUDGET_KEY);
+    expect(budgetKey(7)).toBe("activity:7");
+  });
+});
+
+describe("remainingSeconds", () => {
+  it("subtracts usage and clamps at zero", () => {
+    expect(remainingSeconds(3600, 1200)).toBe(2400);
+    expect(remainingSeconds(3600, 3600)).toBe(0);
+    expect(remainingSeconds(3600, 5000)).toBe(0);
+  });
+
+  it("floors fractional inputs", () => {
+    expect(remainingSeconds(100.9, 40.9)).toBe(60);
+  });
+});
+
+describe("BudgetCache", () => {
+  it("lists a copy of the seeded budgets in order", () => {
+    const cache = new BudgetCache([overall, youtube]);
+    expect(cache.list()).toEqual([overall, youtube]);
+    // Mutating the returned copy must not affect the cache.
+    const first = cache.list()[0];
+    if (!first) throw new Error("expected a seeded budget");
+    first.totalSeconds = 0;
+    expect(cache.get(OVERALL_BUDGET_KEY)?.totalSeconds).toBe(3600);
+  });
+
+  it("replace swaps the whole set", () => {
+    const cache = new BudgetCache([overall]);
+    cache.replace([youtube]);
+    expect(cache.list()).toEqual([youtube]);
+    expect(cache.get(OVERALL_BUDGET_KEY)).toBeUndefined();
+  });
+
+  it("applyGrant adds seconds to the overall budget", () => {
+    const cache = new BudgetCache([overall]);
+    const updated = cache.applyGrant(null, 900);
+    expect(updated?.totalSeconds).toBe(4500);
+    expect(cache.get(OVERALL_BUDGET_KEY)?.totalSeconds).toBe(4500);
+  });
+
+  it("applyGrant adds seconds to the targeted activity budget", () => {
+    const cache = new BudgetCache([overall, youtube]);
+    expect(cache.applyGrant(7, 300)?.totalSeconds).toBe(2100);
+    // The overall budget is untouched.
+    expect(cache.get(OVERALL_BUDGET_KEY)?.totalSeconds).toBe(3600);
+  });
+
+  it("applyGrant returns null for an unknown budget", () => {
+    const cache = new BudgetCache([overall]);
+    expect(cache.applyGrant(99, 300)).toBeNull();
+  });
+
+  it("ignores a negative grant delta", () => {
+    const cache = new BudgetCache([overall]);
+    expect(cache.applyGrant(null, -100)?.totalSeconds).toBe(3600);
+  });
+});

--- a/client/agent/tests/agent/cadence.test.ts
+++ b/client/agent/tests/agent/cadence.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CadenceTracker,
+  coalesceWarnings,
+  formatCadenceMessage,
+  warningThresholdsSeconds,
+  type CadenceWarning,
+} from "../../src/agent/cadence.js";
+
+const MIN = 60;
+
+describe("warningThresholdsSeconds", () => {
+  it("emits 15-minute multiples, 10, and 5..1 minutes, all below the total", () => {
+    // A 60-minute budget: 45/30/15 (multiples of 15, < 60), 10, 5/4/3/2/1.
+    expect(warningThresholdsSeconds(60 * MIN)).toEqual(
+      [45, 30, 15, 10, 5, 4, 3, 2, 1].map((m) => m * MIN),
+    );
+  });
+
+  it("drops boundaries at or above the total so a fresh budget is silent", () => {
+    // Exactly 15 minutes: 15 == total is excluded, so it starts warning at 10.
+    expect(warningThresholdsSeconds(15 * MIN)).toEqual([10, 5, 4, 3, 2, 1].map((m) => m * MIN));
+    // 20 minutes: only the 15-minute boundary from the coarse tier.
+    expect(warningThresholdsSeconds(20 * MIN)).toEqual([15, 10, 5, 4, 3, 2, 1].map((m) => m * MIN));
+  });
+
+  it("has no boundaries for a budget of a minute or less", () => {
+    expect(warningThresholdsSeconds(MIN)).toEqual([]);
+    expect(warningThresholdsSeconds(30)).toEqual([]);
+    expect(warningThresholdsSeconds(0)).toEqual([]);
+  });
+});
+
+describe("CadenceTracker", () => {
+  it("warns once per boundary as a 20-minute budget drains, then times up", () => {
+    const t = new CadenceTracker("overall", "overall screen time", 20 * MIN);
+    // Above the first boundary: silence.
+    expect(t.observe(20 * MIN)).toBeNull();
+    expect(t.observe(16 * MIN)).toBeNull();
+
+    const fired: number[] = [];
+    for (let s = 15 * MIN; s >= 0; s -= 30) {
+      const w = t.observe(s);
+      if (w) fired.push(w.thresholdSeconds);
+    }
+    // 15, 10, 5, 4, 3, 2, 1 minute boundaries, then the 0 "times up".
+    expect(fired).toEqual([15, 10, 5, 4, 3, 2, 1, 0].map((m) => (m === 0 ? 0 : m * MIN)));
+  });
+
+  it("does not re-announce a boundary already crossed", () => {
+    const t = new CadenceTracker("a", "A", 20 * MIN);
+    expect(t.observe(15 * MIN)?.thresholdSeconds).toBe(15 * MIN);
+    // Hovering just under 15 must not re-fire the 15-minute warning.
+    expect(t.observe(15 * MIN - 1)).toBeNull();
+    expect(t.observe(11 * MIN)).toBeNull();
+    // The 10-minute boundary is the next to fire.
+    expect(t.observe(10 * MIN)?.thresholdSeconds).toBe(10 * MIN);
+  });
+
+  it("announces the deepest boundary reached on a large jump", () => {
+    const t = new CadenceTracker("a", "A", 60 * MIN);
+    // First reading is already at 3m20s: announce the deepest reached (4 min),
+    // not the stale 15/10/5 boundaries above it.
+    const w = t.observe(200);
+    expect(w?.kind).toBe("warning");
+    expect(w?.thresholdSeconds).toBe(4 * MIN);
+    // Then it continues from there.
+    expect(t.observe(3 * MIN)?.thresholdSeconds).toBe(3 * MIN);
+  });
+
+  it("fires timesUp exactly once and clamps negative remaining to zero", () => {
+    const t = new CadenceTracker("a", "A", 5 * MIN);
+    const first = t.observe(0);
+    expect(first?.kind).toBe("timesUp");
+    expect(first?.remainingSeconds).toBe(0);
+    expect(t.observe(-10)).toBeNull();
+    expect(t.observe(0)).toBeNull();
+  });
+
+  it("only ever times up for a sub-minute budget (no boundaries)", () => {
+    const t = new CadenceTracker("a", "A", 40);
+    expect(t.observe(40)).toBeNull();
+    expect(t.observe(1)).toBeNull();
+    expect(t.observe(0)?.kind).toBe("timesUp");
+  });
+
+  it("carries the budget identity into the warning", () => {
+    const t = new CadenceTracker("activity:7", "YouTube", 6 * MIN);
+    const w = t.observe(5 * MIN);
+    expect(w).toMatchObject({ budgetKey: "activity:7", budgetLabel: "YouTube" });
+  });
+});
+
+describe("coalesceWarnings / formatCadenceMessage", () => {
+  const warn = (key: string, label: string, thresholdSeconds: number): CadenceWarning => ({
+    budgetKey: key,
+    budgetLabel: label,
+    kind: "warning",
+    remainingSeconds: thresholdSeconds,
+    thresholdSeconds,
+  });
+
+  it("groups budgets crossing the same boundary into one toast", () => {
+    const groups = coalesceWarnings([
+      warn("activity:7", "YouTube", 5 * MIN),
+      warn("activity:9", "Discord", 5 * MIN),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.budgets.map((b) => b.label)).toEqual(["YouTube", "Discord"]);
+    expect(groups[0]?.message).toBe("YouTube and Discord have 5 minutes left.");
+  });
+
+  it("keeps distinct boundaries and kinds separate", () => {
+    const groups = coalesceWarnings([
+      warn("a", "A", 5 * MIN),
+      warn("b", "B", 1 * MIN),
+      { ...warn("c", "C", 0), kind: "timesUp", thresholdSeconds: 0 },
+    ]);
+    expect(groups.map((g) => g.kind)).toEqual(["warning", "warning", "timesUp"]);
+  });
+
+  it("formats singular minute, plurals, and the times-up message", () => {
+    expect(
+      formatCadenceMessage({ kind: "warning", thresholdSeconds: MIN, budgets: [{ label: "A" }] }),
+    ).toBe("A has 1 minute left.");
+    expect(
+      formatCadenceMessage({
+        kind: "warning",
+        thresholdSeconds: 3 * MIN,
+        budgets: [{ label: "A" }, { label: "B" }, { label: "C" }],
+      }),
+    ).toBe("A, B and C have 3 minutes left.");
+    expect(
+      formatCadenceMessage({ kind: "timesUp", thresholdSeconds: 0, budgets: [{ label: "A" }] }),
+    ).toBe("Time's up — save and quit! A is out of time.");
+    expect(
+      formatCadenceMessage({
+        kind: "timesUp",
+        thresholdSeconds: 0,
+        budgets: [{ label: "A" }, { label: "B" }],
+      }),
+    ).toBe("Time's up — save and quit! A and B are out of time.");
+  });
+
+  it("returns no groups for an empty tick", () => {
+    expect(coalesceWarnings([])).toEqual([]);
+  });
+});

--- a/client/agent/tests/agent/config.test.ts
+++ b/client/agent/tests/agent/config.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  agentConfigSchema,
+  AgentConfigError,
+  DEFAULT_AW_BASE_URL,
+  DEFAULT_GRACE_SECONDS,
+  DEFAULT_SOUND_PROFILE,
+  defaultNotificationPrefs,
+  loadConfigFromEnv,
+} from "../../src/agent/config.js";
+
+describe("agentConfigSchema", () => {
+  it("applies defaults for the optional fields", () => {
+    const cfg = agentConfigSchema.parse({ userId: 7, socketPath: "/run/pct/1001.sock" });
+    expect(cfg.awBaseUrl).toBe(DEFAULT_AW_BASE_URL);
+    expect(cfg.backoff).toEqual({ baseMs: 1_000, maxMs: 60_000 });
+    expect(cfg.tickIntervalMs).toBe(1_000);
+    expect(cfg.notifications).toEqual({
+      enabled: true,
+      soundProfile: DEFAULT_SOUND_PROFILE,
+      graceSeconds: DEFAULT_GRACE_SECONDS,
+      cadenceOverrides: null,
+    });
+  });
+
+  it("requires a positive userId and a non-empty socketPath", () => {
+    expect(agentConfigSchema.safeParse({ userId: 0, socketPath: "/s" }).success).toBe(false);
+    expect(agentConfigSchema.safeParse({ userId: 7, socketPath: "" }).success).toBe(false);
+  });
+
+  it("rejects a backoff where maxMs < baseMs", () => {
+    const r = agentConfigSchema.safeParse({
+      userId: 7,
+      socketPath: "/s",
+      backoff: { baseMs: 5_000, maxMs: 1_000 },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("bounds graceSeconds to 0..60 and validates the sound profile", () => {
+    const base = { userId: 7, socketPath: "/s" };
+    expect(
+      agentConfigSchema.safeParse({ ...base, notifications: { graceSeconds: 61 } }).success,
+    ).toBe(false);
+    expect(
+      agentConfigSchema.safeParse({ ...base, notifications: { soundProfile: "loud" } }).success,
+    ).toBe(false);
+    expect(
+      agentConfigSchema.safeParse({ ...base, notifications: { soundProfile: "prominent" } })
+        .success,
+    ).toBe(true);
+  });
+});
+
+describe("defaultNotificationPrefs", () => {
+  it("returns the documented defaults", () => {
+    expect(defaultNotificationPrefs()).toEqual({
+      enabled: true,
+      soundProfile: "subtle",
+      graceSeconds: 15,
+      cadenceOverrides: null,
+    });
+  });
+});
+
+describe("loadConfigFromEnv", () => {
+  it("builds a config from the minimal required environment", () => {
+    const cfg = loadConfigFromEnv({
+      PCT_AGENT_USER_ID: "7",
+      PCT_AGENT_SOCKET: "/run/pct/1001.sock",
+    });
+    expect(cfg.userId).toBe(7);
+    expect(cfg.socketPath).toBe("/run/pct/1001.sock");
+    expect(cfg.awBaseUrl).toBe(DEFAULT_AW_BASE_URL);
+  });
+
+  it("reads optional overrides", () => {
+    const cfg = loadConfigFromEnv({
+      PCT_AGENT_USER_ID: "7",
+      PCT_AGENT_SOCKET: "/s",
+      PCT_AGENT_AW_URL: "http://127.0.0.1:5666",
+      PCT_AGENT_TICK_MS: "500",
+      PCT_AGENT_SIGKILL_MS: "8000",
+      PCT_AGENT_BACKOFF_BASE_MS: "250",
+      PCT_AGENT_BACKOFF_MAX_MS: "5000",
+    });
+    expect(cfg.awBaseUrl).toBe("http://127.0.0.1:5666");
+    expect(cfg.tickIntervalMs).toBe(500);
+    expect(cfg.sigkillEscalationMs).toBe(8000);
+    expect(cfg.backoff).toEqual({ baseMs: 250, maxMs: 5000 });
+  });
+
+  it("treats blank optional overrides as absent (keeps defaults)", () => {
+    const cfg = loadConfigFromEnv({
+      PCT_AGENT_USER_ID: "7",
+      PCT_AGENT_SOCKET: "/s",
+      PCT_AGENT_TICK_MS: "  ",
+    });
+    expect(cfg.tickIntervalMs).toBe(1_000);
+  });
+
+  it("throws AgentConfigError when a required value is missing", () => {
+    expect(() => loadConfigFromEnv({ PCT_AGENT_SOCKET: "/s" })).toThrow(AgentConfigError);
+    expect(() => loadConfigFromEnv({ PCT_AGENT_USER_ID: "7" })).toThrow(AgentConfigError);
+  });
+
+  it("throws AgentConfigError on a non-numeric userId", () => {
+    expect(() => loadConfigFromEnv({ PCT_AGENT_USER_ID: "nope", PCT_AGENT_SOCKET: "/s" })).toThrow(
+      AgentConfigError,
+    );
+  });
+});

--- a/client/agent/tests/agent/effects.test.ts
+++ b/client/agent/tests/agent/effects.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CanberraSoundPlayer,
+  DesktopNotifier,
+  OsProcessSignaller,
+  parseNotificationId,
+  soundNameForEvent,
+  SpawnCommandRunner,
+  type CommandResult,
+  type CommandRunner,
+} from "../../src/agent/effects.js";
+
+/** A CommandRunner that records calls and returns a scripted result. */
+class FakeRunner implements CommandRunner {
+  calls: { command: string; args: string[] }[] = [];
+  constructor(private readonly script: (command: string) => Promise<CommandResult>) {}
+  run(command: string, args: readonly string[]): Promise<CommandResult> {
+    this.calls.push({ command, args: [...args] });
+    return this.script(command);
+  }
+}
+
+const ok = (stdout: string): CommandResult => ({ code: 0, stdout, stderr: "" });
+
+describe("parseNotificationId", () => {
+  it("extracts the uint32 id gdbus prints", () => {
+    expect(parseNotificationId("(uint32 42,)")).toBe(42);
+  });
+  it("returns null when no id is present", () => {
+    expect(parseNotificationId("")).toBeNull();
+    expect(parseNotificationId("(nothing)")).toBeNull();
+  });
+});
+
+describe("DesktopNotifier", () => {
+  it("calls gdbus Notify and returns the parsed id", async () => {
+    const runner = new FakeRunner(() => Promise.resolve(ok("(uint32 7,)")));
+    const notifier = new DesktopNotifier({ runner, appName: "pct-client-agent" });
+
+    const handle = await notifier.notify({ title: "Hi", body: "there", urgency: "critical" });
+
+    expect(handle.id).toBe(7);
+    const call = runner.calls[0];
+    expect(call?.command).toBe("gdbus");
+    expect(call?.args).toContain("org.freedesktop.Notifications.Notify");
+    expect(call?.args).toContain("pct-client-agent");
+    expect(call?.args).toContain("Hi");
+    expect(call?.args).toContain("there");
+    // replaces_id is 0 for a fresh toast; urgency byte 2 = critical.
+    expect(call?.args).toContain("0");
+    expect(call?.args).toContain("{'urgency': <byte 2>}");
+  });
+
+  it("update passes the prior id as replaces_id", async () => {
+    const runner = new FakeRunner(() => Promise.resolve(ok("(uint32 9,)")));
+    const notifier = new DesktopNotifier({ runner });
+    const handle = await notifier.update({ id: 5 }, { title: "t", body: "b" });
+    expect(handle.id).toBe(9);
+    expect(runner.calls[0]?.args).toContain("5");
+    // No urgency ⇒ empty hints dict.
+    expect(runner.calls[0]?.args).toContain("{}");
+  });
+
+  it("falls back to notify-send when gdbus exits non-zero", async () => {
+    const runner = new FakeRunner((command) =>
+      command === "gdbus"
+        ? Promise.resolve({ code: 1, stdout: "", stderr: "boom" })
+        : Promise.resolve(ok("")),
+    );
+    const notifier = new DesktopNotifier({ runner });
+    const handle = await notifier.notify({ title: "T", body: "B", urgency: "low" });
+    expect(handle.id).toBeNull();
+    expect(runner.calls.map((c) => c.command)).toEqual(["gdbus", "notify-send"]);
+    expect(runner.calls[1]?.args).toEqual(["--urgency", "low", "T", "B"]);
+  });
+
+  it("falls back when gdbus cannot be spawned, and swallows a missing notify-send", async () => {
+    const runner = new FakeRunner((command) =>
+      command === "gdbus"
+        ? Promise.reject(new Error("ENOENT"))
+        : Promise.reject(new Error("ENOENT")),
+    );
+    const notifier = new DesktopNotifier({ runner });
+    const handle = await notifier.notify({ title: "T", body: "B" });
+    expect(handle.id).toBeNull();
+    expect(runner.calls.map((c) => c.command)).toEqual(["gdbus", "notify-send"]);
+  });
+});
+
+describe("soundNameForEvent", () => {
+  it("maps each event to its freedesktop sound name", () => {
+    expect(soundNameForEvent("warning")).toBe("message-new-instant");
+    expect(soundNameForEvent("final-warning")).toBe("dialog-warning");
+    expect(soundNameForEvent("grant")).toBe("complete");
+    expect(soundNameForEvent("timesUp")).toBe("bell");
+  });
+});
+
+describe("CanberraSoundPlayer", () => {
+  it("plays a named sound through canberra-gtk-play", async () => {
+    const runner = new FakeRunner(() => Promise.resolve(ok("")));
+    await new CanberraSoundPlayer({ runner }).play("bell");
+    expect(runner.calls[0]).toEqual({ command: "canberra-gtk-play", args: ["-i", "bell"] });
+  });
+
+  it("is a no-op for a null sound", async () => {
+    const runner = new FakeRunner(() => Promise.resolve(ok("")));
+    await new CanberraSoundPlayer({ runner }).play(null);
+    expect(runner.calls).toHaveLength(0);
+  });
+
+  it("swallows a missing canberra binary", async () => {
+    const runner = new FakeRunner(() => Promise.reject(new Error("ENOENT")));
+    await expect(new CanberraSoundPlayer({ runner }).play("bell")).resolves.toBeUndefined();
+  });
+});
+
+describe("OsProcessSignaller", () => {
+  it("returns true when the signal is delivered", () => {
+    const spy = vi.spyOn(process, "kill").mockReturnValue(true);
+    try {
+      expect(new OsProcessSignaller().signal(1234, "SIGTERM")).toBe(true);
+      expect(spy).toHaveBeenCalledWith(1234, "SIGTERM");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("returns false when the process is already gone (ESRCH)", () => {
+    const spy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+    });
+    try {
+      expect(new OsProcessSignaller().signal(999999, "SIGKILL")).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rethrows a non-ESRCH error (e.g. EPERM)", () => {
+    const spy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    });
+    try {
+      expect(() => new OsProcessSignaller().signal(1, "SIGTERM")).toThrow(/not permitted/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("SpawnCommandRunner", () => {
+  it("runs a real command and captures its exit code and stdout", async () => {
+    const result = await new SpawnCommandRunner().run("node", ["--version"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toMatch(/^v\d+/);
+  });
+
+  it("rejects when the binary cannot be spawned", async () => {
+    await expect(
+      new SpawnCommandRunner().run("pct-nonexistent-binary-xyz", []),
+    ).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/client/agent/tests/agent/force-close.test.ts
+++ b/client/agent/tests/agent/force-close.test.ts
@@ -1,13 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import type { NotificationHandle, Notifier, ProcessSignaller } from "../../src/agent/effects.js";
-import {
-  ForceCloseController,
-  SystemScheduler,
-  type ForceCloseDeps,
-  type Scheduler,
-  type TimerHandle,
-} from "../../src/agent/force-close.js";
+import { ForceCloseController, type ForceCloseDeps } from "../../src/agent/force-close.js";
+import type { Scheduler, TimerHandle } from "../../src/agent/scheduler.js";
 
 const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
@@ -78,12 +73,13 @@ function build(overrides: Partial<ForceCloseDeps> = {}): {
     resolvePids: () => Promise.resolve([111, 222]),
     graceSeconds: 3,
     sigkillEscalationMs: 5_000,
+    renderToasts: true,
     ...overrides,
   };
   return { controller: new ForceCloseController(deps), notifier, signaller, scheduler };
 }
 
-describe("ForceCloseController", () => {
+describe("ForceCloseController.begin (local grace path)", () => {
   it("counts down, updating the toast each second, then SIGTERM→SIGKILL", async () => {
     const { controller, notifier, signaller, scheduler } = build();
     await controller.begin({ activityId: 7, label: "YouTube" });
@@ -119,6 +115,26 @@ describe("ForceCloseController", () => {
     expect(signaller.sent.map((s) => s.signal)).toEqual(["SIGTERM", "SIGTERM"]);
   });
 
+  it("ignores a repeat begin for an already-counting activity", async () => {
+    const { controller, notifier } = build();
+    await controller.begin({ activityId: 7, label: "YouTube" });
+    await controller.begin({ activityId: 7, label: "YouTube" });
+    expect(notifier.notified).toHaveLength(1);
+  });
+});
+
+describe("ForceCloseController.forceCloseNow (server path — grace already elapsed)", () => {
+  it("kills immediately with no fresh countdown even when graceSeconds > 0", async () => {
+    const { controller, notifier, signaller, scheduler } = build({ graceSeconds: 15 });
+    await controller.forceCloseNow({ activityId: 7, label: "YouTube" });
+    // No 1 Hz countdown interval was started.
+    expect(scheduler.intervals.size).toBe(0);
+    expect(notifier.notified[0]?.body).toContain("closing now");
+    expect(signaller.sent.map((s) => s.signal)).toEqual(["SIGTERM", "SIGTERM"]);
+  });
+});
+
+describe("ForceCloseController grant-cancel", () => {
   it("cancels the countdown on a grant top-up and does not kill", async () => {
     const { controller, notifier, signaller, scheduler } = build();
     await controller.begin({ activityId: 7, label: "YouTube" });
@@ -131,6 +147,24 @@ describe("ForceCloseController", () => {
     expect(signaller.sent).toHaveLength(0);
   });
 
+  it("a grant during the SIGTERM→SIGKILL window cancels the pending SIGKILL", async () => {
+    const { controller, signaller, scheduler } = build({ graceSeconds: 0 });
+    await controller.forceCloseNow({ activityId: 7, label: "YouTube" });
+    // SIGTERM sent, escalation scheduled but not yet fired.
+    expect(signaller.sent.map((s) => s.signal)).toEqual(["SIGTERM", "SIGTERM"]);
+    await controller.cancel(7, "granted — keep going");
+    scheduler.fireTimeouts(); // the escalation must have been cancelled
+    expect(signaller.sent.some((s) => s.signal === "SIGKILL")).toBe(false);
+  });
+
+  it("cancel is a no-op for an unknown activity", async () => {
+    const { controller, notifier } = build();
+    await controller.cancel(999, "nope");
+    expect(notifier.updated).toHaveLength(0);
+  });
+});
+
+describe("ForceCloseController misc", () => {
   it("skips the kill (degraded) when no PIDs resolve", async () => {
     const { controller, signaller } = build({
       graceSeconds: 0,
@@ -141,49 +175,19 @@ describe("ForceCloseController", () => {
     expect(controller.isCountingDown(7)).toBe(false);
   });
 
-  it("ignores a repeat begin for an already-counting activity", async () => {
-    const { controller, notifier } = build();
+  it("suppresses toasts and sound when renderToasts is false, but still kills", async () => {
+    const { controller, notifier, signaller } = build({ graceSeconds: 0, renderToasts: false });
     await controller.begin({ activityId: 7, label: "YouTube" });
-    await controller.begin({ activityId: 7, label: "YouTube" });
-    expect(notifier.notified).toHaveLength(1);
+    expect(notifier.notified).toHaveLength(0);
+    expect(signaller.sent.map((s) => s.signal)).toEqual(["SIGTERM", "SIGTERM"]);
   });
 
-  it("cancel is a no-op for an unknown activity", async () => {
-    const { controller, notifier } = build();
-    await controller.cancel(999, "nope");
-    expect(notifier.updated).toHaveLength(0);
-  });
-
-  it("stop clears all in-flight countdowns", async () => {
-    const { controller } = build();
-    await controller.begin({ activityId: 7, label: "A" });
-    await controller.begin({ activityId: 8, label: "B" });
+  it("stop clears all in-flight countdowns and escalations", async () => {
+    const { controller, signaller, scheduler } = build({ graceSeconds: 0 });
+    await controller.forceCloseNow({ activityId: 7, label: "A" });
     controller.stop();
     expect(controller.isCountingDown(7)).toBe(false);
-    expect(controller.isCountingDown(8)).toBe(false);
-  });
-});
-
-describe("SystemScheduler", () => {
-  it("fires a real timeout and lets cancel prevent it", async () => {
-    const scheduler = new SystemScheduler();
-    let fired = false;
-    await new Promise<void>((resolve) => scheduler.timeout(() => resolve(), 1));
-    const cancelled = scheduler.timeout(() => (fired = true), 10);
-    scheduler.cancel(cancelled);
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(fired).toBe(false);
-  });
-
-  it("fires a real interval that cancel stops", async () => {
-    const scheduler = new SystemScheduler();
-    let ticks = 0;
-    const handle = scheduler.interval(() => (ticks += 1), 1);
-    await new Promise((resolve) => setTimeout(resolve, 15));
-    scheduler.cancel(handle);
-    const seen = ticks;
-    await new Promise((resolve) => setTimeout(resolve, 15));
-    expect(seen).toBeGreaterThan(0);
-    expect(ticks).toBe(seen);
+    scheduler.fireTimeouts(); // escalation was cancelled by stop()
+    expect(signaller.sent.some((s) => s.signal === "SIGKILL")).toBe(false);
   });
 });

--- a/client/agent/tests/agent/force-close.test.ts
+++ b/client/agent/tests/agent/force-close.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import type { NotificationHandle, Notifier, ProcessSignaller } from "../../src/agent/effects.js";
+import {
+  ForceCloseController,
+  SystemScheduler,
+  type ForceCloseDeps,
+  type Scheduler,
+  type TimerHandle,
+} from "../../src/agent/force-close.js";
+
+const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+class FakeNotifier implements Notifier {
+  notified: { title: string; body: string }[] = [];
+  updated: { title: string; body: string }[] = [];
+  #next = 1;
+  notify(o: { title: string; body: string }): Promise<NotificationHandle> {
+    this.notified.push({ title: o.title, body: o.body });
+    return Promise.resolve({ id: this.#next++ });
+  }
+  update(_h: NotificationHandle, o: { title: string; body: string }): Promise<NotificationHandle> {
+    this.updated.push({ title: o.title, body: o.body });
+    return Promise.resolve({ id: this.#next++ });
+  }
+}
+
+class FakeSignaller implements ProcessSignaller {
+  sent: { pid: number; signal: string }[] = [];
+  signal(pid: number, signal: NodeJS.Signals): boolean {
+    this.sent.push({ pid, signal });
+    return true;
+  }
+}
+
+class FakeScheduler implements Scheduler {
+  intervals = new Map<TimerHandle, () => void>();
+  timeouts = new Map<TimerHandle, () => void>();
+  interval(callback: () => void): TimerHandle {
+    const handle = { token: Symbol("interval") };
+    this.intervals.set(handle, callback);
+    return handle;
+  }
+  timeout(callback: () => void): TimerHandle {
+    const handle = { token: Symbol("timeout") };
+    this.timeouts.set(handle, callback);
+    return handle;
+  }
+  cancel(handle: TimerHandle): void {
+    this.intervals.delete(handle);
+    this.timeouts.delete(handle);
+  }
+  /** Invoke the single live interval callback (the running countdown). */
+  tick(): void {
+    for (const cb of this.intervals.values()) cb();
+  }
+  /** Fire and clear all pending one-shot timeouts (the SIGKILL escalation). */
+  fireTimeouts(): void {
+    const cbs = [...this.timeouts.values()];
+    this.timeouts.clear();
+    for (const cb of cbs) cb();
+  }
+}
+
+function build(overrides: Partial<ForceCloseDeps> = {}): {
+  controller: ForceCloseController;
+  notifier: FakeNotifier;
+  signaller: FakeSignaller;
+  scheduler: FakeScheduler;
+} {
+  const notifier = new FakeNotifier();
+  const signaller = new FakeSignaller();
+  const scheduler = new FakeScheduler();
+  const deps: ForceCloseDeps = {
+    notifier,
+    signaller,
+    scheduler,
+    resolvePids: () => Promise.resolve([111, 222]),
+    graceSeconds: 3,
+    sigkillEscalationMs: 5_000,
+    ...overrides,
+  };
+  return { controller: new ForceCloseController(deps), notifier, signaller, scheduler };
+}
+
+describe("ForceCloseController", () => {
+  it("counts down, updating the toast each second, then SIGTERM→SIGKILL", async () => {
+    const { controller, notifier, signaller, scheduler } = build();
+    await controller.begin({ activityId: 7, label: "YouTube" });
+
+    // Immediate "time's up" toast with the 3-second countdown.
+    expect(notifier.notified).toHaveLength(1);
+    expect(notifier.notified[0]?.body).toContain("closing in 3 seconds");
+    expect(controller.isCountingDown(7)).toBe(true);
+
+    scheduler.tick(); // 3 → 2
+    scheduler.tick(); // 2 → 1
+    await flush();
+    expect(notifier.updated.at(-1)?.body).toContain("closing in 1 second");
+
+    scheduler.tick(); // 1 → 0 → forceClose
+    await flush();
+    expect(signaller.sent).toEqual([
+      { pid: 111, signal: "SIGTERM" },
+      { pid: 222, signal: "SIGTERM" },
+    ]);
+
+    scheduler.fireTimeouts(); // escalation
+    expect(signaller.sent.filter((s) => s.signal === "SIGKILL").map((s) => s.pid)).toEqual([
+      111, 222,
+    ]);
+    expect(controller.isCountingDown(7)).toBe(false);
+  });
+
+  it("force-closes immediately when the grace period is zero", async () => {
+    const { controller, notifier, signaller } = build({ graceSeconds: 0 });
+    await controller.begin({ activityId: 7, label: "YouTube" });
+    expect(notifier.notified[0]?.body).toContain("closing now");
+    expect(signaller.sent.map((s) => s.signal)).toEqual(["SIGTERM", "SIGTERM"]);
+  });
+
+  it("cancels the countdown on a grant top-up and does not kill", async () => {
+    const { controller, notifier, signaller, scheduler } = build();
+    await controller.begin({ activityId: 7, label: "YouTube" });
+    await controller.cancel(7, "Mum granted +30 minutes — keep going");
+
+    expect(controller.isCountingDown(7)).toBe(false);
+    expect(notifier.updated.at(-1)).toMatchObject({ title: "More time!" });
+    scheduler.tick(); // the interval was cancelled; nothing happens
+    await flush();
+    expect(signaller.sent).toHaveLength(0);
+  });
+
+  it("skips the kill (degraded) when no PIDs resolve", async () => {
+    const { controller, signaller } = build({
+      graceSeconds: 0,
+      resolvePids: () => Promise.resolve([]),
+    });
+    await controller.begin({ activityId: 7, label: "YouTube" });
+    expect(signaller.sent).toHaveLength(0);
+    expect(controller.isCountingDown(7)).toBe(false);
+  });
+
+  it("ignores a repeat begin for an already-counting activity", async () => {
+    const { controller, notifier } = build();
+    await controller.begin({ activityId: 7, label: "YouTube" });
+    await controller.begin({ activityId: 7, label: "YouTube" });
+    expect(notifier.notified).toHaveLength(1);
+  });
+
+  it("cancel is a no-op for an unknown activity", async () => {
+    const { controller, notifier } = build();
+    await controller.cancel(999, "nope");
+    expect(notifier.updated).toHaveLength(0);
+  });
+
+  it("stop clears all in-flight countdowns", async () => {
+    const { controller } = build();
+    await controller.begin({ activityId: 7, label: "A" });
+    await controller.begin({ activityId: 8, label: "B" });
+    controller.stop();
+    expect(controller.isCountingDown(7)).toBe(false);
+    expect(controller.isCountingDown(8)).toBe(false);
+  });
+});
+
+describe("SystemScheduler", () => {
+  it("fires a real timeout and lets cancel prevent it", async () => {
+    const scheduler = new SystemScheduler();
+    let fired = false;
+    await new Promise<void>((resolve) => scheduler.timeout(() => resolve(), 1));
+    const cancelled = scheduler.timeout(() => (fired = true), 10);
+    scheduler.cancel(cancelled);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fired).toBe(false);
+  });
+
+  it("fires a real interval that cancel stops", async () => {
+    const scheduler = new SystemScheduler();
+    let ticks = 0;
+    const handle = scheduler.interval(() => (ticks += 1), 1);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    scheduler.cancel(handle);
+    const seen = ticks;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(seen).toBeGreaterThan(0);
+    expect(ticks).toBe(seen);
+  });
+});

--- a/client/agent/tests/agent/scheduler.test.ts
+++ b/client/agent/tests/agent/scheduler.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { SystemScheduler } from "../../src/agent/scheduler.js";
+
+describe("SystemScheduler", () => {
+  it("fires a real timeout and lets cancel prevent it", async () => {
+    const scheduler = new SystemScheduler();
+    let fired = false;
+    await new Promise<void>((resolve) => scheduler.timeout(() => resolve(), 1));
+    const cancelled = scheduler.timeout(() => (fired = true), 10);
+    scheduler.cancel(cancelled);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fired).toBe(false);
+  });
+
+  it("fires a real interval that cancel stops", async () => {
+    const scheduler = new SystemScheduler();
+    let ticks = 0;
+    const handle = scheduler.interval(() => (ticks += 1), 1);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    scheduler.cancel(handle);
+    const seen = ticks;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(seen).toBeGreaterThan(0);
+    expect(ticks).toBe(seen);
+  });
+});

--- a/client/agent/tests/agent/socket-client.test.ts
+++ b/client/agent/tests/agent/socket-client.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Dispatcher } from "../../src/bridge/dispatch.js";
 import { StreamLogger, type Logger } from "../../src/bridge/logger.js";
 import type { EventFrame, ServerEvent } from "../../src/bridge/protocol.js";
-import type { Scheduler, TimerHandle } from "../../src/agent/force-close.js";
+import type { Scheduler, TimerHandle } from "../../src/agent/scheduler.js";
 import {
   AgentSocketClient,
   type SocketFactory,

--- a/client/agent/tests/agent/socket-client.test.ts
+++ b/client/agent/tests/agent/socket-client.test.ts
@@ -1,0 +1,227 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { Dispatcher } from "../../src/bridge/dispatch.js";
+import { StreamLogger, type Logger } from "../../src/bridge/logger.js";
+import type { EventFrame, ServerEvent } from "../../src/bridge/protocol.js";
+import type { Scheduler, TimerHandle } from "../../src/agent/force-close.js";
+import {
+  AgentSocketClient,
+  type SocketFactory,
+  type SocketLike,
+} from "../../src/agent/socket-client.js";
+
+const noop = (): void => undefined;
+const silentLogger: Logger = { debug: noop, info: noop, warn: noop, error: noop };
+const backoff = { baseMs: 1, maxMs: 10 };
+
+const frameLine = (event: ServerEvent, seq = 1): string =>
+  JSON.stringify({ seq, at: "2026-07-03T12:00:00.000Z", event } satisfies EventFrame) + "\n";
+
+/** A controllable in-memory socket matching {@link SocketLike}'s overloads. */
+class FakeSocket implements SocketLike {
+  #connect?: () => void;
+  #close?: () => void;
+  #data?: (chunk: Buffer) => void;
+  #error?: (err: Error) => void;
+  destroyed = false;
+
+  on(event: "connect" | "close", listener: () => void): this;
+  on(event: "data", listener: (chunk: Buffer) => void): this;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(
+    event: "connect" | "close" | "data" | "error",
+    listener: (() => void) | ((chunk: Buffer) => void) | ((err: Error) => void),
+  ): this {
+    if (event === "connect") this.#connect = listener as () => void;
+    else if (event === "close") this.#close = listener as () => void;
+    else if (event === "data") this.#data = listener as (chunk: Buffer) => void;
+    else this.#error = listener as (err: Error) => void;
+    return this;
+  }
+  destroy(): void {
+    this.destroyed = true;
+  }
+  emitConnect(): void {
+    this.#connect?.();
+  }
+  emitData(chunk: Buffer): void {
+    this.#data?.(chunk);
+  }
+  emitClose(): void {
+    this.#close?.();
+  }
+  emitError(err: Error): void {
+    this.#error?.(err);
+  }
+}
+
+/** Records scheduled timeouts so a reconnect can be triggered on demand. */
+class FakeScheduler implements Scheduler {
+  timeouts: (() => void)[] = [];
+  cancelled = 0;
+  interval(): TimerHandle {
+    return { token: Symbol() };
+  }
+  timeout(callback: () => void): TimerHandle {
+    this.timeouts.push(callback);
+    return { token: Symbol() };
+  }
+  cancel(): void {
+    this.cancelled += 1;
+  }
+}
+
+describe("AgentSocketClient (fake socket)", () => {
+  it("decodes multiple newline-delimited frames from one chunk", () => {
+    let socket: FakeSocket | undefined;
+    const factory: SocketFactory = () => (socket = new FakeSocket());
+    const events: ServerEvent[] = [];
+    const client = new AgentSocketClient({
+      socketPath: "/x.sock",
+      onEvent: (e) => events.push(e),
+      backoff,
+      scheduler: new FakeScheduler(),
+      logger: silentLogger,
+      factory,
+    });
+    client.start();
+    socket?.emitConnect();
+    socket?.emitData(
+      Buffer.from(
+        frameLine({ type: "lockout.cleared", userId: 1 }, 1) +
+          frameLine({ type: "enforce.session_lock", userId: 1 }, 2),
+      ),
+    );
+    expect(events.map((e) => e.type)).toEqual(["lockout.cleared", "enforce.session_lock"]);
+  });
+
+  it("reassembles a frame split across two chunks", () => {
+    let socket: FakeSocket | undefined;
+    const factory: SocketFactory = () => (socket = new FakeSocket());
+    const events: ServerEvent[] = [];
+    const client = new AgentSocketClient({
+      socketPath: "/x.sock",
+      onEvent: (e) => events.push(e),
+      backoff,
+      scheduler: new FakeScheduler(),
+      logger: silentLogger,
+      factory,
+    });
+    client.start();
+    const line = frameLine({ type: "lockout.cleared", userId: 1 });
+    socket?.emitData(Buffer.from(line.slice(0, 10)));
+    socket?.emitData(Buffer.from(line.slice(10)));
+    expect(events).toHaveLength(1);
+  });
+
+  it("drops a malformed frame without tearing down the connection", () => {
+    let socket: FakeSocket | undefined;
+    const factory: SocketFactory = () => (socket = new FakeSocket());
+    const events: ServerEvent[] = [];
+    const client = new AgentSocketClient({
+      socketPath: "/x.sock",
+      onEvent: (e) => events.push(e),
+      backoff,
+      scheduler: new FakeScheduler(),
+      logger: silentLogger,
+      factory,
+    });
+    client.start();
+    socket?.emitData(Buffer.from("{not json}\n"));
+    socket?.emitData(Buffer.from(frameLine({ type: "lockout.cleared", userId: 1 })));
+    expect(events).toHaveLength(1);
+  });
+
+  it("schedules a reconnect on close and stops cleanly", () => {
+    const sockets: FakeSocket[] = [];
+    const factory: SocketFactory = () => {
+      const s = new FakeSocket();
+      sockets.push(s);
+      return s;
+    };
+    const scheduler = new FakeScheduler();
+    const client = new AgentSocketClient({
+      socketPath: "/x.sock",
+      onEvent: () => undefined,
+      backoff,
+      scheduler,
+      logger: silentLogger,
+      factory,
+    });
+    client.start();
+    sockets[0]?.emitError(new Error("boom"));
+    sockets[0]?.emitClose();
+    expect(scheduler.timeouts).toHaveLength(1);
+    scheduler.timeouts[0]?.(); // fire the reconnect
+    expect(sockets).toHaveLength(2);
+    client.stop();
+    expect(sockets[1]?.destroyed).toBe(true);
+  });
+});
+
+describe("AgentSocketClient (real bridge Dispatcher)", () => {
+  let dir: string;
+  let dispatcher: Dispatcher;
+  let client: AgentSocketClient;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pct-agent-sock-"));
+  });
+  afterEach(async () => {
+    client.stop();
+    await dispatcher.stop();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("receives a frame the bridge dispatches over a real AF_UNIX socket", async () => {
+    const socketPath = join(dir, "1001.sock");
+    dispatcher = new Dispatcher({
+      users: [{ userId: 42, linuxUid: 1001 }],
+      socketPath: () => socketPath,
+      socketMode: 0o600,
+      logger: new StreamLogger({
+        sinks: { out: { write: () => undefined }, err: { write: () => undefined } },
+      }),
+    });
+    await dispatcher.start();
+
+    const received: ServerEvent[] = [];
+    client = new AgentSocketClient({
+      socketPath,
+      onEvent: (e) => received.push(e),
+      backoff,
+      scheduler: new FakeScheduler(),
+      logger: silentLogger,
+    });
+    client.start();
+
+    await waitFor(() => dispatcher.connectionCount(42) === 1);
+    dispatcher.dispatch({
+      seq: 1,
+      at: "2026-07-03T12:00:00.000Z",
+      event: {
+        type: "grant.applied",
+        userId: 42,
+        grantedSeconds: 600,
+        reason: "chores",
+        activityId: null,
+      },
+    });
+    await waitFor(() => received.length === 1);
+
+    expect(received[0]).toMatchObject({ type: "grant.applied", grantedSeconds: 600 });
+  });
+});
+
+/** Poll `predicate` until true (or a short timeout), for the live socket test. */
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("waitFor timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}

--- a/client/agent/tests/agent/usage.test.ts
+++ b/client/agent/tests/agent/usage.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { OVERALL_BUDGET_KEY } from "../../src/agent/budget.js";
+import { AwUsageSource, dayTimeperiod, type FetchLike } from "../../src/agent/usage.js";
+
+/** A fetch stub returning a scripted response, recording the request. */
+function fakeFetch(
+  response: { ok: boolean; status: number; json: () => Promise<unknown> } | Error,
+): { fetchFn: FetchLike; calls: { url: string; body: string }[] } {
+  const calls: { url: string; body: string }[] = [];
+  const fetchFn: FetchLike = (url, init) => {
+    calls.push({ url, body: init.body });
+    return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+  };
+  return { fetchFn, calls };
+}
+
+const json = (value: unknown) => ({
+  ok: true,
+  status: 200,
+  json: () => Promise.resolve(value),
+});
+
+describe("dayTimeperiod", () => {
+  it("spans local midnight to the next local midnight", () => {
+    const tp = dayTimeperiod(new Date(2026, 6, 3, 14, 30, 0));
+    const [start, end] = tp.split("/");
+    if (start === undefined || end === undefined) throw new Error("expected start/end");
+    expect(new Date(end).getTime() - new Date(start).getTime()).toBe(24 * 60 * 60 * 1000);
+  });
+});
+
+describe("AwUsageSource", () => {
+  const now = () => new Date(2026, 6, 3, 12, 0, 0);
+
+  it("queries aw-server and maps the summed duration to the overall budget", async () => {
+    const { fetchFn, calls } = fakeFetch(json([5400.7]));
+    const source = new AwUsageSource({ baseUrl: "http://127.0.0.1:5600/", fetchFn, now });
+
+    const used = await source.usedSeconds();
+
+    expect(used.get(OVERALL_BUDGET_KEY)).toBe(5400); // floored
+    expect(calls[0]?.url).toBe("http://127.0.0.1:5600/api/0/query/");
+    expect(calls[0]?.body).toContain("aw-watcher-afk_");
+    expect(calls[0]?.body).toContain("not-afk");
+  });
+
+  it("returns an empty map on a non-2xx response", async () => {
+    const { fetchFn } = fakeFetch({ ok: false, status: 500, json: () => Promise.resolve(null) });
+    const used = await new AwUsageSource({
+      baseUrl: "http://127.0.0.1:5600",
+      fetchFn,
+      now,
+    }).usedSeconds();
+    expect(used.size).toBe(0);
+  });
+
+  it("returns an empty map when the response shape is invalid", async () => {
+    const { fetchFn } = fakeFetch(json({ not: "an array" }));
+    const used = await new AwUsageSource({
+      baseUrl: "http://127.0.0.1:5600",
+      fetchFn,
+      now,
+    }).usedSeconds();
+    expect(used.size).toBe(0);
+  });
+
+  it("returns an empty map when aw-server is unreachable", async () => {
+    const { fetchFn } = fakeFetch(new Error("ECONNREFUSED"));
+    const used = await new AwUsageSource({
+      baseUrl: "http://127.0.0.1:5600",
+      fetchFn,
+      now,
+    }).usedSeconds();
+    expect(used.size).toBe(0);
+  });
+
+  it("clamps a negative duration to zero", async () => {
+    const { fetchFn } = fakeFetch(json([-10]));
+    const used = await new AwUsageSource({
+      baseUrl: "http://127.0.0.1:5600",
+      fetchFn,
+      now,
+    }).usedSeconds();
+    expect(used.get(OVERALL_BUDGET_KEY)).toBe(0);
+  });
+});

--- a/client/agent/vitest.config.ts
+++ b/client/agent/vitest.config.ts
@@ -12,10 +12,10 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**"],
-      // src/main.ts is a thin bootstrap (load config + start the bridge + wait
-      // for a shutdown signal); its process-lifecycle wiring can't run under
-      // the unit harness. The bridge it builds is covered via Bridge in tests.
-      exclude: ["src/main.ts"],
+      // Thin bootstraps (load config + build + start + wait for a shutdown
+      // signal); their process-lifecycle wiring can't run under the unit
+      // harness. What they build (Bridge, Agent) is covered via tests.
+      exclude: ["src/main.ts", "src/agent/main.ts"],
       thresholds: {
         lines: 80,
         branches: 80,


### PR DESCRIPTION
## Summary

Implements the per-user **`pct-client-agent`** (Phase 8b) — the `systemd --user`
daemon rendering the supervised-user experience in
`docs/client-notifications.md` — as a new `client/agent/src/agent/` alongside
the already-landed `pct-client-bridge` (#101) in the same package. Everything
is built on injected seams, so the whole daemon unit-tests deterministically
with no clock, sockets, or desktop processes.

**What it does**

- **Socket intake** (`socket-client.ts`) — connects to the bridge's per-user
  `AF_UNIX` socket, splits the newline-delimited JSON frame stream, validates
  each frame with the shared `decodeFrame`, and reconnects with the package's
  full-jitter backoff. The mirror of the bridge's outbound `ws-client.ts`.
- **Local warning cadence** (`cadence.ts`) — the exact 15/5/1-minute boundary
  rules as a pure per-budget engine (fires once per boundary, announces the
  deepest boundary on a jump, one final "time's up"), with multi-budget
  coalescing into a single toast.
- **Cached budgets** (`budget.ts`) — remaining = `max(0, total − used)`;
  additive `grant.applied` top-ups re-arm the cadence.
- **Grace + force-close** (`force-close.ts`) — immediate "time's up" toast with
  a per-second countdown, cancel + "keep going" on a grant top-up, then
  `SIGTERM`→(5s)→`SIGKILL` of the user's own PIDs.
- **Desktop effects** (`effects.ts`) — `gdbus`→`notify-send` toasts (with
  in-place countdown replacement), `canberra-gtk-play` sound with the
  `off`/`subtle`/`prominent` mapping, `process.kill` signaller — all
  subprocesses, no native bindings.
- **Local usage** (`usage.ts`) — polls `aw-server`'s query2 REST API for the
  overall budget's active seconds; degrades to empty (never throws) when
  `aw-server` is unreachable.
- **Orchestrator + entrypoint** (`agent.ts`, `main.ts`) — the tick loop + event
  handling (`grant.applied`, `policy.changed`, `enforce.force_close`,
  `enforce.session_lock` [announce only — Timekpr does the kill],
  `lockout.cleared`), respecting the notification master switch while still
  enforcing.

## Plan

Linked plan: `.claude/plans/issue-103-pct-client-agent.md`
Roadmap: `docs/roadmap.md` → Phase 8b (`pct-client-agent` per-user service).
Landed in three commits: pure cores → effects/force-close/usage → orchestrator.

## New dependencies

None — the package's existing `zod` (MIT) covers config + frame validation.

## License-boundary note

No GPL linkage. The agent speaks to the bridge over a local JSON `AF_UNIX`
socket, to `aw-server` over REST, and renders via the desktop's own CLI tools
(`gdbus`/`notify-send`/`canberra-gtk-play`) as subprocesses. `timekpra`
session-kill stays the bridge's Phase-8c job. No GPL binary added to any image;
the `.deb` (deferred, #106) bundles its own Node runtime. Tamper-resistance
stays in bounds — the agent acts only on the user's own processes.

## Deferred (out of scope, tracked)

- **Client-side policy distribution** — pushing per-user budgets + activity
  **matchers** + `NotificationPolicy` to the agent, which unlocks per-activity
  usage and force-close PID resolution (both ship behind degraded seams today:
  empty budget cache, `resolvePids → []`, overall-only usage) → **#381** (filed).
  This is why the PR is *Part of* #103 rather than a full close — the agent's
  logic is complete, but it needs #381's data feed to enforce per-app limits in
  production.
- Interactive toast action buttons + client→server action frame → **#337**
  (buttons stay inert here).
- `enforce.session_lock` / lockout `timekpra --kill-session` → Phase 8c
  **#107/#108** (the bridge's privileged surface; the agent only toasts).
- `.deb` packaging, `systemd --user` unit, `/run/pct` tmpfiles → **#106**.
- Structured `cadence_overrides` semantics → **#302**.
- ADR-0007 version handshake → follow-up gated on the #165 server side.

## Test plan

- [x] `cadence` / `budget` / `config` — pure-core units (boundary set, drain,
      no-re-announce, deepest-on-jump, times-up-once, coalescing/formatting;
      cache + grants; schema defaults/bounds + env loader).
- [x] `effects` — gdbus arg-vector + id parse + notify-send fallback; sound
      map; ESRCH/EPERM signaller; real `SpawnCommandRunner` (node --version /
      ENOENT).
- [x] `force-close` — countdown → SIGTERM→SIGKILL, grace-0, grant-cancel,
      degraded-no-PIDs, dup-begin, stop; real `SystemScheduler`.
- [x] `usage` — query2 mapping, non-2xx / invalid-shape / unreachable → empty,
      clamp; local day window.
- [x] `socket-client` — multi-frame / split-frame / poison-frame / reconnect
      with a fake socket, **and a real end-to-end frame over a live bridge
      `Dispatcher` AF_UNIX socket**.
- [x] `agent` — cadence urgency+sound, overall-vs-per-app times-up, disabled
      notifications still enforce, sound-off, event handling, lifecycle.
- [x] `npm run format:check && npm run lint && npm run typecheck && npm test` —
      133 passing, coverage gate 80% held (agent modules ~99%).

Part of #103 (agent core; client-side policy distribution tracked in #381).

🤖 Generated with [Claude Code](https://claude.com/claude-code)