### PR TITLE
feat(admin): budget-sourced picker for per-budget cadence overrides (#388)

### DIFF
--- a/server/frontend/src/lib/views/NotificationsView.svelte
+++ b/server/frontend/src/lib/views/NotificationsView.svelte
@@ -15,17 +15,25 @@
   (`server/src/policy/notification.ts`): a map of budget key
   (`overall` | `activity:<id>` | `group:<id>`) → `{ warningMinutes }`, the
   "minutes remaining" marks that replace the built-in 15/5/1-minute set for that
-  budget. This view edits them as rows (scope + optional target id + a
-  comma-separated minute list), plus a "Clear all" that reverts to the built-in
-  cadence. Rows carry the budget's numeric id directly; a friendly budget picker
-  sourced from the user's budgets is a follow-up (fits #343's combined editor).
+  budget. This view edits them as rows (a budget picker + a comma-separated
+  minute list), plus a "Clear all" that reverts to the built-in cadence.
+
+  The budget picker (#388) is sourced from the user's own budgets and labelled
+  with the activity/activity-group names (`Activity — firefox`, `Group — Games`)
+  rather than asking the admin to type a numeric target id. Options are keyed by
+  `(scope, target)` — the same key the grammar stores — and de-duplicated across
+  a target's daily / weekly / monthly rollover windows into a single entry. A
+  stored override whose budget no longer exists stays pickable (its key is added
+  to the option list) so hydrate→save is a faithful round-trip.
 -->
 <script lang="ts">
   import { onMount } from "svelte";
   import { ApiError } from "$lib/api/client.js";
   import type {
+    ActivityGroupResponse,
+    ActivityResponse,
+    BudgetResponse,
     NotificationPolicyResponse,
-    Scope,
     SoundProfile,
     UserResponse,
   } from "$lib/api/contract.js";
@@ -35,6 +43,9 @@
     deleteNotificationPolicy,
   } from "$lib/api/notifications.js";
   import { listUsers } from "$lib/api/users.js";
+  import { listBudgets } from "$lib/api/budgets.js";
+  import { listActivities } from "$lib/api/activities.js";
+  import { listActivityGroups } from "$lib/api/activity-groups.js";
 
   // Documented bounds + vocabulary (`docs/client-notifications.md`, mirrored by
   // `server/src/policy/notification.ts`'s single-source constants). Hardcoded
@@ -51,12 +62,6 @@
   const WARNING_MINUTES_MAX_COUNT = 32;
   const CADENCE_OVERRIDE_KEYS_MAX = 64;
 
