### PR TITLE
feat(telemetry): durable per-client pull cursor (#382)

### DIFF
--- a/.claude/plans/issue-382-durable-telemetry-cursor.md
+++ b/.claude/plans/issue-382-durable-telemetry-cursor.md
@@ -1,0 +1,87 @@
+# Plan — #382 Durable per-client telemetry pull cursor (survive restart)
+
+Roadmap: `docs/roadmap.md` → Phase 5 (ActivityWatch telemetry pull).
+Issue: #382 (follow-up to #327, which introduced the **in-memory** cursor).
+
+## What exists on `main` (don't rebuild)
+
+- `enforcement/telemetry-consumer.ts` — `createUsageTelemetryConsumer` holds an
+  **in-memory** `Map<number, Date>` cursor (last successfully-pulled window
+  `end`, keyed by `clientId`). Each pass queries
+  `[cursor.get(id) ?? (passEnd − initialLookback), passEnd)` and, only after a
+  successful `insertUsageSamples`, advances `cursor.set(id, end)`. A mid-pull
+  throw leaves the cursor unmoved so the window re-pulls next pass.
+- `enforcement/pipeline.ts` — owns the cursor: `const cursor = new Map()` at
+  construction, seeds the consumer + the sweep, pins `currentPassEnd` per pass.
+- `policy/usage.ts` — `insertUsageSamples` is a plain append (no uniqueness
+  constraint); cross-pull de-dup is explicitly the pull layer's job.
+- `policy/schema.ts` — `clients` table (`last_seen`, `versions_reported_at`,
+  … all nullable `integer(mode:"timestamp")` columns to mirror).
+
+## The gap this closes
+
+The cursor is process-local, so after a restart a client's first pass re-pulls
+the whole `PCT_ENFORCEMENT_INITIAL_LOOKBACK_SECONDS` window (default 900 s),
+which overlaps already-persisted samples → a bounded restart double-count.
+Persisting the cursor makes the first post-restart window start exactly where
+the last successful pull ended: no overlap, no gap.
+
+## Design decision — column vs table
+
+Persist on **`clients`** as a nullable `last_telemetry_pull_at` timestamp
+column, not a separate `telemetry_cursors` table. The cursor is strictly 1:1
+with a client, dies with the client (no orphan rows, no extra FK/cascade), and
+mirrors the existing `last_seen` / `versions_reported_at` nullable-timestamp
+columns. `NULL` is the "no cursor yet" state → fall back to `initialLookback`.
+
+**Idempotent-insert alternative (issue's "alternatively/additionally"): not
+taken.** Adding a uniqueness constraint / overlap-aware upsert to
+`usage_samples` is a larger change with its own semantics question (what is the
+natural key of a clipped interval?) and would alter the deliberately-plain
+append. The cursor-persistence approach directly fixes the documented restart
+overlap with a single nullable column and no change to the write path. Noted in
+the PR.
+
+## Phases
+
+### Phase 1 — schema + migration + cursor DB access (+ tests)
+- `policy/schema.ts`: add `lastTelemetryPullAt: integer("last_telemetry_pull_at",
+  { mode: "timestamp" })` to `clients`, with a doc comment.
+- `npm run db:generate` → timestamp-prefixed migration under `server/drizzle/`
+  (never hand-numbered, per #133).
+- New `policy/telemetry-cursor.ts`:
+  - `loadTelemetryCursors(db): Map<number, Date>` — every client with a non-null
+    `last_telemetry_pull_at`, as a `clientId → Date` map (seed source on boot).
+  - `saveTelemetryCursor(db, clientId, end): void` — persist the advance.
+- `tests/policy/telemetry-cursor.test.ts`: save writes the column; load returns
+  only non-null rows as a map; save overwrites an earlier value; empty DB → empty
+  map.
+
+### Phase 2 — wire persistence into consumer + pipeline (+ tests)
+- `telemetry-consumer.ts`: after the existing `cursor.set(client.id, end)`, call
+  `saveTelemetryCursor(db, client.id, end)` — same success point, so a mid-pull
+  throw still leaves **both** cursors unmoved. Update the module doc block (the
+  "does not survive a restart — a durable cursor is tracked as a follow-up" note
+  now describes shipped behaviour).
+- `pipeline.ts`: seed `const cursor = loadTelemetryCursors(db)` instead of
+  `new Map()`. Update the adjacent comment.
+- Extend `tests/enforcement/telemetry-consumer.test.ts`: a successful pull
+  persists `last_telemetry_pull_at` on the `clients` row; a failed pull leaves it
+  `null`.
+- Extend `tests/enforcement/pipeline.test.ts`: a client with a persisted cursor
+  seeds the in-memory cursor so the first pass's window starts at the persisted
+  `end` (not `passEnd − initialLookback`) — asserted via the AW source's observed
+  query `start`.
+
+### Phase 3 — finalize
+- `cd server && npm run format && npm run lint:fix && npm run typecheck && npm test`
+  (coverage ≥ 80%).
+- Draft PR (Closes #382), license-boundary note (N/A — Drizzle reads/writes
+  only), test plan. Subagent review, address comments, mark ready.
+
+## Guardrails
+- License boundary: **N/A** — Drizzle (Apache-2.0) + better-sqlite3 (MIT) only;
+  no GPL linkage, no GPL binary in the image, no transport/packaging change.
+- No new dependency.
+- Never weaken the existing consumer tests; the failure-leaves-cursor-unmoved
+  invariant must hold for the persisted cursor too.

--- a/server/drizzle/20260727173433_mute_star_brand.sql
+++ b/server/drizzle/20260727173433_mute_star_brand.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `clients` ADD `last_telemetry_pull_at` integer;

--- a/server/drizzle/meta/20260727173433_snapshot.json
+++ b/server/drizzle/meta/20260727173433_snapshot.json
@@ -1,0 +1,2123 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ac26c2ad-19e3-49c6-92eb-b7241706e9f2",
+  "prevId": "43667f24-7b7d-462c-a34a-5b52f11245e2",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matcher": {
+          "name": "matcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'exact'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "activities_kind_check": {
+          "name": "activities_kind_check",
+          "value": "\"activities\".\"kind\" in ('app', 'app_group', 'domain', 'domain_group')"
+        },
+        "activities_match_type_check": {
+          "name": "activities_match_type_check",
+          "value": "\"activities\".\"match_type\" in ('exact', 'substring', 'glob', 'regex')"
+        }
+      }
+    },
+    "activities_to_groups": {
+      "name": "activities_to_groups",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activities_to_groups_activity_id_activities_id_fk": {
+          "name": "activities_to_groups_activity_id_activities_id_fk",
+          "tableFrom": "activities_to_groups",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activities_to_groups_group_id_activity_groups_id_fk": {
+          "name": "activities_to_groups_group_id_activity_groups_id_fk",
+          "tableFrom": "activities_to_groups",
+          "tableTo": "activity_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activities_to_groups_activity_id_group_id_pk": {
+          "columns": [
+            "activity_id",
+            "group_id"
+          ],
+          "name": "activities_to_groups_activity_id_group_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_groups": {
+      "name": "activity_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "activity_groups_name_unique": {
+          "name": "activity_groups_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "admin_credentials": {
+      "name": "admin_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "admin_credentials_singleton_check": {
+          "name": "admin_credentials_singleton_check",
+          "value": "\"admin_credentials\".\"id\" = 1"
+        }
+      }
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_port": {
+          "name": "target_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_at_idx": {
+          "name": "audit_log_at_idx",
+          "columns": [
+            "at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_client_at_idx": {
+          "name": "audit_log_client_at_idx",
+          "columns": [
+            "client_id",
+            "at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_log_client_id_clients_id_fk": {
+          "name": "audit_log_client_id_clients_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "audit_log_outcome_check": {
+          "name": "audit_log_outcome_check",
+          "value": "\"audit_log\".\"outcome\" in ('ok', 'failed', 'unreachable', 'timeout', 'parse_error')"
+        },
+        "audit_log_duration_check": {
+          "name": "audit_log_duration_check",
+          "value": "\"audit_log\".\"duration_ms\" >= 0"
+        }
+      }
+    },
+    "budgets": {
+      "name": "budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seconds_allowed": {
+          "name": "seconds_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "budgets_user_scope_window_idx": {
+          "name": "budgets_user_scope_window_idx",
+          "columns": [
+            "user_id",
+            "scope",
+            "window"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "budgets_scope_check": {
+          "name": "budgets_scope_check",
+          "value": "\"budgets\".\"scope\" in ('overall', 'activity', 'group')"
+        },
+        "budgets_window_check": {
+          "name": "budgets_window_check",
+          "value": "\"budgets\".\"window\" in ('daily', 'weekly', 'monthly')"
+        },
+        "budgets_seconds_check": {
+          "name": "budgets_seconds_check",
+          "value": "\"budgets\".\"seconds_allowed\" >= 0"
+        },
+        "budgets_target_coherence_check": {
+          "name": "budgets_target_coherence_check",
+          "value": "(\"budgets\".\"scope\" = 'overall') = (\"budgets\".\"target_id\" is null)"
+        }
+      }
+    },
+    "clients": {
+      "name": "clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ssh_user": {
+          "name": "ssh_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_hash": {
+          "name": "bearer_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_telemetry_pull_at": {
+          "name": "last_telemetry_pull_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_version": {
+          "name": "agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "component_versions": {
+          "name": "component_versions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "versions_reported_at": {
+          "name": "versions_reported_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'linux'"
+        },
+        "update_required": {
+          "name": "update_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "clients_hostname_unique": {
+          "name": "clients_hostname_unique",
+          "columns": [
+            "hostname"
+          ],
+          "isUnique": true
+        },
+        "clients_bearer_token_hash_unique": {
+          "name": "clients_bearer_token_hash_unique",
+          "columns": [
+            "bearer_token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "clients_platform_check": {
+          "name": "clients_platform_check",
+          "value": "\"clients\".\"platform\" in ('linux', 'windows')"
+        }
+      }
+    },
+    "enrolment_tokens": {
+      "name": "enrolment_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supervised_users": {
+          "name": "supervised_users",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_client_id": {
+          "name": "consumed_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "enrolment_tokens_token_hash_unique": {
+          "name": "enrolment_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "enrolment_tokens_consumed_client_id_clients_id_fk": {
+          "name": "enrolment_tokens_consumed_client_id_clients_id_fk",
+          "tableFrom": "enrolment_tokens",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "consumed_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exceptions": {
+      "name": "exceptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "exceptions_user_expires_idx": {
+          "name": "exceptions_user_expires_idx",
+          "columns": [
+            "user_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "exceptions_user_id_users_id_fk": {
+          "name": "exceptions_user_id_users_id_fk",
+          "tableFrom": "exceptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "exceptions_target_kind_check": {
+          "name": "exceptions_target_kind_check",
+          "value": "\"exceptions\".\"target_kind\" in ('overall', 'activity', 'group')"
+        },
+        "exceptions_action_check": {
+          "name": "exceptions_action_check",
+          "value": "\"exceptions\".\"action\" in ('allow', 'deny', 'extend')"
+        },
+        "exceptions_target_coherence_check": {
+          "name": "exceptions_target_coherence_check",
+          "value": "(\"exceptions\".\"target_kind\" = 'overall') = (\"exceptions\".\"target_id\" is null)"
+        },
+        "exceptions_effective_window_check": {
+          "name": "exceptions_effective_window_check",
+          "value": "\"exceptions\".\"effective_from\" is null or \"exceptions\".\"effective_from\" < \"exceptions\".\"expires_at\""
+        }
+      }
+    },
+    "grants": {
+      "name": "grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seconds_granted": {
+          "name": "seconds_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "grants_source_ref_unique": {
+          "name": "grants_source_ref_unique",
+          "columns": [
+            "source_ref"
+          ],
+          "isUnique": true
+        },
+        "grants_user_scope_target_idx": {
+          "name": "grants_user_scope_target_idx",
+          "columns": [
+            "user_id",
+            "scope",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "grants_user_expires_idx": {
+          "name": "grants_user_expires_idx",
+          "columns": [
+            "user_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "grants_user_id_users_id_fk": {
+          "name": "grants_user_id_users_id_fk",
+          "tableFrom": "grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "grants_scope_check": {
+          "name": "grants_scope_check",
+          "value": "\"grants\".\"scope\" in ('overall', 'activity', 'group')"
+        },
+        "grants_seconds_check": {
+          "name": "grants_seconds_check",
+          "value": "\"grants\".\"seconds_granted\" > 0"
+        },
+        "grants_target_coherence_check": {
+          "name": "grants_target_coherence_check",
+          "value": "(\"grants\".\"scope\" = 'overall') = (\"grants\".\"target_id\" is null)"
+        },
+        "grants_source_check": {
+          "name": "grants_source_check",
+          "value": "\"grants\".\"source\" = 'admin' or \"grants\".\"source\" like 'integration:%'"
+        }
+      }
+    },
+    "group_budgets": {
+      "name": "group_budgets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_group_id": {
+          "name": "user_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seconds_allowed": {
+          "name": "seconds_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_budgets_group_scope_window_idx": {
+          "name": "group_budgets_group_scope_window_idx",
+          "columns": [
+            "user_group_id",
+            "scope",
+            "window"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_budgets_user_group_id_user_groups_id_fk": {
+          "name": "group_budgets_user_group_id_user_groups_id_fk",
+          "tableFrom": "group_budgets",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "user_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "group_budgets_scope_check": {
+          "name": "group_budgets_scope_check",
+          "value": "\"group_budgets\".\"scope\" in ('overall', 'activity', 'group')"
+        },
+        "group_budgets_window_check": {
+          "name": "group_budgets_window_check",
+          "value": "\"group_budgets\".\"window\" in ('daily', 'weekly', 'monthly')"
+        },
+        "group_budgets_seconds_check": {
+          "name": "group_budgets_seconds_check",
+          "value": "\"group_budgets\".\"seconds_allowed\" >= 0"
+        },
+        "group_budgets_target_coherence_check": {
+          "name": "group_budgets_target_coherence_check",
+          "value": "(\"group_budgets\".\"scope\" = 'overall') = (\"group_budgets\".\"target_id\" is null)"
+        }
+      }
+    },
+    "group_exceptions": {
+      "name": "group_exceptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_group_id": {
+          "name": "user_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "group_exceptions_group_expires_idx": {
+          "name": "group_exceptions_group_expires_idx",
+          "columns": [
+            "user_group_id",
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_exceptions_user_group_id_user_groups_id_fk": {
+          "name": "group_exceptions_user_group_id_user_groups_id_fk",
+          "tableFrom": "group_exceptions",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "user_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "group_exceptions_target_kind_check": {
+          "name": "group_exceptions_target_kind_check",
+          "value": "\"group_exceptions\".\"target_kind\" in ('overall', 'activity', 'group')"
+        },
+        "group_exceptions_action_check": {
+          "name": "group_exceptions_action_check",
+          "value": "\"group_exceptions\".\"action\" in ('allow', 'deny', 'extend')"
+        },
+        "group_exceptions_target_coherence_check": {
+          "name": "group_exceptions_target_coherence_check",
+          "value": "(\"group_exceptions\".\"target_kind\" = 'overall') = (\"group_exceptions\".\"target_id\" is null)"
+        },
+        "group_exceptions_effective_window_check": {
+          "name": "group_exceptions_effective_window_check",
+          "value": "\"group_exceptions\".\"effective_from\" is null or \"group_exceptions\".\"effective_from\" < \"group_exceptions\".\"expires_at\""
+        }
+      }
+    },
+    "group_schedules": {
+      "name": "group_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_group_id": {
+          "name": "user_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_days": {
+          "name": "recurrence_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_start_minute": {
+          "name": "recurrence_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_end_minute": {
+          "name": "recurrence_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "group_schedules_group_ordinal_idx": {
+          "name": "group_schedules_group_ordinal_idx",
+          "columns": [
+            "user_group_id",
+            "ordinal"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_schedules_user_group_id_user_groups_id_fk": {
+          "name": "group_schedules_user_group_id_user_groups_id_fk",
+          "tableFrom": "group_schedules",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "user_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "group_schedules_target_kind_check": {
+          "name": "group_schedules_target_kind_check",
+          "value": "\"group_schedules\".\"target_kind\" in ('overall', 'activity', 'group')"
+        },
+        "group_schedules_action_check": {
+          "name": "group_schedules_action_check",
+          "value": "\"group_schedules\".\"action\" in ('allow', 'deny', 'extend')"
+        },
+        "group_schedules_target_coherence_check": {
+          "name": "group_schedules_target_coherence_check",
+          "value": "(\"group_schedules\".\"target_kind\" = 'overall') = (\"group_schedules\".\"target_id\" is null)"
+        },
+        "group_schedules_recurrence_days_check": {
+          "name": "group_schedules_recurrence_days_check",
+          "value": "\"group_schedules\".\"recurrence_days\" is null or (\"group_schedules\".\"recurrence_days\" between 1 and 127)"
+        },
+        "group_schedules_recurrence_minutes_check": {
+          "name": "group_schedules_recurrence_minutes_check",
+          "value": "(\"group_schedules\".\"recurrence_start_minute\" is null) = (\"group_schedules\".\"recurrence_end_minute\" is null) and (\"group_schedules\".\"recurrence_start_minute\" is null or (\"group_schedules\".\"recurrence_start_minute\" >= 0 and \"group_schedules\".\"recurrence_end_minute\" <= 1440 and \"group_schedules\".\"recurrence_start_minute\" < \"group_schedules\".\"recurrence_end_minute\"))"
+        },
+        "group_schedules_effective_window_check": {
+          "name": "group_schedules_effective_window_check",
+          "value": "\"group_schedules\".\"effective_from\" is null or \"group_schedules\".\"effective_to\" is null or \"group_schedules\".\"effective_from\" < \"group_schedules\".\"effective_to\""
+        }
+      }
+    },
+    "integration_tokens": {
+      "name": "integration_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_secret": {
+          "name": "hashed_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "integration_tokens_name_unique": {
+          "name": "integration_tokens_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_policies": {
+      "name": "notification_policies",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sound_profile": {
+          "name": "sound_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'subtle'"
+        },
+        "grace_seconds": {
+          "name": "grace_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 15
+        },
+        "cadence_overrides_json": {
+          "name": "cadence_overrides_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_policies_user_id_users_id_fk": {
+          "name": "notification_policies_user_id_users_id_fk",
+          "tableFrom": "notification_policies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "notification_policies_sound_profile_check": {
+          "name": "notification_policies_sound_profile_check",
+          "value": "\"notification_policies\".\"sound_profile\" in ('off', 'subtle', 'prominent')"
+        },
+        "notification_policies_grace_check": {
+          "name": "notification_policies_grace_check",
+          "value": "\"notification_policies\".\"grace_seconds\" between 0 and 60"
+        }
+      }
+    },
+    "retention_overrides": {
+      "name": "retention_overrides",
+      "columns": {
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keep_forever": {
+          "name": "keep_forever",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "days": {
+          "name": "days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "retention_overrides_category_check": {
+          "name": "retention_overrides_category_check",
+          "value": "\"retention_overrides\".\"category\" in ('usage_samples', 'grant_ledger', 'audit_log', 'date_overrides')"
+        },
+        "retention_overrides_coherence_check": {
+          "name": "retention_overrides_coherence_check",
+          "value": "(\"retention_overrides\".\"keep_forever\" = 1 and \"retention_overrides\".\"days\" is null) or (\"retention_overrides\".\"keep_forever\" = 0 and \"retention_overrides\".\"days\" > 0)"
+        }
+      }
+    },
+    "schedules": {
+      "name": "schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_days": {
+          "name": "recurrence_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_start_minute": {
+          "name": "recurrence_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_end_minute": {
+          "name": "recurrence_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "schedules_user_ordinal_idx": {
+          "name": "schedules_user_ordinal_idx",
+          "columns": [
+            "user_id",
+            "ordinal"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedules_user_id_users_id_fk": {
+          "name": "schedules_user_id_users_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "schedules_target_kind_check": {
+          "name": "schedules_target_kind_check",
+          "value": "\"schedules\".\"target_kind\" in ('overall', 'activity', 'group')"
+        },
+        "schedules_action_check": {
+          "name": "schedules_action_check",
+          "value": "\"schedules\".\"action\" in ('allow', 'deny', 'extend')"
+        },
+        "schedules_target_coherence_check": {
+          "name": "schedules_target_coherence_check",
+          "value": "(\"schedules\".\"target_kind\" = 'overall') = (\"schedules\".\"target_id\" is null)"
+        },
+        "schedules_recurrence_days_check": {
+          "name": "schedules_recurrence_days_check",
+          "value": "\"schedules\".\"recurrence_days\" is null or (\"schedules\".\"recurrence_days\" between 1 and 127)"
+        },
+        "schedules_recurrence_minutes_check": {
+          "name": "schedules_recurrence_minutes_check",
+          "value": "(\"schedules\".\"recurrence_start_minute\" is null) = (\"schedules\".\"recurrence_end_minute\" is null) and (\"schedules\".\"recurrence_start_minute\" is null or (\"schedules\".\"recurrence_start_minute\" >= 0 and \"schedules\".\"recurrence_end_minute\" <= 1440 and \"schedules\".\"recurrence_start_minute\" < \"schedules\".\"recurrence_end_minute\"))"
+        },
+        "schedules_effective_window_check": {
+          "name": "schedules_effective_window_check",
+          "value": "\"schedules\".\"effective_from\" is null or \"schedules\".\"effective_to\" is null or \"schedules\".\"effective_from\" < \"schedules\".\"effective_to\""
+        }
+      }
+    },
+    "transport_queue": {
+      "name": "transport_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coalesce_key": {
+          "name": "coalesce_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "transport_queue_client_coalesce_unique": {
+          "name": "transport_queue_client_coalesce_unique",
+          "columns": [
+            "client_id",
+            "coalesce_key"
+          ],
+          "isUnique": true
+        },
+        "transport_queue_client_status_id_idx": {
+          "name": "transport_queue_client_status_id_idx",
+          "columns": [
+            "client_id",
+            "status",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transport_queue_client_id_clients_id_fk": {
+          "name": "transport_queue_client_id_clients_id_fk",
+          "tableFrom": "transport_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "transport_queue_status_check": {
+          "name": "transport_queue_status_check",
+          "value": "\"transport_queue\".\"status\" in ('pending', 'failed')"
+        },
+        "transport_queue_attempts_check": {
+          "name": "transport_queue_attempts_check",
+          "value": "\"transport_queue\".\"attempts\" >= 0"
+        }
+      }
+    },
+    "usage_samples": {
+      "name": "usage_samples",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_samples_user_started_idx": {
+          "name": "usage_samples_user_started_idx",
+          "columns": [
+            "user_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "usage_samples_user_activity_started_idx": {
+          "name": "usage_samples_user_activity_started_idx",
+          "columns": [
+            "user_id",
+            "activity_id",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "usage_samples_user_id_users_id_fk": {
+          "name": "usage_samples_user_id_users_id_fk",
+          "tableFrom": "usage_samples",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_samples_client_id_clients_id_fk": {
+          "name": "usage_samples_client_id_clients_id_fk",
+          "tableFrom": "usage_samples",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_samples_activity_id_activities_id_fk": {
+          "name": "usage_samples_activity_id_activities_id_fk",
+          "tableFrom": "usage_samples",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "usage_samples_interval_check": {
+          "name": "usage_samples_interval_check",
+          "value": "\"usage_samples\".\"ended_at\" >= \"usage_samples\".\"started_at\""
+        }
+      }
+    },
+    "user_group_memberships": {
+      "name": "user_group_memberships",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_group_memberships_group_idx": {
+          "name": "user_group_memberships_group_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_group_memberships_user_id_users_id_fk": {
+          "name": "user_group_memberships_user_id_users_id_fk",
+          "tableFrom": "user_group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_group_memberships_group_id_user_groups_id_fk": {
+          "name": "user_group_memberships_group_id_user_groups_id_fk",
+          "tableFrom": "user_group_memberships",
+          "tableTo": "user_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_group_memberships_user_id_group_id_pk": {
+          "columns": [
+            "user_id",
+            "group_id"
+          ],
+          "name": "user_group_memberships_user_id_group_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_groups": {
+      "name": "user_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "user_groups_name_unique": {
+          "name": "user_groups_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_pins": {
+      "name": "user_pins",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_pin": {
+          "name": "hashed_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_pins_user_id_users_id_fk": {
+          "name": "user_pins_user_id_users_id_fk",
+          "tableFrom": "user_pins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tz": {
+          "name": "tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_on_clients": {
+      "name": "users_on_clients",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "os_username": {
+          "name": "os_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "os_user_ref": {
+          "name": "os_user_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_on_clients_client_idx": {
+          "name": "users_on_clients_client_idx",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "users_on_clients_client_user_ref_unique": {
+          "name": "users_on_clients_client_user_ref_unique",
+          "columns": [
+            "client_id",
+            "os_user_ref"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_on_clients_user_id_users_id_fk": {
+          "name": "users_on_clients_user_id_users_id_fk",
+          "tableFrom": "users_on_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_on_clients_client_id_clients_id_fk": {
+          "name": "users_on_clients_client_id_clients_id_fk",
+          "tableFrom": "users_on_clients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_on_clients_user_id_client_id_pk": {
+          "columns": [
+            "user_id",
+            "client_id"
+          ],
+          "name": "users_on_clients_user_id_client_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1782578822511,
       "tag": "20260627164702_chunky_sentinels",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1785173673727,
+      "tag": "20260727173433_mute_star_brand",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/enforcement/pipeline.ts
+++ b/server/src/enforcement/pipeline.ts
@@ -34,6 +34,7 @@ import type { FastifyBaseLogger } from "fastify";
 
 import type { PolicyDb } from "../policy/db.js";
 import { clients } from "../policy/schema.js";
+import { loadTelemetryCursors } from "../policy/telemetry-cursor.js";
 import type { AuditSink } from "../transport/audit/index.js";
 import {
   runTelemetryPull,
@@ -174,7 +175,10 @@ export function createEnforcementPipeline(
   // shared by both the telemetry window and the sweep — so enforcement
   // evaluates at exactly the boundary the samples were credited to, not a few
   // seconds later when the (awaited) pull returns.
-  const cursor = new Map<number, Date>();
+  // Seed the per-client cursor from the durable column (#382) so a restart
+  // resumes each client's pull where it left off; a client with no persisted
+  // cursor is absent from the map and falls back to `initialLookback`.
+  const cursor = loadTelemetryCursors(db);
   let currentPassEnd = now();
 
   // Caller-driven sweep (no internal cron): `tick()` runs after each rollup,

--- a/server/src/enforcement/telemetry-consumer.ts
+++ b/server/src/enforcement/telemetry-consumer.ts
@@ -11,13 +11,17 @@
  * — the rollups the Phase-8 enforcement sweep then reads.
  *
  * **Pull window / cursor.** `usage_samples` is a plain append with no
- * uniqueness constraint and there is no durable pull cursor yet (#162 deferred
- * it). To keep overlapping passes from double-counting, this consumer holds an
+ * uniqueness constraint (#162 made cross-pull de-dup the pull layer's job). To
+ * keep overlapping passes from double-counting, this consumer holds an
  * in-memory per-client cursor of the last successfully-pulled window `end`:
  * each pass queries `[cursor ?? (passEnd − initialLookback), passEnd]` and, only
- * after a successful insert, advances the cursor to `passEnd`. The cursor does
- * not survive a restart — a durable cursor is tracked as a follow-up — so a
- * restart re-pulls at most `initialLookback`. Missing telemetry credits no
+ * after a successful insert, advances the cursor to `passEnd`. That cursor is
+ * now also **durable** (#382): the pipeline seeds it from
+ * `clients.last_telemetry_pull_at` on boot and this consumer persists each
+ * advance via {@link saveTelemetryCursor}, so a restart resumes exactly where
+ * the last successful pull ended rather than re-pulling `initialLookback` and
+ * overlapping already-persisted samples. A client with no persisted cursor yet
+ * still falls back to `initialLookback`. Missing telemetry credits no
  * consumption (#88), so any gap is non-punitive.
  *
  * **Single supervised user per client (Alpha-1).** `aw-server` binds one OS
@@ -35,6 +39,7 @@ import { eq } from "drizzle-orm";
 
 import type { PolicyDb } from "../policy/db.js";
 import { activities, usersOnClients } from "../policy/schema.js";
+import { saveTelemetryCursor } from "../policy/telemetry-cursor.js";
 import { insertUsageSamples } from "../policy/usage.js";
 import type {
   ActivityMatcher,
@@ -216,8 +221,11 @@ export function createUsageTelemetryConsumer(
     // Advance the cursor after a successful pull (regardless of row count, so a
     // clean pull that matched nothing still moves forward). A mid-pull failure
     // throws and is isolated by runTelemetryPull, leaving the cursor unmoved so
-    // the same window is re-pulled next pass rather than skipped.
+    // the same window is re-pulled next pass rather than skipped. The in-memory
+    // and durable (#382) cursors advance together at this one success point, so
+    // that throw leaves both unmoved.
     cursor.set(client.id, end);
+    saveTelemetryCursor(db, client.id, end);
 
     logger.info(
       {

--- a/server/src/enforcement/telemetry-consumer.ts
+++ b/server/src/enforcement/telemetry-consumer.ts
@@ -18,11 +18,14 @@
  * after a successful insert, advances the cursor to `passEnd`. That cursor is
  * now also **durable** (#382): the pipeline seeds it from
  * `clients.last_telemetry_pull_at` on boot and this consumer persists each
- * advance via {@link saveTelemetryCursor}, so a restart resumes exactly where
- * the last successful pull ended rather than re-pulling `initialLookback` and
- * overlapping already-persisted samples. A client with no persisted cursor yet
- * still falls back to `initialLookback`. Missing telemetry credits no
- * consumption (#88), so any gap is non-punitive.
+ * advance via {@link saveTelemetryCursor} in the **same transaction** as the
+ * sample insert, so the cursor can never commit ahead of (or behind) the rows
+ * it accounts for. A restart therefore resumes exactly where the last
+ * successful pull ended rather than re-pulling `initialLookback` and
+ * overlapping already-persisted samples — even if the process is killed
+ * mid-pass. A client with no persisted cursor yet still falls back to
+ * `initialLookback`. Missing telemetry credits no consumption (#88), so any gap
+ * is non-punitive.
  *
  * **Single supervised user per client (Alpha-1).** `aw-server` binds one OS
  * account's activity on `:5600`; the loopback tunnel can't disambiguate several
@@ -216,16 +219,26 @@ export function createUsageTelemetryConsumer(
     // hinge on an unverified aw-server semantic. (Under a stricter start-time
     // filter this can only under-credit an event's out-of-window tail — bounded
     // and non-punitive per #88 — never over-credit.)
-    const inserted = insertUsageSamples(db, clipToWindow(candidates, start, end));
+    // Persist the samples and advance the durable cursor (#382) in one
+    // transaction so the two commit or roll back together. Without it, a crash
+    // in the window *between* the two writes (SIGKILL / OOM / power loss) after
+    // the insert commits but before the cursor advance would, on the next boot,
+    // leave the cursor behind the already-persisted samples → that window is
+    // re-pulled and its rows appended a second time (`usage_samples` has no
+    // uniqueness constraint, by design), a punitive over-count. Wrapping both
+    // closes that window. An empty-but-clean pull inserts nothing yet still
+    // advances the cursor — intended.
+    const inserted = db.transaction((tx) => {
+      const rows = insertUsageSamples(tx, clipToWindow(candidates, start, end));
+      saveTelemetryCursor(tx, client.id, end);
+      return rows;
+    });
 
-    // Advance the cursor after a successful pull (regardless of row count, so a
-    // clean pull that matched nothing still moves forward). A mid-pull failure
-    // throws and is isolated by runTelemetryPull, leaving the cursor unmoved so
-    // the same window is re-pulled next pass rather than skipped. The in-memory
-    // and durable (#382) cursors advance together at this one success point, so
-    // that throw leaves both unmoved.
+    // Advance the in-memory cursor only after the transaction commits, so it can
+    // never outrun the durable one. A mid-pull failure throws before this (and
+    // rolls the transaction back), leaving both cursors unmoved so the same
+    // window is re-pulled next pass rather than skipped.
     cursor.set(client.id, end);
-    saveTelemetryCursor(db, client.id, end);
 
     logger.info(
       {

--- a/server/src/policy/db.ts
+++ b/server/src/policy/db.ts
@@ -54,6 +54,15 @@ export type PolicyDb = BetterSQLite3Database<typeof schema> & {
   $client: Database.Database;
 };
 
+/**
+ * A transaction handle over the policy store — the argument drizzle hands the
+ * `db.transaction((tx) => …)` callback. Structurally a {@link PolicyDb} without
+ * the `$client` escape hatch, so a write helper that must run either directly
+ * or inside a transaction takes `PolicyDb | PolicyTx` and callers can pass
+ * either the db or a `tx`.
+ */
+export type PolicyTx = Parameters<Parameters<PolicyDb["transaction"]>[0]>[0];
+
 /** Options for {@link createDb}. */
 export interface CreateDbOptions {
   /**

--- a/server/src/policy/schema.ts
+++ b/server/src/policy/schema.ts
@@ -160,6 +160,16 @@ export const clients = sqliteTable(
     bearerTokenHash: text("bearer_token_hash"),
     enrolledAt: timestampNow("enrolled_at"),
     lastSeen: integer("last_seen", { mode: "timestamp" }),
+    /**
+     * Durable telemetry pull cursor (#382): the `end` of the last window whose
+     * `UsageSample` rows were successfully persisted for this client. The
+     * Phase-5 pull seeds its in-memory cursor from this on boot and advances
+     * both together after each successful insert, so the first pass after a
+     * restart resumes exactly here instead of re-pulling the whole
+     * `initialLookback` window (a bounded double-count). `NULL` = no successful
+     * pull yet → the pull falls back to `initialLookback`.
+     */
+    lastTelemetryPullAt: integer("last_telemetry_pull_at", { mode: "timestamp" }),
     agentVersion: text("agent_version"),
     componentVersions: text("component_versions", { mode: "json" }).$type<ComponentVersions>(),
     versionsReportedAt: integer("versions_reported_at", { mode: "timestamp" }),

--- a/server/src/policy/telemetry-cursor.ts
+++ b/server/src/policy/telemetry-cursor.ts
@@ -21,7 +21,7 @@
  */
 import { eq, isNotNull } from "drizzle-orm";
 
-import type { PolicyDb } from "./db.js";
+import type { PolicyDb, PolicyTx } from "./db.js";
 import { clients } from "./schema.js";
 
 /**
@@ -51,6 +51,6 @@ export function loadTelemetryCursors(db: PolicyDb): Map<number, Date> {
  * in lock-step and a mid-pull failure (which throws before this runs) leaves
  * both unmoved, re-pulling the same window next pass.
  */
-export function saveTelemetryCursor(db: PolicyDb, clientId: number, end: Date): void {
+export function saveTelemetryCursor(db: PolicyDb | PolicyTx, clientId: number, end: Date): void {
   db.update(clients).set({ lastTelemetryPullAt: end }).where(eq(clients.id, clientId)).run();
 }

--- a/server/src/policy/telemetry-cursor.ts
+++ b/server/src/policy/telemetry-cursor.ts
@@ -1,0 +1,56 @@
+/**
+ * Durable telemetry pull cursor (#382): the persistence half of the Phase-5
+ * per-client pull cursor.
+ *
+ * `enforcement/telemetry-consumer.ts` keeps an in-memory `Map<clientId, Date>`
+ * of the last successfully-pulled window `end` so overlapping passes within one
+ * process don't double-count. This module promotes that cursor to a **durable**
+ * one on the `clients.last_telemetry_pull_at` column, so a dashboard restart
+ * resumes each client's pull exactly where it left off instead of re-pulling
+ * the whole `initialLookback` window (a bounded double-count against
+ * already-persisted samples).
+ *
+ * The cursor lives on `clients` (not a separate table) because it is strictly
+ * 1:1 with a client and dies with it — no orphan rows, no extra FK — mirroring
+ * the existing nullable-timestamp columns (`last_seen`, `versions_reported_at`).
+ * A `NULL` column is the "no successful pull yet" state the pull reads as
+ * "fall back to `initialLookback`".
+ *
+ * License boundary: none touched — Drizzle (Apache-2.0) + better-sqlite3 (MIT)
+ * reads/writes only; no GPL surface, no transport call.
+ */
+import { eq, isNotNull } from "drizzle-orm";
+
+import type { PolicyDb } from "./db.js";
+import { clients } from "./schema.js";
+
+/**
+ * Every client with a persisted cursor, as a `clientId → last-pulled-end` map —
+ * the seed the pull loads into its in-memory cursor on boot. Clients with no
+ * successful pull yet (`NULL`) are absent from the map, so the pull falls back
+ * to `initialLookback` for them exactly as it does on a cold start.
+ */
+export function loadTelemetryCursors(db: PolicyDb): Map<number, Date> {
+  const rows = db
+    .select({ clientId: clients.id, lastTelemetryPullAt: clients.lastTelemetryPullAt })
+    .from(clients)
+    .where(isNotNull(clients.lastTelemetryPullAt))
+    .all();
+  const cursors = new Map<number, Date>();
+  for (const row of rows) {
+    // The `isNotNull` filter guarantees this, but the column type is nullable;
+    // the guard narrows `Date | null → Date` without an unchecked cast.
+    if (row.lastTelemetryPullAt !== null) cursors.set(row.clientId, row.lastTelemetryPullAt);
+  }
+  return cursors;
+}
+
+/**
+ * Persist a client's cursor advance. Called at the same point the in-memory
+ * cursor advances — after a successful `UsageSample` insert — so the two stay
+ * in lock-step and a mid-pull failure (which throws before this runs) leaves
+ * both unmoved, re-pulling the same window next pass.
+ */
+export function saveTelemetryCursor(db: PolicyDb, clientId: number, end: Date): void {
+  db.update(clients).set({ lastTelemetryPullAt: end }).where(eq(clients.id, clientId)).run();
+}

--- a/server/src/policy/usage.ts
+++ b/server/src/policy/usage.ts
@@ -29,7 +29,7 @@
 import { and, asc, eq, gt, inArray, lt } from "drizzle-orm";
 
 import { effectiveWindow, type TimezoneChange } from "./budget-window.js";
-import type { PolicyDb } from "./db.js";
+import type { PolicyDb, PolicyTx } from "./db.js";
 import type { BudgetWindow } from "./enums.js";
 import { activitiesToGroups, usageSamples } from "./schema.js";
 
@@ -81,7 +81,10 @@ export interface WindowQuery {
  * on the supplied `Date`s is floored on write; the normaliser already emits
  * second-aligned boundaries, so for its output the persisted row is exact.
  */
-export function insertUsageSamples(db: PolicyDb, samples: readonly UsageSampleInsert[]): number {
+export function insertUsageSamples(
+  db: PolicyDb | PolicyTx,
+  samples: readonly UsageSampleInsert[],
+): number {
   if (samples.length === 0) return 0;
   const rows = samples.map((s) => ({
     userId: s.userId,

--- a/server/tests/api/policy-dtos.test.ts
+++ b/server/tests/api/policy-dtos.test.ts
@@ -48,6 +48,7 @@ describe("policy DTO mappers", () => {
       agentVersion: null,
       componentVersions: null,
       versionsReportedAt: null,
+      lastTelemetryPullAt: null,
       platform: "linux",
       updateRequired: false,
     };
@@ -73,6 +74,7 @@ describe("policy DTO mappers", () => {
       agentVersion: null,
       componentVersions: null,
       versionsReportedAt: null,
+      lastTelemetryPullAt: null,
       platform: "linux",
       updateRequired: false,
     };
@@ -90,6 +92,7 @@ describe("policy DTO mappers", () => {
       agentVersion: null,
       componentVersions: null,
       versionsReportedAt: null,
+      lastTelemetryPullAt: null,
       platform: "linux",
       updateRequired: false,
     };
@@ -107,6 +110,7 @@ describe("policy DTO mappers", () => {
       agentVersion: null,
       componentVersions: null,
       versionsReportedAt: null,
+      lastTelemetryPullAt: null,
       platform: "windows",
       updateRequired: false,
     };

--- a/server/tests/enforcement/pipeline.test.ts
+++ b/server/tests/enforcement/pipeline.test.ts
@@ -26,6 +26,7 @@ import {
   usersOnClients,
   usageSamples,
 } from "../../src/policy/schema.js";
+import { saveTelemetryCursor } from "../../src/policy/telemetry-cursor.js";
 import { buildApp } from "../../src/web/app.js";
 import { loadSettings } from "../../src/config.js";
 import { testDb, type TestDb } from "../helpers/db.js";
@@ -164,6 +165,47 @@ describe("createEnforcementPipeline", () => {
     expect(result.sweep.evaluated).toBe(1);
     expect(result.sweep.decisions).toBe(1);
 
+    pipeline.stop();
+  });
+
+  it("seeds the in-memory cursor from the durable column so a restart resumes there (#382)", async () => {
+    const clientId = db
+      .insert(clients)
+      .values({ hostname: "alice-pc", sshUser: "pct-agent" })
+      .returning()
+      .get().id;
+    const userId = db.insert(users).values({ displayName: "Alice" }).returning().get().id;
+    db.insert(usersOnClients)
+      .values({ userId, clientId, osUsername: "alice", osUserRef: "1001" })
+      .run();
+    db.insert(activities).values({ kind: "app", matcher: "firefox" }).run();
+
+    // A durable cursor persisted by an earlier process lifetime, 2 min before
+    // this pass's end and well inside the 3600s initialLookback window — so the
+    // observed query start distinguishes "seeded from the column" (11:58) from
+    // "cold-start fallback" (11:00).
+    const persisted = new Date("2024-02-15T11:58:00.000Z");
+    saveTelemetryCursor(db, clientId, persisted);
+
+    let observedStart: Date | null = null;
+    const pipeline = createEnforcementPipeline(
+      baseOptions({
+        loadClients: () => [{ id: clientId, hostname: "alice-pc", sshUser: "pct-agent" }],
+        createSource: (): AwEventSource => ({
+          getWindowEvents: (q) => {
+            observedStart = q.start;
+            return Promise.resolve([]);
+          },
+          getAfkEvents: () => Promise.resolve([]),
+        }),
+      }),
+    );
+    if (pipeline === null) throw new Error("expected a pipeline with credentials present");
+
+    await pipeline.runOnce();
+
+    // Resumed at the persisted cursor, not `passEnd − initialLookback`.
+    expect(observedStart).toEqual(persisted);
     pipeline.stop();
   });
 

--- a/server/tests/enforcement/telemetry-consumer.test.ts
+++ b/server/tests/enforcement/telemetry-consumer.test.ts
@@ -23,6 +23,7 @@ import type {
   TelemetryConsumeContext,
   TelemetryLogger,
 } from "../../src/transport/activitywatch/telemetry.js";
+import { saveTelemetryCursor } from "../../src/policy/telemetry-cursor.js";
 import { testDb, type TestDb } from "../helpers/db.js";
 
 /** A logger whose calls are inspectable. */
@@ -277,6 +278,31 @@ describe("createUsageTelemetryConsumer", () => {
     expect(db.select().from(usageSamples).all()).toHaveLength(0);
     // The durable cursor stays unmoved too (#382): the same window re-pulls.
     expect(persistedCursor(clientId)).toBeNull();
+  });
+
+  it("leaves a pre-existing durable cursor unchanged when the pull fails (#382)", async () => {
+    const { clientId } = seedClient(["Alice"]);
+    db.insert(activities).values({ kind: "app", matcher: "firefox" }).run();
+    // A cursor an earlier successful pass already advanced.
+    const earlier = new Date("2024-02-15T11:50:00.000Z");
+    saveTelemetryCursor(db, clientId, earlier);
+    const cursor = new Map<number, Date>([[clientId, earlier]]);
+    const boom: AwEventSource = {
+      getWindowEvents: () => Promise.reject(new Error("aw-server exploded")),
+      getAfkEvents: () => Promise.resolve([]),
+    };
+    const consume = createUsageTelemetryConsumer({
+      db,
+      cursor,
+      passEnd: () => PASS_END,
+      initialLookbackMs: LOOKBACK_MS,
+      createSource: () => boom,
+    });
+
+    await expect(consume(context(clientId, fakeLogger()))).rejects.toThrow("aw-server exploded");
+    // The failed pass must not rewind or clobber the already-advanced cursor.
+    expect(persistedCursor(clientId)).toEqual(earlier);
+    expect(cursor.get(clientId)).toEqual(earlier);
   });
 
   it("persists the cursor durably on a successful pull (#382)", async () => {

--- a/server/tests/enforcement/telemetry-consumer.test.ts
+++ b/server/tests/enforcement/telemetry-consumer.test.ts
@@ -3,6 +3,7 @@
  * #162 pull, turned on by #327). Drives `createUsageTelemetryConsumer` against a
  * seeded in-memory DB and a fake `aw-server` event source — no live tunnel.
  */
+import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -91,6 +92,17 @@ describe("createUsageTelemetryConsumer", () => {
       baseUrl: "http://127.0.0.1:54321",
       logger,
     };
+  }
+
+  /** The durable cursor persisted on the client row (#382), or `null`. */
+  function persistedCursor(clientId: number): Date | null {
+    const row = db
+      .select({ lastTelemetryPullAt: clients.lastTelemetryPullAt })
+      .from(clients)
+      .where(eq(clients.id, clientId))
+      .get();
+    if (row === undefined) throw new Error(`no client ${clientId}`);
+    return row.lastTelemetryPullAt;
   }
 
   it("normalises a single-user client's window events into usage samples and advances the cursor", async () => {
@@ -263,5 +275,42 @@ describe("createUsageTelemetryConsumer", () => {
     await expect(consume(context(clientId, fakeLogger()))).rejects.toThrow("aw-server exploded");
     expect(cursor.has(clientId)).toBe(false);
     expect(db.select().from(usageSamples).all()).toHaveLength(0);
+    // The durable cursor stays unmoved too (#382): the same window re-pulls.
+    expect(persistedCursor(clientId)).toBeNull();
+  });
+
+  it("persists the cursor durably on a successful pull (#382)", async () => {
+    const { clientId } = seedClient(["Alice"]);
+    db.insert(activities).values({ kind: "app", matcher: "firefox" }).run();
+    const consume = createUsageTelemetryConsumer({
+      db,
+      cursor: new Map(),
+      passEnd: () => PASS_END,
+      initialLookbackMs: LOOKBACK_MS,
+      createSource: () => fakeSource([windowEvent("firefox", "2024-02-15T11:55:00.000Z", 120)]),
+    });
+
+    await consume(context(clientId, fakeLogger()));
+
+    // Advanced to this pass's end, so a restart resumes here rather than
+    // re-pulling `initialLookback`.
+    expect(persistedCursor(clientId)).toEqual(PASS_END);
+  });
+
+  it("persists the cursor even when a clean pull matched nothing (#382)", async () => {
+    const { clientId } = seedClient(["Alice"]);
+    db.insert(activities).values({ kind: "app", matcher: "firefox" }).run();
+    const consume = createUsageTelemetryConsumer({
+      db,
+      cursor: new Map(),
+      passEnd: () => PASS_END,
+      initialLookbackMs: LOOKBACK_MS,
+      createSource: () => fakeSource([]), // no events this pass
+    });
+
+    await consume(context(clientId, fakeLogger()));
+
+    expect(db.select().from(usageSamples).all()).toHaveLength(0);
+    expect(persistedCursor(clientId)).toEqual(PASS_END);
   });
 });

--- a/server/tests/policy/telemetry-cursor.test.ts
+++ b/server/tests/policy/telemetry-cursor.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the durable telemetry pull cursor (#382): the
+ * `loadTelemetryCursors` / `saveTelemetryCursor` DB access on
+ * `clients.last_telemetry_pull_at`. Runs against a migrated in-memory DB.
+ */
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { clients } from "../../src/policy/schema.js";
+import { loadTelemetryCursors, saveTelemetryCursor } from "../../src/policy/telemetry-cursor.js";
+import { testDb, type TestDb } from "../helpers/db.js";
+
+describe("telemetry cursor persistence", () => {
+  let db: TestDb;
+
+  beforeEach(() => {
+    db = testDb();
+  });
+
+  /** Insert a client, return its id. */
+  function seedClient(hostname: string): number {
+    return db.insert(clients).values({ hostname, sshUser: "pct-agent" }).returning().get().id;
+  }
+
+  /** Read the persisted cursor column for one client. */
+  function persistedCursor(clientId: number): Date | null {
+    const row = db
+      .select({ lastTelemetryPullAt: clients.lastTelemetryPullAt })
+      .from(clients)
+      .where(eq(clients.id, clientId))
+      .get();
+    if (row === undefined) throw new Error(`no client ${clientId}`);
+    return row.lastTelemetryPullAt;
+  }
+
+  it("returns an empty map when no client has a cursor", () => {
+    seedClient("fresh-pc");
+    expect(loadTelemetryCursors(db).size).toBe(0);
+  });
+
+  it("saveTelemetryCursor writes the window end to the client row", () => {
+    const clientId = seedClient("alice-pc");
+    const end = new Date("2024-02-15T12:00:00.000Z");
+
+    saveTelemetryCursor(db, clientId, end);
+
+    expect(persistedCursor(clientId)).toEqual(end);
+  });
+
+  it("loadTelemetryCursors returns only clients with a persisted cursor, keyed by id", () => {
+    const withCursor = seedClient("alice-pc");
+    const withoutCursor = seedClient("bob-pc");
+    const end = new Date("2024-02-15T12:00:00.000Z");
+    saveTelemetryCursor(db, withCursor, end);
+
+    const cursors = loadTelemetryCursors(db);
+
+    expect(cursors.size).toBe(1);
+    expect(cursors.get(withCursor)).toEqual(end);
+    expect(cursors.has(withoutCursor)).toBe(false);
+  });
+
+  it("saveTelemetryCursor overwrites an earlier value (a later pass advances it)", () => {
+    const clientId = seedClient("alice-pc");
+    const earlier = new Date("2024-02-15T12:00:00.000Z");
+    const later = new Date("2024-02-15T12:05:00.000Z");
+
+    saveTelemetryCursor(db, clientId, earlier);
+    saveTelemetryCursor(db, clientId, later);
+
+    expect(persistedCursor(clientId)).toEqual(later);
+    expect(loadTelemetryCursors(db).get(clientId)).toEqual(later);
+  });
+
+  it("keeps cursors independent per client", () => {
+    const alice = seedClient("alice-pc");
+    const bob = seedClient("bob-pc");
+    const aliceEnd = new Date("2024-02-15T12:00:00.000Z");
+    const bobEnd = new Date("2024-02-15T13:30:00.000Z");
+
+    saveTelemetryCursor(db, alice, aliceEnd);
+    saveTelemetryCursor(db, bob, bobEnd);
+
+    const cursors = loadTelemetryCursors(db);
+    expect(cursors.get(alice)).toEqual(aliceEnd);
+    expect(cursors.get(bob)).toEqual(bobEnd);
+  });
+});


### PR DESCRIPTION
## Summary

- Promote the Phase-5 telemetry pull cursor from the **in-memory** `Map` introduced in #327 to a **durable** per-client cursor persisted on `clients.last_telemetry_pull_at`, so a dashboard restart resumes each client's pull exactly where the last successful pull ended instead of re-pulling the whole `PCT_ENFORCEMENT_INITIAL_LOOKBACK_SECONDS` window (a bounded double-count against already-persisted samples).
- The pipeline seeds its in-memory cursor from the column on boot; the consumer persists each advance at the **same** success point it advances the in-memory cursor, so a mid-pull failure leaves both unmoved and the window re-pulls next pass. A client with no persisted cursor still falls back to `initialLookback`.

## Design note — column vs table

Persisted as a nullable timestamp column on `clients` (not a separate `telemetry_cursors` table): the cursor is strictly 1:1 with a client, dies with it (no orphan rows, no extra FK), and mirrors the existing `last_seen` / `versions_reported_at` nullable-timestamp columns. `NULL` = "no successful pull yet".

The issue's *"alternatively/additionally"* idempotent-insert option was **not taken**: adding a uniqueness constraint / overlap-aware upsert to `usage_samples` is a larger change with its own natural-key question and would alter the deliberately-plain append. Cursor persistence fixes the documented restart overlap with a single nullable column and no change to the write path.

## Plan

Linked plan: `.claude/plans/issue-382-durable-telemetry-cursor.md`
Roadmap: docs/roadmap.md → Phase 5 (ActivityWatch telemetry pull)

## License-boundary note

N/A — Drizzle (Apache-2.0) + better-sqlite3 (MIT) reads/writes only. No GPL source linked in-process, no GPL binary added to the image, no transport or packaging change.

## Test plan

- [x] `policy/telemetry-cursor.test.ts` — `saveTelemetryCursor` writes the column; `loadTelemetryCursors` returns only clients with a persisted value, keyed by id; overwrite/advance; per-client independence; empty DB → empty map.
- [x] `enforcement/telemetry-consumer.test.ts` — a successful pull (incl. a clean pull that matched nothing) persists the cursor to the `clients` row; a failed pull leaves it `NULL` (both cursors unmoved).
- [x] `enforcement/pipeline.test.ts` — a client with a persisted cursor seeds the in-memory cursor so the first pass's window `start` resumes at the persisted `end`, not `passEnd − initialLookback`.
- [x] Full gate green from `server/`: `format:check`, `lint`, `typecheck`, `npm test` (1876 tests, coverage 98.9% ≥ 80%).

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7yoTLkNNgCU8jEvoJAL3v)_