### PR TITLE
feat(events): capability-based frame gating on the event stream (#288)

### DIFF
--- a/.claude/plans/288-event-capability-gating.md
+++ b/.claude/plans/288-event-capability-gating.md
@@ -1,0 +1,88 @@
+# Plan — #288 Event stream: capability-based frame gating (ADR 0007 §4)
+
+Roadmap: Phase 8b. Follow-up to #165 (event-stream version handshake).
+ADR: `docs/adr/0007-event-stream-version-compatibility.md` §4.
+
+## Problem
+
+The `/api/events/stream` handshake (#165) already negotiates a client's
+`capabilities` set (`events/protocol.ts` → `helloFrameSchema.capabilities`),
+but nothing gates outbound frames on it. On `accept`, `stream.ts` calls
+`hub.register(clientId, socket)` and **discards** the advertised capabilities;
+the `EventHub` fan-out (`publishToClient` / `broadcast`) sends every frame to
+every open connection regardless of what the client can honour.
+
+ADR 0007 §4: *"The server only sends a frame type a client advertised support
+for; an older client simply never receives a frame it couldn't handle, and is
+**not** refused for it."* The `enforce.*` producers already exist (#99), so the
+gate is now implementable and testable end-to-end.
+
+## Scope (this PR — the backend correctness core)
+
+1. **Capability vocabulary + frame→capability map** — new
+   `server/src/events/capabilities.ts`:
+   - `CLIENT_CAPABILITIES` constants: `per_app_close`, `session_budget`
+     (the ADR §4 examples with frame producers today; `applocker_deny` /
+     `dns_filter` are forward-looking and add trivially when their frames land).
+   - `capabilityForEvent(event): ClientCapability | null` — a **pure,
+     exhaustive** switch over `ServerEventType`. A new frame type fails to
+     compile until its gate is declared (`assertNever`). Mapping:
+     | event | required capability |
+     | --- | --- |
+     | `enforce.force_close` | `per_app_close` |
+     | `enforce.session_lock` | `session_budget` |
+     | `lockout.cleared` | `session_budget` |
+     | `grant.applied` | — (baseline, ungated) |
+     | `policy.changed` | — (baseline, ungated) |
+
+     `lockout.cleared` gates on `session_budget`: it only clears an
+     overall-budget lockout, which can only happen on a client doing
+     session-budget enforcement (matches this issue's `enforce.*`/`lockout.*`
+     wording). `grant.applied` / `policy.changed` are informational nudges every
+     client re-renders, so they stay ungated.
+
+2. **Hub gating** — `server/src/events/hub.ts`:
+   - Store each connection's advertised capabilities alongside the socket
+     (`Map<EventSocket, ReadonlySet<string>>` per client).
+   - `register(clientId, socket, capabilities = [])` records them; default `[]`
+     = advertises nothing = receives only ungated frames (the correct default
+     for an older client).
+   - `publishToClient` / `broadcast` withhold a gated frame from any connection
+     whose advertised set lacks the required capability. `delivered` counts only
+     sockets actually written to.
+
+3. **Thread the negotiated capabilities** — `server/src/events/stream.ts`:
+   on `accept`, pass `hello.capabilities` into `hub.register`.
+
+4. **Barrels** — export the new surface from `events/index.ts`; re-export the
+   capability vocabulary + type from `api/index.ts` (part of the
+   `/api/events/stream` contract the bridge consumes).
+
+## Deferred (tracked follow-up, not this PR)
+
+- **Surface per-client capabilities in the admin Clients view** (grey out
+  unsupported controls — the Windows-client modularity seam,
+  `docs/windows-client-support.md`). That's a schema-persistence + DTO +
+  frontend slice; adding an unused `Client.capabilities` column here would be
+  dead code until the UI consumes it. File a focused follow-up and link it from
+  the PR. The live per-connection gate (this PR) is the load-bearing
+  correctness deliverable; the admin surface is a UX nicety on top.
+
+## Tests
+
+- New `tests/events/capabilities.test.ts` — `capabilityForEvent` mapping +
+  constant values.
+- `tests/events/hub.test.ts` — existing fan-out/stamping tests use
+  `lockout.cleared` (now gated), so their fakes register advertising
+  `session_budget` (faithful adaptation, not a weakening); **add** a
+  `capability gating` describe: withheld without the cap, delivered with it,
+  ungated frames reach everyone, mixed connections filtered, `delivered` count,
+  broadcast gating, distinct capabilities don't cross-authorise.
+- `tests/events/stream.test.ts` — add an end-to-end assertion that a client
+  advertising only `session_budget` receives `enforce.session_lock` but not
+  `enforce.force_close` (verifies the register-threading through the route).
+
+## License boundary
+
+None touched — pure TypeScript event-hub logic + Fastify/`@fastify/websocket`
+(MIT). No GPL linkage, no image change.

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -263,4 +263,6 @@ export {
   type ServerEvent,
   type ServerEventType,
   type EventFrame,
+  CLIENT_CAPABILITIES,
+  type ClientCapability,
 } from "../events/index.js";

--- a/server/src/enforcement/force-close.ts
+++ b/server/src/enforcement/force-close.ts
@@ -6,7 +6,7 @@
  * over-budget app. The preferred path is the event stream — emit
  * `enforce.force_close` (#100) and let the per-user `pct-client-agent` do the
  * kill, avoiding an SSH round-trip and a privileged client helper
- * (`docs/roadmap.md` → Phase 8). When the bridge isn't reachable, fall back to
+ * (`docs/roadmap.md` → Phase 8). When no agent receives that frame, fall back to
  * an ad-hoc, user-scoped `pkill` over the Phase-4 SSH facade. Both paths are
  * recorded in the #85 audit log.
  *
@@ -19,10 +19,16 @@
  * calls {@link ForceCloseTrigger.enforce} after each telemetry rollup is the
  * scheduler (#117), wired separately.
  *
- * **Reachability is the delivery count, not a separate probe.** `publishToClient`
- * returns how many live sockets the frame reached; `0` means the bridge is gone,
- * so we fall back. Reading delivery rather than a prior `isClientLive()` closes
- * the check-then-close race (a socket dropping between the two) for free.
+ * **The delivery count is the dispatch signal, not a separate probe.**
+ * `publishToClient` returns how many live sockets actually received the frame;
+ * `> 0` means an agent has it and will do the kill. `0` means none did — the
+ * client is offline, **or** it is connected but did not advertise the
+ * `per_app_close` capability, so the hub withheld the frame it couldn't honour
+ * (ADR 0007 §4). Both cases resolve to the same correct fallback: the
+ * capability-independent, server-side SSH `pkill` (which is how such a client is
+ * enforced at all), audited as the SSH path it actually took. Reading delivery
+ * rather than a prior `isClientLive()` also closes the check-then-close race (a
+ * socket dropping between the two) for free.
  *
  * License boundary: none touched — plain TypeScript over injected seams.
  */
@@ -67,7 +73,8 @@ export interface ForceCloseDeps {
   /** Expand a decision's `(scope, targetId)` into the concrete apps to close. */
   resolveActivities(scope: EnforcementScope, targetId: number): readonly ForceCloseActivity[];
   /**
-   * Run the user-scoped `pkill` fallback for one app on one offline client and
+   * Run the user-scoped `pkill` fallback for one app on a client whose agent
+   * did not receive the event frame (offline, or lacking `per_app_close`) and
    * record its audit entry. Contract: **never throws** — it audits every
    * outcome (including failures) so a wedged client can't break the fan-out.
    */
@@ -153,7 +160,7 @@ export class ForceCloseTrigger {
     }
   }
 
-  /** Emit the event to one client, or `pkill`-fall-back if it isn't reachable. */
+  /** Emit the event to one client, or `pkill`-fall-back if no agent received it. */
   async #closeOnClient(
     userId: number,
     client: ForceCloseClient,
@@ -169,9 +176,11 @@ export class ForceCloseTrigger {
       this.#deps.recordEventAudit({ client, userId, activityId: activity.activityId });
       return;
     }
-    // Bridge not reachable on this client — fall back to the SSH pkill. Defensive
-    // catch only: forceCloseOverSsh's contract is to audit + swallow, but a bug
-    // there must not abort the rest of the fan-out.
+    // No agent received the frame on this client (offline, or it lacks the
+    // per_app_close capability so the hub withheld it) — fall back to the SSH
+    // pkill, the capability-independent enforcement path. Defensive catch only:
+    // forceCloseOverSsh's contract is to audit + swallow, but a bug there must
+    // not abort the rest of the fan-out.
     try {
       await this.#deps.forceCloseOverSsh({ client, activity, userId });
     } catch (err: unknown) {

--- a/server/src/events/capabilities.ts
+++ b/server/src/events/capabilities.ts
@@ -1,0 +1,84 @@
+/**
+ * Client capability vocabulary and the frame → capability gate (ADR 0007 §4).
+ *
+ * Additive evolution of the event stream rides on `capabilities`, not on the
+ * `eventProtocol` version window: the server "only sends a frame type a client
+ * advertised support for; an older client simply never receives a frame it
+ * couldn't handle, and is **not** refused for it." A client advertises which
+ * enforcement primitives it supports in its `hello` (`events/protocol.ts`), and
+ * this module answers the one question the {@link ../events/hub.ts EventHub}
+ * asks on every publish: *does this event require a capability, and if so which
+ * one?*
+ *
+ * Isolated here — pure, I/O-free, mirroring `events/protocol.ts` — so the gate
+ * is a single, exhaustively-typed decision the fan-out routes through, and so a
+ * new frame type cannot be added without declaring whether it is gated.
+ *
+ * License boundary: none touched — plain TypeScript.
+ */
+import type { ServerEvent } from "./taxonomy.js";
+
+/**
+ * The capability flags a client can advertise in its `hello` (ADR 0007 §4).
+ * These are the additive feature flags naming the optional enforcement
+ * primitives a client supports; adding one is never a breaking change.
+ *
+ * Only the two primitives with frame producers today are named. The ADR also
+ * anticipates `applocker_deny` (AppArmor per-app deny, Phase 6) and
+ * `dns_filter` (Phase 7); they gain a constant here the moment their frame
+ * types join the taxonomy — the exhaustiveness check in
+ * {@link capabilityForEvent} forces exactly that.
+ */
+export const CLIENT_CAPABILITIES = {
+  /** Per-app / app-group process force-close (`enforce.force_close`). */
+  perAppClose: "per_app_close",
+  /**
+   * Overall session-budget enforcement — lock on exhaustion
+   * (`enforce.session_lock`) and unlock on a restoring grant
+   * (`lockout.cleared`).
+   */
+  sessionBudget: "session_budget",
+} as const;
+
+/** A capability string the server knows how to gate on. */
+export type ClientCapability = (typeof CLIENT_CAPABILITIES)[keyof typeof CLIENT_CAPABILITIES];
+
+/**
+ * The capability a client must have advertised to be sent `event`, or `null`
+ * for a **baseline** frame every client receives.
+ *
+ * Exhaustive over the event taxonomy: the `default` branch narrows `event` to
+ * `never`, so adding a new `ServerEvent` type is a compile error until its gate
+ * is declared here — a frame can never silently reach clients that can't honour
+ * it, nor be silently withheld from ones that can.
+ *
+ * - `enforce.force_close` → `per_app_close` (the agent kills the app's
+ *   processes; a client without per-app close can't act on it).
+ * - `enforce.session_lock` / `lockout.cleared` → `session_budget` (both concern
+ *   the overall-screen-time lock a session-budget client owns).
+ * - `grant.applied` / `policy.changed` → `null`: informational nudges every
+ *   client re-renders regardless of its enforcement primitives.
+ */
+export function capabilityForEvent(event: ServerEvent): ClientCapability | null {
+  switch (event.type) {
+    case "enforce.force_close":
+      return CLIENT_CAPABILITIES.perAppClose;
+    case "enforce.session_lock":
+    case "lockout.cleared":
+      return CLIENT_CAPABILITIES.sessionBudget;
+    case "grant.applied":
+    case "policy.changed":
+      return null;
+    default:
+      return assertExhaustive(event);
+  }
+}
+
+/**
+ * Compile-time exhaustiveness guard: reachable only if a `ServerEvent` variant
+ * is left unhandled above, which is then a type error. Throws defensively if a
+ * value outside the (zod-validated) taxonomy ever reaches it at runtime.
+ */
+function assertExhaustive(event: never): never {
+  throw new Error(`unhandled server event: ${JSON.stringify(event)}`);
+}

--- a/server/src/events/hub.ts
+++ b/server/src/events/hub.ts
@@ -11,11 +11,21 @@
  * minimal {@link EventSocket} interface, so the hub unit-tests with plain
  * fakes and the route ({@link ./stream.ts}) supplies the real socket. A client
  * may briefly hold more than one connection (e.g. a reconnect racing a
- * not-yet-closed socket), so connections are stored as a set per client and a
- * publish reaches every open one.
+ * not-yet-closed socket), so connections are stored per client and a publish
+ * reaches every open one.
+ *
+ * **Capability gating (ADR 0007 §4).** Each connection carries the
+ * `capabilities` it advertised in its `hello` (threaded in by {@link ./stream.ts}
+ * at `accept`). Before writing a frame the hub asks {@link capabilityForEvent}
+ * whether the event is gated; a gated frame is withheld from any connection
+ * that did not advertise the matching capability — an older or
+ * differently-capable client simply never receives a frame it can't honour, and
+ * is not disconnected for it. Baseline frames (no required capability) reach
+ * every open connection.
  *
  * License boundary: none touched — plain TypeScript.
  */
+import { capabilityForEvent } from "./capabilities.js";
 import type { ServerEvent } from "./taxonomy.js";
 
 /**
@@ -40,18 +50,28 @@ export const SOCKET_OPEN = 1;
  * so producers anywhere in the process can publish without re-plumbing.
  */
 export class EventHub {
-  /** Live connections per `Client.id`. Entries are pruned when a set empties. */
-  readonly #byClient = new Map<number, Set<EventSocket>>();
+  /**
+   * Live connections per `Client.id`, each mapped to the capability set it
+   * advertised at `accept`. Entries are pruned when a client's last connection
+   * is gone.
+   */
+  readonly #byClient = new Map<number, Map<EventSocket, ReadonlySet<string>>>();
   /** Monotonic sequence stamped onto each published frame. */
   #seq = 0;
 
-  /** Register a client's connection. Idempotent for the same socket. */
-  register(clientId: number, socket: EventSocket): void {
-    const set = this.#byClient.get(clientId);
-    if (set === undefined) {
-      this.#byClient.set(clientId, new Set([socket]));
+  /**
+   * Register a client's connection with the `capabilities` it advertised in its
+   * `hello` (ADR 0007 §4). Idempotent for the same socket; re-registering
+   * refreshes its capability set. Defaults to an empty set — a connection that
+   * advertised nothing receives only ungated (baseline) frames.
+   */
+  register(clientId: number, socket: EventSocket, capabilities: Iterable<string> = []): void {
+    const caps: ReadonlySet<string> = new Set(capabilities);
+    const conns = this.#byClient.get(clientId);
+    if (conns === undefined) {
+      this.#byClient.set(clientId, new Map([[socket, caps]]));
     } else {
-      set.add(socket);
+      conns.set(socket, caps);
     }
   }
 
@@ -61,10 +81,10 @@ export class EventHub {
    * the socket was never registered.
    */
   unregister(clientId: number, socket: EventSocket): void {
-    const set = this.#byClient.get(clientId);
-    if (set === undefined) return;
-    set.delete(socket);
-    if (set.size === 0) this.#byClient.delete(clientId);
+    const conns = this.#byClient.get(clientId);
+    if (conns === undefined) return;
+    conns.delete(socket);
+    if (conns.size === 0) this.#byClient.delete(clientId);
   }
 
   /**
@@ -72,9 +92,9 @@ export class EventHub {
    * number of sockets the frame was written to (0 if the client is offline).
    */
   publishToClient(clientId: number, event: ServerEvent): number {
-    const set = this.#byClient.get(clientId);
-    if (set === undefined) return 0;
-    return this.#send(set, event);
+    const conns = this.#byClient.get(clientId);
+    if (conns === undefined) return 0;
+    return this.#write(conns, this.#frame(event), capabilityForEvent(event));
   }
 
   /**
@@ -84,9 +104,10 @@ export class EventHub {
    */
   broadcast(event: ServerEvent): number {
     const frame = this.#frame(event);
+    const required = capabilityForEvent(event);
     let delivered = 0;
-    for (const set of this.#byClient.values()) {
-      delivered += this.#write(set, frame);
+    for (const conns of this.#byClient.values()) {
+      delivered += this.#write(conns, frame, required);
     }
     return delivered;
   }
@@ -104,20 +125,24 @@ export class EventHub {
   /** Total live connections across all clients. */
   get connectionCount(): number {
     let total = 0;
-    for (const set of this.#byClient.values()) total += set.size;
+    for (const conns of this.#byClient.values()) total += conns.size;
     return total;
   }
 
-  /** Stamp + serialize an event, then write it to a set of sockets. */
-  #send(set: Set<EventSocket>, event: ServerEvent): number {
-    return this.#write(set, this.#frame(event));
-  }
-
-  /** Write an already-serialized frame to every open socket in the set. */
-  #write(set: Set<EventSocket>, frame: string): number {
+  /**
+   * Write an already-serialized frame to every open connection whose advertised
+   * capabilities satisfy `required` (`null` = ungated, so it reaches all).
+   * A closing/closed socket is skipped (its close handler cleans it up).
+   */
+  #write(
+    conns: Map<EventSocket, ReadonlySet<string>>,
+    frame: string,
+    required: string | null,
+  ): number {
     let delivered = 0;
-    for (const socket of set) {
+    for (const [socket, caps] of conns) {
       if (socket.readyState !== SOCKET_OPEN) continue;
+      if (required !== null && !caps.has(required)) continue;
       socket.send(frame);
       delivered += 1;
     }

--- a/server/src/events/index.ts
+++ b/server/src/events/index.ts
@@ -11,6 +11,7 @@
 export const moduleName = "events";
 
 export { EventHub, SOCKET_OPEN, type EventSocket } from "./hub.js";
+export { CLIENT_CAPABILITIES, capabilityForEvent, type ClientCapability } from "./capabilities.js";
 export { registerEventStream, type EventStreamOptions } from "./stream.js";
 export {
   startHeartbeat,

--- a/server/src/events/stream.ts
+++ b/server/src/events/stream.ts
@@ -215,9 +215,18 @@ export async function registerEventStream(
           }
 
           socket.send(JSON.stringify(result.frame));
-          hub.register(clientId, socket);
+          // Thread the negotiated capabilities into the hub so the fan-out can
+          // withhold frames the client can't honour (ADR 0007 §4). `hello` is
+          // non-null on accept; `?? []` satisfies the type system without a
+          // non-null assertion (a null hello is refused above).
+          hub.register(clientId, socket, hello?.capabilities ?? []);
           log.info(
-            { event: "event_stream_open", clientId, eventProtocol: result.frame.eventProtocol },
+            {
+              event: "event_stream_open",
+              clientId,
+              eventProtocol: result.frame.eventProtocol,
+              capabilities: hello?.capabilities ?? [],
+            },
             "client event stream opened",
           );
 

--- a/server/tests/events/capabilities.test.ts
+++ b/server/tests/events/capabilities.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for the frame → capability gate (#288, ADR 0007 §4). Pure and
+ * I/O-free: assert the capability vocabulary matches the ADR's wire strings and
+ * that every event type maps to the intended gate (or to `null` for a baseline
+ * frame every client receives).
+ */
+import { describe, expect, it } from "vitest";
+
+import { CLIENT_CAPABILITIES, capabilityForEvent } from "../../src/events/capabilities.js";
+import type { ServerEvent } from "../../src/events/taxonomy.js";
+
+describe("CLIENT_CAPABILITIES", () => {
+  it("uses the ADR 0007 §4 wire strings", () => {
+    // These strings cross the wire in the client `hello`; they must not drift.
+    expect(CLIENT_CAPABILITIES.perAppClose).toBe("per_app_close");
+    expect(CLIENT_CAPABILITIES.sessionBudget).toBe("session_budget");
+  });
+});
+
+describe("capabilityForEvent", () => {
+  it("gates enforce.force_close on per_app_close", () => {
+    const event: ServerEvent = { type: "enforce.force_close", userId: 1, activityId: 7 };
+    expect(capabilityForEvent(event)).toBe("per_app_close");
+  });
+
+  it("gates enforce.session_lock on session_budget", () => {
+    const event: ServerEvent = { type: "enforce.session_lock", userId: 1 };
+    expect(capabilityForEvent(event)).toBe("session_budget");
+  });
+
+  it("gates lockout.cleared on session_budget", () => {
+    const event: ServerEvent = { type: "lockout.cleared", userId: 1 };
+    expect(capabilityForEvent(event)).toBe("session_budget");
+  });
+
+  it("leaves grant.applied ungated (baseline frame)", () => {
+    const event: ServerEvent = {
+      type: "grant.applied",
+      userId: 1,
+      grantedSeconds: 1800,
+      reason: "chores done",
+      activityId: null,
+    };
+    expect(capabilityForEvent(event)).toBeNull();
+  });
+
+  it("leaves policy.changed ungated (baseline frame)", () => {
+    const event: ServerEvent = { type: "policy.changed", userId: 1 };
+    expect(capabilityForEvent(event)).toBeNull();
+  });
+});

--- a/server/tests/events/hub.test.ts
+++ b/server/tests/events/hub.test.ts
@@ -2,11 +2,12 @@
  * Unit tests for the fan-out hub (#100). Connections are plain fakes behind
  * the {@link EventSocket} interface, so these cover the registry + publish
  * logic without a real WebSocket: per-client isolation, multi-connection
- * delivery, skipping non-open sockets, broadcast, liveness/counts, and the
- * stamped frame.
+ * delivery, skipping non-open sockets, broadcast, liveness/counts, the stamped
+ * frame, and capability-based frame gating (#288, ADR 0007 §4).
  */
 import { describe, expect, it } from "vitest";
 
+import { CLIENT_CAPABILITIES } from "../../src/events/capabilities.js";
 import { EventHub, SOCKET_OPEN, type EventSocket } from "../../src/events/hub.js";
 import type { ServerEvent } from "../../src/events/taxonomy.js";
 
@@ -19,7 +20,18 @@ class FakeSocket implements EventSocket {
   }
 }
 
+/** `lockout.cleared` is gated on `session_budget`; fakes advertise it to receive it. */
+const SESSION_BUDGET = [CLIENT_CAPABILITIES.sessionBudget];
+const PER_APP_CLOSE = [CLIENT_CAPABILITIES.perAppClose];
+
 const lockoutCleared = (userId: number): ServerEvent => ({ type: "lockout.cleared", userId });
+const policyChanged = (userId: number): ServerEvent => ({ type: "policy.changed", userId });
+const forceClose = (userId: number, activityId: number): ServerEvent => ({
+  type: "enforce.force_close",
+  userId,
+  activityId,
+});
+const sessionLock = (userId: number): ServerEvent => ({ type: "enforce.session_lock", userId });
 
 describe("EventHub — fan-out", () => {
   it("delivers a published event only to the targeted client's connections", () => {
@@ -27,9 +39,9 @@ describe("EventHub — fan-out", () => {
     const a1 = new FakeSocket();
     const a2 = new FakeSocket();
     const b1 = new FakeSocket();
-    hub.register(1, a1);
-    hub.register(1, a2);
-    hub.register(2, b1);
+    hub.register(1, a1, SESSION_BUDGET);
+    hub.register(1, a2, SESSION_BUDGET);
+    hub.register(2, b1, SESSION_BUDGET);
 
     const delivered = hub.publishToClient(1, lockoutCleared(1));
 
@@ -49,8 +61,8 @@ describe("EventHub — fan-out", () => {
     const open = new FakeSocket();
     const closing = new FakeSocket();
     closing.readyState = 2; // CLOSING
-    hub.register(1, open);
-    hub.register(1, closing);
+    hub.register(1, open, SESSION_BUDGET);
+    hub.register(1, closing, SESSION_BUDGET);
 
     expect(hub.publishToClient(1, lockoutCleared(1))).toBe(1);
     expect(open.sent).toHaveLength(1);
@@ -61,12 +73,94 @@ describe("EventHub — fan-out", () => {
     const hub = new EventHub();
     const a = new FakeSocket();
     const b = new FakeSocket();
-    hub.register(1, a);
-    hub.register(2, b);
+    hub.register(1, a, SESSION_BUDGET);
+    hub.register(2, b, SESSION_BUDGET);
 
     expect(hub.broadcast(lockoutCleared(1))).toBe(2);
     expect(a.sent).toHaveLength(1);
     expect(b.sent).toHaveLength(1);
+  });
+});
+
+describe("EventHub — capability gating (ADR 0007 §4)", () => {
+  it("delivers a baseline (ungated) frame to a connection that advertised nothing", () => {
+    const hub = new EventHub();
+    const socket = new FakeSocket();
+    hub.register(1, socket); // no capabilities
+
+    expect(hub.publishToClient(1, policyChanged(1))).toBe(1);
+    expect(socket.sent).toHaveLength(1);
+  });
+
+  it("withholds a gated frame from a connection lacking the capability", () => {
+    const hub = new EventHub();
+    const socket = new FakeSocket();
+    hub.register(1, socket); // advertises nothing
+
+    // Gated on per_app_close / session_budget respectively — neither advertised.
+    expect(hub.publishToClient(1, forceClose(1, 7))).toBe(0);
+    expect(hub.publishToClient(1, sessionLock(1))).toBe(0);
+    expect(socket.sent).toHaveLength(0);
+    // ...but the connection is still live: gating withholds, never disconnects.
+    expect(hub.isClientLive(1)).toBe(true);
+  });
+
+  it("delivers a gated frame to a connection that advertised the capability", () => {
+    const hub = new EventHub();
+    const socket = new FakeSocket();
+    hub.register(1, socket, PER_APP_CLOSE);
+
+    expect(hub.publishToClient(1, forceClose(1, 7))).toBe(1);
+    expect(socket.sent).toHaveLength(1);
+  });
+
+  it("does not let one capability authorise a frame gated on another", () => {
+    const hub = new EventHub();
+    const socket = new FakeSocket();
+    hub.register(1, socket, PER_APP_CLOSE); // has per_app_close, not session_budget
+
+    expect(hub.publishToClient(1, forceClose(1, 7))).toBe(1); // per_app_close ✓
+    expect(hub.publishToClient(1, sessionLock(1))).toBe(0); // needs session_budget ✗
+    expect(socket.sent).toHaveLength(1);
+  });
+
+  it("filters a gated frame per-connection within one client", () => {
+    const hub = new EventHub();
+    const capable = new FakeSocket();
+    const incapable = new FakeSocket();
+    hub.register(1, capable, PER_APP_CLOSE);
+    hub.register(1, incapable, SESSION_BUDGET);
+
+    const delivered = hub.publishToClient(1, forceClose(1, 7));
+
+    expect(delivered).toBe(1);
+    expect(capable.sent).toHaveLength(1);
+    expect(incapable.sent).toHaveLength(0);
+  });
+
+  it("gates broadcasts the same way across clients", () => {
+    const hub = new EventHub();
+    const capable = new FakeSocket();
+    const incapable = new FakeSocket();
+    hub.register(1, capable, SESSION_BUDGET);
+    hub.register(2, incapable); // advertises nothing
+
+    const delivered = hub.broadcast(sessionLock(1));
+
+    expect(delivered).toBe(1);
+    expect(capable.sent).toHaveLength(1);
+    expect(incapable.sent).toHaveLength(0);
+  });
+
+  it("re-registering the same socket refreshes its capability set", () => {
+    const hub = new EventHub();
+    const socket = new FakeSocket();
+    hub.register(1, socket); // nothing → withheld
+    expect(hub.publishToClient(1, forceClose(1, 7))).toBe(0);
+
+    hub.register(1, socket, PER_APP_CLOSE); // now capable
+    expect(hub.publishToClient(1, forceClose(1, 7))).toBe(1);
+    expect(hub.connectionCount).toBe(1); // still one connection, not two
   });
 });
 
@@ -107,10 +201,10 @@ describe("EventHub — frame stamping", () => {
   it("wraps the event in a frame with a monotonic seq and an ISO timestamp", () => {
     const hub = new EventHub();
     const socket = new FakeSocket();
-    hub.register(1, socket);
+    hub.register(1, socket, SESSION_BUDGET);
 
     hub.publishToClient(1, lockoutCleared(1));
-    hub.publishToClient(1, { type: "policy.changed", userId: 1 });
+    hub.publishToClient(1, policyChanged(1));
 
     const [firstRaw, secondRaw] = socket.sent;
     if (firstRaw === undefined || secondRaw === undefined) {

--- a/server/tests/events/stream.test.ts
+++ b/server/tests/events/stream.test.ts
@@ -95,12 +95,15 @@ function awaitOpen(ws: WebSocket): Promise<void> {
 }
 
 /** A well-formed client hello at the given protocol (defaults to the server's). */
-function helloFrame(eventProtocol: number = EVENT_PROTOCOL): string {
+function helloFrame(
+  eventProtocol: number = EVENT_PROTOCOL,
+  capabilities: string[] = ["session_budget"],
+): string {
   return JSON.stringify({
     type: "hello",
     agentVersion: "1.4.2",
     eventProtocol,
-    capabilities: ["session_budget"],
+    capabilities,
   });
 }
 
@@ -285,5 +288,44 @@ describe("GET /api/events/stream — version handshake (#165)", () => {
     expect(accept.type).toBe("accept");
     // A compatible connect clears the stale flag.
     await vi.waitFor(() => expect(repo.getClient(db, clientId)?.updateRequired).toBe(false));
+  });
+});
+
+describe("GET /api/events/stream — capability gating (#288, ADR 0007 §4)", () => {
+  it("delivers only the frames whose capability the hello advertised", async () => {
+    harness = buildTestApp();
+    const { app } = harness;
+    const token = generateToken();
+    const clientId = enrolClientWithToken(harness, token);
+    await app.listen({ port: 0, host: "127.0.0.1" });
+
+    const ws = connect(app, { authorization: `Bearer ${token}` });
+    const nextMessage = messageReader(ws);
+    await awaitOpen(ws);
+    // Advertise session_budget only — not per_app_close.
+    ws.send(helloFrame(EVENT_PROTOCOL, ["session_budget"]));
+
+    const accept = JSON.parse(await nextMessage()) as { type: string };
+    expect(accept.type).toBe("accept");
+    await vi.waitFor(() => expect(app.eventHub.isClientLive(clientId)).toBe(true));
+
+    // enforce.force_close is gated on per_app_close (not advertised) → withheld.
+    expect(
+      app.eventHub.publishToClient(clientId, {
+        type: "enforce.force_close",
+        userId: 1,
+        activityId: 7,
+      }),
+    ).toBe(0);
+
+    // enforce.session_lock is gated on session_budget (advertised) → delivered.
+    expect(
+      app.eventHub.publishToClient(clientId, { type: "enforce.session_lock", userId: 1 }),
+    ).toBe(1);
+
+    // The next frame the client actually receives is the session_lock — proving
+    // the withheld force_close never crossed the wire.
+    const frame = JSON.parse(await nextMessage()) as EventFrame;
+    expect(frame.event.type).toBe("enforce.session_lock");
   });
 });


### PR DESCRIPTION
## Summary

- The `/api/events/stream` handshake already negotiates each client's `capabilities` set (#165), but the `EventHub` discarded them and fanned every frame out to every connection. Per **ADR 0007 §4**, the server should only send a frame type a client advertised support for.
- Adds `events/capabilities.ts` — the capability vocabulary (`per_app_close`, `session_budget`) and a **pure, exhaustive** `capabilityForEvent` map. `enforce.force_close` → `per_app_close`; `enforce.session_lock` / `lockout.cleared` → `session_budget`; `grant.applied` / `policy.changed` stay ungated. The exhaustive switch makes a new frame type a compile error until its gate is declared.
- `EventHub` records each connection's advertised capabilities and **withholds a gated frame from any connection lacking the matching capability** (both `publishToClient` and `broadcast`); an older / differently-capable client simply never receives a frame it can't honour, and is **not** disconnected for it. `stream.ts` threads the accepted `hello.capabilities` into `hub.register`.

## Plan

Linked plan: `.claude/plans/288-event-capability-gating.md`
Roadmap: docs/roadmap.md → Phase 8b. Follow-up to #165 (ADR 0007).

## Deferred (tracked)

- **Surface per-client supported capabilities in the admin Clients view** (persist on the `Client` row + DTO + grey-out UI — the Windows-client modularity seam) → filed as **#400**. Adding an unused `Client.capabilities` column here would be dead code until the UI consumes it; the live per-connection gate in this PR is the load-bearing correctness deliverable.

## License-boundary note

N/A for GPL boundaries — pure TypeScript event-hub logic + Fastify/`@fastify/websocket` (MIT). No GPL linkage, no transport/packaging change, no image change. No new dependencies.

## Test plan

- [x] `tests/events/capabilities.test.ts` — the `capabilityForEvent` mapping + the `CLIENT_CAPABILITIES` wire-string values.
- [x] `tests/events/hub.test.ts` — new `capability gating` suite: withheld without the cap, delivered with it, ungated frames reach everyone, per-connection filtering within one client, `delivered` counts only recipients, broadcast gating, one capability doesn't authorise another, re-register refreshes caps. (Existing fan-out/stamping tests that use the now-gated `lockout.cleared` advertise `session_budget` — a faithful adaptation, not a weakening.)
- [x] `tests/events/stream.test.ts` — end-to-end: a client advertising only `session_budget` receives `enforce.session_lock` but not `enforce.force_close`, verifying the handshake→hub capability threading through the real route.
- [x] Full gate green from `server/`: `format:check`, `lint`, `typecheck` (`tsc --noEmit`), `vitest run` with the 80% coverage gate.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0135iXaCUhombHP3eABPmuBZ)_