-  const SCOPE_OPTIONS: ReadonlyArray<{ value: Scope; label: string }> = [
-    { value: "overall", label: "Overall screen time" },
-    { value: "activity", label: "Activity" },
-    { value: "group", label: "Activity group" },
-  ];
-
   const SOUND_PROFILE_OPTIONS: ReadonlyArray<{ value: SoundProfile; label: string }> = [
     { value: "off", label: "Off — no sounds" },
     { value: "subtle", label: "Subtle (default)" },
@@ -68,10 +73,18 @@
   let error = $state<string | null>(null);
   let notice = $state<string | null>(null);
 
+  // Global catalogues used only to label the budget picker with human-readable
+  // activity/group names (#388). Loaded once on mount; name resolution is
+  // best-effort — a missing catalogue just falls back to an id label.
+  let activities = $state<ActivityResponse[]>([]);
+  let activityGroups = $state<ActivityGroupResponse[]>([]);
+
   // The user whose policy is being edited, and that policy's loaded state.
   let selectedUserId = $state<number | null>(null);
   let policy = $state<NotificationPolicyResponse | null>(null);
   let loadingPolicy = $state(false);
+  // The selected user's budgets — the source of the cadence picker options.
+  let budgets = $state<BudgetResponse[]>([]);
 
   // Editable form fields, hydrated from the loaded policy.
   let formEnabled = $state(true);
@@ -82,20 +95,27 @@
   let clearingCadence = $state(false);
   let savingCadence = $state(false);
 
-  // One editable per-budget cadence override. `targetId` is unused for the
-  // `overall` scope; `minutes` is a comma-separated list of "minutes remaining"
-  // warn-at marks. `id` is a stable key for the {#each} so removing a middle
-  // row doesn't reshuffle input focus.
+  // One editable per-budget cadence override. `key` is the pinned storage key
+  // (`overall` | `activity:<id>` | `group:<id>`) chosen from the budget picker;
+  // `minutes` is a comma-separated list of "minutes remaining" warn-at marks.
+  // `id` is a stable key for the {#each} so removing a middle row doesn't
+  // reshuffle input focus.
   interface CadenceRow {
     id: number;
-    scope: Scope;
-    targetId: string;
+    key: string;
     minutes: string;
   }
   let cadenceRows = $state<CadenceRow[]>([]);
   let nextRowId = 0;
 
-  onMount(loadUsers);
+  onMount(loadInitial);
+
+  // Load the user list and the label catalogues together on mount. The user
+  // list gates the whole view; the catalogues only decorate the picker, so a
+  // catalogue failure never blocks editing (keys fall back to id labels).
+  async function loadInitial(): Promise<void> {
+    await Promise.all([loadUsers(), loadCatalogues()]);
+  }
 
   async function loadUsers(): Promise<void> {
     loadingUsers = true;
@@ -106,6 +126,18 @@
       error = messageOf(err);
     } finally {
       loadingUsers = false;
+    }
+  }
+
+  async function loadCatalogues(): Promise<void> {
+    try {
+      const [acts, groups] = await Promise.all([listActivities(), listActivityGroups()]);
+      activities = acts;
+      activityGroups = groups;
+    } catch (err) {
+      // Name resolution is best-effort: keep the view usable and let the picker
+      // fall back to id labels rather than blocking on a catalogue read.
+      error ??= messageOf(err);
     }
   }
 
@@ -130,12 +162,26 @@
     }
   }
 
