### PR TITLE
feat(admin): retention windows editor UI (#214)

### DIFF
--- a/docs/plans/214-retention-editor-ui.md
+++ b/docs/plans/214-retention-editor-ui.md
@@ -1,0 +1,84 @@
+# Plan — #214: Admin UI retention windows editor
+
+Roadmap: `docs/roadmap.md` → Phase 11 (epic #135). Follow-up to #136 (retention
+backend: config model, `isExpired`, and the `/api/retention` CRUD — already on
+`main`).
+
+## Goal
+
+A `/admin` surface for viewing and adjusting data-retention windows, consuming
+the `/api/retention` contract shipped in #136. Frontend-only; no server or
+transport change, no license/tamper surface (type-only `/api` consumption).
+
+## Backend contract (already on `main`)
+
+`server/src/api/retention/` — DTOs re-exported from the `api/` barrel:
+
+- `GET /api/retention` → `RetentionConfigResponse`
+  `{ defaultDays: number, categories: RetentionEntryResponse[] }`.
+- `PUT /api/retention/:category` (body `SetRetentionOverrideRequest`, a
+  discriminated union on `keepForever`: `{ keepForever: true }` or
+  `{ keepForever: false, days: 1..MAX_RETENTION_DAYS }`) → the resulting
+  `override` entry.
+- `DELETE /api/retention/:category` → the resulting default-inherited entry
+  (idempotent — clearing a non-overridden category is a no-op).
+
+`RetentionEntryResponse = { category, source: "default"|"override",
+keepForever, days: number|null, updatedAt: string|null }`.
+
+Categories (`retentionCategoryValues`, declaration order): `usage_samples`,
+`grant_ledger`, `audit_log`, `date_overrides`.
+
+The global default comes from the environment (`PCT_RETENTION_DEFAULT_DAYS`);
+only per-category overrides are persisted → the default is **read-only** in the
+UI, with a "restart to change" note.
+
+## Deliverables
+
+1. `contract.ts` — add the retention DTO type re-exports (from
+   `../../../../src/api/retention/dtos.js`) and the `RetentionCategory` enum
+   type (from `policy/enums.js`). Type-only, per the contract module's rule.
+2. `$lib/api/retention.ts` — thin typed wrappers over `apiFetch`
+   (`fetchRetention`, `setRetentionOverride`, `clearRetentionOverride`),
+   mirroring `$lib/api/integration-tokens.ts`.
+3. `RetentionView.svelte` — mirrors the `IntegrationTokensView` shape:
+   - Loads config on mount (browser-guarded), inline `role="alert"` error,
+     loading + empty states.
+   - Read-only global-default banner (env-configured note).
+   - One row per category: human label + description, effective window
+     ("Kept forever" | "N days"), a source badge (inherited default vs
+     override).
+   - Per-row edit controls: mode select (Custom window | Keep forever), a
+     bounded day input (enabled only for Custom), a **Save override** (PUT)
+     button, and a **Clear override** (DELETE) button enabled only when the
+     row is currently an override. Per-row in-flight state so only the acting
+     row shows progress; success replaces just that row's entry from the
+     response.
+4. Nav + view wiring in `routes/admin/+page.svelte` (`{ id: "retention",
+   label: "Data retention" }` + an `{:else if activeView === "retention"}`
+   branch).
+
+## Tests (mirroring existing conventions)
+
+- `tests/api/retention.test.ts` — URL/method/body assertions over a mocked
+  `fetch` (GET, PUT custom, PUT keep-forever, DELETE), like
+  `tests/api/integration-tokens.test.ts`.
+- `tests/components/retention-view.test.ts` — render the real component against
+  a mocked `$lib/api/retention`: renders categories, marks
+  override-vs-inherited, saves a custom override, saves keep-forever, clears an
+  override, and surfaces an `ApiError` inline; like
+  `tests/components/integration-tokens-view-crud.test.ts`.
+
+## Gates
+
+- `cd server/frontend && npm run check` (svelte-check 0/0), `npm test` (vitest),
+  `npm run build` (vite build OK).
+- Server gate unchanged (no server src touched) — but run
+  `format:check`/`lint`/`typecheck`/`test` from `server/` to confirm green.
+
+## Out of scope / deferred
+
+- Editing the global default in the UI (it is environment-configured — shown
+  read-only). No new issue needed; documented behaviour from #136.
+- Wiring a live "next purge run" indicator (the scheduled purge job #137 is a
+  separate roadmap item); this editor only manages the windows.

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -81,6 +81,11 @@ export type {
 } from "../../../../src/api/policy/preview-dtos.js";
 export type { AuditEntryResponse, AuditListResponse } from "../../../../src/api/audit/dtos.js";
 export type {
+  RetentionEntryResponse,
+  RetentionConfigResponse,
+  SetRetentionOverrideRequest,
+} from "../../../../src/api/retention/dtos.js";
+export type {
   CreateIntegrationTokenRequest,
   IntegrationTokenCreatedResponse,
   IntegrationTokenSummaryResponse,
@@ -112,6 +117,7 @@ export type {
   ScheduleAction,
   SoundProfile,
   AuditOutcome,
+  RetentionCategory,
 } from "../../../../src/policy/enums.js";
 export type { BudgetCadenceOverride } from "../../../../src/policy/notification.js";
 export type { ErrorEnvelope, ErrorDetail } from "../../../../src/api/errors.js";

--- a/server/frontend/src/lib/api/retention.ts
+++ b/server/frontend/src/lib/api/retention.ts
@@ -1,0 +1,50 @@
+/**
+ * Calls for the data-retention windows API (#136 contract, #214 admin UI).
+ *
+ * The same proven shape as `$lib/api/integration-tokens`: thin typed wrappers
+ * over {@link apiFetch}, with the request/response types imported from the
+ * shared `/api` contract so the frontend never re-declares a DTO. Retention
+ * config is a global default window (environment-configured, read-only here)
+ * plus per-category overrides the admin can pin or clear.
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type {
+  RetentionCategory,
+  RetentionConfigResponse,
+  RetentionEntryResponse,
+  SetRetentionOverrideRequest,
+} from "./contract.js";
+
+/** The full retention config: the global default plus every category's entry. */
+export function fetchRetention(): Promise<RetentionConfigResponse> {
+  return apiFetch<RetentionConfigResponse>("/retention");
+}
+
+/**
+ * Pin an override for one category — a custom window (`{ keepForever: false,
+ * days }`) or keep-forever (`{ keepForever: true }`). Resolves to the resulting
+ * `override` entry.
+ */
+export function setRetentionOverride(
+  category: RetentionCategory,
+  body: SetRetentionOverrideRequest,
+): Promise<RetentionEntryResponse> {
+  return apiFetch<RetentionEntryResponse>(`/retention/${encodeURIComponent(category)}`, {
+    method: "PUT",
+    body,
+  });
+}
+
+/**
+ * Clear a category's override, reverting it to the global default. Idempotent:
+ * clearing a category with no override still resolves to its default entry.
+ */
+export function clearRetentionOverride(
+  category: RetentionCategory,
+): Promise<RetentionEntryResponse> {
+  return apiFetch<RetentionEntryResponse>(`/retention/${encodeURIComponent(category)}`, {
+    method: "DELETE",
+  });
+}

--- a/server/frontend/src/lib/views/RetentionView.svelte
+++ b/server/frontend/src/lib/views/RetentionView.svelte
@@ -53,6 +53,14 @@
     return CATEGORY_META[category as RetentionCategory] ?? { label: category, description: "" };
   }
 
+  // Mirrors `MAX_RETENTION_DAYS` in `server/src/policy/retention.ts` (~100 years).
+  // A runtime value can't be imported here without dragging server code into the
+  // frontend bundle (the contract module is deliberately type-only), so the bound
+  // is duplicated as a literal; the server remains the authority and rejects an
+  // out-of-range value regardless. Used for the native input `max` and a
+  // pre-flight guard so a too-large window doesn't need a server round-trip to fail.
+  const MAX_RETENTION_DAYS = 36_525;
+
   /** Per-row draft: the edit state seeded from (and re-seeded after) a save. */
   interface Draft {
     keepForever: boolean;
@@ -133,8 +141,8 @@
       body = { keepForever: true };
     } else {
       const days = Number.parseInt(draft.days, 10);
-      if (!Number.isInteger(days) || days < 1) {
-        error = "Enter a whole number of days (1 or more), or choose keep forever.";
+      if (!Number.isInteger(days) || days < 1 || days > MAX_RETENTION_DAYS) {
+        error = `Enter a whole number of days between 1 and ${MAX_RETENTION_DAYS}, or choose keep forever.`;
         return;
       }
       body = { keepForever: false, days };
@@ -143,7 +151,7 @@
     savingCategory = entry.category;
     error = null;
     try {
-      const updated = await setRetentionOverride(entry.category as RetentionCategory, body);
+      const updated = await setRetentionOverride(entry.category, body);
       applyEntry(updated);
     } catch (err) {
       error = messageOf(err);
@@ -156,7 +164,7 @@
     clearingCategory = entry.category;
     error = null;
     try {
-      const reverted = await clearRetentionOverride(entry.category as RetentionCategory);
+      const reverted = await clearRetentionOverride(entry.category);
       applyEntry(reverted);
     } catch (err) {
       error = messageOf(err);
@@ -229,6 +237,7 @@
           {@const meta = metaFor(entry.category)}
           {@const draft = drafts[entry.category]}
           {@const isOverride = entry.source === "override"}
+          {@const busy = savingCategory === entry.category || clearingCategory === entry.category}
           <tr>
             <td>
               <div class="cat-name">{meta.label}</div>
@@ -249,7 +258,7 @@
                     aria-label={`${meta.label} retention mode`}
                     value={draft.keepForever ? "forever" : "custom"}
                     onchange={(e) => setMode(entry.category, e.currentTarget.value === "forever")}
-                    disabled={savingCategory === entry.category}
+                    disabled={busy}
                   >
                     <option value="custom">Custom window</option>
                     <option value="forever">Keep forever</option>
@@ -257,11 +266,12 @@
                   <input
                     type="number"
                     min="1"
+                    max={MAX_RETENTION_DAYS}
                     step="1"
                     aria-label={`${meta.label} retention days`}
                     value={draft.days}
                     oninput={(e) => setDays(entry.category, e.currentTarget.value)}
-                    disabled={draft.keepForever || savingCategory === entry.category}
+                    disabled={draft.keepForever || busy}
                   />
                   <span class="unit muted">days</span>
                 </div>
@@ -270,7 +280,7 @@
             <td class="actions">
               <button
                 onclick={() => handleSave(entry)}
-                disabled={savingCategory === entry.category}
+                disabled={busy}
                 aria-label={`Save ${meta.label} retention`}
               >
                 {savingCategory === entry.category ? "Saving…" : "Save override"}
@@ -278,7 +288,7 @@
               <button
                 class="ghost"
                 onclick={() => handleClear(entry)}
-                disabled={!isOverride || clearingCategory === entry.category}
+                disabled={!isOverride || busy}
                 aria-label={`Clear ${meta.label} override`}
               >
                 {clearingCategory === entry.category ? "Clearing…" : "Clear override"}

--- a/server/frontend/src/lib/views/RetentionView.svelte
+++ b/server/frontend/src/lib/views/RetentionView.svelte
@@ -1,0 +1,425 @@
+<!--
+  Data-retention windows editor (#214): the admin surface for the retention
+  config whose backend landed in #136. Loads `/api/retention` on mount (browser
+  only — the page is prerendered to a static shell), and lets the admin pin or
+  clear a per-category override. All calls go through the typed
+  `$lib/api/retention` wrappers; errors are surfaced inline.
+
+  The global default window is environment-configured (`PCT_RETENTION_DEFAULT_DAYS`)
+  and only per-category overrides are persisted, so the default is shown
+  read-only with a "restart to change" note (matching #136's server model). A
+  category is either inherited from that default (`source: "default"`) or pinned
+  by an override — a custom day count or keep-forever.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ApiError } from "$lib/api/client.js";
+  import type {
+    RetentionCategory,
+    RetentionEntryResponse,
+    SetRetentionOverrideRequest,
+  } from "$lib/api/contract.js";
+  import {
+    clearRetentionOverride,
+    fetchRetention,
+    setRetentionOverride,
+  } from "$lib/api/retention.js";
+
+  // Human labels + a one-line description per known category. Typed against the
+  // contract's `RetentionCategory` so it can never drift from the set the
+  // server defines (the same drift-checked pattern `IntegrationTokensView` uses
+  // for `SCOPE_OPTIONS`). A category the server adds later still renders — it
+  // falls back to its raw key (see `metaFor`).
+  const CATEGORY_META: Record<RetentionCategory, { label: string; description: string }> = {
+    usage_samples: {
+      label: "Usage samples",
+      description: "ActivityWatch-derived per-activity usage rows.",
+    },
+    grant_ledger: {
+      label: "Grant ledger",
+      description: "Screen-time grants awarded by the admin or an integration.",
+    },
+    audit_log: {
+      label: "Audit log",
+      description: "Record of every command issued to a client.",
+    },
+    date_overrides: {
+      label: "Date-specific overrides",
+      description: "One-off / future-dated schedule exceptions.",
+    },
+  };
+
+  function metaFor(category: string): { label: string; description: string } {
+    return CATEGORY_META[category as RetentionCategory] ?? { label: category, description: "" };
+  }
+
+  /** Per-row draft: the edit state seeded from (and re-seeded after) a save. */
+  interface Draft {
+    keepForever: boolean;
+    /** Day count as typed; parsed + validated on save. */
+    days: string;
+  }
+
+  let defaultDays = $state<number | null>(null);
+  let entries = $state<RetentionEntryResponse[]>([]);
+  let drafts = $state<Record<string, Draft>>({});
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  // The category whose Save / Clear is in flight, so only that row shows
+  // progress (mirrors `IntegrationTokensView`'s `revokingId`).
+  let savingCategory = $state<string | null>(null);
+  let clearingCategory = $state<string | null>(null);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const config = await fetchRetention();
+      defaultDays = config.defaultDays;
+      entries = config.categories;
+      drafts = seedDrafts(config.categories, config.defaultDays);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  /** Seed every row's edit state from its current entry. */
+  function seedDrafts(
+    rows: readonly RetentionEntryResponse[],
+    fallbackDays: number,
+  ): Record<string, Draft> {
+    const next: Record<string, Draft> = {};
+    for (const row of rows) {
+      next[row.category] = draftFor(row, fallbackDays);
+    }
+    return next;
+  }
+
+  /**
+   * The draft for one entry. A keep-forever row still seeds a sensible day
+   * value (its own days, else the global default) so toggling back to a custom
+   * window doesn't start from empty.
+   */
+  function draftFor(row: RetentionEntryResponse, fallbackDays: number): Draft {
+    return {
+      keepForever: row.keepForever,
+      days: String(row.days ?? fallbackDays),
+    };
+  }
+
+  function setMode(category: string, keepForever: boolean): void {
+    const current = drafts[category];
+    if (current === undefined) return;
+    drafts = { ...drafts, [category]: { ...current, keepForever } };
+  }
+
+  function setDays(category: string, days: string): void {
+    const current = drafts[category];
+    if (current === undefined) return;
+    drafts = { ...drafts, [category]: { ...current, days } };
+  }
+
+  async function handleSave(entry: RetentionEntryResponse): Promise<void> {
+    const draft = drafts[entry.category];
+    if (draft === undefined) return;
+
+    let body: SetRetentionOverrideRequest;
+    if (draft.keepForever) {
+      body = { keepForever: true };
+    } else {
+      const days = Number.parseInt(draft.days, 10);
+      if (!Number.isInteger(days) || days < 1) {
+        error = "Enter a whole number of days (1 or more), or choose keep forever.";
+        return;
+      }
+      body = { keepForever: false, days };
+    }
+
+    savingCategory = entry.category;
+    error = null;
+    try {
+      const updated = await setRetentionOverride(entry.category as RetentionCategory, body);
+      applyEntry(updated);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      savingCategory = null;
+    }
+  }
+
+  async function handleClear(entry: RetentionEntryResponse): Promise<void> {
+    clearingCategory = entry.category;
+    error = null;
+    try {
+      const reverted = await clearRetentionOverride(entry.category as RetentionCategory);
+      applyEntry(reverted);
+    } catch (err) {
+      error = messageOf(err);
+    } finally {
+      clearingCategory = null;
+    }
+  }
+
+  /** Replace one entry (and re-seed its draft) from a server response. */
+  function applyEntry(updated: RetentionEntryResponse): void {
+    entries = entries.map((row) => (row.category === updated.category ? updated : row));
+    drafts = { ...drafts, [updated.category]: draftFor(updated, defaultDays ?? 0) };
+  }
+
+  /** The current effective window, human-readable. */
+  function windowLabel(entry: RetentionEntryResponse): string {
+    if (entry.keepForever) return "Kept forever";
+    return `${entry.days} day${entry.days === 1 ? "" : "s"}`;
+  }
+
+  /** Render any thrown value as a UI-safe message. */
+  function messageOf(err: unknown): string {
+    if (err instanceof ApiError) return err.message;
+    return err instanceof Error ? err.message : "Something went wrong";
+  }
+</script>
+
+<section>
+  <header class="head">
+    <h1>Data retention</h1>
+    <p class="hint">
+      How long each class of dated data is kept before the automatic purge removes it. Recurrence
+      rules themselves are never purged — only dated history (usage samples, grants, the audit log,
+      and date-specific overrides).
+    </p>
+  </header>
+
+  {#if error}
+    <p class="error" role="alert">{error}</p>
+  {/if}
+
+  {#if defaultDays !== null}
+    <div class="default-banner" role="note">
+      <span class="default-label">Global default</span>
+      <strong>{defaultDays} day{defaultDays === 1 ? "" : "s"}</strong>
+      <span class="muted">
+        Environment-configured (<code>PCT_RETENTION_DEFAULT_DAYS</code>); restart the server to
+        change it. Categories without an override inherit this window.
+      </span>
+    </div>
+  {/if}
+
+  {#if loading}
+    <p class="muted">Loading retention settings…</p>
+  {:else if entries.length === 0}
+    <p class="muted">No retention categories to configure.</p>
+  {:else}
+    <table>
+      <thead>
+        <tr>
+          <th>Category</th>
+          <th>Effective window</th>
+          <th>Source</th>
+          <th>Override</th>
+          <th class="actions-col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each entries as entry (entry.category)}
+          {@const meta = metaFor(entry.category)}
+          {@const draft = drafts[entry.category]}
+          {@const isOverride = entry.source === "override"}
+          <tr>
+            <td>
+              <div class="cat-name">{meta.label}</div>
+              {#if meta.description}<div class="cat-desc muted">{meta.description}</div>{/if}
+            </td>
+            <td>{windowLabel(entry)}</td>
+            <td>
+              {#if isOverride}
+                <span class="badge override">override</span>
+              {:else}
+                <span class="badge inherited">inherited default</span>
+              {/if}
+            </td>
+            <td class="edit">
+              {#if draft}
+                <div class="edit-row">
+                  <select
+                    aria-label={`${meta.label} retention mode`}
+                    value={draft.keepForever ? "forever" : "custom"}
+                    onchange={(e) => setMode(entry.category, e.currentTarget.value === "forever")}
+                    disabled={savingCategory === entry.category}
+                  >
+                    <option value="custom">Custom window</option>
+                    <option value="forever">Keep forever</option>
+                  </select>
+                  <input
+                    type="number"
+                    min="1"
+                    step="1"
+                    aria-label={`${meta.label} retention days`}
+                    value={draft.days}
+                    oninput={(e) => setDays(entry.category, e.currentTarget.value)}
+                    disabled={draft.keepForever || savingCategory === entry.category}
+                  />
+                  <span class="unit muted">days</span>
+                </div>
+              {/if}
+            </td>
+            <td class="actions">
+              <button
+                onclick={() => handleSave(entry)}
+                disabled={savingCategory === entry.category}
+                aria-label={`Save ${meta.label} retention`}
+              >
+                {savingCategory === entry.category ? "Saving…" : "Save override"}
+              </button>
+              <button
+                class="ghost"
+                onclick={() => handleClear(entry)}
+                disabled={!isOverride || clearingCategory === entry.category}
+                aria-label={`Clear ${meta.label} override`}
+              >
+                {clearingCategory === entry.category ? "Clearing…" : "Clear override"}
+              </button>
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</section>
+
+<style>
+  h1 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+  .hint {
+    margin: 0.25rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+  }
+  code {
+    background: #f3f4f6;
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.25rem;
+    font-size: 0.85em;
+  }
+  .default-banner {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    flex-wrap: wrap;
+    margin-bottom: 1.25rem;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid #e5e7eb;
+    background: #f9fafb;
+    border-radius: 0.5rem;
+    font-size: 0.9rem;
+  }
+  .default-label {
+    font-weight: 600;
+    color: #374151;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  }
+  th,
+  td {
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+    vertical-align: top;
+  }
+  th {
+    background: #f9fafb;
+    font-weight: 600;
+    color: #374151;
+  }
+  .cat-name {
+    font-weight: 600;
+  }
+  .cat-desc {
+    font-size: 0.8rem;
+    margin-top: 0.15rem;
+  }
+  .edit-row {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .edit select,
+  .edit input[type="number"] {
+    padding: 0.4rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    font-size: 0.85rem;
+  }
+  .edit input[type="number"] {
+    width: 6rem;
+  }
+  .unit {
+    font-size: 0.8rem;
+  }
+  .badge {
+    font-size: 0.72rem;
+    padding: 0.15rem 0.45rem;
+    border-radius: 0.3rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .badge.override {
+    background: #dbeafe;
+    color: #1e40af;
+  }
+  .badge.inherited {
+    background: #f3f4f6;
+    color: #4b5563;
+  }
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .actions-col {
+    width: 1%;
+    white-space: nowrap;
+  }
+  button {
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 0.4rem;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+    white-space: nowrap;
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost {
+    background: #e5e7eb;
+    color: #374151;
+  }
+  .muted {
+    color: #6b7280;
+  }
+  .error {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.4rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.85rem;
+  }
+</style>

--- a/server/frontend/src/routes/admin/+page.svelte
+++ b/server/frontend/src/routes/admin/+page.svelte
@@ -38,6 +38,7 @@
   import LinksView from "$lib/views/LinksView.svelte";
   import IntegrationTokensView from "$lib/views/IntegrationTokensView.svelte";
   import AuditLogView from "$lib/views/AuditLogView.svelte";
+  import RetentionView from "$lib/views/RetentionView.svelte";
 
   // `null` while the initial session probe (and, if authenticated, the setup
   // status fetch) are in flight. Both fetches complete before `session` is set,
@@ -113,6 +114,7 @@
     { id: "notifications", label: "Notifications" },
     { id: "integrations", label: "Integrations" },
     { id: "audit", label: "Audit log" },
+    { id: "retention", label: "Data retention" },
   ];
   let activeView = $state<string>("dashboard");
 
@@ -234,6 +236,8 @@
       <IntegrationTokensView />
     {:else if activeView === "audit"}
       <AuditLogView />
+    {:else if activeView === "retention"}
+      <RetentionView />
     {:else}
       <DashboardView {username} onnavigate={(id) => (activeView = id)} />
     {/if}

--- a/server/frontend/tests/api/retention.test.ts
+++ b/server/frontend/tests/api/retention.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearRetentionOverride,
+  fetchRetention,
+  setRetentionOverride,
+} from "../../src/lib/api/retention.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("retention API", () => {
+  it("fetchRetention GETs /api/retention", async () => {
+    const config = {
+      defaultDays: 365,
+      categories: [
+        { category: "usage_samples", source: "default", keepForever: false, days: 365, updatedAt: null },
+      ],
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, config));
+
+    const result = await fetchRetention();
+
+    expect(result).toEqual(config);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/retention");
+    expect((init as RequestInit).method).toBe("GET");
+  });
+
+  it("setRetentionOverride PUTs a custom day count", async () => {
+    const entry = {
+      category: "audit_log",
+      source: "override",
+      keepForever: false,
+      days: 30,
+      updatedAt: "2026-08-07T00:00:00.000Z",
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, entry));
+
+    const body = { keepForever: false as const, days: 30 };
+    const result = await setRetentionOverride("audit_log", body);
+
+    expect(result).toEqual(entry);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/retention/audit_log");
+    expect((init as RequestInit).method).toBe("PUT");
+    expect((init as RequestInit).body).toBe(JSON.stringify(body));
+  });
+
+  it("setRetentionOverride PUTs keep-forever without a day count", async () => {
+    const entry = {
+      category: "grant_ledger",
+      source: "override",
+      keepForever: true,
+      days: null,
+      updatedAt: "2026-08-07T00:00:00.000Z",
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, entry));
+
+    const body = { keepForever: true as const };
+    const result = await setRetentionOverride("grant_ledger", body);
+
+    expect(result).toEqual(entry);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/retention/grant_ledger");
+    expect((init as RequestInit).method).toBe("PUT");
+    expect((init as RequestInit).body).toBe(JSON.stringify(body));
+  });
+
+  it("clearRetentionOverride DELETEs /api/retention/:category and returns the default entry", async () => {
+    const reverted = {
+      category: "date_overrides",
+      source: "default",
+      keepForever: false,
+      days: 365,
+      updatedAt: null,
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, reverted));
+
+    const result = await clearRetentionOverride("date_overrides");
+
+    expect(result).toEqual(reverted);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/api/retention/date_overrides");
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+});

--- a/server/frontend/tests/components/retention-view.test.ts
+++ b/server/frontend/tests/components/retention-view.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Flow test for `RetentionView` (#214).
+ *
+ * Mirrors `integration-tokens-view-crud.test.ts`: renders the real component
+ * against a mocked `$lib/api/retention` (no live backend) and exercises the
+ * highest-value flows — list + override-vs-inherited marking, the read-only
+ * global default, saving a custom override, saving keep-forever, clearing an
+ * override, client-side day validation, and the inline error surface.
+ */
+import { fireEvent, render, screen, within } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  RetentionConfigResponse,
+  RetentionEntryResponse,
+} from "../../src/lib/api/contract.js";
+
+const fetchRetention = vi.fn<() => Promise<RetentionConfigResponse>>();
+const setRetentionOverride =
+  vi.fn<(category: string, body: unknown) => Promise<RetentionEntryResponse>>();
+const clearRetentionOverride = vi.fn<(category: string) => Promise<RetentionEntryResponse>>();
+
+vi.mock("$lib/api/retention", () => ({
+  fetchRetention: () => fetchRetention(),
+  setRetentionOverride: (category: string, body: unknown) => setRetentionOverride(category, body),
+  clearRetentionOverride: (category: string) => clearRetentionOverride(category),
+}));
+
+const { default: RetentionView } = await import("../../src/lib/views/RetentionView.svelte");
+
+function entry(overrides: Partial<RetentionEntryResponse> = {}): RetentionEntryResponse {
+  return {
+    category: "usage_samples",
+    source: "default",
+    keepForever: false,
+    days: 365,
+    updatedAt: null,
+    ...overrides,
+  } as RetentionEntryResponse;
+}
+
+function config(
+  categories: RetentionEntryResponse[],
+  defaultDays = 365,
+): RetentionConfigResponse {
+  return { defaultDays, categories };
+}
+
+beforeEach(() => {
+  fetchRetention.mockReset();
+  setRetentionOverride.mockReset();
+  clearRetentionOverride.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RetentionView", () => {
+  it("renders each category with its window, marks override-vs-inherited, and shows the read-only default", async () => {
+    fetchRetention.mockResolvedValue(
+      config([
+        entry({ category: "usage_samples", source: "default", days: 365 }),
+        entry({
+          category: "audit_log",
+          source: "override",
+          keepForever: false,
+          days: 30,
+          updatedAt: "2026-08-07T00:00:00.000Z",
+        }),
+      ]),
+    );
+
+    render(RetentionView);
+
+    expect(await screen.findByText("Usage samples")).toBeInTheDocument();
+    expect(screen.getByText("Audit log")).toBeInTheDocument();
+    expect(fetchRetention).toHaveBeenCalledOnce();
+
+    // The overridden row is badged as an override; the inherited row is not.
+    expect(screen.getByText("override")).toBeInTheDocument();
+    expect(screen.getByText("inherited default")).toBeInTheDocument();
+    expect(screen.getByText("30 days")).toBeInTheDocument();
+
+    // The global default is surfaced read-only with the env note.
+    const note = screen.getByRole("note");
+    expect(note).toHaveTextContent("365 days");
+    expect(note).toHaveTextContent("PCT_RETENTION_DEFAULT_DAYS");
+
+    // Clear is disabled for a row that only inherits the default.
+    expect(
+      screen.getByRole("button", { name: "Clear Usage samples override" }),
+    ).toBeDisabled();
+  });
+
+  it("saves a custom-day override and reflects it in the row", async () => {
+    fetchRetention.mockResolvedValue(
+      config([entry({ category: "usage_samples", source: "default", days: 365 })]),
+    );
+    setRetentionOverride.mockResolvedValue(
+      entry({
+        category: "usage_samples",
+        source: "override",
+        keepForever: false,
+        days: 30,
+        updatedAt: "2026-08-07T00:00:00.000Z",
+      }),
+    );
+
+    render(RetentionView);
+    await screen.findByText("Usage samples");
+
+    await fireEvent.input(screen.getByLabelText("Usage samples retention days"), {
+      target: { value: "30" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save Usage samples retention" }));
+
+    expect(setRetentionOverride).toHaveBeenCalledWith("usage_samples", {
+      keepForever: false,
+      days: 30,
+    });
+    expect(await screen.findByText("30 days")).toBeInTheDocument();
+    expect(screen.getByText("override")).toBeInTheDocument();
+    // The Clear action becomes available once the row is an override.
+    expect(
+      screen.getByRole("button", { name: "Clear Usage samples override" }),
+    ).not.toBeDisabled();
+  });
+
+  it("saves a keep-forever override without a day count", async () => {
+    fetchRetention.mockResolvedValue(
+      config([entry({ category: "grant_ledger", source: "default", days: 365 })]),
+    );
+    setRetentionOverride.mockResolvedValue(
+      entry({
+        category: "grant_ledger",
+        source: "override",
+        keepForever: true,
+        days: null,
+        updatedAt: "2026-08-07T00:00:00.000Z",
+      }),
+    );
+
+    render(RetentionView);
+    await screen.findByText("Grant ledger");
+
+    await fireEvent.change(screen.getByLabelText("Grant ledger retention mode"), {
+      target: { value: "forever" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save Grant ledger retention" }));
+
+    expect(setRetentionOverride).toHaveBeenCalledWith("grant_ledger", { keepForever: true });
+    expect(await screen.findByText("Kept forever")).toBeInTheDocument();
+  });
+
+  it("clears an override, reverting the row to the inherited default", async () => {
+    fetchRetention.mockResolvedValue(
+      config([
+        entry({
+          category: "audit_log",
+          source: "override",
+          keepForever: false,
+          days: 30,
+          updatedAt: "2026-08-07T00:00:00.000Z",
+        }),
+      ]),
+    );
+    clearRetentionOverride.mockResolvedValue(
+      entry({ category: "audit_log", source: "default", keepForever: false, days: 365 }),
+    );
+
+    render(RetentionView);
+    await screen.findByText("Audit log");
+    expect(screen.getByText("override")).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Clear Audit log override" }));
+
+    expect(clearRetentionOverride).toHaveBeenCalledWith("audit_log");
+    expect(await screen.findByText("inherited default")).toBeInTheDocument();
+    // "365 days" also appears in the global-default banner, so scope to the row's table.
+    expect(within(screen.getByRole("table")).getByText("365 days")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear Audit log override" })).toBeDisabled();
+  });
+
+  it("rejects a non-positive day count client-side without calling the API", async () => {
+    fetchRetention.mockResolvedValue(
+      config([entry({ category: "usage_samples", source: "default", days: 365 })]),
+    );
+
+    render(RetentionView);
+    await screen.findByText("Usage samples");
+
+    await fireEvent.input(screen.getByLabelText("Usage samples retention days"), {
+      target: { value: "0" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save Usage samples retention" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/whole number of days/i);
+    expect(setRetentionOverride).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an ApiError from the load in the inline alert", async () => {
+    const { ApiError } = await import("../../src/lib/api/client.js");
+    fetchRetention.mockRejectedValue(new ApiError(500, "internal", "The server exploded."));
+
+    render(RetentionView);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("The server exploded.");
+  });
+});

--- a/server/frontend/tests/components/retention-view.test.ts
+++ b/server/frontend/tests/components/retention-view.test.ts
@@ -200,6 +200,91 @@ describe("RetentionView", () => {
     expect(setRetentionOverride).not.toHaveBeenCalled();
   });
 
+  it("rejects a day count above the maximum client-side without calling the API", async () => {
+    fetchRetention.mockResolvedValue(
+      config([entry({ category: "usage_samples", source: "default", days: 365 })]),
+    );
+
+    render(RetentionView);
+    await screen.findByText("Usage samples");
+
+    await fireEvent.input(screen.getByLabelText("Usage samples retention days"), {
+      target: { value: "40000" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save Usage samples retention" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/between 1 and/i);
+    expect(setRetentionOverride).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a save error inline without losing the row", async () => {
+    const { ApiError } = await import("../../src/lib/api/client.js");
+    fetchRetention.mockResolvedValue(
+      config([entry({ category: "usage_samples", source: "default", days: 365 })]),
+    );
+    setRetentionOverride.mockRejectedValue(new ApiError(400, "invalid", "Days out of range."));
+
+    render(RetentionView);
+    await screen.findByText("Usage samples");
+
+    await fireEvent.input(screen.getByLabelText("Usage samples retention days"), {
+      target: { value: "30" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save Usage samples retention" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Days out of range.");
+    // The row is unchanged — still inheriting the default, not flipped to override.
+    expect(screen.getByText("inherited default")).toBeInTheDocument();
+  });
+
+  it("toggles a keep-forever override back to a custom window and saves it", async () => {
+    fetchRetention.mockResolvedValue(
+      config([
+        entry({
+          category: "grant_ledger",
+          source: "override",
+          keepForever: true,
+          days: null,
+          updatedAt: "2026-08-07T00:00:00.000Z",
+        }),
+      ]),
+    );
+    setRetentionOverride.mockResolvedValue(
+      entry({
+        category: "grant_ledger",
+        source: "override",
+        keepForever: false,
+        days: 45,
+        updatedAt: "2026-08-07T00:00:00.000Z",
+      }),
+    );
+
+    render(RetentionView);
+    await screen.findByText("Grant ledger");
+    expect(screen.getByText("Kept forever")).toBeInTheDocument();
+
+    // The day input is disabled while keep-forever is selected...
+    const daysInput = screen.getByLabelText("Grant ledger retention days");
+    expect(daysInput).toBeDisabled();
+
+    // ...and re-enables when the mode toggles back to Custom.
+    await fireEvent.change(screen.getByLabelText("Grant ledger retention mode"), {
+      target: { value: "custom" },
+    });
+    expect(daysInput).not.toBeDisabled();
+
+    await fireEvent.input(daysInput, { target: { value: "45" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Save Grant ledger retention" }));
+
+    expect(setRetentionOverride).toHaveBeenCalledWith("grant_ledger", {
+      keepForever: false,
+      days: 45,
+    });
+    expect(await screen.findByText("45 days")).toBeInTheDocument();
+  });
+
   it("surfaces an ApiError from the load in the inline alert", async () => {
     const { ApiError } = await import("../../src/lib/api/client.js");
     fetchRetention.mockRejectedValue(new ApiError(500, "internal", "The server exploded."));


### PR DESCRIPTION
## Summary

- Adds the `/admin` **Data retention** view for viewing and adjusting data-retention windows, consuming the `/api/retention` contract shipped in #136 (now on `main`). The UI was deliberately deferred from #136 because it depended on the `/admin/*` shell (#53), which has since landed.
- `RetentionView.svelte` lists each category with its effective window, marks **override vs inherited-default**, and gives per-row controls to set a **custom day count**, **keep forever**, or **clear the override** (revert to default). The env-configured global default (`PCT_RETENTION_DEFAULT_DAYS`) is surfaced **read-only** with a "restart to change" note, matching #136's server model (only per-category overrides are persisted).
- `$lib/api/retention.ts` adds thin typed wrappers over `apiFetch` (`fetchRetention` / `setRetentionOverride` / `clearRetentionOverride`), and the retention DTO types are re-exported from the shared `/api` contract module — the frontend never re-declares a DTO. Nav + view are wired into `routes/admin/+page.svelte`.

## Plan

Linked plan: `docs/plans/214-retention-editor-ui.md`
Roadmap: `docs/roadmap.md` → Phase 11 (epic #135). Follow-up to #136.

## License-boundary note

N/A — frontend-only, type-only consumption of the JSON `/api` contract. No GPL imports, no transport/packaging change, no image change, no new dependencies.

## Test plan

- [x] `tests/api/retention.test.ts` — URL/method/body over a mocked `fetch`: `GET /retention`, `PUT` custom day count, `PUT` keep-forever (no `days`), `DELETE`.
- [x] `tests/components/retention-view.test.ts` — renders categories + override/inherited badges + read-only default banner; saves a custom override; saves keep-forever; clears an override back to the inherited default; rejects a non-positive day count client-side without an API call; surfaces an `ApiError` from load inline.
- [x] Frontend gate green (mirrors CI `frontend-build`): `svelte-check` 0 errors / 0 warnings, `vitest` **366 passing** (54 files), `vite build` OK.
- [x] Server source untouched → server gate (`format:check`/`lint`/`typecheck`/`test` + 80% coverage) unaffected; pre-commit excludes `frontend/` from the TS hooks, and the new files are trailing-whitespace/EOF clean.

## Notes / out of scope

- Editing the **global default** in the UI is deliberately out of scope — it is environment-configured (`PCT_RETENTION_DEFAULT_DAYS`, restart to change), shown read-only. This is documented #136 behaviour, not deferred work.
- A live "next purge run" indicator belongs to the scheduled purge job (#137), a separate Phase-11 roadmap item; this editor only manages the windows.

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QA7aRKm18zSMFjU2sb9roh)_