### PR TITLE
refactor(adguard): extract RestartBackoff + lifecycle state machine (#310)

### DIFF
--- a/.claude/plans/issue-310-adguard-supervisor-backoff-fsm.md
+++ b/.claude/plans/issue-310-adguard-supervisor-backoff-fsm.md
@@ -1,0 +1,126 @@
+# Issue #310 — Extract backoff + state-machine from `AdGuardManagedSupervisor`
+
+Roadmap: code-review complexity cleanup (label `code-review`/`complexity`,
+severity Medium). No roadmap phase — it is a maintainability refactor of the
+Phase-7 managed-AdGuard supervisor (`#96`).
+
+## Sequencing note (cleared)
+
+The issue said "do this after PR #291 (managed-AdGuard wiring) merges." #291 is
+no longer open, so the hold is cleared and `transport/adguard/*` is safe to
+touch.
+
+## Goal
+
+Behaviour-preserving decomposition of `server/src/transport/adguard/supervisor.ts`
+(`AdGuardManagedSupervisor`, ~211 lines). Two extractions the code-review asked
+for:
+
+1. **`RestartBackoff` utility** — owns the restart count, the stable-run reset,
+   the restart cap, and the exponential-delay computation that is currently
+   inline in `#onExit` (`:312-335`). Independently unit-testable.
+2. **Explicit lifecycle state machine** — the `AdGuardManagedState` union plus a
+   declared **transition table** and a tiny machine that tracks the current
+   state, so reachable states and valid transitions are obvious instead of being
+   threaded implicitly through `#settle` calls.
+
+No functional change. The existing `tests/transport/adguard/supervisor.test.ts`
+(13 tests) is the behaviour guard and must stay green **unchanged**.
+
+## Constraints that shape the design
+
+- **`bootstrap()` never throws** (documented contract; `main.ts` fires it with a
+  bare `void`). The event-handler paths `#onExit` / `#onSpawnError` run as
+  process-event callbacks *outside* any `try/catch`. Therefore the state machine
+  must be **advisory**: an unexpected transition is logged (via the injected
+  logger) and still applied — it must never throw. Throwing would risk an
+  unhandled exception in an event callback and break the never-throw guarantee.
+- **Export surface must be preserved.** `AdGuardManagedState` and
+  `AdGuardManagedStatus` are re-exported by `transport/adguard/index.ts` and
+  consumed by `service.ts` and `api/system/dtos.ts`. Keep both importable from
+  `supervisor.ts`.
+- **License boundary unchanged** — pure process supervision; AdGuard is still
+  reached only over its REST API. No GPL linkage, no image change, no new
+  dependency.
+- **`#stopping` stays a separate latch.** It encodes *intent to stop*, which is
+  orthogonal to the observed lifecycle state (it gates exit→restart-vs-stopped
+  and suppresses a post-fetch spawn). Folding it into the state enum would be a
+  semantic change with behaviour risk, so it is left as-is (documented).
+
+## Design
+
+### New file: `transport/adguard/backoff.ts`
+
+```ts
+export interface RestartBackoffOptions {
+  maxRestarts: number;   // cap on consecutive restarts
+  stableMs: number;      // uptime after which the counter resets
+  baseMs: number;        // base delay (doubles per attempt)
+  maxMs: number;         // delay ceiling
+}
+
+export class RestartBackoff {
+  get count(): number;                 // consecutive restarts so far (status.restarts)
+  markStarted(nowMs: number): void;    // record a spawn time (for stable reset)
+  /**
+   * Call after an *unexpected* exit. Applies the stable-run reset, then either
+   * returns the next backoff delay (ms) and bumps the count, or `null` when the
+   * restart cap is exceeded (caller -> `failed`).
+   */
+  nextDelayMs(nowMs: number): number | null;
+}
+```
+
+Encapsulates exactly today's arithmetic:
+- stable reset: `if (startedAt !== null && now - startedAt >= stableMs) count = 0`
+- cap: `if (count >= maxRestarts) return null`
+- else `count += 1; return min(baseMs * 2 ** (count - 1), maxMs)`
+
+### New file: `transport/adguard/lifecycle.ts`
+
+- Move the `AdGuardManagedState` union here (with its doc comment).
+- `STATE_TRANSITIONS: Readonly<Record<AdGuardManagedState, readonly AdGuardManagedState[]>>`
+  declaring the reachable next-states (derived from the actual code paths:
+  idle->fetching/stopped; fetching->starting/failed/stopped;
+  starting->running/failed/stopped; running->starting/failed/stopped;
+  failed->fetching/stopped; stopped->fetching).
+- `isValidTransition(from, to): boolean` — pure, directly unit-tested.
+- `LifecycleMachine` — holds the current state; `transition(to, onInvalid?)`
+  updates the state and invokes `onInvalid(from, to)` (advisory) when the
+  transition is not in the table. Never throws.
+
+`supervisor.ts` re-exports the type: `export { type AdGuardManagedState } from "./lifecycle.js";`
+so `service.ts` / `index.ts` imports are unaffected. `AdGuardManagedStatus`
+stays defined in `supervisor.ts`.
+
+### Refactor `supervisor.ts`
+
+- Replace `#restarts` + inline backoff math with a `RestartBackoff` instance;
+  `status.restarts` reads `#backoff.count`. `markStarted` is called in
+  `#spawnChild`; `nextDelayMs` in `#onExit`.
+- Replace the state field held in `#status.state` with a `LifecycleMachine`
+  read by `#settle`; `#settle` asks the machine to transition and passes an
+  `onInvalid` callback that logs a `warn` (so a mis-transition is a visible
+  signal, not a crash).
+- `#settle` still writes the immutable `AdGuardManagedStatus` snapshot exactly
+  as today (same fields, same `checkedAt`/detail/logging semantics).
+
+## Tests
+
+- Keep `supervisor.test.ts` unchanged — the primary behaviour guard.
+- Add `tests/transport/adguard/backoff.test.ts`: base/doubling/ceiling delays,
+  cap -> `null`, stable-run reset, `count` progression, `markStarted`.
+- Add `tests/transport/adguard/lifecycle.test.ts`: `isValidTransition` truth
+  table (each declared edge true; representative invalid edges false), and the
+  `LifecycleMachine` advisory-`onInvalid` callback + state tracking.
+
+## Quality gate
+
+From `server/`: `npm run format` -> `npm run lint:fix` -> `npm run typecheck` ->
+`npm test` (coverage gate 80%). All green before commit.
+
+## Phases
+
+1. `RestartBackoff` + its tests; wire into `supervisor.ts`; gate green.
+2. `LifecycleMachine` + transition table + its tests; wire into `supervisor.ts`;
+   gate green. (Push opens the draft PR after phase 1; phase 2 updates it.)

--- a/server/src/transport/adguard/backoff.ts
+++ b/server/src/transport/adguard/backoff.ts
@@ -1,0 +1,72 @@
+/**
+ * Restart backoff for the managed AdGuard Home supervisor (#96, #310).
+ *
+ * Owns the "how often may we restart, and how long do we wait" policy that used
+ * to live inline in `AdGuardManagedSupervisor.#onExit`: a consecutive-restart
+ * counter, a stable-run reset (a single crash after a long healthy run is not
+ * held against the cap), a hard cap, and an exponential delay with a ceiling.
+ *
+ * Pure and time-injected — the caller passes a monotonic-enough "now" (ms), so
+ * this is unit-testable without real timers or a clock.
+ */
+
+/** Tuning for {@link RestartBackoff} (the supervisor's restart knobs). */
+export interface RestartBackoffOptions {
+  /** Max consecutive restarts before {@link RestartBackoff.nextDelayMs} gives up. */
+  readonly maxRestarts: number;
+  /** Uptime (ms) after which a run counts as "stable" and the counter resets. */
+  readonly stableMs: number;
+  /** Base delay (ms) between restarts; doubles per attempt. */
+  readonly baseMs: number;
+  /** Delay ceiling (ms). */
+  readonly maxMs: number;
+}
+
+/**
+ * Tracks consecutive restart attempts and computes the next backoff delay.
+ *
+ * Usage mirrors the supervisor's lifecycle:
+ * - {@link markStarted} when a child is spawned (records the start time so the
+ *   next exit can tell whether the run was stable).
+ * - {@link nextDelayMs} after an *unexpected* exit: returns the delay to wait
+ *   before the next restart, or `null` once the restart cap is exceeded.
+ */
+export class RestartBackoff {
+  readonly #options: RestartBackoffOptions;
+  #count = 0;
+  #startedAt: number | null = null;
+
+  constructor(options: RestartBackoffOptions) {
+    this.#options = options;
+  }
+
+  /** Consecutive restarts recorded so far (surfaced as `status.restarts`). */
+  get count(): number {
+    return this.#count;
+  }
+
+  /** Record the moment the current child started, for the stable-run reset. */
+  markStarted(nowMs: number): void {
+    this.#startedAt = nowMs;
+  }
+
+  /**
+   * Decide what to do after an unexpected child exit.
+   *
+   * First applies the stable-run reset: if the child ran for at least
+   * `stableMs`, the consecutive-restart counter is cleared so a lone crash after
+   * days of uptime does not count against the cap. Then either returns the next
+   * backoff delay (ms) — bumping the attempt counter — or `null` when the cap
+   * (`maxRestarts`) has been reached, meaning the caller should give up.
+   */
+  nextDelayMs(nowMs: number): number | null {
+    if (this.#startedAt !== null && nowMs - this.#startedAt >= this.#options.stableMs) {
+      this.#count = 0;
+    }
+    if (this.#count >= this.#options.maxRestarts) {
+      return null;
+    }
+    this.#count += 1;
+    return Math.min(this.#options.baseMs * 2 ** (this.#count - 1), this.#options.maxMs);
+  }
+}

--- a/server/src/transport/adguard/lifecycle.ts
+++ b/server/src/transport/adguard/lifecycle.ts
@@ -1,0 +1,95 @@
+/**
+ * Lifecycle state machine for the managed AdGuard Home supervisor (#96, #310).
+ *
+ * Makes the supervisor's implicit lifecycle explicit: the set of states, the
+ * declared transitions between them, and a tiny machine that tracks the current
+ * state. Extracted so the reachable states and valid transitions are obvious in
+ * one place instead of being threaded through the supervisor's `#settle` calls.
+ *
+ * The machine is deliberately **advisory**: an undeclared transition invokes an
+ * `onInvalid` callback (the supervisor logs it) but is still applied — it never
+ * throws. The supervisor drives transitions from process-event callbacks
+ * (`onExit` / `onError`) that run outside any `try/catch`, and `bootstrap()` is
+ * contractually never-throwing, so a throw here would be unsafe.
+ */
+
+/**
+ * Lifecycle state of the managed AdGuard Home process.
+ *
+ * - `idle` — built but not yet bootstrapped (a freshly constructed supervisor;
+ *   building the app spawns nothing).
+ * - `fetching` — `bootstrap()` is acquiring the binary / seeding config.
+ * - `starting` — the child process is being spawned.
+ * - `running` — the child is up.
+ * - `stopped` — stopped on purpose (graceful shutdown).
+ * - `failed` — acquisition failed, the process could not be spawned, or it
+ *   exited unexpectedly too many times; `detail` says why.
+ */
+export type AdGuardManagedState =
+  | "idle"
+  | "fetching"
+  | "starting"
+  | "running"
+  | "stopped"
+  | "failed";
+
+/**
+ * Declared transitions: for each state, the states reachable from it.
+ *
+ * Derived from the supervisor's actual paths:
+ * - `idle` → `fetching` (bootstrap) or `stopped` (stop before anything runs).
+ * - `fetching` → `starting` (acquired, spawning), `failed` (acquisition failed),
+ *   or `stopped` (stop landed during the fetch).
+ * - `starting` → `running` (spawned) or `failed` (spawn threw synchronously).
+ * - `running` → `starting` (restart after an unexpected exit), `failed` (spawn
+ *   error, or the restart cap exceeded), or `stopped` (graceful stop).
+ * - `stopped` → `fetching` (a later re-bootstrap).
+ * - `failed` → `fetching` (re-bootstrap) or `stopped` (stop after a failure).
+ */
+export const STATE_TRANSITIONS: Readonly<
+  Record<AdGuardManagedState, readonly AdGuardManagedState[]>
+> = {
+  idle: ["fetching", "stopped"],
+  fetching: ["starting", "failed", "stopped"],
+  starting: ["running", "failed"],
+  running: ["starting", "failed", "stopped"],
+  stopped: ["fetching"],
+  failed: ["fetching", "stopped"],
+};
+
+/** Whether moving from `from` to `to` is a declared transition. */
+export function isValidTransition(from: AdGuardManagedState, to: AdGuardManagedState): boolean {
+  return STATE_TRANSITIONS[from].includes(to);
+}
+
+/** Called when a transition is not in {@link STATE_TRANSITIONS}. */
+export type OnInvalidTransition = (from: AdGuardManagedState, to: AdGuardManagedState) => void;
+
+/**
+ * Tracks the current lifecycle state and applies transitions.
+ *
+ * Advisory only (see the module doc): an undeclared transition notifies
+ * `onInvalid` and is still applied; a self-transition (`from === to`) is a
+ * silent no-op change. Never throws.
+ */
+export class LifecycleMachine {
+  #state: AdGuardManagedState;
+
+  constructor(initial: AdGuardManagedState = "idle") {
+    this.#state = initial;
+  }
+
+  /** The current lifecycle state. */
+  get state(): AdGuardManagedState {
+    return this.#state;
+  }
+
+  /** Move to `next`, notifying `onInvalid` if the transition is undeclared. */
+  transition(next: AdGuardManagedState, onInvalid?: OnInvalidTransition): void {
+    const from = this.#state;
+    if (from !== next && !isValidTransition(from, next)) {
+      onInvalid?.(from, next);
+    }
+    this.#state = next;
+  }
+}

--- a/server/src/transport/adguard/supervisor.ts
+++ b/server/src/transport/adguard/supervisor.ts
@@ -23,27 +23,11 @@ import { spawn } from "node:child_process";
 import { join } from "node:path";
 
 import { acquireAdGuardHome, type AcquireConfig, type AcquireResult } from "./acquire.js";
+import { RestartBackoff } from "./backoff.js";
+import { LifecycleMachine, type AdGuardManagedState } from "./lifecycle.js";
 import { writeSeedConfigIfAbsent, type SeedConfigOptions } from "./managed-config.js";
 
-/**
- * Lifecycle state of the managed AdGuard Home process.
- *
- * - `idle` — built but not yet bootstrapped (a freshly constructed supervisor;
- *   building the app spawns nothing).
- * - `fetching` — `bootstrap()` is acquiring the binary / seeding config.
- * - `starting` — the child process is being spawned.
- * - `running` — the child is up.
- * - `stopped` — stopped on purpose (graceful shutdown).
- * - `failed` — acquisition failed, the process could not be spawned, or it
- *   exited unexpectedly too many times; `detail` says why.
- */
-export type AdGuardManagedState =
-  | "idle"
-  | "fetching"
-  | "starting"
-  | "running"
-  | "stopped"
-  | "failed";
+export { type AdGuardManagedState } from "./lifecycle.js";
 
 /** An immutable snapshot of the supervisor's last-observed state. */
 export interface AdGuardManagedStatus {
@@ -170,8 +154,8 @@ export class AdGuardManagedSupervisor {
   #version: string | null = null;
   #child: ManagedProcess | null = null;
   #stopping = false;
-  #restarts = 0;
-  #startedAt: number | null = null;
+  readonly #backoff: RestartBackoff;
+  readonly #lifecycle = new LifecycleMachine("idle");
   #logger: AdGuardManagedLogger | undefined;
   /** Resolvers awaiting the current child's exit (used by {@link stop}). */
   #exitWaiters: (() => void)[] = [];
@@ -190,6 +174,12 @@ export class AdGuardManagedSupervisor {
       backoffBaseMs: deps.backoffBaseMs ?? 1_000,
       backoffMaxMs: deps.backoffMaxMs ?? 60_000,
     };
+    this.#backoff = new RestartBackoff({
+      maxRestarts: this.#deps.maxRestarts,
+      stableMs: this.#deps.stableMs,
+      baseMs: this.#deps.backoffBaseMs,
+      maxMs: this.#deps.backoffMaxMs,
+    });
 
     this.#binaryPath = join(config.dataDir, "AdGuardHome");
     this.#configPath = join(config.dataDir, "conf", CONFIG_FILENAME);
@@ -197,7 +187,7 @@ export class AdGuardManagedSupervisor {
     this.#adminEndpoint = `http://127.0.0.1:${config.adminPort}`;
 
     this.#status = {
-      state: "idle",
+      state: this.#lifecycle.state,
       binaryPath: this.#binaryPath,
       version: null,
       adminEndpoint: this.#adminEndpoint,
@@ -280,7 +270,7 @@ export class AdGuardManagedSupervisor {
     const args = ["--no-check-update", "--config", this.#configPath, "--work-dir", this.#workDir];
     const child = this.#deps.spawn(this.#binaryPath, args);
     this.#child = child;
-    this.#startedAt = this.#deps.now().getTime();
+    this.#backoff.markStarted(this.#deps.now().getTime());
 
     // Capture `child` so a stale event from a previous process is ignored. Node
     // emits BOTH `error` and `exit` for a failed spawn; whichever fires first
@@ -309,30 +299,22 @@ export class AdGuardManagedSupervisor {
       return;
     }
 
-    // Reset the consecutive-restart counter when the run was stable long enough,
-    // so a single crash after days of uptime is not counted against the cap.
-    const startedAt = this.#startedAt;
-    if (startedAt !== null && this.#deps.now().getTime() - startedAt >= this.#deps.stableMs) {
-      this.#restarts = 0;
-    }
-
+    // The backoff owns the stable-run reset (a single crash after days of uptime
+    // is not counted against the cap), the cap check, and the delay computation.
     const reason = `exited unexpectedly (code ${String(code)}, signal ${String(signal)})`;
-    if (this.#restarts >= this.#deps.maxRestarts) {
+    const backoffMs = this.#backoff.nextDelayMs(this.#deps.now().getTime());
+    if (backoffMs === null) {
       const detail = `${reason}; exceeded the restart cap (${this.#deps.maxRestarts})`;
       this.#settle("failed", detail, `AdGuard Home ${detail}`, "error");
       return;
     }
 
-    this.#restarts += 1;
-    const backoff = Math.min(
-      this.#deps.backoffBaseMs * 2 ** (this.#restarts - 1),
-      this.#deps.backoffMaxMs,
-    );
+    const attempt = this.#backoff.count;
     this.#logger?.warn(
-      { event: "adguard_managed", restarts: this.#restarts, backoffMs: backoff },
-      `AdGuard Home ${reason}; restarting in ${backoff}ms (attempt ${this.#restarts})`,
+      { event: "adguard_managed", restarts: attempt, backoffMs },
+      `AdGuard Home ${reason}; restarting in ${backoffMs}ms (attempt ${attempt})`,
     );
-    void this.#scheduleRestart(backoff);
+    void this.#scheduleRestart(backoffMs);
   }
 
   async #scheduleRestart(backoffMs: number): Promise<void> {
@@ -354,12 +336,18 @@ export class AdGuardManagedSupervisor {
     msg: string,
     level: "info" | "error" = "info",
   ): void {
+    this.#lifecycle.transition(state, (from, to) =>
+      this.#logger?.warn(
+        { event: "adguard_managed", from, to },
+        `AdGuard Home managed supervisor: unexpected state transition ${from} -> ${to}`,
+      ),
+    );
     this.#status = {
-      state,
+      state: this.#lifecycle.state,
       binaryPath: this.#binaryPath,
       version: this.#version,
       adminEndpoint: this.#adminEndpoint,
-      restarts: this.#restarts,
+      restarts: this.#backoff.count,
       checkedAt: this.#deps.now().toISOString(),
       detail,
     };

--- a/server/tests/transport/adguard/backoff.test.ts
+++ b/server/tests/transport/adguard/backoff.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the managed AdGuard Home restart backoff (#310).
+ *
+ * Pure arithmetic over an injected "now" — no timers, no clock. Mirrors the
+ * restart policy `AdGuardManagedSupervisor` used to compute inline.
+ */
+import { describe, expect, it } from "vitest";
+
+import { RestartBackoff } from "../../../src/transport/adguard/backoff.js";
+
+const OPTS = { maxRestarts: 5, stableMs: 60_000, baseMs: 1_000, maxMs: 60_000 };
+
+describe("RestartBackoff", () => {
+  it("starts at zero restarts", () => {
+    expect(new RestartBackoff(OPTS).count).toBe(0);
+  });
+
+  it("returns an exponentially doubling delay, bumping the count each attempt", () => {
+    const backoff = new RestartBackoff(OPTS);
+    backoff.markStarted(0);
+
+    // Every exit looks instantaneous (now === startedAt) → never a stable reset.
+    expect(backoff.nextDelayMs(0)).toBe(1_000); // base, attempt 1
+    expect(backoff.count).toBe(1);
+    expect(backoff.nextDelayMs(0)).toBe(2_000); // attempt 2
+    expect(backoff.nextDelayMs(0)).toBe(4_000); // attempt 3
+    expect(backoff.nextDelayMs(0)).toBe(8_000); // attempt 4
+    expect(backoff.count).toBe(4);
+  });
+
+  it("caps the delay at maxMs", () => {
+    const backoff = new RestartBackoff({ ...OPTS, maxRestarts: 100, maxMs: 5_000 });
+    backoff.markStarted(0);
+    const delays = Array.from({ length: 6 }, () => backoff.nextDelayMs(0));
+    // 1000, 2000, 4000, then clamped to the 5000 ceiling.
+    expect(delays).toEqual([1_000, 2_000, 4_000, 5_000, 5_000, 5_000]);
+  });
+
+  it("returns null once the restart cap is reached", () => {
+    const backoff = new RestartBackoff({ ...OPTS, maxRestarts: 2 });
+    backoff.markStarted(0);
+    expect(backoff.nextDelayMs(0)).toBe(1_000); // 1
+    expect(backoff.nextDelayMs(0)).toBe(2_000); // 2
+    expect(backoff.nextDelayMs(0)).toBeNull(); // cap exceeded → give up
+    expect(backoff.count).toBe(2); // count not bumped past the cap
+  });
+
+  it("resets the counter after a stable run", () => {
+    const backoff = new RestartBackoff({ ...OPTS, maxRestarts: 2, stableMs: 1_000 });
+
+    // First crash is immediate (uptime 0 < stableMs) → count 1.
+    backoff.markStarted(0);
+    expect(backoff.nextDelayMs(0)).toBe(1_000);
+    expect(backoff.count).toBe(1);
+
+    // Next run is stable (5000 - 4000 >= stableMs) → reset to 0, then bump to 1.
+    backoff.markStarted(4_000);
+    expect(backoff.nextDelayMs(5_000)).toBe(1_000);
+    expect(backoff.count).toBe(1);
+  });
+
+  it("does not reset when it has never been started", () => {
+    const backoff = new RestartBackoff({ ...OPTS, stableMs: 0 });
+    // startedAt is null → the stable-reset guard is skipped even with stableMs 0.
+    expect(backoff.nextDelayMs(1_000)).toBe(1_000);
+    expect(backoff.count).toBe(1);
+  });
+
+  it("gives up immediately when maxRestarts is zero", () => {
+    const backoff = new RestartBackoff({ ...OPTS, maxRestarts: 0 });
+    backoff.markStarted(0);
+    expect(backoff.nextDelayMs(0)).toBeNull();
+    expect(backoff.count).toBe(0);
+  });
+});

--- a/server/tests/transport/adguard/lifecycle.test.ts
+++ b/server/tests/transport/adguard/lifecycle.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the managed AdGuard Home lifecycle state machine (#310).
+ *
+ * The transition table is verified as pure data, and the machine's advisory
+ * (never-throwing) `onInvalid` behaviour is exercised directly.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LifecycleMachine,
+  STATE_TRANSITIONS,
+  isValidTransition,
+  type AdGuardManagedState,
+} from "../../../src/transport/adguard/lifecycle.js";
+
+const ALL_STATES: readonly AdGuardManagedState[] = [
+  "idle",
+  "fetching",
+  "starting",
+  "running",
+  "stopped",
+  "failed",
+];
+
+describe("isValidTransition", () => {
+  it("accepts every declared edge", () => {
+    for (const from of ALL_STATES) {
+      for (const to of STATE_TRANSITIONS[from]) {
+        expect(isValidTransition(from, to)).toBe(true);
+      }
+    }
+  });
+
+  it("rejects edges absent from the table", () => {
+    // A representative sample of transitions the supervisor never makes.
+    expect(isValidTransition("idle", "running")).toBe(false);
+    expect(isValidTransition("running", "fetching")).toBe(false);
+    expect(isValidTransition("stopped", "running")).toBe(false);
+    expect(isValidTransition("failed", "running")).toBe(false);
+    expect(isValidTransition("starting", "stopped")).toBe(false);
+  });
+
+  it("declares the supervisor's real happy path", () => {
+    expect(isValidTransition("idle", "fetching")).toBe(true);
+    expect(isValidTransition("fetching", "starting")).toBe(true);
+    expect(isValidTransition("starting", "running")).toBe(true);
+    expect(isValidTransition("running", "stopped")).toBe(true);
+    // Restart-after-crash and re-bootstrap edges.
+    expect(isValidTransition("running", "starting")).toBe(true);
+    expect(isValidTransition("failed", "fetching")).toBe(true);
+  });
+});
+
+describe("LifecycleMachine", () => {
+  it("starts idle by default and tracks the current state", () => {
+    const machine = new LifecycleMachine();
+    expect(machine.state).toBe("idle");
+
+    machine.transition("fetching");
+    expect(machine.state).toBe("fetching");
+    machine.transition("starting");
+    machine.transition("running");
+    expect(machine.state).toBe("running");
+  });
+
+  it("accepts an explicit initial state", () => {
+    expect(new LifecycleMachine("running").state).toBe("running");
+  });
+
+  it("does not call onInvalid for a declared transition", () => {
+    const onInvalid = vi.fn();
+    const machine = new LifecycleMachine("idle");
+    machine.transition("fetching", onInvalid);
+    expect(onInvalid).not.toHaveBeenCalled();
+  });
+
+  it("calls onInvalid for an undeclared transition but still applies it", () => {
+    const onInvalid = vi.fn();
+    const machine = new LifecycleMachine("idle");
+    machine.transition("running", onInvalid); // idle -> running is undeclared
+    expect(onInvalid).toHaveBeenCalledWith("idle", "running");
+    expect(machine.state).toBe("running"); // advisory: still applied
+  });
+
+  it("treats a self-transition as a silent no-op change", () => {
+    const onInvalid = vi.fn();
+    const machine = new LifecycleMachine("running");
+    machine.transition("running", onInvalid);
+    expect(onInvalid).not.toHaveBeenCalled();
+    expect(machine.state).toBe("running");
+  });
+
+  it("never throws even without an onInvalid callback", () => {
+    const machine = new LifecycleMachine("idle");
+    expect(() => machine.transition("running")).not.toThrow();
+    expect(machine.state).toBe("running");
+  });
+});

--- a/server/tests/transport/adguard/supervisor.test.ts
+++ b/server/tests/transport/adguard/supervisor.test.ts
@@ -327,3 +327,49 @@ describe("createAdGuardManagedSupervisor", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+describe("AdGuardManagedSupervisor lifecycle transitions", () => {
+  it("never logs an unexpected state transition across the real flows", async () => {
+    const { spawn, procs } = fakeSpawn();
+    const warnings: string[] = [];
+    // Record only the message text so we can assert the advisory transition
+    // warning is never emitted while still allowing the legit restart warning.
+    const logger = {
+      info: () => undefined,
+      warn: (_obj: object, msg?: string) => {
+        if (msg !== undefined) warnings.push(msg);
+      },
+      error: () => undefined,
+    };
+    const sup = createAdGuardManagedSupervisor(CONFIG, {
+      acquire: okAcquire,
+      writeSeedConfig: () => true,
+      spawn,
+      delay: () => Promise.resolve(),
+      maxRestarts: 2,
+      stableMs: 60_000,
+      now: () => new Date(0), // every run instantaneous → no stable reset
+    });
+
+    // Exercise every real path the transition table must cover:
+    // idle→fetching→starting→running, running→starting (restart) ×2,
+    // running→failed (cap), failed→fetching→…→running (re-bootstrap),
+    // running→stopped (graceful stop).
+    await sup.bootstrap(logger);
+    only(procs, procs.length - 1).triggerExit(1, null); // restart 1
+    await flush();
+    only(procs, procs.length - 1).triggerExit(1, null); // restart 2
+    await flush();
+    only(procs, procs.length - 1).triggerExit(1, null); // cap exceeded → failed
+    await flush();
+    expect(sup.status.state).toBe("failed");
+
+    await sup.bootstrap(logger); // re-bootstrap from failed
+    expect(sup.status.state).toBe("running");
+    only(procs, procs.length - 1).autoExitOn = "SIGTERM";
+    await sup.stop();
+    expect(sup.status.state).toBe("stopped");
+
+    expect(warnings.some((msg) => msg.includes("unexpected state transition"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Behaviour-preserving decomposition of `AdGuardManagedSupervisor`, per the code-review finding in #310 — the sequencing hold (wait for PR #291) is now cleared (#291 merged).

- **`RestartBackoff`** (`transport/adguard/backoff.ts`) owns the consecutive-restart counter, the stable-run reset, the restart cap, and the exponential-delay computation that were inline in `#onExit`. Pure and time-injected.
- **`LifecycleMachine` + `STATE_TRANSITIONS`** (`transport/adguard/lifecycle.ts`) make the supervisor's states and valid transitions explicit (enum + transition table) instead of threading them implicitly through `#settle`. The machine is **advisory**: an undeclared transition is logged via the injected logger and still applied — it never throws, preserving `bootstrap()`'s never-throw contract and the `onExit`/`onError` process-event callback paths.
- `supervisor.ts` shrinks by ~40 lines of inline logic; the `AdGuardManagedState` type moves to `lifecycle.ts` and is re-exported from `supervisor.ts`, so `transport/adguard/index.ts`, `service.ts`, and `api/system/dtos.ts` import paths are unchanged.

`#stopping` is deliberately left as a separate latch (intent-to-stop is orthogonal to the observed lifecycle state); folding it into the enum would be a semantic change with behaviour risk.

## Plan

Linked plan: `.claude/plans/issue-310-adguard-supervisor-backoff-fsm.md`
Roadmap: code-review complexity cleanup (Phase-7 managed-AdGuard supervisor, #96)

## License-boundary note

N/A — pure process supervision refactor. AdGuard Home is still reached only over its REST API (`CLAUDE.md` rule 4/5); no GPL linkage, no subprocess/REST boundary collapsed, no Docker-image change, no new dependency.

## Test plan

- [x] Existing `tests/transport/adguard/supervisor.test.ts` (13 tests) is the behaviour guard — passes **unchanged**.
- [x] New `backoff.test.ts` — doubling/ceiling delays, cap → `null`, stable-run reset, count progression, never-started guard, `maxRestarts: 0`.
- [x] New `lifecycle.test.ts` — `isValidTransition` truth table (every declared edge + representative invalid edges), advisory `onInvalid` callback, self-transition no-op, never-throws.
- [x] `npm run format` / `lint:fix` / `typecheck` — clean.
- [x] `npm test` — 1691 passing, coverage gate 80% held (`backoff.ts` + `lifecycle.ts` 100%). The `/api/system/adguard-managed` route test passes, confirming the export surface is intact.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYjrs7RE7vxeYL5LXeLqKp)_