### PR TITLE
feat(policy): compose date-specific exceptions into the effective policy (#142)

### DIFF
--- a/docs/adr/0012-date-specific-override-composition.md
+++ b/docs/adr/0012-date-specific-override-composition.md
@@ -1,0 +1,134 @@
+# ADR 0012 — Date-specific override composition and the `extend` action
+
+- **Status:** Accepted (2026-08-07)
+- **Issue:** [#142](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/142)
+- **Phase:** 13 (additive layer on the Phase 2/4 foundation)
+- **Builds on:** [ADR 0004](0004-schedule-precedence.md) (first-match-wins),
+  [ADR 0005](0005-recurrence-and-date-scoping.md) (recurrence + date anchoring),
+  [ADR 0007 (group-targeted rules)](0007-group-targeted-policy-rules.md)
+
+## Context
+
+[ADR 0005](0005-recurrence-and-date-scoping.md) reserved the columns for
+date-anchored policy and defined the "active at instant *T*" predicate for both
+`schedules` (`effective_from`/`effective_to`) and `exceptions`
+(`[effective_from ?? created_at, expires_at)`). The Phase-4 resolver (#143,
+`policy/resolve.ts`) implemented that predicate **for `schedules`** — a
+date-scoped recurring rule is already a candidate only while its effective
+window is open.
+
+What ADR 0005 left for #142 is the other half: **how a one-off `exception`
+composes into the effective policy.** Today `effectivePolicy` consumes
+`schedules`, `budgets`, and `grants` but **not** `exceptions`, so a one-off
+override ("no screen time on 2026-06-30", "allow games until 9pm tonight",
+"screen-free vacation week") resolves to nothing — the `exceptions` CRUD is
+display-only. This ADR fixes the composition model and, per the review note on
+#142, pins the `extend` action, which had been an undefined synonym for `allow`.
+
+The `exceptions` shape carries a `target` (`overall` / `activity` / `group`), an
+`action` (`allow` / `deny` / `extend`), and an active window — the same
+allow/deny/extend *access* vocabulary as `schedules`, and deliberately **no**
+seconds amount (an additive time amount is a `Grant`, not an exception). So an
+exception is naturally a schedule-like access rule that is date-anchored rather
+than recurrence-anchored.
+
+## Decisions
+
+### 1. Exceptions are a top-precedence, date-anchored access layer
+
+An active exception composes into the resolver as a **schedule-like rule at the
+head of the precedence order**, above every recurring `schedule` rule. It feeds
+the existing first-match-wins engine (ADR 0004) rather than a second mechanism:
+
+- **Candidacy (date gate).** An exception is a candidate on local day *D* iff
+  its active window `[effective_from ?? created_at, expires_at)` overlaps *D*'s
+  bounds in the user's effective timezone — the exception analogue of
+  `appliesOnDay` for schedules, evaluated at day granularity (ADR 0005 anchors
+  the bounds at local-day boundaries, so this is exact for every in-contract
+  input).
+- **Intra-day window.** An exception carries no intra-day recurrence, so a
+  candidate exception applies to the **whole day** (`[0, 1440)` local minutes) —
+  the same treatment `schedules` give a date-scoped rule with no recurrence
+  window.
+- **Precedence.** Exceptions are placed **before** the recurring schedule rules
+  in the first-match order, so an active override wins over the recurring rules
+  for the target it covers — the issue's recommended "date-specific overrides
+  win over recurring rules". Within the exception layer the order is
+  **own-before-group** (ADR 0007 precedence) and **newest-before-older** (a more
+  recently created one-off wins), giving a deterministic result when two
+  overrides are active at once.
+
+This satisfies the "coming up" intent: the `?date=` preview for a future day
+already re-resolves against that day, so a future-dated exception surfaces the
+moment its window opens, with no materialised rows (ADR 0005 §3).
+
+### 2. `extend` widens the allowed window
+
+`extend` is defined as a **pure widening union** applied after the allow/deny
+first-match resolution: every active `extend` window (whether from a `schedule`
+or an `exception`) is unioned onto the resolved allowed set. An `extend`
+therefore **grants access past a standing `deny`** — the mechanism
+[#364](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/364)
+needs for Nintendo-style "adjust bedtime as well" same-day extensions.
+
+- This is a strict superset of the prior behaviour: `extend` still permits
+  access in its own window (it previously resolved as `allow` under
+  first-match). The union only *adds* the case where an `extend` window was
+  suppressed by a higher-precedence overlapping `deny` — now it widens past it.
+- `extend` never *removes* allowed time; a `deny` that should win over an
+  `extend` must be expressed as the absence of the `extend`, not the two
+  competing. A self-contradictory same-day `deny` + `extend` on the same target
+  resolves to allowed for the extend window (widening is applied last) — an
+  authoring anomaly the editor may warn about, not a resolver concern.
+
+### 3. Exceptions do not enter the recurring `timekpra` allowed-hours grid
+
+The `timekpra` allowed-days/allowed-hours push is a **static weekly grid**
+(`policy/weekly-windows.ts` → `transport/timekpr/allowed-hours.ts`): it resolves
+`effectivePolicy` for each of the seven weekdays of a reference week and keys the
+result by ISO weekday. A one-off calendar date **cannot** be expressed as a
+weekly-recurring pattern, so exceptions are deliberately kept out of that grid —
+exactly as `weekly-windows.ts` already documents ("date-specific overrides (#142)
+… a later, separately-composed layer"). Pushing a date-specific override to a
+client **when its window arrives** (and reverting after) is an offline-queue
+scheduler concern
+([#84](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/84)),
+tracked as a follow-up. This ADR scopes exceptions to the per-day
+`effectivePolicy` answer (the display, the `?date=` preview, and that future
+per-day push), not the recurring grid.
+
+Because exceptions carry no seconds amount, they do not change
+`overallSeconds` or the per-activity quotas — only the allow/deny/extend
+**access windows**. Per-activity quota reduction from `deny` rules is unchanged
+(recurring `schedules` do not do it today either) and is out of scope here.
+
+## Consequences
+
+- **Resolver.** `EffectivePolicyInput` gains an optional `exceptions` field
+  (default `[]`, so the push and force-close callers that legitimately omit
+  exceptions are unchanged); `effectivePolicy` composes active exceptions into
+  `allowedWindows` as above, and `resolveAllowedWindows` folds in the `extend`
+  union.
+- **Group-aware composition.** `gatherUserExceptions` (in
+  `policy/group-resolution.ts`) merges a user's own exceptions with their
+  inherited group exceptions, mirroring `gatherUserScheduleRules`, so the
+  effective view reflects group overrides too (no repeat of the #362
+  display-vs-enforce drift within the resolver's own answer).
+- **Endpoint.** `GET /api/users/:userId/effective` loads exceptions via that
+  helper — the single composition point stays the resolver.
+- **Deferred.** The date-arrival/offline-queue push of date-specific overrides
+  (#84) and the per-activity deny-quota question are follow-ups.
+
+## Alternatives not chosen
+
+- **Exceptions as their own resolution pass** (separate from schedule
+  precedence). Rejected: exceptions share the allow/deny/extend access
+  vocabulary and target model of schedules, so modelling them as a
+  top-precedence rule layer reuses ADR 0004 first-match-wins verbatim instead of
+  a parallel evaluator that could drift.
+- **`extend` as a first-match `allow` synonym** (status quo). Rejected: it left
+  `extend` meaningless and gave #364 nothing to build on. Widening-union gives it
+  a distinct, useful meaning.
+- **`extend` dropped entirely** in favour of plain allow-exceptions. Rejected:
+  the union semantics are cheap and unblock #364; dropping the action would be a
+  breaking enum change for no gain.

--- a/docs/adr/0012-date-specific-override-composition.md
+++ b/docs/adr/0012-date-specific-override-composition.md
@@ -46,10 +46,16 @@ the existing first-match-wins engine (ADR 0004) rather than a second mechanism:
   `appliesOnDay` for schedules, evaluated at day granularity (ADR 0005 anchors
   the bounds at local-day boundaries, so this is exact for every in-contract
   input).
-- **Intra-day window.** An exception carries no intra-day recurrence, so a
-  candidate exception applies to the **whole day** (`[0, 1440)` local minutes) —
-  the same treatment `schedules` give a date-scoped rule with no recurrence
-  window.
+- **Intra-day window.** An exception carries no intra-day *recurrence*, but its
+  active window `[effective_from ?? created_at, expires_at)` is a precise instant
+  range — an `expires_at` is an exact instant ("allow games until 9pm tonight"),
+  not a day boundary. So on each day it covers, the exception applies over the
+  local-minute window its instant range **intersects** with that day: an interior
+  day of a multi-day override is the full `[0, 1440)`, while the first/last day is
+  the partial window the instants carve out (e.g. `[0, 1260)` for an override that
+  expires at 21:00 local). A day-aligned override (both bounds at local midnight)
+  degenerates to whole days, exactly as the "screen-free vacation week" example
+  intends.
 - **Precedence.** Exceptions are placed **before** the recurring schedule rules
   in the first-match order, so an active override wins over the recurring rules
   for the target it covers — the issue's recommended "date-specific overrides
@@ -101,6 +107,14 @@ Because exceptions carry no seconds amount, they do not change
 `overallSeconds` or the per-activity quotas — only the allow/deny/extend
 **access windows**. Per-activity quota reduction from `deny` rules is unchanged
 (recurring `schedules` do not do it today either) and is out of scope here.
+
+Consequently, **only `overall`-scoped exceptions have an observable effect
+today**: like `activity`/`group`-scoped *schedule* rules, an
+`activity`/`group`-scoped exception is gathered and composed but resolves to a
+no-op (it neither builds an overall window nor reduces a quota) until per-target
+deny enforcement lands. `gatherUserExceptions` still returns all target kinds so
+the composition is ready when that enforcement does; the authoring editor should
+signal that non-`overall` exceptions are not yet enforced.
 
 ## Consequences
 

--- a/docs/plans/142-date-specific-overrides.md
+++ b/docs/plans/142-date-specific-overrides.md
@@ -1,0 +1,74 @@
+# Plan — #142 Date-specific / future-dated rules (exception composition)
+
+Roadmap: `docs/roadmap.md` → Phase 13 (additive layer on the Phase 2/4 foundation).
+Issue: [#142](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/142).
+
+## What already exists (no work needed)
+
+- **Schedule date-scoping** (`effective_from`/`effective_to`) is already honoured
+  by the resolver: `isRuleActiveAt` and `appliesOnDay` in `policy/resolve.ts` gate
+  candidacy on the effective window. "Applies only during spring break" already
+  works for `schedules`.
+- The **`exceptions.effective_from`** column (and `group_exceptions`) is reserved
+  (#146, ADR 0005 §2): an exception is active during
+  `[effective_from ?? created_at, expires_at)`. No migration is needed.
+
+## The gap this delivers
+
+`effectivePolicy` (`policy/resolve.ts`) consumes `schedules`, `budgets`, `grants`
+— **never `exceptions`**. So a one-off / future-dated override (`allow` / `deny`
+/ `extend`) resolves to nothing today; the `exceptions` CRUD is display-only.
+This slice composes the exception layer into the resolver so the effective
+answer (and the future-dated `?date=` preview) reflects overrides.
+
+## Design decisions (recorded in ADR 0012)
+
+1. **Precedence.** Active exceptions are a **date-anchored, top-precedence layer
+   above recurring schedule rules** — an active override wins over the recurring
+   rules for the target it covers, per the issue's recommendation. It feeds the
+   existing first-match-wins engine (ADR 0004): exception rules are prepended to
+   the schedule rules, so they win every segment they cover. Within the exception
+   layer, own-before-group and newest-before-older.
+2. **`extend` = widen.** After allow/deny first-match resolution, every active
+   `extend` window (schedule **or** exception) is unioned onto the allowed set,
+   so it grants access **past a standing deny**. This is the mechanism #364 needs
+   for "adjust bedtime as well". Pre-existing `extend`-wins-its-own-segment
+   behaviour is unchanged (the union is a no-op when the extend already wins
+   first-match); the union only adds the widen-past-a-higher-precedence-deny case.
+3. **Scope of the push.** Exceptions compose into the per-day `allowedWindows`
+   that `effectivePolicy` produces — the display/preview answer. They do **not**
+   enter the *recurring* `timekpra` allowed-hours grid (`weekly-windows.ts`): a
+   one-off calendar date cannot be expressed as a weekly-recurring pattern, and
+   `weekly-windows.ts` already documents that date-specific overrides are "a
+   later, separately-composed layer". Pushing a date-specific override to the
+   client **when its window arrives** (and reverting after) is the offline-queue
+   scheduler (#84) — deferred to a tracked follow-up.
+
+## Implementation phases
+
+### Phase 1 — resolver + ADR (core)
+- `resolve.ts`: add `ExceptionInput` + optional `exceptions` on
+  `EffectivePolicyInput`; `exceptionAppliesOnDay` day-overlap gate; compose
+  active `overall` exceptions as top-precedence full-day rules into
+  `allowedWindows`; fold the `extend` union into `resolveAllowedWindows`.
+  `exceptions` is **optional** (default `[]`) so the push/enforce callers that
+  legitimately omit it are unchanged.
+- `docs/adr/0012-date-specific-override-composition.md`.
+- `tests/policy/resolve.test.ts`: allow/deny override, date gate
+  (future `effective_from`, expired), `effective_from ?? created_at`, `extend`
+  widens past a higher-precedence deny, precedence order.
+
+### Phase 2 — group-aware gather + endpoint wiring
+- `group-resolution.ts`: `gatherUserExceptions(db, userId)` — own exceptions
+  (newest-first) then inherited group exceptions (groups ascending id), so the
+  effective view reflects group overrides too (no #362-style drift).
+- `api/policy/effective.ts`: load `gatherUserExceptions` and pass to
+  `effectivePolicy`.
+- `tests/policy/group-resolution.test.ts`: own+group gather, ordering.
+
+## Deferred (tracked follow-up, linked from the PR)
+- Recurring-grid / date-arrival **push** of date-specific overrides via the
+  offline queue (#84) + revert — new issue.
+- Per-activity **quota** reduction from `deny` rules (schedules don't do this
+  today either) — out of scope, noted.
+- Exception provenance in the `activeRules` wire list (a UI aid for #343).

--- a/server/src/api/policy/effective.ts
+++ b/server/src/api/policy/effective.ts
@@ -24,6 +24,7 @@ import { resolveEffectiveTz, localCalendarDate } from "../../policy/budget-windo
 import { scheduleActionSchema, scopeSchema } from "../../policy/enums.js";
 import {
   gatherUserBudgets,
+  gatherUserExceptions,
   gatherUserScheduleRules,
   type GatheredBudget,
 } from "../../policy/group-resolution.js";
@@ -182,6 +183,9 @@ export function registerEffectiveRoutes(scope: FastifyInstance, settings: Settin
       // The user's effective budget baseline: own budgets, plus inherited group
       // budgets for any slot the user has not overridden (#134, ADR 0008).
       const budgetRows = gatherUserBudgets(scope.db, userId);
+      // Date-specific overrides: own exceptions merged with inherited group
+      // exceptions, in precedence order (#142, ADR 0012).
+      const exceptionRows = gatherUserExceptions(scope.db, userId);
       const grantRows: GrantInput[] = scope.db
         .select()
         .from(grants)
@@ -195,6 +199,7 @@ export function registerEffectiveRoutes(scope: FastifyInstance, settings: Settin
           schedules: scheduleRules,
           budgets: budgetRows,
           grants: grantRows,
+          exceptions: exceptionRows,
         }),
       );
     },

--- a/server/src/policy/group-resolution.ts
+++ b/server/src/policy/group-resolution.ts
@@ -28,21 +28,23 @@
  *
  * Each rule is tagged with its {@link RuleSource} so the future inherited-vs-
  * local editor (#124) can show which rules are local and which are inherited
- * (and from which group). Exceptions are intentionally not resolved here —
- * exception composition into the effective policy is #142 and `resolve.ts`
- * consumes neither user nor group exceptions yet.
+ * (and from which group). The same user-over-group merge is applied to
+ * date-specific overrides by {@link gatherUserExceptions} (#142, ADR 0012), so
+ * the effective view reflects inherited group exceptions too.
  *
  * License boundary: none touched — plain TypeScript over the policy model.
  */
 import type { PolicyDb } from "./db.js";
 import {
   listGroupBudgets,
+  listGroupExceptions,
   listGroupSchedules,
   listUserBudgets,
+  listUserExceptions,
   listUserGroupsForUser,
   listUserSchedules,
 } from "./repository.js";
-import type { BudgetInput } from "./resolve.js";
+import type { BudgetInput, ExceptionInput } from "./resolve.js";
 import { byOrdinal, type ScheduleRule } from "./schedule-precedence.js";
 
 /** Where a gathered rule came from: the user's own list, or an inherited group. */
@@ -222,4 +224,52 @@ export function mergeBudgetsWithGroups(
  */
 export function gatherUserBudgets(db: PolicyDb, userId: number): GatheredBudget[] {
   return mergeBudgetsWithGroups(db, userId, listUserBudgets(db, userId));
+}
+
+/** Copy the {@link ExceptionInput} fields off a user or group exception row. */
+function pickExceptionFields(row: {
+  id: number;
+  targetKind: ExceptionInput["targetKind"];
+  targetId: number | null;
+  action: ExceptionInput["action"];
+  effectiveFrom: Date | null;
+  expiresAt: Date;
+  createdAt: Date;
+}): ExceptionInput {
+  return {
+    id: row.id,
+    targetKind: row.targetKind,
+    targetId: row.targetId,
+    action: row.action,
+    effectiveFrom: row.effectiveFrom,
+    expiresAt: row.expiresAt,
+    createdAt: row.createdAt,
+  };
+}
+
+/** Sort exceptions newest-first (descending `createdAt`, then `id`) within a level. */
+function newestFirst(a: ExceptionInput, b: ExceptionInput): number {
+  return b.createdAt.getTime() - a.createdAt.getTime() || b.id - a.id;
+}
+
+/**
+ * The user's effective date-specific overrides (#142, ADR 0012 §1),
+ * **in precedence order** for {@link import("./resolve.js").effectivePolicy}:
+ *
+ * 1. the user's own exceptions, newest-first (a more recently authored one-off
+ *    wins);
+ * 2. then, for each group the user belongs to (ascending group `id`), that
+ *    group's exceptions, newest-first.
+ *
+ * Own-before-group mirrors the schedule precedence (ADR 0007) so an individual's
+ * override wins over an inherited group override. Unlike schedules there is no
+ * `ordinal` and no dense re-sequencing: the resolver treats array position as
+ * precedence directly, so this order *is* the contract.
+ */
+export function gatherUserExceptions(db: PolicyDb, userId: number): ExceptionInput[] {
+  const own = listUserExceptions(db, userId).map(pickExceptionFields).sort(newestFirst);
+  const inherited = listUserGroupsForUser(db, userId).flatMap((group) =>
+    listGroupExceptions(db, group.id).map(pickExceptionFields).sort(newestFirst),
+  );
+  return [...own, ...inherited];
 }

--- a/server/src/policy/resolve.ts
+++ b/server/src/policy/resolve.ts
@@ -25,12 +25,14 @@
  * the user's effective timezone, via {@link import("./budget-window.js")}
  * (ADR 0001) — local time enters only here, storage stays UTC.
  *
- * **Scope of this slice.** Recurring windows + uniform budgets + active grants,
- * exactly the Phase-4 core of #143. Exception/date-specific-override
- * composition (#142) and weekday-varying budgets (#141) are additive layers
- * that plug into the same resolver later; they are intentionally not resolved
- * here so this does not code against #142's not-yet-decided cross-layer
- * ordering.
+ * **Scope of this slice.** Recurring windows + uniform budgets + active grants
+ * (the Phase-4 core of #143) plus **date-specific overrides** — the optional
+ * `exceptions` layer (#142, `docs/adr/0012-date-specific-override-composition.md`):
+ * an active one-off `allow`/`deny`/`extend` override wins over the recurring
+ * rules for the target it covers, and `extend` widens the allowed window past a
+ * standing deny. Exceptions affect only the per-day allow/deny/extend **access
+ * windows**, never the seconds budgets (an additive time amount is a `Grant`,
+ * not an exception). Weekday-varying budgets (#141) remain a later layer.
  *
  * License boundary: none touched — pure TypeScript over the policy model.
  */
@@ -70,6 +72,29 @@ export interface GrantInput {
   readonly expiresAt: Date;
   /** Revocation instant; `null` for a live grant (revoking never edits in place). */
   readonly revokedAt: Date | null;
+}
+
+/**
+ * The subset of an {@link import("./schema.js").exceptions} row (or a group
+ * exception, or a test fixture) the resolver reads. A one-off, date-anchored
+ * override active during `[effective_from ?? created_at, expires_at)` (ADR 0005
+ * §2). Structural so callers pass a user row, a group row, or a fixture.
+ *
+ * An exception carries an access `action`, not a seconds amount — it composes
+ * into the allow/deny/extend windows, never the budgets (ADR 0012 §1).
+ */
+export interface ExceptionInput {
+  /** Stable identity, used as the newest-first tiebreak within the exception layer. */
+  readonly id: number;
+  readonly targetKind: Scope;
+  readonly targetId: number | null;
+  readonly action: ScheduleAction;
+  /** Active-window start; `null` ⇒ active from {@link createdAt}. */
+  readonly effectiveFrom: Date | null;
+  /** Exclusive active-window end (the exception's `expires_at`). */
+  readonly expiresAt: Date;
+  /** Row creation instant — the active-window start when {@link effectiveFrom} is `null`. */
+  readonly createdAt: Date;
 }
 
 /** A half-open allowed-access interval in local minutes-from-midnight `[start, end)`. */
@@ -137,6 +162,15 @@ export interface EffectivePolicyInput {
   readonly schedules: readonly ScheduleRule[];
   readonly budgets: readonly BudgetInput[];
   readonly grants: readonly GrantInput[];
+  /**
+   * Date-specific overrides (#142), **in precedence order** (index 0 = highest;
+   * `gatherUserExceptions` yields own-before-group, newest-before-older). Each
+   * active exception composes as a top-precedence, whole-day rule above the
+   * recurring `schedules` (ADR 0012). Optional — the recurring `timekpra` push
+   * and the force-close sweep legitimately omit it (a one-off date is not a
+   * recurring grid entry, and exceptions carry no quota), so it defaults to `[]`.
+   */
+  readonly exceptions?: readonly ExceptionInput[];
 }
 
 /** Is `rule`'s recurrence the always-on degenerate (every recurrence field NULL)? */
@@ -229,12 +263,43 @@ function ruleWindow(rule: ScheduleRule): { start: number; end: number } {
 }
 
 /**
+ * Sort `windows` by start and merge every overlapping or abutting pair into the
+ * minimal set of maximal, ascending, non-overlapping intervals. Empty and
+ * inverted (`start >= end`) inputs are dropped.
+ */
+function mergeWindows(windows: readonly AllowedWindow[]): AllowedWindow[] {
+  const sorted = windows.filter((w) => w.start < w.end).sort((a, b) => a.start - b.start);
+  const merged: AllowedWindow[] = [];
+  for (const window of sorted) {
+    const last = merged[merged.length - 1];
+    if (last !== undefined && window.start <= last.end) {
+      // Overlaps or abuts the current run — extend it (never shrink).
+      merged[merged.length - 1] = { start: last.start, end: Math.max(last.end, window.end) };
+    } else {
+      merged.push({ start: window.start, end: window.end });
+    }
+  }
+  return merged;
+}
+
+/**
  * Resolve the day's allowed overall-access windows from the `overall`-scoped
- * candidate rules. Walks the minute timeline at every rule boundary; within
- * each segment the first rule (by precedence order) whose window covers it
- * wins, and the segment is allowed unless that winner is `deny`. With no
- * winner the baseline is allow (ADR 0004). Adjacent allowed segments are
- * merged so the result is the minimal set of maximal windows.
+ * candidate rules, in precedence order (highest first — active exceptions are
+ * already prepended by {@link effectivePolicy}, ADR 0012 §1).
+ *
+ * Two composition steps:
+ *
+ * 1. **allow/deny first-match** — walk the minute timeline at every rule
+ *    boundary; within each segment the first rule whose window covers it wins,
+ *    and the segment is allowed unless that winner is `deny`. With no winner the
+ *    baseline is allow (ADR 0004). (`extend` participates here as a permit, so
+ *    it still wins its own segment exactly as before.)
+ * 2. **`extend` union** (ADR 0012 §2) — every active `extend` window is then
+ *    unioned onto the allowed set, so an `extend` widens access even past a
+ *    higher-precedence overlapping `deny`. This only ever *adds* allowed time.
+ *
+ * The union is merged with the first-match result into the minimal set of
+ * maximal windows.
  */
 function resolveAllowedWindows(overallRules: readonly ActiveRule[]): AllowedWindow[] {
   // Segment boundaries: day edges plus every rule window edge, deduped/sorted.
@@ -253,14 +318,26 @@ function resolveAllowedWindows(overallRules: readonly ActiveRule[]): AllowedWind
     const winner = overallRules.find((r) => r.startMinute <= start && r.endMinute >= end);
     const allowed = winner === undefined || winner.action !== "deny";
     if (!allowed) continue;
-    const last = windows[windows.length - 1];
-    if (last !== undefined && last.end === start) {
-      windows[windows.length - 1] = { start: last.start, end };
-    } else {
-      windows.push({ start, end });
-    }
+    windows.push({ start, end });
   }
-  return windows;
+
+  // Widen with every `extend` window (ADR 0012 §2), then merge to maximal windows.
+  const extendWindows = overallRules
+    .filter((rule) => rule.action === "extend")
+    .map((rule) => ({ start: rule.startMinute, end: rule.endMinute }));
+  return mergeWindows([...windows, ...extendWindows]);
+}
+
+/**
+ * Is `exc` active on the local day whose UTC bounds are `[dayStart, dayEnd)`?
+ * Its active window is `[effective_from ?? created_at, expires_at)` (ADR 0005
+ * §2); this is the exception analogue of {@link appliesOnDay}, applied at day
+ * granularity (ADR 0005 anchors the bounds at local-day boundaries, exact for
+ * every in-contract input).
+ */
+function exceptionAppliesOnDay(exc: ExceptionInput, dayStart: Date, dayEnd: Date): boolean {
+  const from = exc.effectiveFrom ?? exc.createdAt;
+  return from.getTime() < dayEnd.getTime() && exc.expiresAt.getTime() > dayStart.getTime();
 }
 
 /** Is `grant` live and overlapping the day's `[dayStart, dayEnd)` UTC bounds? */
@@ -375,9 +452,26 @@ export function effectivePolicy(input: EffectivePolicyInput): EffectivePolicy {
       };
     });
 
-  const allowedWindows = resolveAllowedWindows(
-    activeRules.filter((rule) => rule.targetKind === "overall"),
-  );
+  // Date-specific overrides (#142, ADR 0012): each exception active on the day
+  // becomes a whole-day rule at the head of the precedence order, so an active
+  // override wins over the recurring rules for the target it covers. The
+  // `exceptions` array is already in precedence order (own-before-group,
+  // newest-before-older); its order is preserved.
+  const exceptionRules: ActiveRule[] = (input.exceptions ?? [])
+    .filter((exc) => exceptionAppliesOnDay(exc, dayStart, dayEnd))
+    .map((exc) => ({
+      id: exc.id,
+      targetKind: exc.targetKind,
+      targetId: exc.targetId,
+      action: exc.action,
+      startMinute: 0,
+      endMinute: MINUTES_PER_DAY,
+    }));
+
+  const allowedWindows = resolveAllowedWindows([
+    ...exceptionRules.filter((rule) => rule.targetKind === "overall"),
+    ...activeRules.filter((rule) => rule.targetKind === "overall"),
+  ]);
 
   // Budgets: the overall daily allowance and the per-activity/per-group quotas,
   // each folding in active grants overlapping the day (`dayBounds` carries the

--- a/server/src/policy/resolve.ts
+++ b/server/src/policy/resolve.ts
@@ -46,6 +46,9 @@ import type { BudgetWindow, Scope, ScheduleAction } from "./enums.js";
 import { MINUTES_PER_DAY } from "./recurrence.js";
 import { byOrdinal, type RuleActivePredicate, type ScheduleRule } from "./schedule-precedence.js";
 
+/** Milliseconds in one minute — for projecting a UTC instant onto local minutes-of-day. */
+const MS_PER_MINUTE = 60_000;
+
 /**
  * The subset of a {@link import("./schema.js").budgets} row the resolver reads.
  * Structural so callers pass either a Drizzle row or a test fixture.
@@ -146,9 +149,11 @@ export interface EffectivePolicy {
   /** Effective per-activity / per-group daily allowances, ascending by target. */
   readonly perActivitySeconds: ActivityQuota[];
   /**
-   * Every schedule rule in play on the day (all scopes), in precedence order
+   * Every **schedule** rule in play on the day (all scopes), in precedence order
    * (`ordinal`, then `id`). Lets a preview surface render inherited/competing
-   * rules, not just the resolved `overall` windows.
+   * rules, not just the resolved `overall` windows. Date-specific exceptions are
+   * composed into {@link allowedWindows} but deliberately not listed here yet —
+   * surfacing their provenance in this list is #343.
    */
   readonly activeRules: ActiveRule[];
 }
@@ -330,14 +335,32 @@ function resolveAllowedWindows(overallRules: readonly ActiveRule[]): AllowedWind
 
 /**
  * Is `exc` active on the local day whose UTC bounds are `[dayStart, dayEnd)`?
- * Its active window is `[effective_from ?? created_at, expires_at)` (ADR 0005
- * §2); this is the exception analogue of {@link appliesOnDay}, applied at day
- * granularity (ADR 0005 anchors the bounds at local-day boundaries, exact for
- * every in-contract input).
+ * The exception's local-minute `[start, end)` window on the day whose UTC bounds
+ * are `[dayStart, dayEnd)`, or `null` when its active window
+ * `[effective_from ?? created_at, expires_at)` (ADR 0005 §2) does not overlap
+ * the day at all.
+ *
+ * The active window is a precise instant range (an exception `expires_at` is an
+ * exact instant — "allow games until 9pm tonight", ADR 0012 §1), so it is
+ * **intersected** with the day and projected onto local minutes: an interior day
+ * of a multi-day override yields the full `[0, 1440)`, while the first/last day
+ * yields the partial window the instants carve out. Minutes-since-local-midnight
+ * are the elapsed real minutes from `dayStart` (the UTC instant of local
+ * midnight), matching the resolver's existing minute model.
  */
-function exceptionAppliesOnDay(exc: ExceptionInput, dayStart: Date, dayEnd: Date): boolean {
-  const from = exc.effectiveFrom ?? exc.createdAt;
-  return from.getTime() < dayEnd.getTime() && exc.expiresAt.getTime() > dayStart.getTime();
+function exceptionWindowOnDay(
+  exc: ExceptionInput,
+  dayStart: Date,
+  dayEnd: Date,
+): { start: number; end: number } | null {
+  const fromMs = (exc.effectiveFrom ?? exc.createdAt).getTime();
+  const startMs = Math.max(fromMs, dayStart.getTime());
+  const endMs = Math.min(exc.expiresAt.getTime(), dayEnd.getTime());
+  if (startMs >= endMs) return null;
+  return {
+    start: Math.round((startMs - dayStart.getTime()) / MS_PER_MINUTE),
+    end: Math.round((endMs - dayStart.getTime()) / MS_PER_MINUTE),
+  };
 }
 
 /** Is `grant` live and overlapping the day's `[dayStart, dayEnd)` UTC bounds? */
@@ -453,20 +476,25 @@ export function effectivePolicy(input: EffectivePolicyInput): EffectivePolicy {
     });
 
   // Date-specific overrides (#142, ADR 0012): each exception active on the day
-  // becomes a whole-day rule at the head of the precedence order, so an active
-  // override wins over the recurring rules for the target it covers. The
-  // `exceptions` array is already in precedence order (own-before-group,
-  // newest-before-older); its order is preserved.
-  const exceptionRules: ActiveRule[] = (input.exceptions ?? [])
-    .filter((exc) => exceptionAppliesOnDay(exc, dayStart, dayEnd))
-    .map((exc) => ({
-      id: exc.id,
-      targetKind: exc.targetKind,
-      targetId: exc.targetId,
-      action: exc.action,
-      startMinute: 0,
-      endMinute: MINUTES_PER_DAY,
-    }));
+  // becomes a rule at the head of the precedence order — over the local-minute
+  // window its instant range carves out of the day — so an active override wins
+  // over the recurring rules for the target it covers. The `exceptions` array is
+  // already in precedence order (own-before-group, newest-before-older); its
+  // order is preserved.
+  const exceptionRules: ActiveRule[] = (input.exceptions ?? []).flatMap((exc) => {
+    const window = exceptionWindowOnDay(exc, dayStart, dayEnd);
+    if (window === null) return [];
+    return [
+      {
+        id: exc.id,
+        targetKind: exc.targetKind,
+        targetId: exc.targetId,
+        action: exc.action,
+        startMinute: window.start,
+        endMinute: window.end,
+      },
+    ];
+  });
 
   const allowedWindows = resolveAllowedWindows([
     ...exceptionRules.filter((rule) => rule.targetKind === "overall"),

--- a/server/tests/api/policy-effective.test.ts
+++ b/server/tests/api/policy-effective.test.ts
@@ -13,8 +13,10 @@ import { SESSION_COOKIE } from "../../src/auth/session.js";
 import { loadSettings } from "../../src/config.js";
 import {
   budgets,
+  exceptions,
   grants,
   groupBudgets,
+  groupExceptions,
   groupSchedules,
   schedules,
   userGroupMemberships,
@@ -345,5 +347,94 @@ describe("GET /api/users/:userId/effective", () => {
     });
     expect(after.json().allowedWindows).toEqual([]);
     expect(after.json().activeRules).toHaveLength(1);
+  });
+
+  it("composes a date-specific exception override into the day (#142)", async () => {
+    const userId = await createUser("Alice"); // tz null → UTC
+    // A one-off "no screen time" deny active only for the first week of July.
+    harness.db
+      .insert(exceptions)
+      .values({
+        userId,
+        targetKind: "overall",
+        targetId: null,
+        action: "deny",
+        effectiveFrom: new Date("2026-07-01T00:00:00Z"),
+        expiresAt: new Date("2026-07-08T00:00:00Z"),
+      })
+      .run();
+
+    // Before the override window: unrestricted.
+    const before = await auth({
+      method: "GET",
+      url: `/api/users/${userId}/effective?date=2026-06-20`,
+    });
+    expect(before.json().allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+
+    // Within the override window: access denied all day.
+    const during = await auth({
+      method: "GET",
+      url: `/api/users/${userId}/effective?date=2026-07-03`,
+    });
+    expect(during.json().allowedWindows).toEqual([]);
+
+    // After it expires: unrestricted again.
+    const after = await auth({
+      method: "GET",
+      url: `/api/users/${userId}/effective?date=2026-07-20`,
+    });
+    expect(after.json().allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+
+  it("inherits a group exception into a member's effective day (#142)", async () => {
+    const userId = await createUser("Alice"); // tz null → UTC
+    const group = harness.db
+      .insert(userGroups)
+      .values({ name: "Kids" })
+      .returning({ id: userGroups.id })
+      .get();
+    if (group === undefined) throw new Error("group insert returned no row");
+    harness.db.insert(userGroupMemberships).values({ userId, groupId: group.id }).run();
+
+    // Group-wide "screen-free vacation" deny spanning the queried day — inherited
+    // by the member. `effectiveFrom` is set explicitly (rather than defaulting to
+    // the created-at wall clock) so the window is deterministic regardless of when
+    // the test runs.
+    harness.db
+      .insert(groupExceptions)
+      .values({
+        userGroupId: group.id,
+        targetKind: "overall",
+        targetId: null,
+        action: "deny",
+        effectiveFrom: new Date("2026-06-01T00:00:00Z"),
+        expiresAt: new Date("2030-01-01T00:00:00Z"),
+      })
+      .run();
+
+    const inherited = await auth({
+      method: "GET",
+      url: `/api/users/${userId}/effective?date=2026-06-20`,
+    });
+    expect(inherited.json().allowedWindows).toEqual([]);
+
+    // The member's own `allow` override wins over the inherited group deny.
+    harness.db
+      .insert(exceptions)
+      .values({
+        userId,
+        targetKind: "overall",
+        targetId: null,
+        action: "allow",
+        effectiveFrom: new Date("2026-06-01T00:00:00Z"),
+        expiresAt: new Date("2030-01-01T00:00:00Z"),
+      })
+      .run();
+
+    const overridden = await auth({
+      method: "GET",
+      url: `/api/users/${userId}/effective?date=2026-06-20`,
+    });
+    expect(overridden.json().allowedWindows).toEqual([{ start: 0, end: 1440 }]);
   });
 });

--- a/server/tests/policy/group-resolution.test.ts
+++ b/server/tests/policy/group-resolution.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   gatherUserBudgets,
+  gatherUserExceptions,
   gatherUserScheduleRules,
   mergeScheduleRulesWithGroups,
 } from "../../src/policy/group-resolution.js";
@@ -340,5 +341,114 @@ describe("gatherUserBudgets (#134)", () => {
     expect(gathered).toHaveLength(2);
     expect(gathered.every((b) => b.source.kind === "group")).toBe(true);
     expect(gathered.reduce((sum, b) => sum + b.secondsAllowed, 0)).toBe(1800);
+  });
+});
+
+describe("gatherUserExceptions (#142, ADR 0012)", () => {
+  let db: TestDb;
+  let userId: number;
+  const expiresAt = new Date("2030-01-01T00:00:00Z");
+  beforeEach(() => {
+    db = testDb();
+    userId = repo.createUser(db, { displayName: "Alice" }).id;
+  });
+  afterEach(() => {
+    db.$client.close();
+  });
+
+  it("returns an empty list for a user with no exceptions and no groups", () => {
+    expect(gatherUserExceptions(db, userId)).toEqual([]);
+  });
+
+  it("returns only the user's own exceptions, newest-first, when in no group", () => {
+    const first = repo.createException(db, {
+      userId,
+      targetKind: "overall",
+      action: "deny",
+      expiresAt,
+    });
+    const second = repo.createException(db, {
+      userId,
+      targetKind: "overall",
+      action: "allow",
+      expiresAt,
+    });
+    // Newest-first: same-second createdAt ties break on descending id.
+    expect(gatherUserExceptions(db, userId).map((e) => e.id)).toEqual([second.id, first.id]);
+  });
+
+  it("places the user's own exceptions before inherited group exceptions", () => {
+    const group = repo.createUserGroup(db, { name: "Kids" });
+    repo.addUserToGroup(db, group.id, userId);
+    const groupExc = repo.createGroupException(db, {
+      userGroupId: group.id,
+      targetKind: "overall",
+      action: "deny",
+      expiresAt,
+    });
+    const ownExc = repo.createException(db, {
+      userId,
+      targetKind: "overall",
+      action: "allow",
+      expiresAt,
+    });
+
+    const gathered = gatherUserExceptions(db, userId);
+    // Own first (highest precedence), then the inherited group override.
+    expect(gathered.map((e) => e.id)).toEqual([ownExc.id, groupExc.id]);
+    expect(gathered.map((e) => e.action)).toEqual(["allow", "deny"]);
+  });
+
+  it("orders inherited exceptions by ascending group id, then newest-first within a group", () => {
+    const groupA = repo.createUserGroup(db, { name: "A" });
+    const groupB = repo.createUserGroup(db, { name: "B" });
+    repo.addUserToGroup(db, groupA.id, userId);
+    repo.addUserToGroup(db, groupB.id, userId);
+    const bExc = repo.createGroupException(db, {
+      userGroupId: groupB.id,
+      targetKind: "overall",
+      action: "deny",
+      expiresAt,
+    });
+    const aExc1 = repo.createGroupException(db, {
+      userGroupId: groupA.id,
+      targetKind: "overall",
+      action: "deny",
+      expiresAt,
+    });
+    const aExc2 = repo.createGroupException(db, {
+      userGroupId: groupA.id,
+      targetKind: "overall",
+      action: "allow",
+      expiresAt,
+    });
+
+    // groupA (lower id) first — newest-first within it — then groupB.
+    expect(gatherUserExceptions(db, userId).map((e) => e.id)).toEqual([
+      aExc2.id,
+      aExc1.id,
+      bExc.id,
+    ]);
+  });
+
+  it("preserves each exception's active-window fields for the resolver", () => {
+    const effectiveFrom = new Date("2029-06-01T00:00:00Z");
+    repo.createException(db, {
+      userId,
+      targetKind: "activity",
+      targetId: 5,
+      action: "extend",
+      effectiveFrom,
+      expiresAt,
+    });
+    const [gathered] = gatherUserExceptions(db, userId);
+    expect(gathered).toMatchObject({
+      targetKind: "activity",
+      targetId: 5,
+      action: "extend",
+      effectiveFrom,
+      expiresAt,
+    });
+    expect(gathered?.createdAt).toBeInstanceOf(Date);
   });
 });

--- a/server/tests/policy/resolve.test.ts
+++ b/server/tests/policy/resolve.test.ts
@@ -14,6 +14,7 @@ import {
   ruleActiveAt,
   type BudgetInput,
   type EffectivePolicyInput,
+  type ExceptionInput,
   type GrantInput,
 } from "../../src/policy/resolve.js";
 import { resolveEffectiveAction, type ScheduleRule } from "../../src/policy/schedule-precedence.js";
@@ -36,6 +37,23 @@ function mkRule(overrides: Partial<ScheduleRule> = {}): ScheduleRule {
     effectiveFrom: null,
     effectiveTo: null,
     action: "allow",
+    ...overrides,
+  };
+}
+
+/**
+ * Build an {@link ExceptionInput}, defaulting to an `overall` `deny` that is
+ * active across the whole test day (2024-06-03). Overridable per test.
+ */
+function mkException(overrides: Partial<ExceptionInput> = {}): ExceptionInput {
+  return {
+    id: 1,
+    targetKind: "overall",
+    targetId: null,
+    action: "deny",
+    effectiveFrom: null,
+    expiresAt: new Date("2024-06-10T00:00:00Z"),
+    createdAt: new Date("2024-06-01T00:00:00Z"),
     ...overrides,
   };
 }
@@ -217,6 +235,26 @@ describe("effectivePolicy — allowed windows", () => {
     ]);
   });
 
+  it("`extend` widens the allowed window past a higher-precedence deny (ADR 0012 §2)", () => {
+    // A higher-precedence blanket deny would normally block the whole day; a
+    // lower-precedence `extend` window unions allowed time back in on top.
+    const result = effectivePolicy(
+      mkInput({
+        schedules: [
+          mkRule({ id: 1, ordinal: 0, action: "deny" }),
+          mkRule({
+            id: 2,
+            ordinal: 1,
+            action: "extend",
+            recurrenceStartMinute: 960,
+            recurrenceEndMinute: 1080,
+          }),
+        ],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([{ start: 960, end: 1080 }]);
+  });
+
   it("merges adjacent allowed segments split by a rule boundary into one window", () => {
     // A mid-day allow rule on a baseline-allow day splits the timeline into
     // three abutting allowed segments; they must collapse back to a single
@@ -336,6 +374,117 @@ describe("effectivePolicy — activeRules", () => {
       },
     ]);
     // The activity-scoped rule does not shape the overall allowed windows.
+    expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+});
+
+describe("effectivePolicy — date-specific exceptions (#142)", () => {
+  it("an active `deny` override blocks access over a baseline-allow day", () => {
+    const result = effectivePolicy(mkInput({ exceptions: [mkException({ action: "deny" })] }));
+    expect(result.allowedWindows).toEqual([]);
+  });
+
+  it("an active `allow` override wins over a recurring deny for the day", () => {
+    const result = effectivePolicy(
+      mkInput({
+        // A recurring blanket deny that, alone, would block the whole day.
+        schedules: [mkRule({ id: 1, ordinal: 0, action: "deny" })],
+        exceptions: [mkException({ action: "allow" })],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+
+  it("is not active before its effective_from (future-dated override)", () => {
+    const result = effectivePolicy(
+      mkInput({
+        // Override starts 2024-06-05, resolving the 2024-06-03 day → not yet active.
+        exceptions: [
+          mkException({ action: "deny", effectiveFrom: new Date("2024-06-05T00:00:00Z") }),
+        ],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+
+  it("becomes active on the day its effective_from opens", () => {
+    const result = effectivePolicy(
+      mkInput({
+        date: { year: 2024, month: 6, day: 5 },
+        exceptions: [
+          mkException({
+            action: "deny",
+            effectiveFrom: new Date("2024-06-05T00:00:00Z"),
+            expiresAt: new Date("2024-06-06T00:00:00Z"),
+          }),
+        ],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([]);
+  });
+
+  it("is not active after it has expired", () => {
+    const result = effectivePolicy(
+      mkInput({
+        exceptions: [mkException({ action: "deny", expiresAt: new Date("2024-06-02T00:00:00Z") })],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+
+  it("uses created_at as the active-window start when effective_from is null", () => {
+    // created_at is after the resolved day → not yet active despite no effective_from.
+    const result = effectivePolicy(
+      mkInput({
+        exceptions: [
+          mkException({
+            action: "deny",
+            effectiveFrom: null,
+            createdAt: new Date("2024-06-04T00:00:00Z"),
+          }),
+        ],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+
+  it("resolves overrides in precedence order — index 0 wins", () => {
+    // Two active overall overrides; the first in the array (highest precedence)
+    // decides, mirroring gatherUserExceptions' own-before-group / newest-first.
+    const result = effectivePolicy(
+      mkInput({
+        exceptions: [
+          mkException({ id: 2, action: "allow" }),
+          mkException({ id: 1, action: "deny" }),
+        ],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+
+  it("an `extend` override widens past a recurring deny", () => {
+    const result = effectivePolicy(
+      mkInput({
+        schedules: [mkRule({ id: 1, ordinal: 0, action: "deny" })],
+        exceptions: [mkException({ action: "extend" })],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+
+  it("an override on a non-overall target does not change the overall windows", () => {
+    const result = effectivePolicy(
+      mkInput({
+        exceptions: [mkException({ action: "deny", targetKind: "activity", targetId: 7 })],
+      }),
+    );
+    // Overall access is untouched by an activity-scoped override (parity with
+    // activity-scoped schedule rules, which also don't build overall windows).
+    expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+
+  it("ignores exceptions entirely when the field is omitted (default [])", () => {
+    const result = effectivePolicy(mkInput());
     expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
   });
 });

--- a/server/tests/policy/resolve.test.ts
+++ b/server/tests/policy/resolve.test.ts
@@ -255,6 +255,43 @@ describe("effectivePolicy — allowed windows", () => {
     expect(result.allowedWindows).toEqual([{ start: 960, end: 1080 }]);
   });
 
+  it("unions multiple `extend` windows over a deny, merging abutting ones", () => {
+    const result = effectivePolicy(
+      mkInput({
+        schedules: [
+          mkRule({ id: 1, ordinal: 0, action: "deny" }),
+          mkRule({
+            id: 2,
+            ordinal: 1,
+            action: "extend",
+            recurrenceStartMinute: 480,
+            recurrenceEndMinute: 600,
+          }),
+          mkRule({
+            id: 3,
+            ordinal: 2,
+            action: "extend",
+            recurrenceStartMinute: 600,
+            recurrenceEndMinute: 720,
+          }),
+          mkRule({
+            id: 4,
+            ordinal: 3,
+            action: "extend",
+            recurrenceStartMinute: 900,
+            recurrenceEndMinute: 960,
+          }),
+        ],
+      }),
+    );
+    // The two abutting extends (480–600, 600–720) merge into one; the disjoint
+    // 900–960 stays separate. Everything else remains denied.
+    expect(result.allowedWindows).toEqual([
+      { start: 480, end: 720 },
+      { start: 900, end: 960 },
+    ]);
+  });
+
   it("merges adjacent allowed segments split by a rule boundary into one window", () => {
     // A mid-day allow rule on a baseline-allow day splits the timeline into
     // three abutting allowed segments; they must collapse back to a single
@@ -448,7 +485,7 @@ describe("effectivePolicy — date-specific exceptions (#142)", () => {
     expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
   });
 
-  it("resolves overrides in precedence order — index 0 wins", () => {
+  it("resolves overrides in precedence order — index 0 allow wins", () => {
     // Two active overall overrides; the first in the array (highest precedence)
     // decides, mirroring gatherUserExceptions' own-before-group / newest-first.
     const result = effectivePolicy(
@@ -460,6 +497,52 @@ describe("effectivePolicy — date-specific exceptions (#142)", () => {
       }),
     );
     expect(result.allowedWindows).toEqual([{ start: 0, end: 1440 }]);
+  });
+
+  it("resolves overrides in precedence order — index 0 deny wins → no access", () => {
+    const result = effectivePolicy(
+      mkInput({
+        exceptions: [
+          mkException({ id: 2, action: "deny" }),
+          mkException({ id: 1, action: "allow" }),
+        ],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([]);
+  });
+
+  it("honours a mid-day expiry: an `allow` override until 21:00 over a recurring deny", () => {
+    // "allow games until 9pm tonight" — a precise-instant expiry, not a day
+    // boundary — carves the [0, 1260) window out of an otherwise all-day deny.
+    const result = effectivePolicy(
+      mkInput({
+        schedules: [mkRule({ id: 1, ordinal: 0, action: "deny" })],
+        exceptions: [
+          mkException({
+            action: "allow",
+            effectiveFrom: new Date("2024-06-03T00:00:00Z"),
+            expiresAt: new Date("2024-06-03T21:00:00Z"),
+          }),
+        ],
+      }),
+    );
+    expect(result.allowedWindows).toEqual([{ start: 0, end: 1260 }]);
+  });
+
+  it("honours a mid-day expiry: a `deny` override until 21:00 on a baseline-allow day", () => {
+    const result = effectivePolicy(
+      mkInput({
+        exceptions: [
+          mkException({
+            action: "deny",
+            effectiveFrom: new Date("2024-06-03T00:00:00Z"),
+            expiresAt: new Date("2024-06-03T21:00:00Z"),
+          }),
+        ],
+      }),
+    );
+    // Denied until 21:00, then the baseline-allow resumes.
+    expect(result.allowedWindows).toEqual([{ start: 1260, end: 1440 }]);
   });
 
   it("an `extend` override widens past a recurring deny", () => {


### PR DESCRIPTION
## Summary

- The Phase-4 resolver already honoured schedule **date-scoping**
  (`effective_from`/`effective_to`), but `effectivePolicy` never consumed
  **exceptions** — so a one-off / future-dated override (`allow`/`deny`/`extend`)
  resolved to nothing and the exceptions CRUD was display-only. This wires
  exceptions into the resolver as a top-precedence, date-anchored layer.
- Defines the **`extend`** action (previously an undefined synonym for `allow`)
  as a *widening union*: an active `extend` window grants access past a standing
  `deny` — the mechanism [#364](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/364) needs.
- Group exceptions are merged in via a new `gatherUserExceptions` helper, so the
  effective view reflects inherited group overrides too (no #362-style drift).

## Plan

Linked plan: `docs/plans/142-date-specific-overrides.md`
Design decision: `docs/adr/0012-date-specific-override-composition.md`
Roadmap: `docs/roadmap.md` → Phase 13 (additive layer on the Phase 2/4 foundation)

### Key design decisions (recorded in ADR 0012, for maintainer review)

1. **Precedence** — active exceptions win over recurring schedule rules for the
   target they cover (the issue's recommendation); own-before-group,
   newest-before-older within the exception layer. They feed the existing
   first-match-wins engine (ADR 0004), not a second evaluator.
2. **`extend` = widen** — unioned onto the allowed set after allow/deny
   resolution; only ever *adds* time. Pre-existing "extend wins its own segment"
   behaviour is unchanged (the union is a no-op there).
3. **Scope** — exceptions affect only the per-day allow/deny/extend **access
   windows** (never the seconds budgets — an additive amount is a `Grant`), and
   deliberately **do not** enter the recurring `timekpra` allowed-hours grid: a
   one-off calendar date is not a weekly-recurring pattern, exactly as
   `weekly-windows.ts` already documents.

## License-boundary note

N/A — no transport or packaging changes. Pure TypeScript over the policy model;
no GPL imports, no GPL binaries added to the image. `timekpra`/Ansible
subprocess and REST boundaries are untouched.

## Deferred (tracked)

- **Date-arrival / offline-queue push** of date-specific overrides to the client
  (push when the window opens, revert after) — inherently the #84 scheduler, not
  the recurring grid. Tracked in **#399**.
- Per-activity **quota** reduction from `deny` rules (recurring schedules don't
  do this today either) — out of scope, noted in the ADR.

## Test plan

- [x] `tests/policy/resolve.test.ts` — allow/deny override wins over recurring
  rules; date gate (future `effective_from`, becomes active on open day, expired,
  `effective_from ?? created_at`); `extend` widens past a higher-precedence deny;
  precedence order (index 0 wins); non-overall target no-op; omitted-field default.
- [x] `tests/policy/group-resolution.test.ts` — `gatherUserExceptions` own+group
  membership, own-before-group, ascending-group-id + newest-first ordering, field
  preservation.
- [x] `tests/api/policy-effective.test.ts` — a date-specific exception composes
  through `GET /api/users/:userId/effective` across before/during/after windows;
  an inherited group exception applies to a member and the member's own override
  wins.
- [x] Full gate green: `format:check`, `lint`, `typecheck`, `vitest` (1895 tests
  pass, coverage ≥ 80%).

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)