+  // Load the selected user's budgets to source the cadence picker options.
+  // Best-effort: a failure leaves the picker with the always-present "Overall"
+  // entry plus any keys the stored overrides already carry.
+  async function loadBudgets(userId: number): Promise<void> {
+    try {
+      budgets = await listBudgets(userId);
+    } catch (err) {
+      budgets = [];
+      error ??= messageOf(err);
+    }
+  }
+
   function onSelectUser(): void {
     if (selectedUserId === null) {
       policy = null;
+      budgets = [];
       return;
     }
     void loadPolicy(selectedUserId);
+    void loadBudgets(selectedUserId);
   }
 
   function userName(id: number): string {
@@ -161,26 +207,78 @@
 
   let hasCustomCadence = $derived(policy !== null && policy.cadenceOverrides !== null);
 
-  // --- Per-budget cadence editor (#302) ---
+  // --- Per-budget cadence editor (#302, picker #388) ---
 
   type CadenceOverrideMap = NonNullable<NotificationPolicyResponse["cadenceOverrides"]>;
 
-  // Hydrate editor rows from the stored map: `overall` → scope with no id,
-  // `<scope>:<id>` → scope + id; warn-at marks join to a comma list.
+  interface BudgetOption {
+    key: string;
+    label: string;
+  }
+
+  // Human-readable label for a cadence key. `overall` is fixed; an
+  // activity/group key resolves the name from the loaded catalogues, falling
+  // back to an id label when the referent is missing (deleted, or a catalogue
+  // that failed to load).
+  function labelForKey(key: string): string {
+    if (key === "overall") {
+      return "Overall screen time";
+    }
+    const match = /^(activity|group):([0-9]+)$/.exec(key);
+    if (match === null) {
+      return key;
+    }
+    const id = Number(match[2]);
+    if (match[1] === "activity") {
+      const activity = activities.find((a) => a.id === id);
+      return activity ? `Activity — ${activity.matcher}` : `Activity ${id}`;
+    }
+    const group = activityGroups.find((g) => g.id === id);
+    return group ? `Group — ${group.name}` : `Group ${id}`;
+  }
+
+  // The picker options: always "Overall", plus one entry per distinct
+  // non-overall `(scope, target)` in the user's budgets — de-duplicated across
+  // the target's daily/weekly/monthly windows (the cadence key is keyed by
+  // target, not window). Keys already used by a row are folded in too, so a
+  // stored override for a since-deleted budget stays pickable (a faithful
+  // hydrate→save round-trip). Ordered overall → activities → groups, then by
+  // label.
+  let budgetOptions = $derived.by<BudgetOption[]>(() => {
+    const keys = new Set<string>(["overall"]);
+    for (const budget of budgets) {
+      if (budget.targetId === null) {
+        continue;
+      }
+      if (budget.scope === "activity") {
+        keys.add(`activity:${budget.targetId}`);
+      } else if (budget.scope === "group") {
+        keys.add(`group:${budget.targetId}`);
+      }
+    }
+    for (const row of cadenceRows) {
+      keys.add(row.key);
+    }
+    const rank = (key: string): number =>
+      key === "overall" ? 0 : key.startsWith("activity:") ? 1 : 2;
+    return [...keys]
+      .map((key) => ({ key, label: labelForKey(key) }))
+      .sort((a, b) => rank(a.key) - rank(b.key) || a.label.localeCompare(b.label));
+  });
+
+  // Hydrate editor rows from the stored map: each `<key>` becomes a row whose
+  // picker is set to that key; warn-at marks join to a comma list.
   function rowsFromOverrides(
     overrides: NotificationPolicyResponse["cadenceOverrides"],
   ): CadenceRow[] {
     if (overrides === null) {
       return [];
     }
-    return Object.entries(overrides).map(([key, override]) => {
-      const minutes = override.warningMinutes.join(", ");
-      if (key === "overall") {
-        return { id: nextRowId++, scope: "overall", targetId: "", minutes };
-      }
-      const [scope, id] = key.split(":");
-      return { id: nextRowId++, scope: scope as Scope, targetId: id ?? "", minutes };
-    });
+    return Object.entries(overrides).map(([key, override]) => ({
+      id: nextRowId++,
+      key,
+      minutes: override.warningMinutes.join(", "),
+    }));
   }
 
   // Parse a comma-separated warn-at list into a normalised (deduped, descending)
@@ -210,17 +308,22 @@
     return Array.from(new Set(nums)).sort((a, b) => b - a);
   }
 
