### PR TITLE
feat(config): PCT_TIMEKPR_MIRROR mode + /data/apt/timekpr layout (#391)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,3 +111,19 @@
 # PCT_ADGUARD_ADMIN_PORT=3000
 # PCT_ADGUARD_DATA_DIR=/data/adguard   # binary + config + work dir live here
 # PCT_ADGUARD_VERSION=v0.107.65        # optional: pin a release; latest if unset
+
+# --- Timekpr-nExT package mirror (optional; #389) ---------------------------
+# Mode: disabled (default) | external | managed
+# Config seam only in this release (#391); no runtime effect yet.
+# See docs/server-deployment.md → "Timekpr-nExT package mirror deployment modes".
+# PCT_TIMEKPR_MIRROR=disabled
+
+# external — point clients at an apt repo you already host on the LAN:
+# PCT_TIMEKPR_MIRROR=external
+# PCT_TIMEKPR_MIRROR_URL=https://apt.lan/timekpr
+
+# managed — the dashboard hosts and refreshes the mirror itself:
+# PCT_TIMEKPR_MIRROR=managed
+# PCT_TIMEKPR_MIRROR_DIR=/data/apt/timekpr    # apt repo lives here
+# PCT_TIMEKPR_MIRROR_PACKAGE=timekpr-next     # or timekpr-next-beta
+# PCT_TIMEKPR_MIRROR_VERSION=0.5.5            # optional: pin a version; newest if unset

--- a/docs/plans/391-timekpr-mirror-config.md
+++ b/docs/plans/391-timekpr-mirror-config.md
@@ -1,0 +1,106 @@
+# Plan — #391: `PCT_TIMEKPR_MIRROR` mode + `/data/apt/timekpr` layout
+
+Part of the server-hosted `timekpr-next` mirror epic (**#389**), the first
+implementation slice after the accepted ADR
+[`0011-server-hosted-upstream-package-mirror.md`](../adr/0011-server-hosted-upstream-package-mirror.md)
+(#390/#396). Roadmap: `docs/roadmap.md` → Phase 14.
+
+## Goal
+
+Add the **config seam** for the mirror — a validated mode + its options + the
+documented `/data` layout — with **no runtime behaviour yet**. This is the
+contract the later slices build against: the fetch/refresh job (#392), the
+signed-index/serve/advertise slice (#393), and the client baseline path (#394).
+
+## Why now / why this shape
+
+ADR 0011 models the mirror on the existing AdGuard Home
+`disabled | external | managed` trichotomy (`config.ts` → `adguardSchema`,
+ADR 0009). Mirroring that established pattern keeps the config surface
+consistent and keeps the license boundary intact by construction: the mirror
+lives in the `/data` volume, fetched at runtime, **never baked into the image**
+— the same precedent that already lets managed-mode AdGuard Home live in
+`/data`. `license-guard.yml` (which scans the image) is unaffected because this
+slice ships no binary and no fetch behaviour.
+
+The maintainer's recorded decisions (ADR 0011 → "Confirmed direction", and the
+#391 thread) that this schema must honour:
+
+- **Configurable package/channel** — stable `timekpr-next` or a beta variant
+  (`timekpr-next-beta`), chosen on the server so a client never has to know
+  which channel it gets.
+- **Optional pinned version** — mirror the AdGuard `PCT_ADGUARD_VERSION`
+  pattern.
+- **`/data`-resident** default dir, overridable — mirror the AdGuard `dataDir`
+  pattern.
+
+## Design — `timekprMirrorSchema`
+
+A `z.discriminatedUnion("mode", …)` added to `server/src/config.ts` beside
+`adguardSchema`, and threaded into `settingsSchema` as `timekprMirror` +
+assembled in `loadSettings`:
+
+- **`disabled`** (default) — no fields. Today's behaviour (client installs from
+  the distro repo; the PPA stays opt-in).
+- **`external`** — `url: z.url()` (required, `PCT_TIMEKPR_MIRROR_URL`): point
+  clients at an apt repo the homelab already hosts. Required-ness is enforced by
+  `z.url()` on the branch (same as `adguardSchema`'s external `url`), so a
+  missing URL fails fast at startup naming the field.
+- **`managed`** — the dashboard maintains the mirror under:
+  - `dataDir: z.string().min(1).default("/data/apt/timekpr")`
+    (`PCT_TIMEKPR_MIRROR_DIR`) — mirrors AdGuard's `dataDir`.
+  - `package: z.enum(["timekpr-next", "timekpr-next-beta"]).default("timekpr-next")`
+    (`PCT_TIMEKPR_MIRROR_PACKAGE`) — the server-chosen channel.
+  - `version: z.string().min(1).optional()` (`PCT_TIMEKPR_MIRROR_VERSION`) —
+    optional pinned upstream version, mirrors AdGuard's `version`.
+
+No `superRefine` is needed: the mirror's `external` mode carries no
+credentials (unlike AdGuard), so `z.url()` alone covers its one required field.
+
+### Env vars
+
+| Var | Mode | Meaning | Default |
+|---|---|---|---|
+| `PCT_TIMEKPR_MIRROR` | all | `disabled` \| `external` \| `managed` | `disabled` |
+| `PCT_TIMEKPR_MIRROR_URL` | external | apt repo URL the homelab hosts | — (required) |
+| `PCT_TIMEKPR_MIRROR_DIR` | managed | `/data` dir the mirror lives under | `/data/apt/timekpr` |
+| `PCT_TIMEKPR_MIRROR_PACKAGE` | managed | `timekpr-next` \| `timekpr-next-beta` | `timekpr-next` |
+| `PCT_TIMEKPR_MIRROR_VERSION` | managed | optional pinned upstream version | unset |
+
+## Docs
+
+- `docs/server-deployment.md` → "Volume layout": add `apt/timekpr/` under
+  `/data`.
+- `docs/server-deployment.md`: a new "Timekpr-nExT package mirror deployment
+  modes" section mirroring the AdGuard-modes section (modes table +
+  configuration example + license posture note that this is the same
+  `/data`-resident, image-GPL-free precedent).
+- `.env.example`: a commented `PCT_TIMEKPR_MIRROR*` block after the AdGuard one.
+
+## Tests (`server/tests/config.test.ts`)
+
+Mirror the `adguardSchema` cases:
+
+- Empty env → `timekprMirror` defaults to `{ mode: "disabled" }` (added to the
+  existing "applies defaults" assertions).
+- Unknown mode (`PCT_TIMEKPR_MIRROR=on`) → `SettingsError` naming `mode`.
+- `external` with a URL → parsed; `external` without a URL → `SettingsError`;
+  `external` with an invalid URL → `SettingsError`.
+- `managed` defaults (dir `/data/apt/timekpr`, package `timekpr-next`, version
+  unset); `managed` with explicit dir + pinned version + beta package; an
+  invalid package value → `SettingsError`.
+
+## Out of scope (tracked on #389)
+
+- Scheduled upstream fetch/refresh job — **#392**.
+- Signed apt index generation + serving `/apt/timekpr/*` + enrol advertisement —
+  **#393**.
+- Client `install-baseline-tools.sh` mirror repo path + orchestrator/enrol
+  plumbing — **#394**.
+- `licensing-analysis.md` note + `license-guard` confirmation — **#395**.
+
+## License-boundary note
+
+Config-only; no behaviour, no binary, no fetch. Pure TypeScript + zod. The
+`/data`-resident approach is already blessed by ADR 0011 (same precedent as
+managed-mode AdGuard Home). No GPL linkage, no image change, no new dependency.

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -58,6 +58,8 @@ container.
 ├── adguard/                    # populated on first run if enabled
 │   ├── AdGuardHome             # binary fetched from upstream releases
 │   └── conf/
+├── apt/
+│   └── timekpr/                # managed timekpr-next mirror (if enabled, #389)
 ├── backups/                    # automatic pre-migration snapshots (#166)
 └── logs/
 ```
@@ -216,6 +218,64 @@ process boundary required by `licensing-analysis.md`. `external` mode
 removes the binary from the deployment entirely; the user runs AdGuard
 themselves. Neither mode causes the dashboard to link or import GPL
 code.
+
+## Timekpr-nExT package mirror deployment modes
+
+Installing Timekpr-nExT on a client normally pulls it from the distro
+repository (or, opt-in, the upstream Launchpad PPA). On a slow link the
+PPA path stalls the enrolment, and the distro version can lag the upstream
+fixes we need. To take Launchpad off the client's critical path and give
+the fleet a fresher version, the dashboard can host its own mirror of the
+`timekpr-next` package, configured through `PCT_TIMEKPR_MIRROR`. This is
+modelled on the AdGuard Home trichotomy above and decided in
+[`docs/adr/0011-server-hosted-upstream-package-mirror.md`](adr/0011-server-hosted-upstream-package-mirror.md)
+(tracking issue #389).
+
+> **Status:** this release ships the configuration seam only (issue #391).
+> The background fetch/refresh job (#392), the served apt index + enrol-time
+> advertisement (#393), and the client-side repo path (#394) land in
+> subsequent Phase-14 slices; setting `managed`/`external` has no runtime
+> effect yet.
+
+| Mode | What the dashboard does | When to use it |
+|---|---|---|
+| `disabled` (default) | No mirror. The client installs `timekpr-next` from the distro repo; the upstream PPA stays opt-in on the client. | You're fine with the distro version, or you accept the PPA round-trip at install time. |
+| `managed` | Maintains a small apt repository under `/data/apt/timekpr/`, refreshed from upstream in the background and served over the LAN; clients point apt at the dashboard at enrol. | You want fast, up-to-date installs with Launchpad off the client's critical path, and you want the dashboard to own the mirror. |
+| `external` | Points clients at an apt repository you already host on the LAN. No fetch, no serving. | You already run an apt mirror for `timekpr-next` and just want clients to use it. |
+
+### Configuration
+
+Set via environment variables:
+
+```bash
+# disabled (default) — nothing to configure
+
+# managed — the dashboard hosts and refreshes the mirror
+PCT_TIMEKPR_MIRROR=managed
+PCT_TIMEKPR_MIRROR_DIR=/data/apt/timekpr        # apt repo lives here
+PCT_TIMEKPR_MIRROR_PACKAGE=timekpr-next         # or timekpr-next-beta
+PCT_TIMEKPR_MIRROR_VERSION=0.5.5                # optional: pin a version; newest if unset
+
+# external — point at an apt repo you already host
+PCT_TIMEKPR_MIRROR=external
+PCT_TIMEKPR_MIRROR_URL=https://apt.lan/timekpr
+```
+
+The mirrored **package/channel is chosen on the server**
+(`PCT_TIMEKPR_MIRROR_PACKAGE`, stable or beta), so a client never has to
+know which channel it gets.
+
+### License posture
+
+`timekpr-next` is GPL, so the mirror follows exactly the AdGuard
+managed-mode precedent: in `managed` mode the mirror is materialised in the
+`/data` volume **at runtime and never baked into the image**, so the
+published image stays GPL-free and `license-guard.yml` (which scans the
+image) is unaffected. The dashboard only *fetches* and *serves files* (and,
+where practical, shells packaging tools out as subprocesses) — no GPL code
+is linked in-process. Source-availability is met by a documented upstream
+source pointer, with source-package mirroring as an optional enhancement.
+See [`docs/licensing-analysis.md`](licensing-analysis.md) and ADR 0011.
 
 ## TrueNAS SCALE deployment
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -131,6 +131,69 @@ const adguardSchema = z.discriminatedUnion("mode", [
   }),
 ]);
 
+/**
+ * The `timekpr-next` upstream packages the mirror can serve (`managed` mode).
+ * The channel is chosen on the *server* so a client never has to know which one
+ * it gets (ADR 0011 → "Confirmed direction"): the stable package, or the beta
+ * variant if the operator opts into it.
+ */
+const TIMEKPR_MIRROR_PACKAGES = ["timekpr-next", "timekpr-next-beta"] as const;
+
+/**
+ * Server-hosted mirror for the upstream (GPL) `timekpr-next` client package,
+ * keyed on `PCT_TIMEKPR_MIRROR` (#391, epic #389).
+ *
+ * Modelled on {@link adguardSchema}'s `disabled | external | managed`
+ * trichotomy (ADR 0009), per ADR 0011: the managed mirror lives in the `/data`
+ * volume, fetched at runtime and **never baked into the image** — the same
+ * boundary-preserving precedent as managed-mode AdGuard Home, so the published
+ * image stays GPL-free (`docs/licensing-analysis.md`, `license-guard.yml`).
+ *
+ * This is the **config seam only** — no fetch/serve behaviour yet. The
+ * background refresh job (#392), the signed apt index + serving + enrol
+ * advertisement (#393), and the client baseline repo path (#394) build against
+ * it. As with `adguardSchema`, the loader assembles a nested object from the
+ * flat `PCT_TIMEKPR_MIRROR_*` env vars before parsing, so each branch narrows
+ * to exactly the fields that mode uses (`docs/server-deployment.md` →
+ * "Timekpr-nExT package mirror deployment modes").
+ */
+const timekprMirrorSchema = z.discriminatedUnion("mode", [
+  z.object({ mode: z.literal("disabled") }),
+  z.object({
+    mode: z.literal("external"),
+    /**
+     * The apt repository URL the homelab already hosts (`PCT_TIMEKPR_MIRROR_URL`).
+     * Required in `external` mode — a missing/invalid value fails fast at startup
+     * naming the field, exactly like `adguardSchema`'s external `url`. The mirror
+     * carries no credentials (unlike AdGuard), so this is its only field.
+     */
+    url: z.url(),
+  }),
+  z.object({
+    mode: z.literal("managed"),
+    /**
+     * Data-volume directory the mirror's apt repo lives under
+     * (`PCT_TIMEKPR_MIRROR_DIR`). Defaults to the documented `/data/apt/timekpr`
+     * layout (`docs/server-deployment.md` → "Volume layout"), mirroring the
+     * AdGuard `dataDir` pattern.
+     */
+    dataDir: z.string().min(1).default("/data/apt/timekpr"),
+    /**
+     * Which upstream package/channel the mirror serves
+     * (`PCT_TIMEKPR_MIRROR_PACKAGE`): the stable `timekpr-next` (default) or the
+     * `timekpr-next-beta` variant. Server-chosen so a client never has to know
+     * which channel it gets (ADR 0011).
+     */
+    package: z.enum(TIMEKPR_MIRROR_PACKAGES).default("timekpr-next"),
+    /**
+     * Optional pinned upstream version to mirror (`PCT_TIMEKPR_MIRROR_VERSION`).
+     * When unset, the (later) refresh job (#392) tracks the newest upstream
+     * release. Mirrors the AdGuard `version` pin.
+     */
+    version: z.string().min(1).optional(),
+  }),
+]);
+
 const settingsSchema = z
   .object({
     /**
@@ -442,6 +505,13 @@ const settingsSchema = z
       probeDeadlineMs: z.coerce.number().int().nonnegative().default(15_000),
     }),
     adguard: adguardSchema,
+    /**
+     * Server-hosted `timekpr-next` package mirror (#391, epic #389). Keyed on
+     * `PCT_TIMEKPR_MIRROR`; parsed-and-ready ahead of the fetch/serve wiring
+     * (#392/#393), like the `telemetry`/`reapply`/`adguard` blocks above. See
+     * {@link timekprMirrorSchema}.
+     */
+    timekprMirror: timekprMirrorSchema,
   })
   .superRefine((settings, ctx) => {
     if (settings.adguard.mode !== "external") return;
@@ -540,6 +610,13 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
       adminPort: env.PCT_ADGUARD_ADMIN_PORT,
       dataDir: env.PCT_ADGUARD_DATA_DIR,
       version: env.PCT_ADGUARD_VERSION,
+    },
+    timekprMirror: {
+      mode: env.PCT_TIMEKPR_MIRROR ?? "disabled",
+      url: env.PCT_TIMEKPR_MIRROR_URL,
+      dataDir: env.PCT_TIMEKPR_MIRROR_DIR,
+      package: env.PCT_TIMEKPR_MIRROR_PACKAGE,
+      version: env.PCT_TIMEKPR_MIRROR_VERSION,
     },
   });
 

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -322,6 +322,18 @@ describe("loadSettings", () => {
       }
     });
 
+    it("ignores other mirror vars when disabled (default mode strips them)", () => {
+      const settings = loadSettings({
+        PCT_TIMEKPR_MIRROR: "disabled",
+        PCT_TIMEKPR_MIRROR_URL: "https://apt.lan/timekpr",
+        PCT_TIMEKPR_MIRROR_DIR: "/srv/apt/timekpr",
+        PCT_TIMEKPR_MIRROR_PACKAGE: "timekpr-next-beta",
+        PCT_TIMEKPR_MIRROR_VERSION: "0.5.5",
+      });
+
+      expect(settings.timekprMirror).toEqual({ mode: "disabled" });
+    });
+
     describe("external mode", () => {
       it("parses the apt repo url", () => {
         const settings = loadSettings({
@@ -335,8 +347,15 @@ describe("loadSettings", () => {
         });
       });
 
-      it("requires a url", () => {
-        expect(() => loadSettings({ PCT_TIMEKPR_MIRROR: "external" })).toThrow(SettingsError);
+      it("requires a url, naming the field", () => {
+        try {
+          loadSettings({ PCT_TIMEKPR_MIRROR: "external" });
+          expect.unreachable("should have thrown");
+        } catch (err) {
+          expect(err).toBeInstanceOf(SettingsError);
+          // Fails fast at startup naming the offending field, not a raw stack.
+          expect((err as SettingsError).message).toContain("url");
+        }
       });
 
       it("requires a valid url", () => {

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -22,6 +22,7 @@ describe("loadSettings", () => {
     expect(settings.sshPublicKeyPath).toBe("/data/secrets/ssh/id_ed25519.pub");
     expect(settings.sshPrivateKeyPath).toBe("/data/secrets/ssh/id_ed25519");
     expect(settings.adguard).toEqual({ mode: "disabled" });
+    expect(settings.timekprMirror).toEqual({ mode: "disabled" });
     expect(settings.telemetry).toEqual({ pullCron: "*/5 * * * *", pullConcurrency: 4 });
     expect(settings.enforcement).toEqual({ cooldownSeconds: 300, initialLookbackSeconds: 900 });
     expect(settings.retention).toEqual({ defaultDays: 365 });
@@ -306,6 +307,83 @@ describe("loadSettings", () => {
           PCT_ADGUARD_ADMIN_PORT: "not-a-port",
         }),
       ).toThrow(SettingsError);
+    });
+  });
+
+  describe("PCT_TIMEKPR_MIRROR (#391)", () => {
+    it("rejects an unknown mirror mode with a readable error", () => {
+      try {
+        loadSettings({ PCT_TIMEKPR_MIRROR: "on" });
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(SettingsError);
+        expect((err as SettingsError).message).toContain("Invalid configuration");
+        expect((err as SettingsError).message).toContain("mode");
+      }
+    });
+
+    describe("external mode", () => {
+      it("parses the apt repo url", () => {
+        const settings = loadSettings({
+          PCT_TIMEKPR_MIRROR: "external",
+          PCT_TIMEKPR_MIRROR_URL: "https://apt.lan/timekpr",
+        });
+
+        expect(settings.timekprMirror).toEqual({
+          mode: "external",
+          url: "https://apt.lan/timekpr",
+        });
+      });
+
+      it("requires a url", () => {
+        expect(() => loadSettings({ PCT_TIMEKPR_MIRROR: "external" })).toThrow(SettingsError);
+      });
+
+      it("requires a valid url", () => {
+        expect(() =>
+          loadSettings({
+            PCT_TIMEKPR_MIRROR: "external",
+            PCT_TIMEKPR_MIRROR_URL: "not-a-url",
+          }),
+        ).toThrow(SettingsError);
+      });
+    });
+
+    describe("managed mode", () => {
+      it("defaults the data dir and package (version unset)", () => {
+        const settings = loadSettings({ PCT_TIMEKPR_MIRROR: "managed" });
+
+        expect(settings.timekprMirror).toEqual({
+          mode: "managed",
+          dataDir: "/data/apt/timekpr",
+          package: "timekpr-next",
+        });
+      });
+
+      it("honours an explicit dir, pinned version, and beta channel", () => {
+        const settings = loadSettings({
+          PCT_TIMEKPR_MIRROR: "managed",
+          PCT_TIMEKPR_MIRROR_DIR: "/srv/apt/timekpr",
+          PCT_TIMEKPR_MIRROR_PACKAGE: "timekpr-next-beta",
+          PCT_TIMEKPR_MIRROR_VERSION: "0.5.5",
+        });
+
+        expect(settings.timekprMirror).toEqual({
+          mode: "managed",
+          dataDir: "/srv/apt/timekpr",
+          package: "timekpr-next-beta",
+          version: "0.5.5",
+        });
+      });
+
+      it("rejects an unknown package/channel", () => {
+        expect(() =>
+          loadSettings({
+            PCT_TIMEKPR_MIRROR: "managed",
+            PCT_TIMEKPR_MIRROR_PACKAGE: "timekpr-nope",
+          }),
+        ).toThrow(SettingsError);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds the **config seam** for the server-hosted `timekpr-next` package mirror (epic **#389**, [ADR 0011](docs/adr/0011-server-hosted-upstream-package-mirror.md)) — a `timekprMirrorSchema` in `server/src/config.ts` modelled on the existing `adguardSchema` `disabled | external | managed` trichotomy (ADR 0009). **No runtime behaviour yet:** this is the contract the fetch/refresh (#392), signed-index/serve/advertise (#393), and client baseline (#394) slices build against.
- Modes + env wiring:
  - `disabled` (default) — today's behaviour (distro repo; PPA stays opt-in).
  - `external` — `PCT_TIMEKPR_MIRROR_URL` (required apt repo URL the homelab hosts).
  - `managed` — `PCT_TIMEKPR_MIRROR_DIR` (default `/data/apt/timekpr`), server-chosen `PCT_TIMEKPR_MIRROR_PACKAGE` (`timekpr-next` | `timekpr-next-beta`, per the ADR requirement noted on #391), optional pinned `PCT_TIMEKPR_MIRROR_VERSION`.
- Docs: `/data/apt/timekpr` added to the "Volume layout"; a new "Timekpr-nExT package mirror deployment modes" section (modes table + config example + license posture) mirroring the AdGuard section; a commented `.env.example` block.

## Plan

Linked plan: `docs/plans/391-timekpr-mirror-config.md`
Roadmap: `docs/roadmap.md` → Phase 14 (fleet updates, epic #163 → mirror epic #389).

## License-boundary note

Config-only — no behaviour, no binary, no fetch. Pure TypeScript + zod. The `/data`-resident (never image-baked) approach is exactly the precedent ADR 0011 draws from managed-mode AdGuard Home, so the published image stays GPL-free and `license-guard` is unaffected. No GPL linkage, no image change, **no new dependency**.

## Test plan

- [x] `server/tests/config.test.ts` — `timekprMirror` defaults to `{ mode: "disabled" }` on an empty env; unknown mode → `SettingsError` naming `mode`; `external` with a url parsed, url required + validated; `managed` defaults (`/data/apt/timekpr`, `timekpr-next`, version unset), explicit dir + pinned version + beta channel, invalid package rejected.
- [x] Full gate green from `server/`: `format` / `lint:fix` / `typecheck` (`tsc --noEmit`) / `npm test` — **1884 passing**, coverage gate (80%) held (`config.ts` 100% lines).

## Deferred (tracked on epic #389)

- Scheduled upstream fetch/refresh job — **#392**.
- Signed apt index + serve `/apt/timekpr/*` + enrol advertisement — **#393**.
- Client `install-baseline-tools.sh` mirror repo path + orchestrator/enrol plumbing — **#394**.
- `licensing-analysis.md` note + `license-guard` confirmation — **#395**.

Part of #389
Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019fv5C2gSESf8xFnEnEG9kL)_