### PR TITLE
docs: pull the timekpr-next mirror forward to Phase 3 (#389)

### DIFF
--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -52,9 +52,12 @@ This repo sequences work by **roadmap phase**, not by a dense custom
 project board:
 
 - [`docs/roadmap.md`](../../docs/roadmap.md) — phased delivery plan. Phase
-  order (0 → 11) is the primary ordering.
-- Phase labels on issues: `phase-1` … `phase-11`. An issue's label tells
-  you which milestone it belongs to.
+  order (0 → 14) is the primary ordering.
+- Phase labels on issues: `phase-1` … `phase-14`, plus the lettered
+  sub-phases `phase-8b` / `phase-8c` (which sort with `phase-8`). An issue's
+  label tells you which milestone it belongs to. A phase whose own issues are
+  all closed can still gain new work when something is deliberately pulled
+  forward — the label is the ordering, not a claim about what's finished.
 - GitHub's native **"Blocked by"** links and any `decision-needed` label.
 - Roadmap project board: <https://github.com/users/BenSeymourODB/projects/2>.
   The board is the visual tracker; the phase label + roadmap doc are the

--- a/docs/adr/0011-server-hosted-upstream-package-mirror.md
+++ b/docs/adr/0011-server-hosted-upstream-package-mirror.md
@@ -2,7 +2,11 @@
 
 - **Status:** Accepted (2026-07-06)
 - **Issue:** [#389](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/389)
-- **Phase:** 14 (Fleet updates & lifecycle management, epic [#163](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/163))
+- **Phase:** 3 (Client install script) for the MVP — pulled forward from
+  Phase 14 on 2026-08-20 because Launchpad latency and distro staleness are
+  *enrolment-time* problems that bite on every install. The signed-apt-index
+  end state remains Phase 14 (Fleet updates & lifecycle management, epic
+  [#163](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/163)).
 - **Relates to:** ADR issue [#167](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/167)
   (client update *channel* — this ADR revisits its "GPL tools stay upstream"
   decision rule for the specific case of `timekpr-next`).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -89,6 +89,20 @@ Goal: enrolling a fresh Mint client is one command.
   `Client`, so the fleet-update work has a version inventory to diff
   against from day one (pulled forward from Phase 14;
   [#164](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/164)).
+- **Server-hosted mirror for `timekpr-next`** so no install depends on a
+  `launchpad.net` PPA-add: the dashboard keeps a `/data`-resident copy of the
+  upstream package, refreshed by a background job and served over the LAN, and
+  advertises it at enrol. Fixes the two problems a live Mint enrolment hit —
+  Launchpad latency on the client's critical path (its `add-apt-repository`
+  timeout is not ours to control) and a distro version that lags the upstream
+  PPA. Ship the MVP (serve the cached `.deb`, advertised at enrol) here; the
+  signed apt index graduates to Phase 14. Design in
+  [`docs/adr/0011-server-hosted-upstream-package-mirror.md`](adr/0011-server-hosted-upstream-package-mirror.md);
+  epic [#389](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/389)
+  (#391 landed the config seam; #392/#393/#394/#395 remain).
+  *Pulled forward from Phase 14 (2026-08-20) — same reasoning as #164 above:
+  it bites on every enrolment, including the Alpha-1 acceptance run (#261),
+  and `install-baseline-tools.sh` is itself a Phase 3 deliverable.*
 
 ## Phase 4 — SSH + `timekpra` transport
 
@@ -425,6 +439,10 @@ once clients are deployed):
   ([#165](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/165)).
 - Automatic pre-migration DB backup, on the backup utility → **Phase 11**
   ([#166](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/166)).
+- Server-hosted `timekpr-next` mirror — the MVP that gets Launchpad off the
+  client's install path → **Phase 3**
+  ([#389](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/389)).
+  The signed apt index stays here.
 
 Phase 14 itself:
 
@@ -456,10 +474,11 @@ Phase 14 itself:
   `update_required`, one-click update
   ([#174](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/174)).
 - Server-hosted mirror for upstream client packages (managed `timekpr-next`
-  mirror): the dashboard maintains a `/data`-resident apt repo, refreshed in
-  the background and served over the LAN, so clients stop round-tripping to
-  Launchpad at install time and get a fresher version than the distro ships.
-  Design in
+  mirror) — **moved to Phase 3**, because getting Launchpad off the client's
+  critical path is an *enrolment-time* fix, not a fleet-upgrade one. What
+  remains a Phase 14 concern is the *end state*: the signed apt index with
+  scheduled auto-refresh that makes clean in-place `apt upgrade`/pinning/
+  rollback possible. Design in
   [`docs/adr/0011-server-hosted-upstream-package-mirror.md`](adr/0011-server-hosted-upstream-package-mirror.md)
   ([#389](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/389)).
 


### PR DESCRIPTION
## Summary

- Re-phase the managed `timekpr-next` mirror MVP from **Phase 14 → Phase 3**, so the hourly `/implement-issue` driver reaches it in its next run instead of after ~10 phases of other work.
- The signed apt index with scheduled auto-refresh **stays in Phase 14** as the end state; only the MVP (fetch → serve → advertise at enrol) moves.
- Correct two stale facts in the `implement-issue` driver notes: the phase-label range is `phase-1`…`phase-14` plus the lettered `phase-8b`/`phase-8c` sub-phases, not `phase-1`…`phase-11`.

## Why

Both problems the mirror solves are **enrolment-time** problems, not fleet-upgrade ones — they bite on every single install:

1. **Launchpad latency.** `add-apt-repository`'s Launchpad lookup has a ~10s timeout hardcoded in `software-properties` — no flag, no env var. Even the curl-based add we landed in #329 (with a configurable `PCT_PPA_FETCH_TIMEOUT`) still leaves Launchpad on the client's critical path. ADR 0011 is explicit that this is a mitigation, not a fix: *"Retries don't help when the per-attempt latency itself is the problem."*
2. **Version staleness.** Mint's referenced `timekpr-next` lags the upstream PPA, so the fast source is stale and the fresh source is the slow one.

Both were observed on a live Mint enrolment. Phase 3's goal is literally *"enrolling a fresh Mint client is one command"*, and `install-baseline-tools.sh` — the script the client half (#394) edits — is already a Phase 3 deliverable. This also puts the fix ahead of the Alpha-1 acceptance run (#261), which would otherwise walk into the same slow/stale install path.

Precedent: #164 (client version reporting) was pulled Phase 14 → Phase 3 for the same reason, and is documented that way in the roadmap.

## Issue changes made alongside this PR

| Issue | Change |
|---|---|
| #389 | `phase-14` → `phase-3`, `+epic` label, retitled `Epic: …`, checklist corrected (#391 ticked), sequencing rationale + dependency order added to body |
| #392 | `phase-14` → `phase-3` |
| #393 | `phase-14` → `phase-3` |
| #394 | `phase-14` → `phase-3` |
| #395 | `phase-14` → `phase-3` |
| #124 | `+epic` label, retitled `Epic: …` (phase label unchanged) — see below |

The `Epic:` title prefix is deliberate: the scheduled driver's prompt says *"start by looking at sub-issues of any whose titles mark them as Epics"*, so marking an umbrella makes the driver recurse into its children rather than attempting the umbrella itself.

**#124** needed the same treatment for the re-phasing to actually take effect. It carries `phase-2`, so it sorts *ahead* of the new phase-3 items — but it is a tracking canvas, not implementable work: its own 2026-07-02 audit comment says it "stays open" only to track #362 (since closed) and #343 goal 3. Its scope all shipped via #181, #182, #134, #270, #363. Marking it as an Epic lets the driver pass over the umbrella and reach the phase-3 queue. Body and comments left untouched — the merge-order notes there are still useful.

## Scheduling effect

`.claude/commands/implement-issue.md` sorts candidates *by `phase-N` label ascending, then issue number ascending*. After this change the head of the queue is #392, then #393 → #394 → #395 — which happens to match their dependency order. Previously the driver would have reached these only after Phases 2, 4, 5, 6, 7, 8, 8b, 8c, 9, 10, 11, 12 and 13.

## License-boundary note

No change to the boundary, and none needed. ADR 0011's reasoning is untouched: the mirror is `/data`-resident and fetched at runtime, **never baked into the image** — the same precedent that already lets managed-mode AdGuard Home live in `/data` (ADR 0009). `license-guard.yml` scans the built image and stays green by construction. This PR only moves *when* that work is scheduled, not *what* it does.

## Test plan

Docs and driver-instruction changes only — no code, no tests affected.

- [x] **All 16 CI checks green** on `0606809`, including `license-guard`-adjacent `Docker image build`, `Unit tests`, `pre-commit hooks` and `SvelteKit build`.
- [x] `prettier` is scoped to `^server/` in `.pre-commit-config.yaml`, so `docs/` is outside the format gate. Verified both edited docs were **already** non-conforming on `main` and deliberately left unreformatted, to avoid a large unrelated diff.
- [x] No trailing whitespace in any added line (35 added lines checked); all three files end with a newline — the two `pre-commit-hooks` that do apply repo-wide.
- [x] Added lines match the surrounding hand-wrapped ~76-column Markdown style; the only >80-column lines are GitHub issue URLs, consistent with the existing file.
- [x] Verified post-change label state: `phase-3` now has 5 open issues (#389 epic + #392–#395), `phase-14` dropped 14 → 9.

Refs #389, #392, #393, #394, #395, #124. Does not close them — this PR only re-sequences the work.