-  // Build the storage key for a row, or `null` when an activity/group row lacks a
-  // positive numeric id.
+  // Validate/normalise a row's picked key against the pinned grammar. The picker
+  // only ever offers valid keys, but the guard keeps the storage contract the
+  // single source of truth and rejects any malformed value defensively.
   function rowKey(row: CadenceRow): string | null {
-    if (row.scope === "overall") {
+    if (row.key === "overall") {
       return "overall";
     }
-    const id = Number(row.targetId);
+    const match = /^(activity|group):([0-9]+)$/.exec(row.key);
+    if (match === null) {
+      return null;
+    }
+    const id = Number(match[2]);
     if (!Number.isInteger(id) || id < 1) {
       return null;
     }
-    return `${row.scope}:${id}`;
+    return `${match[1]}:${id}`;
   }
 
   // Assemble the current rows into a cadence-override payload (or `null` to revert
@@ -238,10 +341,10 @@
     for (const row of cadenceRows) {
       const key = rowKey(row);
       if (key === null) {
-        return { ok: false, message: "Each activity/group override needs a positive numeric ID." };
+        return { ok: false, message: "Each override must target a budget." };
       }
       if (key in map) {
-        return { ok: false, message: `Duplicate override for “${key}”.` };
+        return { ok: false, message: `Duplicate override for “${labelForKey(key)}”.` };
       }
       const minutes = parseMinutes(row.minutes);
       if (minutes === null) {
@@ -277,7 +380,7 @@
   );
 
   function addCadenceRow(): void {
-    cadenceRows = [...cadenceRows, { id: nextRowId++, scope: "overall", targetId: "", minutes: "" }];
+    cadenceRows = [...cadenceRows, { id: nextRowId++, key: "overall", minutes: "" }];
   }
 
   function removeCadenceRow(id: number): void {
@@ -485,9 +588,9 @@
           </div>
           <p class="sublabel cadence-hint">
             Override the built-in 15/5/1-minute warnings for a specific budget.
-            Each row sets the “minutes remaining” marks at which to warn (a
-            comma-separated list, e.g. <code>15, 10, 5</code>); leave the list
-            empty to warn only when time is up. Budgets with no row keep the
+            Pick the budget, then set the “minutes remaining” marks at which to
+            warn (a comma-separated list, e.g. <code>15, 10, 5</code>); leave the
+            list empty to warn only when time is up. Budgets with no row keep the
             built-in cadence.
           </p>
 
@@ -499,21 +602,11 @@
             <ul class="cadence-rows">
               {#each cadenceRows as row (row.id)}
                 <li class="cadence-row">
-                  <select bind:value={row.scope} aria-label="Budget scope">
-                    {#each SCOPE_OPTIONS as option (option.value)}
-                      <option value={option.value}>{option.label}</option>
+                  <select class="budget-pick" bind:value={row.key} aria-label="Budget">
+                    {#each budgetOptions as option (option.key)}
+                      <option value={option.key}>{option.label}</option>
                     {/each}
                   </select>
-                  {#if row.scope !== "overall"}
-                    <input
-                      class="target-id"
-                      type="text"
-                      inputmode="numeric"
-                      placeholder="ID"
-                      bind:value={row.targetId}
-                      aria-label="Target ID"
-                    />
-                  {/if}
                   <input
                     class="minutes"
                     type="text"
@@ -687,8 +780,9 @@
     align-items: center;
     gap: 0.4rem;
   }
-  .cadence-row .target-id {
-    width: 5rem;
+  .cadence-row .budget-pick {
+    flex: 1 1 12rem;
+    min-width: 10rem;
   }
   .cadence-row .minutes {
     flex: 1 1 10rem;

--- a/server/frontend/src/lib/views/NotificationsView.svelte
+++ b/server/frontend/src/lib/views/NotificationsView.svelte
@@ -134,10 +134,11 @@
       const [acts, groups] = await Promise.all([listActivities(), listActivityGroups()]);
       activities = acts;
       activityGroups = groups;
-    } catch (err) {
-      // Name resolution is best-effort: keep the view usable and let the picker
-      // fall back to id labels rather than blocking on a catalogue read.
-      error ??= messageOf(err);
+    } catch {
+      // Name resolution is purely decorative: on failure the picker falls back to
+      // id labels ("Activity 7") and stays fully usable, so we deliberately don't
+      // raise the error banner for it — and avoid racing the concurrent mount-time
+      // user load, which would not clear a banner we set here.
     }
   }
 
@@ -180,8 +181,15 @@
       budgets = [];
       return;
     }
-    void loadPolicy(selectedUserId);
-    void loadBudgets(selectedUserId);
+    void loadUserData(selectedUserId);
+  }
+
+  // Load the policy first, then the budgets, in sequence — `loadPolicy` clears
+  // `error` on entry, so sequencing keeps a budgets-load failure banner from
+  // being clobbered by a concurrent policy load.
+  async function loadUserData(userId: number): Promise<void> {
+    await loadPolicy(userId);
+    await loadBudgets(userId);
   }
 
   function userName(id: number): string {

--- a/server/frontend/tests/components/notifications-view.test.ts
+++ b/server/frontend/tests/components/notifications-view.test.ts
@@ -359,6 +359,37 @@ describe("NotificationsView", () => {
     await waitFor(() => expect(listBudgets).toHaveBeenCalledWith(1));
   });
 
+  it("keeps the editor usable when the budgets load fails (best-effort)", async () => {
+    getNotificationPolicy.mockResolvedValue(
+      policy({ cadenceOverrides: { "activity:7": { warningMinutes: [10] } } }),
+    );
+    listBudgets.mockRejectedValue(new ApiError(500, "server_error", "boom"));
+
+    render(NotificationsView);
+    await selectUser();
+
+    // The stored override still hydrates a pickable row despite the budgets load
+    // failing, and the always-present Overall entry plus the hydrated key remain
+    // selectable — the picker degrades gracefully rather than blocking editing.
+    const picker = (await screen.findByLabelText("Budget")) as HTMLSelectElement;
+    expect(picker.value).toBe("activity:7");
+    expect(screen.getByRole("option", { name: "Overall screen time" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Activity 7" })).toBeInTheDocument();
+  });
+
+  it("falls back to an id label for a stored group override with no catalogue entry", async () => {
+    getNotificationPolicy.mockResolvedValue(
+      policy({ cadenceOverrides: { "group:9": { warningMinutes: [5] } } }),
+    );
+
+    render(NotificationsView);
+    await selectUser();
+
+    const picker = (await screen.findByLabelText("Budget")) as HTMLSelectElement;
+    expect(picker.value).toBe("group:9");
+    expect(screen.getByRole("option", { name: "Group 9" })).toBeInTheDocument();
+  });
+
   it("removes a hydrated row and saving reverts to the built-in cadence (null)", async () => {
     getNotificationPolicy.mockResolvedValue(
       policy({ cadenceOverrides: { overall: { warningMinutes: [10] } } }),

--- a/server/frontend/tests/components/notifications-view.test.ts
+++ b/server/frontend/tests/components/notifications-view.test.ts
@@ -5,21 +5,36 @@
  * grace-bound validation, Save sending the three knobs, Reset → DELETE +
  * reload, and the structured per-budget cadence editor (#302): hydrate rows,
  * add/edit/remove, key + normalise the PUT payload, client-side validation
- * gating, and Clear all → explicit null. The
- * `$lib/api/notifications` + `$lib/api/users` wrappers are mocked; the real
- * `ApiError` is used so the "already at defaults" 404 path is exercised.
+ * gating, and Clear all → explicit null.
+ *
+ * The budget-sourced cadence picker (#388) is covered here too: options are
+ * sourced from the user's budgets and labelled with the activity/group names,
+ * de-duplicated across rollover windows, with a stored override for a
+ * since-deleted budget staying pickable. The
+ * `$lib/api/notifications` + `$lib/api/users` + `$lib/api/budgets` +
+ * `$lib/api/activities` + `$lib/api/activity-groups` wrappers are mocked; the
+ * real `ApiError` is used so the "already at defaults" 404 path is exercised.
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError } from "../../src/lib/api/client.js";
-import type { NotificationPolicyResponse, UserResponse } from "../../src/lib/api/contract.js";
+import type {
+  ActivityGroupResponse,
+  ActivityResponse,
+  BudgetResponse,
+  NotificationPolicyResponse,
+  UserResponse,
+} from "../../src/lib/api/contract.js";
 
 const listUsers = vi.fn<() => Promise<UserResponse[]>>();
 const getNotificationPolicy = vi.fn<(userId: number) => Promise<NotificationPolicyResponse>>();
 const upsertNotificationPolicy =
   vi.fn<(userId: number, input: unknown) => Promise<NotificationPolicyResponse>>();
 const deleteNotificationPolicy = vi.fn<(userId: number) => Promise<void>>();
+const listBudgets = vi.fn<(userId?: number) => Promise<BudgetResponse[]>>();
+const listActivities = vi.fn<() => Promise<ActivityResponse[]>>();
+const listActivityGroups = vi.fn<() => Promise<ActivityGroupResponse[]>>();
 
 vi.mock("$lib/api/users", () => ({ listUsers: () => listUsers() }));
 vi.mock("$lib/api/notifications", () => ({
@@ -28,6 +43,9 @@ vi.mock("$lib/api/notifications", () => ({
     upsertNotificationPolicy(userId, input),
   deleteNotificationPolicy: (userId: number) => deleteNotificationPolicy(userId),
 }));
+vi.mock("$lib/api/budgets", () => ({ listBudgets: (userId?: number) => listBudgets(userId) }));
+vi.mock("$lib/api/activities", () => ({ listActivities: () => listActivities() }));
+vi.mock("$lib/api/activity-groups", () => ({ listActivityGroups: () => listActivityGroups() }));
 
 const { default: NotificationsView } = await import(
   "../../src/lib/views/NotificationsView.svelte"
@@ -54,11 +72,34 @@ function policy(overrides: Partial<NotificationPolicyResponse> = {}): Notificati
   };
 }
 
+function budget(overrides: Partial<BudgetResponse> = {}): BudgetResponse {
+  return {
+    id: 1,
+    userId: 1,
+    scope: "overall",
+    targetId: null,
+    window: "daily",
+    secondsAllowed: 3600,
+    ...overrides,
+  };
+}
+
+function activity(overrides: Partial<ActivityResponse> = {}): ActivityResponse {
+  return { id: 1, kind: "app", matcher: "firefox", matchType: "exact", ...overrides };
+}
+
+function group(overrides: Partial<ActivityGroupResponse> = {}): ActivityGroupResponse {
+  return { id: 1, name: "Games", ...overrides };
+}
+
 beforeEach(() => {
   listUsers.mockReset().mockResolvedValue([user()]);
   getNotificationPolicy.mockReset().mockResolvedValue(policy());
   upsertNotificationPolicy.mockReset().mockResolvedValue(policy());
   deleteNotificationPolicy.mockReset().mockResolvedValue();
+  listBudgets.mockReset().mockResolvedValue([]);
+  listActivities.mockReset().mockResolvedValue([]);
+  listActivityGroups.mockReset().mockResolvedValue([]);
   vi.spyOn(globalThis, "confirm").mockReturnValue(true);
 });
 
@@ -177,7 +218,7 @@ describe("NotificationsView", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  it("hydrates existing per-budget overrides into editable rows", async () => {
+  it("hydrates an existing per-budget override into an editable picker row", async () => {
     getNotificationPolicy.mockResolvedValue(
       policy({ cadenceOverrides: { "activity:7": { warningMinutes: [15, 10, 5] } } }),
     );
@@ -185,11 +226,13 @@ describe("NotificationsView", () => {
     render(NotificationsView);
     await selectUser();
 
-    // The stored activity override hydrates a row: scope, target id, and marks.
-    const scope = (await screen.findByLabelText("Budget scope")) as HTMLSelectElement;
-    expect(scope.value).toBe("activity");
-    expect((screen.getByLabelText("Target ID") as HTMLInputElement).value).toBe("7");
+    // The stored activity override hydrates a row: the picker is set to its key
+    // (kept pickable even with no matching budget), and the marks join to a list.
+    const picker = (await screen.findByLabelText("Budget")) as HTMLSelectElement;
+    expect(picker.value).toBe("activity:7");
     expect((screen.getByLabelText("Warning minutes") as HTMLInputElement).value).toBe("15, 10, 5");
+    // With no budget/catalogue for activity 7 the option falls back to an id label.
+    expect(screen.getByRole("option", { name: "Activity 7" })).toBeInTheDocument();
   });
 
   it("adds a structured override and PUTs the normalised map", async () => {
@@ -205,7 +248,7 @@ describe("NotificationsView", () => {
     expect(save).toBeDisabled();
 
     await fireEvent.click(screen.getByRole("button", { name: "Add override" }));
-    // New rows default to the overall scope (no target-id field).
+    // New rows default to the overall budget.
     await fireEvent.input(screen.getByLabelText("Warning minutes"), {
       target: { value: "5, 15, 10, 10" },
     });
@@ -218,7 +261,9 @@ describe("NotificationsView", () => {
     expect(await screen.findByText("Saved the warning cadence for Alice.")).toBeInTheDocument();
   });
 
-  it("keys an activity override as '<scope>:<id>'", async () => {
+  it("keys an override picked from the user's budgets as '<scope>:<id>'", async () => {
+    listBudgets.mockResolvedValue([budget({ scope: "activity", targetId: 3 })]);
+    listActivities.mockResolvedValue([activity({ id: 3, matcher: "firefox" })]);
     upsertNotificationPolicy.mockResolvedValue(
       policy({ cadenceOverrides: { "activity:3": { warningMinutes: [5] } } }),
     );
@@ -226,8 +271,9 @@ describe("NotificationsView", () => {
     render(NotificationsView);
     await selectUser();
     await fireEvent.click(await screen.findByRole("button", { name: "Add override" }));
-    await fireEvent.change(screen.getByLabelText("Budget scope"), { target: { value: "activity" } });
-    await fireEvent.input(screen.getByLabelText("Target ID"), { target: { value: "3" } });
+    // The activity budget surfaces as a labelled, pickable option.
+    await screen.findByRole("option", { name: "Activity — firefox" });
+    await fireEvent.change(screen.getByLabelText("Budget"), { target: { value: "activity:3" } });
     await fireEvent.input(screen.getByLabelText("Warning minutes"), { target: { value: "5" } });
     await fireEvent.click(screen.getByRole("button", { name: "Save cadence" }));
 
@@ -247,7 +293,7 @@ describe("NotificationsView", () => {
     expect(upsertNotificationPolicy).not.toHaveBeenCalled();
   });
 
-  it("blocks saving two overrides for the same budget", async () => {
+  it("blocks saving two overrides pointed at the same budget", async () => {
     getNotificationPolicy.mockResolvedValue(
       policy({
         cadenceOverrides: {
@@ -260,23 +306,57 @@ describe("NotificationsView", () => {
     render(NotificationsView);
     await selectUser();
 
-    // Point the second row at the same budget as the first.
-    const ids = await screen.findAllByLabelText("Target ID");
-    await fireEvent.input(ids[1] as HTMLInputElement, { target: { value: "1" } });
+    // Point the second row's picker at the same budget as the first.
+    const pickers = await screen.findAllByLabelText("Budget");
+    await fireEvent.change(pickers[1] as HTMLSelectElement, { target: { value: "activity:1" } });
 
     expect(screen.getByRole("alert")).toHaveTextContent("Duplicate override");
     expect(screen.getByRole("button", { name: "Save cadence" })).toBeDisabled();
   });
 
-  it("blocks saving an activity override with no id", async () => {
+  it("labels picker options from the user's budgets and catalogues", async () => {
+    listBudgets.mockResolvedValue([
+      budget({ id: 1, scope: "activity", targetId: 3 }),
+      budget({ id: 2, scope: "group", targetId: 2 }),
+    ]);
+    listActivities.mockResolvedValue([activity({ id: 3, matcher: "firefox" })]);
+    listActivityGroups.mockResolvedValue([group({ id: 2, name: "Games" })]);
+
     render(NotificationsView);
     await selectUser();
     await fireEvent.click(await screen.findByRole("button", { name: "Add override" }));
-    await fireEvent.change(screen.getByLabelText("Budget scope"), { target: { value: "group" } });
-    await fireEvent.input(screen.getByLabelText("Warning minutes"), { target: { value: "5" } });
 
-    expect(screen.getByRole("alert")).toHaveTextContent("positive numeric ID");
-    expect(screen.getByRole("button", { name: "Save cadence" })).toBeDisabled();
+    // Overall is always offered; the activity/group budgets resolve to names.
+    expect(await screen.findByRole("option", { name: "Activity — firefox" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Group — Games" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Overall screen time" })).toBeInTheDocument();
+  });
+
+  it("de-duplicates a target's daily and weekly budgets into one option", async () => {
+    listBudgets.mockResolvedValue([
+      budget({ id: 1, scope: "activity", targetId: 3, window: "daily" }),
+      budget({ id: 2, scope: "activity", targetId: 3, window: "weekly" }),
+    ]);
+    listActivities.mockResolvedValue([activity({ id: 3, matcher: "firefox" })]);
+
+    render(NotificationsView);
+    await selectUser();
+    await fireEvent.click(await screen.findByRole("button", { name: "Add override" }));
+    await screen.findByRole("option", { name: "Activity — firefox" });
+
+    // The cadence key is keyed by target, not window, so the two budgets collapse
+    // to a single "activity:3" option.
+    const activityOptions = screen
+      .getAllByRole("option")
+      .filter((option) => (option as HTMLOptionElement).value === "activity:3");
+    expect(activityOptions).toHaveLength(1);
+  });
+
+  it("loads the selected user's budgets to source the picker", async () => {
+    render(NotificationsView);
+    await selectUser();
+
+    await waitFor(() => expect(listBudgets).toHaveBeenCalledWith(1));
   });
 
   it("removes a hydrated row and saving reverts to the built-in cadence (null)", async () => {


### PR DESCRIPTION
## Summary

- Replaces the raw numeric **target-id text input** in `NotificationsView`'s per-budget warning-cadence editor (#302) with a **budget-sourced picker** labelled with human-readable activity / activity-group names ("Activity — firefox", "Group — Games", "Overall screen time") — the admin no longer has to know an activity/group's numeric id.
- Options are keyed by `(scope, target)` — the same key the pinned #302 grammar stores — and **de-duplicated across a target's daily / weekly / monthly rollover windows** into a single entry (the cadence key is keyed by target, not window).
- Keeps the pinned grammar and validation (`overall` | `activity:<id>` | `group:<id>` → `{ warningMinutes }`) **unchanged** — a UX/authoring improvement over the same contract. A stored override whose budget no longer exists stays pickable, so hydrate→save is a faithful round-trip.

## Plan

Roadmap: `docs/roadmap.md` → Phase 8b. Follow-up to #302 (grammar pin + structured editor).

Implementation notes:
- Loads the selected user's budgets on select (`listBudgets(userId)`), plus the activity / activity-group catalogues once on mount for name resolution. Name resolution is **best-effort** — a catalogue that fails to load is silent and the picker falls back to an id label (`Activity 7`); a budgets-load failure degrades gracefully (Overall + any stored keys stay pickable) and never blocks editing.
- Activities carry no display name, so an activity option is labelled by its `matcher` (matching the `BudgetsView` convention); groups by `name`.

## License-boundary note

N/A — type-only frontend consumption of the JSON `/api`. No GPL imports, no transport/packaging change, no image change, no new dependencies.

## Deferred (tracked)

- **Inherited group budgets as picker targets** — the picker sources from the user's **own** budgets; a `group:<id>` override for a group budget the user only *inherits* via a `UserGroup` isn't offered as a fresh option (a stored one still round-trips as a pickable stale-key). Filed as **#403**, to compose with the resolved-budgets (#363) / combined-editor (#343) layers that already resolve own-vs-inherited budgets.

## Test plan

- [x] `notifications-view.test.ts` — adapted the cases that drove the old scope-select + id-input to the picker (PUT-payload + validation assertions preserved: keys as `<scope>:<id>`, duplicate-budget block, out-of-bounds marks, add/remove/clear → explicit `null`), and added coverage for: name-labelled options from budgets + catalogues, cross-window de-duplication into one option, the stale-key hydrate→edit round-trip, budget loading on select, the best-effort budgets-load-failure path, and the group id-fallback label.
- [x] Frontend gate green (mirrors CI `frontend-build`): `svelte-check` 0 errors / 0 warnings, `vitest` 360 passing, `vite build` OK.
- [x] Server gate green (unchanged server src): `format:check`, `lint`, `typecheck`.

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)