### PR TITLE
feat(timekpr-mirror): scheduled upstream fetch/refresh job (#392)

### DIFF
--- a/docs/plans/392-timekpr-mirror-fetch-refresh.md
+++ b/docs/plans/392-timekpr-mirror-fetch-refresh.md
@@ -1,0 +1,170 @@
+# Plan — #392: scheduled upstream fetch/refresh job for the timekpr mirror
+
+Part of the server-hosted `timekpr-next` mirror epic (**#389**), the second
+implementation slice after the config seam
+([#391](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/391),
+merged) built the `PCT_TIMEKPR_MIRROR` mode + `/data/apt/timekpr` layout.
+ADR: [`0011-server-hosted-upstream-package-mirror.md`](../adr/0011-server-hosted-upstream-package-mirror.md).
+Roadmap: `docs/roadmap.md` → Phase 3.
+
+Dependency order in the epic is **#392 → #393 → #394; #395 last**. This slice is
+the **fetch** half; the signed apt index + serving `/apt/timekpr/*` + enrol
+advertisement is #393, and the client baseline repo path is #394.
+
+## Goal
+
+A **croner-scheduled background job** (same in-process pattern as the telemetry
+pull and the periodic re-apply) that keeps `managed`-mode's
+`/data/apt/timekpr/` current with the upstream `timekpr-next` `.deb`:
+
+- Resolve the newest published `timekpr-next` (or `timekpr-next-beta`) version
+  from the PPA's Launchpad API — or honour the pinned
+  `PCT_TIMEKPR_MIRROR_VERSION`.
+- Download the binary `.deb` into the mirror `dataDir`, with retries/backoff.
+- Skip when already current; log what was fetched.
+
+**This is where the Launchpad latency goes to die:** the fetch runs in the
+background on the server, off every client's install/enrol critical path, and
+is retryable — so a slow Launchpad never blocks an enrolment again (issue #392,
+epic #389 "Problem").
+
+## Why this shape / precedent
+
+This is the direct analogue of **managed-mode AdGuard Home acquisition**
+(`server/src/transport/adguard/{release,acquire}.ts`, #96): fetch a GPL artefact
+from upstream **at runtime into `/data`**, never into the image. So the module
+follows that precedent exactly:
+
+- **Pure coordinate/parse helpers** with no I/O (`release.ts`, mirrors
+  `adguard/release.ts`).
+- **A fetch/refresh function whose every side-effecting boundary (network,
+  filesystem, clock/sleep) is an injected seam** (`refresh.ts`, mirrors
+  `adguard/acquire.ts`), so the whole thing is unit-testable without touching
+  the real network or disk.
+- **A croner scheduler with overlap protection + per-failure backoff +
+  structured logging** (`scheduler.ts`, mirrors
+  `transport/reapply/scheduler.ts` and `adguard/health-poller.ts`), wired by
+  the caller (`main.ts`) after `listen` — not inside `buildApp`, so building the
+  app starts no timer.
+
+## License boundary (non-negotiable, ADR 0011)
+
+Pure TypeScript that **fetches** a GPL `.deb` at runtime and **writes it to the
+`/data` volume** — the exact managed-mode AdGuard precedent (ADR 0009). No GPL
+code is linked, imported, or vendored; no GPL binary is baked into the image
+(`license-guard.yml` scans the image and stays green); index generation and
+serving are out of this slice (#393). Nothing here shells out to GPL packaging
+tools. `CLAUDE.md` → "License boundaries" rules 1 & 5; `docs/licensing-analysis.md`.
+
+## Launchpad resolution contract
+
+The PPA is `~mjasnik/+archive/ubuntu/ppa` (matching
+`client/install-baseline-tools.sh`). Two Launchpad `devel` API round-trips plus
+the download, all off the client path:
+
+1. `GET …/~mjasnik/+archive/ubuntu/ppa?ws.op=getPublishedBinaries&binary_name=<pkg>&status=Published&exact_match=true&order_by_date=true&ws.size=<n>`
+   → a Lazr collection `{ entries: [ { binary_package_version, self_link, … } ] }`.
+   `order_by_date=true` ⇒ `entries[0]` is the most recently published (i.e. the
+   "latest" the ADR tracks). A pinned version selects the first entry whose
+   `binary_package_version` equals the pin.
+2. `GET <self_link>?ws.op=binaryFileUrls` → a JSON array of librarian file URLs;
+   select the one whose basename is `<pkg>_<version>_all.deb` (timekpr-next is
+   `Architecture: all` — one arch-independent `.deb`).
+3. `GET <debUrl>` → the `.deb` bytes.
+
+All three responses are validated with **zod** before use (`CLAUDE.md` → validate
+all external input, including REST responses). Each GET is wrapped in a small
+exponential-backoff retry (injected `sleep` seam).
+
+**Integrity.** The MVP trusts HTTPS to Launchpad and performs a cheap structural
+check — the downloaded bytes must begin with the Debian `ar` global header magic
+(`!<arch>\n`) — rejecting a truncated/HTML error body. Cryptographic integrity
+(apt `Release`/`Packages` SHAs, repo signing key) is the job of the **signed apt
+index slice (#393)**, which is the natural place for it; this is called out in
+the PR and the module docstring, not silently dropped.
+
+## Files
+
+New `server/src/transport/timekpr-mirror/`:
+
+- `release.ts` — PPA/Launchpad URL builders; zod schemas
+  (`publishedBinariesSchema`, `binaryFileUrlsSchema`); `parseLatestPublication`
+  / `selectPinnedPublication`; `selectDebUrl`; `debFilename`; the `.deb` ar
+  magic constant; `TimekprMirrorResolveError`. No I/O.
+- `refresh.ts` — `refreshTimekprMirror(config, deps)` → `{ version, filename,
+  path, fetched }`; skip-when-current via a version sentinel; download + ar-magic
+  validation; `withRetry` (injected `sleep`); `TimekprMirrorDownloadError`,
+  `TimekprMirrorInvalidPackageError`, `DownloadFetch`/`RefreshDeps` seams.
+- `scheduler.ts` — `startTimekprMirrorRefresh(options)` → `{ tick, stop }`;
+  croner `protect: true`; per-failure exponential backoff (reuse the reapply
+  bounds shape); `transport/timekpr-mirror` child logger; a tick never throws.
+- `index.ts` — barrel + `moduleName`.
+
+Tests mirror the layout under `server/tests/transport/timekpr-mirror/`:
+`release.test.ts`, `refresh.test.ts`, `scheduler.test.ts`.
+
+## Config
+
+Add to the `managed` branch of `timekprMirrorSchema` (`server/src/config.ts`):
+
+- `refreshCron` — croner pattern (`PCT_TIMEKPR_MIRROR_REFRESH_CRON`), validated
+  with the shared `isValidCronPattern` refine, default `"0 3 * * *"` (daily at
+  03:00 — package updates are infrequent; a slow Launchpad off the client path
+  makes cadence non-critical).
+
+Env mapping gets `refreshCron: env.PCT_TIMEKPR_MIRROR_REFRESH_CRON`. Docstring
+documents the var (config.ts is the env-var source of truth); the prose docs in
+`server-deployment.md` are #395's slice.
+
+## Wiring
+
+- `buildApp` (`server/src/web/app.ts`): decorate
+  `timekprMirrorRefresh: TimekprMirrorRefreshHandle | null = null` and an
+  `onClose` hook that `?.stop()`s it — the exact `adguardHealthPoll` shape.
+- `main.ts`: after `listen`, when `settings.timekprMirror.mode === "managed"`,
+  start the scheduler, assign it to `app.timekprMirrorRefresh`, and kick one
+  `void app.timekprMirrorRefresh.tick()` to warm the cache immediately (off the
+  critical path). `main.ts` is coverage-excluded, matching the AdGuard wiring.
+
+`disabled` (default) and `external` modes never fetch — external points clients
+at a repo the homelab already hosts, disabled does nothing — so the scheduler
+only exists in `managed` mode.
+
+## Phasing (commit + push per phase → draft PR on first push)
+
+1. **`release.ts` + tests** — pure resolution/parse layer.
+2. **`refresh.ts` + tests** — the download/skip/validate seam.
+3. **`scheduler.ts` + config + wiring + tests** — the croner job made live in
+   managed mode.
+
+## Test plan
+
+- `release.ts`: latest selection (order_by_date first entry); pinned selection
+  (match / not-found error); malformed collection / empty entries → typed error;
+  `selectDebUrl` picks `_all.deb`, rejects when absent; `debFilename`; zod
+  rejects a body missing required fields.
+- `refresh.ts`: first fetch downloads + writes + sentinel; skip-when-current
+  (sentinel matches + file present); re-fetch when sentinel drifts or file
+  missing; pinned version path; non-2xx → `TimekprMirrorDownloadError`; non-`.deb`
+  bytes → `TimekprMirrorInvalidPackageError`; retry succeeds on a later attempt;
+  retry exhaustion throws.
+- `scheduler.ts`: `tick()` calls refresh and logs the outcome; a thrown refresh
+  is caught, logged, and backed off (never escapes the tick); backoff clears
+  after a success; `stop()` halts; default pattern + log component exported.
+
+## Quality gate (each phase, from `server/`)
+
+`npm run format` · `npm run lint:fix` · `npm run typecheck` · `npm test`
+(coverage ≥ 80%). No new runtime dependency (croner, zod, better-sqlite3 already
+present).
+
+## Deferred (tracked in the epic, not this slice)
+
+- Signed apt index generation + `/apt/timekpr/*` serving + enrol advertisement →
+  **#393** (also where cryptographic integrity lands).
+- Client `install-baseline-tools.sh` mirror repo path + orchestrator/enrol
+  plumbing → **#394**.
+- Docs (`server-deployment.md`, `licensing-analysis.md`) + license-guard
+  confirmation → **#395**.
+- Optional upstream **source-package** mirroring (ADR default is a documented
+  upstream source pointer) → epic #389 enhancement.

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -187,10 +187,23 @@ const timekprMirrorSchema = z.discriminatedUnion("mode", [
     package: z.enum(TIMEKPR_MIRROR_PACKAGES).default("timekpr-next"),
     /**
      * Optional pinned upstream version to mirror (`PCT_TIMEKPR_MIRROR_VERSION`).
-     * When unset, the (later) refresh job (#392) tracks the newest upstream
-     * release. Mirrors the AdGuard `version` pin.
+     * When unset, the refresh job (#392) tracks the newest upstream release.
+     * Mirrors the AdGuard `version` pin.
      */
     version: z.string().min(1).optional(),
+    /**
+     * croner pattern for the background fetch/refresh job
+     * (`PCT_TIMEKPR_MIRROR_REFRESH_CRON`, #392). Validated here so a typo fails
+     * fast at startup rather than silently never running. Defaults to daily at
+     * 03:00 — upstream `timekpr-next` releases are infrequent and the fetch runs
+     * off every client's install/enrol critical path, so cadence is not latency
+     * critical (`docs/adr/0011-server-hosted-upstream-package-mirror.md`).
+     */
+    refreshCron: z
+      .string()
+      .min(1)
+      .default("0 3 * * *")
+      .refine(isValidCronPattern, { message: "must be a valid cron pattern (e.g. 0 3 * * *)" }),
   }),
 ]);
 
@@ -507,9 +520,9 @@ const settingsSchema = z
     adguard: adguardSchema,
     /**
      * Server-hosted `timekpr-next` package mirror (#391, epic #389). Keyed on
-     * `PCT_TIMEKPR_MIRROR`; parsed-and-ready ahead of the fetch/serve wiring
-     * (#392/#393), like the `telemetry`/`reapply`/`adguard` blocks above. See
-     * {@link timekprMirrorSchema}.
+     * `PCT_TIMEKPR_MIRROR`. The `managed` branch's `refreshCron` drives the
+     * background fetch/refresh job (#392); the signed apt index + serving is
+     * still ahead (#393). See {@link timekprMirrorSchema}.
      */
     timekprMirror: timekprMirrorSchema,
   })
@@ -617,6 +630,7 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
       dataDir: env.PCT_TIMEKPR_MIRROR_DIR,
       package: env.PCT_TIMEKPR_MIRROR_PACKAGE,
       version: env.PCT_TIMEKPR_MIRROR_VERSION,
+      refreshCron: env.PCT_TIMEKPR_MIRROR_REFRESH_CRON,
     },
   });
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -13,6 +13,7 @@
 import { loadSettings } from "./config.js";
 import { ensureServerSshKeyPair } from "./setup/ssh-keys.js";
 import { startAdGuardHealthPoll } from "./transport/adguard/index.js";
+import { startTimekprMirrorRefresh } from "./transport/timekpr-mirror/index.js";
 import { buildApp } from "./web/app.js";
 
 const HOST = "0.0.0.0";
@@ -88,6 +89,28 @@ async function main(): Promise<void> {
   // onClose hook stops it. `null` when the SSH key is absent (nothing to reach),
   // so the `?.` keeps a keyless first boot a no-op.
   app.enforcementPipeline?.start();
+
+  // Start the managed-mode timekpr-next mirror refresh scheduler (#392, epic
+  // #389) after listen — a first refresh must not delay the dashboard becoming
+  // reachable, and the whole point is to keep the fetch off every client's
+  // install/enrol critical path. Only in `managed` mode: `external` points
+  // clients at a repo the homelab already hosts and `disabled` does nothing.
+  // The scheduler's tick never throws (a failed fetch is logged + backed off),
+  // and buildApp's onClose hook stops it on shutdown. We kick one tick now to
+  // warm the cache immediately.
+  const mirror = settings.timekprMirror;
+  if (mirror.mode === "managed") {
+    app.timekprMirrorRefresh = startTimekprMirrorRefresh({
+      config: {
+        dataDir: mirror.dataDir,
+        package: mirror.package,
+        ...(mirror.version !== undefined ? { version: mirror.version } : {}),
+      },
+      pattern: mirror.refreshCron,
+      log: app.log,
+    });
+    void app.timekprMirrorRefresh.tick();
+  }
 }
 
 void main();

--- a/server/src/transport/timekpr-mirror/index.ts
+++ b/server/src/transport/timekpr-mirror/index.ts
@@ -1,0 +1,30 @@
+/** Server-hosted upstream `timekpr-next` package mirror (managed mode, #389). */
+export const moduleName = "transport/timekpr-mirror";
+
+export {
+  DEB_AR_MAGIC,
+  TIMEKPR_PPA_NAME,
+  TIMEKPR_PPA_OWNER,
+  TimekprMirrorResolveError,
+  binaryFileUrlsSchema,
+  binaryFileUrlsUrl,
+  debFilename,
+  parseLatestPublication,
+  publishedBinariesSchema,
+  publishedBinarySchema,
+  publishedBinariesUrl,
+  selectDebUrl,
+  selectPinnedPublication,
+  type PublishedBinaries,
+  type PublishedBinary,
+} from "./release.js";
+export {
+  VERSION_SENTINEL,
+  refreshTimekprMirror,
+  TimekprMirrorDownloadError,
+  TimekprMirrorInvalidPackageError,
+  type DownloadFetch,
+  type RefreshConfig,
+  type RefreshDeps,
+  type RefreshResult,
+} from "./refresh.js";

--- a/server/src/transport/timekpr-mirror/index.ts
+++ b/server/src/transport/timekpr-mirror/index.ts
@@ -28,3 +28,12 @@ export {
   type RefreshDeps,
   type RefreshResult,
 } from "./refresh.js";
+export {
+  DEFAULT_REFRESH_BACKOFF,
+  DEFAULT_REFRESH_PATTERN,
+  REFRESH_LOG_COMPONENT,
+  startTimekprMirrorRefresh,
+  type RefreshBackoff,
+  type TimekprMirrorRefreshHandle,
+  type TimekprMirrorRefreshOptions,
+} from "./scheduler.js";

--- a/server/src/transport/timekpr-mirror/refresh.ts
+++ b/server/src/transport/timekpr-mirror/refresh.ts
@@ -1,0 +1,281 @@
+/**
+ * Background fetch/refresh of the upstream `timekpr-next` `.deb` into the
+ * managed mirror's data volume (#392, epic #389).
+ *
+ * Resolves the newest published version from the PPA's Launchpad API (or honours
+ * a pinned version), downloads the arch-independent `.deb` into `config.dataDir`,
+ * and records the version in a sentinel so an already-current mirror is a no-op.
+ * This is the "fetched from upstream at runtime into `/data`" half of the mirror
+ * (ADR 0011), the direct analogue of `adguard/acquire.ts` (#96).
+ *
+ * Every side-effecting boundary — network (`fetch`), filesystem, and the retry
+ * clock (`sleep`) — is an injected seam, so the whole module is unit-testable
+ * without touching the real network or disk.
+ *
+ * License boundary: the `.deb` is fetched at runtime and written to `/data`;
+ * nothing here links, imports, or vendors GPL code, and no binary is baked into
+ * the image (`CLAUDE.md` → "License boundaries" rules 1 & 5; ADR 0011). Index
+ * generation, serving, and cryptographic verification are the signed-index
+ * slice's job (#393); this MVP trusts HTTPS + a structural `.deb` check.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  DEB_AR_MAGIC,
+  binaryFileUrlsSchema,
+  binaryFileUrlsUrl,
+  debFilename,
+  parseLatestPublication,
+  publishedBinariesSchema,
+  publishedBinariesUrl,
+  selectDebUrl,
+  selectPinnedPublication,
+  type PublishedBinary,
+} from "./release.js";
+
+/** Filename of the version sentinel written beside the mirrored `.deb`. */
+export const VERSION_SENTINEL = ".pct-timekpr-mirror-version";
+
+/** Default network-retry attempts per Launchpad request / download. */
+const DEFAULT_RETRY_ATTEMPTS = 3;
+
+/** Default base delay (ms) for the exponential retry backoff. */
+const DEFAULT_RETRY_BASE_MS = 1000;
+
+/**
+ * The minimal `fetch` surface the refresh uses — reads JSON, text, and binary
+ * bodies. Structural so the Node 22 global `fetch` satisfies it and a test can
+ * pass a recording fake without a cast (mirrors `adguard/acquire.ts`).
+ */
+export type DownloadFetch = (
+  input: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}>;
+
+/** Configuration the refresh needs (a slice of the `managed` mirror settings). */
+export interface RefreshConfig {
+  /** Data-volume directory the mirror's `.deb` + sentinel live under. */
+  readonly dataDir: string;
+  /** The upstream package/channel to mirror (`timekpr-next` / `timekpr-next-beta`). */
+  readonly package: string;
+  /** Optional pinned version; when unset the newest published version is tracked. */
+  readonly version?: string;
+}
+
+/** Injectable seams so tests never hit the network or real disk. */
+export interface RefreshDeps {
+  /** `fetch` for the API lookups + download; defaults to the global `fetch`. */
+  fetch?: DownloadFetch;
+  /** Existence check; defaults to `node:fs` `existsSync`. */
+  fileExists?: (path: string) => boolean;
+  /** Read the recorded version sentinel, or `null` if absent/unreadable. */
+  readSentinel?: (path: string) => string | null;
+  /** Recursively create a directory (and parents). */
+  makeDir?: (path: string) => void;
+  /** Write the downloaded `.deb`. */
+  writeDeb?: (path: string, contents: Buffer) => void;
+  /** Record the acquired version. */
+  writeSentinel?: (path: string, value: string) => void;
+  /** Sleep between retry attempts; defaults to a real timer. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Network-retry attempts per request; defaults to {@link DEFAULT_RETRY_ATTEMPTS}. */
+  retryAttempts?: number;
+  /** Base delay (ms) for the retry backoff; defaults to {@link DEFAULT_RETRY_BASE_MS}. */
+  retryBaseMs?: number;
+}
+
+/** Outcome of a {@link refreshTimekprMirror} call. */
+export interface RefreshResult {
+  /** The version now present in the mirror. */
+  readonly version: string;
+  /** The `.deb` filename written into the data volume. */
+  readonly filename: string;
+  /** Absolute path to the (now-present) `.deb`. */
+  readonly path: string;
+  /** True when this call downloaded the `.deb`; false when it was already current. */
+  readonly fetched: boolean;
+}
+
+/** Thrown when a Launchpad request or the download returns a non-2xx status. */
+export class TimekprMirrorDownloadError extends Error {
+  constructor(
+    readonly url: string,
+    readonly status: number,
+    statusText: string,
+  ) {
+    super(`timekpr mirror download failed: ${status} ${statusText} for ${url}`.trimEnd());
+    this.name = "TimekprMirrorDownloadError";
+  }
+}
+
+/** Thrown when a downloaded body is not a Debian `.deb` (truncated / error page). */
+export class TimekprMirrorInvalidPackageError extends Error {
+  constructor(readonly url: string) {
+    super(`downloaded body from ${url} is not a Debian package (bad ar header)`);
+    this.name = "TimekprMirrorInvalidPackageError";
+  }
+}
+
+interface ResolvedDeps {
+  fetch: DownloadFetch;
+  fileExists: (path: string) => boolean;
+  readSentinel: (path: string) => string | null;
+  makeDir: (path: string) => void;
+  writeDeb: (path: string, contents: Buffer) => void;
+  writeSentinel: (path: string, value: string) => void;
+  sleep: (ms: number) => Promise<void>;
+  retryAttempts: number;
+  retryBaseMs: number;
+}
+
+function defaultReadSentinel(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+function resolveDeps(deps: RefreshDeps): ResolvedDeps {
+  return {
+    fetch: deps.fetch ?? ((input, init) => fetch(input, init)),
+    fileExists: deps.fileExists ?? existsSync,
+    readSentinel: deps.readSentinel ?? defaultReadSentinel,
+    makeDir: deps.makeDir ?? ((path) => void mkdirSync(path, { recursive: true })),
+    writeDeb: deps.writeDeb ?? ((path, contents) => writeFileSync(path, contents)),
+    writeSentinel: deps.writeSentinel ?? ((path, value) => writeFileSync(path, `${value}\n`)),
+    sleep: deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
+    retryAttempts: deps.retryAttempts ?? DEFAULT_RETRY_ATTEMPTS,
+    retryBaseMs: deps.retryBaseMs ?? DEFAULT_RETRY_BASE_MS,
+  };
+}
+
+/**
+ * Run `op` up to `attempts` times, waiting `baseMs * 2 ** (n-1)` between tries.
+ * The last failure propagates so the caller (the scheduler) can log + back off.
+ */
+async function withRetry<T>(
+  op: () => Promise<T>,
+  attempts: number,
+  baseMs: number,
+  sleep: (ms: number) => Promise<void>,
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await op();
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await sleep(baseMs * 2 ** (attempt - 1));
+      }
+    }
+  }
+  throw lastError;
+}
+
+/** GET a URL and return the response, throwing {@link TimekprMirrorDownloadError} on non-2xx. */
+async function getOk(
+  fetchImpl: DownloadFetch,
+  url: string,
+): Promise<Awaited<ReturnType<DownloadFetch>>> {
+  const response = await fetchImpl(url, {
+    headers: { "user-agent": "linux-parental-controls-toolkit" },
+  });
+  if (!response.ok) {
+    throw new TimekprMirrorDownloadError(url, response.status, response.statusText);
+  }
+  return response;
+}
+
+/** Resolve the publishing record to mirror (pinned version, or the newest). */
+async function resolvePublication(
+  d: ResolvedDeps,
+  config: RefreshConfig,
+): Promise<PublishedBinary> {
+  const url = publishedBinariesUrl(config.package);
+  const body = await withRetry(
+    async () => (await getOk(d.fetch, url)).json(),
+    d.retryAttempts,
+    d.retryBaseMs,
+    d.sleep,
+  );
+  const collection = publishedBinariesSchema.parse(body);
+  return config.version === undefined
+    ? parseLatestPublication(collection)
+    : selectPinnedPublication(collection, config.version);
+}
+
+/** Resolve the `.deb` download URL for a publishing record. */
+async function resolveDebUrl(
+  d: ResolvedDeps,
+  publication: PublishedBinary,
+  config: RefreshConfig,
+): Promise<string> {
+  const url = binaryFileUrlsUrl(publication.self_link);
+  const body = await withRetry(
+    async () => (await getOk(d.fetch, url)).json(),
+    d.retryAttempts,
+    d.retryBaseMs,
+    d.sleep,
+  );
+  const urls = binaryFileUrlsSchema.parse(body);
+  return selectDebUrl(urls, config.package, publication.binary_package_version);
+}
+
+/** Download the `.deb`, verifying its Debian `ar` header. */
+async function downloadDeb(d: ResolvedDeps, debUrl: string): Promise<Buffer> {
+  const bytes = await withRetry(
+    async () => Buffer.from(await (await getOk(d.fetch, debUrl)).arrayBuffer()),
+    d.retryAttempts,
+    d.retryBaseMs,
+    d.sleep,
+  );
+  if (!bytes.subarray(0, DEB_AR_MAGIC.length).equals(Buffer.from(DEB_AR_MAGIC, "ascii"))) {
+    throw new TimekprMirrorInvalidPackageError(debUrl);
+  }
+  return bytes;
+}
+
+/**
+ * Ensure the mirror's `.deb` is current under `config.dataDir`.
+ *
+ * Idempotent: when the resolved version's `.deb` is already present and the
+ * sentinel matches, no download happens (`fetched: false`). Otherwise the newest
+ * (or pinned) version is downloaded, structurally verified, and written with an
+ * updated sentinel. Throws on any resolution/download/verification failure so
+ * the scheduler can log it and back off; it does not swallow errors itself.
+ */
+export async function refreshTimekprMirror(
+  config: RefreshConfig,
+  deps: RefreshDeps = {},
+): Promise<RefreshResult> {
+  const d = resolveDeps(deps);
+  const sentinelPath = join(config.dataDir, VERSION_SENTINEL);
+
+  const publication = await resolvePublication(d, config);
+  const version = publication.binary_package_version;
+  const filename = debFilename(config.package, version);
+  const path = join(config.dataDir, filename);
+
+  if (d.fileExists(path) && d.readSentinel(sentinelPath) === version) {
+    return { version, filename, path, fetched: false };
+  }
+
+  const debUrl = await resolveDebUrl(d, publication, config);
+  const bytes = await downloadDeb(d, debUrl);
+
+  d.makeDir(config.dataDir);
+  d.writeDeb(path, bytes);
+  d.writeSentinel(sentinelPath, version);
+
+  return { version, filename, path, fetched: true };
+}

--- a/server/src/transport/timekpr-mirror/refresh.ts
+++ b/server/src/transport/timekpr-mirror/refresh.ts
@@ -153,7 +153,9 @@ function resolveDeps(deps: RefreshDeps): ResolvedDeps {
     writeDeb: deps.writeDeb ?? ((path, contents) => writeFileSync(path, contents)),
     writeSentinel: deps.writeSentinel ?? ((path, value) => writeFileSync(path, `${value}\n`)),
     sleep: deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
-    retryAttempts: deps.retryAttempts ?? DEFAULT_RETRY_ATTEMPTS,
+    // Clamp to ≥ 1 so a single attempt always runs — otherwise `withRetry` would
+    // never enter its loop and throw an `undefined` "last error".
+    retryAttempts: Math.max(1, deps.retryAttempts ?? DEFAULT_RETRY_ATTEMPTS),
     retryBaseMs: deps.retryBaseMs ?? DEFAULT_RETRY_BASE_MS,
   };
 }

--- a/server/src/transport/timekpr-mirror/release.ts
+++ b/server/src/transport/timekpr-mirror/release.ts
@@ -1,0 +1,170 @@
+/**
+ * Upstream (Launchpad PPA) release coordinates for the `timekpr-next` mirror
+ * (#392, epic #389).
+ *
+ * Pure helpers that build the Launchpad `devel` API URLs and parse/validate the
+ * responses that {@link ./refresh.ts refreshTimekprMirror} fetches against. No
+ * I/O here — this is the direct analogue of `adguard/release.ts` (#96): the
+ * fetch module does the network + filesystem work behind injected seams.
+ *
+ * The PPA is `~mjasnik/+archive/ubuntu/ppa`, matching
+ * `client/install-baseline-tools.sh` (`TIMEKPR_PPA_LP_API`). `timekpr-next` is
+ * an `Architecture: all` Python package, so there is exactly one arch-independent
+ * `<pkg>_<version>_all.deb` per version.
+ *
+ * License boundary: none touched — plain URL/string helpers + zod parsing; the
+ * `.deb` they point at is fetched at runtime into `/data` and never linked,
+ * imported, or baked into the image (`CLAUDE.md` → "License boundaries" rules
+ * 1 & 5; ADR 0011; `docs/licensing-analysis.md`).
+ */
+import { z } from "zod";
+
+/** The Launchpad person/PPA the mirror tracks (matches the client installer). */
+export const TIMEKPR_PPA_OWNER = "mjasnik";
+export const TIMEKPR_PPA_NAME = "ppa";
+
+/** Base of the Launchpad `devel` API archive resource for the PPA. */
+const LP_ARCHIVE_URL =
+  `https://api.launchpad.net/devel/~${TIMEKPR_PPA_OWNER}` + `/+archive/ubuntu/${TIMEKPR_PPA_NAME}`;
+
+/**
+ * The Debian `ar` archive global header every `.deb` begins with. The fetch
+ * module rejects a download that does not start with these bytes (a truncated
+ * body or an HTML error page served with a 200), a cheap structural integrity
+ * check ahead of the cryptographic verification the signed apt index adds (#393).
+ */
+export const DEB_AR_MAGIC = "!<arch>\n";
+
+/**
+ * How many published-binary records to request per resolution. `order_by_date`
+ * returns newest first, so a small window comfortably covers "the latest" and a
+ * recent pin without paginating; a pin older than this fails loudly (asking the
+ * operator to un-pin or update) rather than silently mis-resolving.
+ */
+const PUBLISHED_BINARIES_PAGE_SIZE = 75;
+
+/** Thrown when the Launchpad response cannot be resolved to a usable release. */
+export class TimekprMirrorResolveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimekprMirrorResolveError";
+  }
+}
+
+/**
+ * One `binary_package_publishing_history` entry from `getPublishedBinaries`.
+ * Only the fields the resolver needs are modelled; Launchpad sends many more and
+ * zod strips the rest.
+ */
+export const publishedBinarySchema = z.object({
+  binary_package_name: z.string().min(1),
+  binary_package_version: z.string().min(1),
+  /** The entry's own resource URL; `binaryFileUrls` is derived from it. */
+  self_link: z.url(),
+});
+export type PublishedBinary = z.infer<typeof publishedBinarySchema>;
+
+/** The Lazr collection wrapper `getPublishedBinaries` returns. */
+export const publishedBinariesSchema = z.object({
+  entries: z.array(publishedBinarySchema),
+});
+export type PublishedBinaries = z.infer<typeof publishedBinariesSchema>;
+
+/** `binaryFileUrls` returns a bare JSON array of librarian file URLs. */
+export const binaryFileUrlsSchema = z.array(z.url());
+
+/**
+ * Build the `getPublishedBinaries` API URL for a package on the PPA.
+ *
+ * `status=Published` + `exact_match=true` scope the result to the live binary of
+ * exactly this package; `order_by_date=true` returns the most recent publication
+ * first so {@link parseLatestPublication} can take `entries[0]`.
+ */
+export function publishedBinariesUrl(packageName: string): string {
+  const params = new URLSearchParams({
+    "ws.op": "getPublishedBinaries",
+    binary_name: packageName,
+    status: "Published",
+    exact_match: "true",
+    order_by_date: "true",
+    "ws.size": String(PUBLISHED_BINARIES_PAGE_SIZE),
+  });
+  return `${LP_ARCHIVE_URL}?${params.toString()}`;
+}
+
+/** Build the `binaryFileUrls` API URL for a publishing record's `self_link`. */
+export function binaryFileUrlsUrl(selfLink: string): string {
+  const separator = selfLink.includes("?") ? "&" : "?";
+  return `${selfLink}${separator}ws.op=binaryFileUrls`;
+}
+
+/**
+ * Resolve the newest published record from a validated collection.
+ *
+ * `order_by_date=true` means `entries[0]` is the most recently published, which
+ * for a PPA is the newest version — the "latest" ADR 0011 tracks. Throws
+ * {@link TimekprMirrorResolveError} when the collection is empty.
+ */
+export function parseLatestPublication(collection: PublishedBinaries): PublishedBinary {
+  const [latest] = collection.entries;
+  if (latest === undefined) {
+    throw new TimekprMirrorResolveError(
+      "Launchpad returned no published binaries for the configured timekpr package/channel",
+    );
+  }
+  return latest;
+}
+
+/**
+ * Select the publishing record matching a pinned version from a validated
+ * collection. Throws {@link TimekprMirrorResolveError} when no entry on the page
+ * matches (an unpublished or too-old pin).
+ */
+export function selectPinnedPublication(
+  collection: PublishedBinaries,
+  version: string,
+): PublishedBinary {
+  const match = collection.entries.find((entry) => entry.binary_package_version === version);
+  if (match === undefined) {
+    throw new TimekprMirrorResolveError(
+      `pinned timekpr version ${version} is not among the published binaries; ` +
+        `un-pin PCT_TIMEKPR_MIRROR_VERSION or set a currently-published version`,
+    );
+  }
+  return match;
+}
+
+/** The expected `.deb` filename for an `Architecture: all` package version. */
+export function debFilename(packageName: string, version: string): string {
+  return `${packageName}_${version}_all.deb`;
+}
+
+/**
+ * Pick the binary `.deb` download URL for `<pkg>_<version>_all.deb` from a
+ * validated `binaryFileUrls` array.
+ *
+ * Launchpad may list several files for a publication (e.g. multiple builds); the
+ * arch-independent `_all.deb` for this exact version is selected by basename.
+ * Throws {@link TimekprMirrorResolveError} when it is absent.
+ */
+export function selectDebUrl(
+  urls: readonly string[],
+  packageName: string,
+  version: string,
+): string {
+  const wanted = debFilename(packageName, version);
+  const match = urls.find((url) => basename(url) === wanted);
+  if (match === undefined) {
+    throw new TimekprMirrorResolveError(
+      `Launchpad listed no ${wanted} among the published files for ${packageName} ${version}`,
+    );
+  }
+  return match;
+}
+
+/** The last path segment of a URL, ignoring any query/fragment. */
+function basename(url: string): string {
+  const path = url.split(/[?#]/, 1)[0] ?? url;
+  const segments = path.split("/");
+  return segments[segments.length - 1] ?? "";
+}

--- a/server/src/transport/timekpr-mirror/release.ts
+++ b/server/src/transport/timekpr-mirror/release.ts
@@ -134,9 +134,21 @@ export function selectPinnedPublication(
   return match;
 }
 
+/**
+ * The version token apt uses in a `.deb` filename: any Debian *epoch* (`N:`
+ * prefix) is stripped, since the epoch is metadata that never appears in the
+ * on-disk filename. `timekpr-next` carries no epoch today, but keying the
+ * filename off the raw version would mis-match the librarian file the moment
+ * upstream ever added one — so strip it defensively.
+ */
+function debFileVersion(version: string): string {
+  const colon = version.indexOf(":");
+  return colon === -1 ? version : version.slice(colon + 1);
+}
+
 /** The expected `.deb` filename for an `Architecture: all` package version. */
 export function debFilename(packageName: string, version: string): string {
-  return `${packageName}_${version}_all.deb`;
+  return `${packageName}_${debFileVersion(version)}_all.deb`;
 }
 
 /**

--- a/server/src/transport/timekpr-mirror/scheduler.ts
+++ b/server/src/transport/timekpr-mirror/scheduler.ts
@@ -1,0 +1,132 @@
+/**
+ * Scheduled upstream fetch/refresh for the managed `timekpr-next` mirror
+ * (#392, epic #389).
+ *
+ * A croner job (`CLAUDE.md` → "Scheduling: croner for in-process periodic
+ * jobs") that, each tick, brings `/data/apt/timekpr/` current with the upstream
+ * `.deb` via {@link refreshTimekprMirror}. It runs on the server, in the
+ * background, **off every client's install/enrol critical path** — so a slow or
+ * unreachable Launchpad never blocks an enrolment (issue #392; epic #389
+ * "Problem"). A failed refresh is logged and the job is backed off with
+ * exponential delay so a persistently unreachable upstream doesn't retry every
+ * tick; a later successful pass clears the backoff.
+ *
+ * Wired by the caller (`main.ts`) only in `managed` mode, after `listen` — like
+ * `startAdGuardHealthPoll` and `startPeriodicReapply`, building the app starts no
+ * timer. `external` mode points clients at a repo the homelab already hosts and
+ * `disabled` does nothing, so neither fetches.
+ *
+ * License boundary: none touched — croner (MIT) + the injected {@link
+ * refreshTimekprMirror} seam, which only fetches a `.deb` into `/data`. Nothing
+ * links, imports, or vendors GPL code (ADR 0011; `docs/licensing-analysis.md`).
+ */
+import { Cron } from "croner";
+import type { FastifyBaseLogger } from "fastify";
+
+import { refreshTimekprMirror, type RefreshConfig, type RefreshDeps } from "./refresh.js";
+
+/**
+ * Default cadence: refresh daily at 03:00. Upstream `timekpr-next` releases are
+ * infrequent and the fetch is off the client critical path, so a tight cadence
+ * would only dial Launchpad more often for no benefit.
+ */
+export const DEFAULT_REFRESH_PATTERN = "0 3 * * *";
+
+/** The pino `component` tag every scheduler log line carries (#11). */
+export const REFRESH_LOG_COMPONENT = "transport/timekpr-mirror";
+
+/** Exponential backoff bounds after a failed refresh. */
+export interface RefreshBackoff {
+  /** Delay after the first failure; doubles each consecutive failure. */
+  readonly baseMs: number;
+  /** Ceiling the doubling is clamped to. */
+  readonly maxMs: number;
+}
+
+/** Default backoff: 5 min after the first failure, doubling up to 6 hours. */
+export const DEFAULT_REFRESH_BACKOFF: RefreshBackoff = {
+  baseMs: 5 * 60 * 1000,
+  maxMs: 6 * 60 * 60 * 1000,
+};
+
+/** Wiring for {@link startTimekprMirrorRefresh}. */
+export interface TimekprMirrorRefreshOptions {
+  /** The managed mirror config slice (dataDir, package, optional pinned version). */
+  readonly config: RefreshConfig;
+  /** Base logger; a `transport/timekpr-mirror` child is derived for the job's lines. */
+  readonly log: FastifyBaseLogger;
+  /** croner pattern; defaults to {@link DEFAULT_REFRESH_PATTERN}. */
+  readonly pattern?: string;
+  /** Backoff bounds; defaults to {@link DEFAULT_REFRESH_BACKOFF}. */
+  readonly backoff?: RefreshBackoff;
+  /** Clock seam for backoff scheduling; defaults to `Date.now`. */
+  readonly now?: () => number;
+  /** Refresh seams (network/filesystem/retry); defaults let production hit the real deps. */
+  readonly refreshDeps?: RefreshDeps;
+}
+
+/** A running scheduler the caller can kick manually or stop on shutdown. */
+export interface TimekprMirrorRefreshHandle {
+  /** Run one refresh pass now (also what each cron tick invokes). */
+  tick(): Promise<void>;
+  /** Stop the schedule permanently (e.g. on `app.close()`). */
+  stop(): void;
+}
+
+/**
+ * Start the mirror refresh scheduler and return a handle.
+ *
+ * Overlapping runs are suppressed (croner `protect`), so a slow download can't
+ * stack up behind the schedule. A tick never throws: a failed refresh is caught,
+ * logged, and backed off; a success clears the backoff. The caller typically
+ * kicks {@link TimekprMirrorRefreshHandle.tick} once after `listen` to warm the
+ * cache immediately (still off the client path).
+ */
+export function startTimekprMirrorRefresh(
+  options: TimekprMirrorRefreshOptions,
+): TimekprMirrorRefreshHandle {
+  const { config, log } = options;
+  const pattern = options.pattern ?? DEFAULT_REFRESH_PATTERN;
+  const backoff = options.backoff ?? DEFAULT_REFRESH_BACKOFF;
+  const now = options.now ?? Date.now;
+  const child = log.child({ component: REFRESH_LOG_COMPONENT });
+
+  /** Consecutive failures + the epoch-ms before which the next tick is skipped. */
+  let failures = 0;
+  let nextEligibleAt = 0;
+
+  const tick = async (): Promise<void> => {
+    if (now() < nextEligibleAt) {
+      child.debug({ nextEligibleAt }, "timekpr mirror refresh skipped: in backoff");
+      return;
+    }
+    try {
+      const result = await refreshTimekprMirror(config, options.refreshDeps);
+      failures = 0;
+      nextEligibleAt = 0;
+      if (result.fetched) {
+        child.info(
+          { version: result.version, filename: result.filename },
+          "timekpr mirror refreshed",
+        );
+      } else {
+        child.debug({ version: result.version }, "timekpr mirror already current");
+      }
+    } catch (error) {
+      failures += 1;
+      const delay = Math.min(backoff.baseMs * 2 ** (failures - 1), backoff.maxMs);
+      nextEligibleAt = now() + delay;
+      child.warn(
+        { err: error, failures, nextRetryMs: delay },
+        "timekpr mirror refresh failed; backing off",
+      );
+    }
+  };
+
+  const job = new Cron(pattern, { name: "timekpr-mirror-refresh", protect: true }, tick);
+
+  return {
+    tick,
+    stop: () => job.stop(),
+  };
+}

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -24,6 +24,7 @@ import {
   type AdGuardService,
 } from "../transport/adguard/index.js";
 import { type PolicyPushTransport } from "../transport/policy-push/index.js";
+import { type TimekprMirrorRefreshHandle } from "../transport/timekpr-mirror/index.js";
 import { buildAppServices } from "./app-services.js";
 import { registerFrontend } from "./frontend.js";
 import { registerInstallScript } from "./install-script.js";
@@ -77,6 +78,14 @@ declare module "fastify" {
      * after `listen`, and `buildApp`'s `onClose` hook stops it.
      */
     enforcementPipeline: EnforcementPipelineHandle | null;
+    /**
+     * The managed-mode `timekpr-next` mirror refresh scheduler handle (#392), or
+     * `null` until wired. Like the other schedulers it is **not** started by
+     * `buildApp` (so building the app — including tests — starts no timer);
+     * `main.ts` assigns it after `listen` in `managed` mirror mode. `buildApp`
+     * only owns its teardown: an `onClose` hook stops it if set.
+     */
+    timekprMirrorRefresh: TimekprMirrorRefreshHandle | null;
   }
 }
 
@@ -200,6 +209,16 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   app.decorate("adguardHealthPoll", null);
   app.addHook("onClose", async () => {
     app.adguardHealthPoll?.stop();
+  });
+
+  // The managed-mode timekpr mirror refresh scheduler (#392) is likewise started
+  // by main.ts after listen (not here, so building the app starts no timer);
+  // buildApp owns only its teardown. Initialised null and stopped on close if
+  // main.ts wired it — read from the decorator so the value main.ts assigns is
+  // the one torn down.
+  app.decorate("timekprMirrorRefresh", null);
+  app.addHook("onClose", async () => {
+    app.timekprMirrorRefresh?.stop();
   });
 
   app.get("/", async (_request, reply) => {

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -376,6 +376,7 @@ describe("loadSettings", () => {
           mode: "managed",
           dataDir: "/data/apt/timekpr",
           package: "timekpr-next",
+          refreshCron: "0 3 * * *",
         });
       });
 
@@ -392,6 +393,7 @@ describe("loadSettings", () => {
           dataDir: "/srv/apt/timekpr",
           package: "timekpr-next-beta",
           version: "0.5.5",
+          refreshCron: "0 3 * * *",
         });
       });
 
@@ -402,6 +404,27 @@ describe("loadSettings", () => {
             PCT_TIMEKPR_MIRROR_PACKAGE: "timekpr-nope",
           }),
         ).toThrow(SettingsError);
+      });
+
+      it("honours an explicit refresh cron pattern (#392)", () => {
+        const settings = loadSettings({
+          PCT_TIMEKPR_MIRROR: "managed",
+          PCT_TIMEKPR_MIRROR_REFRESH_CRON: "30 4 * * 1",
+        });
+
+        expect(settings.timekprMirror).toMatchObject({
+          mode: "managed",
+          refreshCron: "30 4 * * 1",
+        });
+      });
+
+      it("rejects an invalid refresh cron pattern, naming the field (#392)", () => {
+        expect(() =>
+          loadSettings({
+            PCT_TIMEKPR_MIRROR: "managed",
+            PCT_TIMEKPR_MIRROR_REFRESH_CRON: "not a cron",
+          }),
+        ).toThrow(/valid cron pattern/);
       });
     });
   });

--- a/server/tests/transport/timekpr-mirror/refresh.test.ts
+++ b/server/tests/transport/timekpr-mirror/refresh.test.ts
@@ -248,4 +248,18 @@ describe("refreshTimekprMirror", () => {
       ),
     ).rejects.toThrow("connection reset");
   });
+
+  it("clamps a non-positive retryAttempts to a single attempt", async () => {
+    // retryAttempts: 0 must still run once (clamped) and surface the real error,
+    // never an `undefined` "last error" from a loop that never entered.
+    const fetchImpl: DownloadFetch = async () => {
+      throw new Error("connection reset");
+    };
+    await expect(
+      refreshTimekprMirror(
+        { dataDir: DATA_DIR, package: PKG },
+        { fetch: fetchImpl, sleep: async () => undefined, retryAttempts: 0, ...memFs().deps },
+      ),
+    ).rejects.toThrow("connection reset");
+  });
 });

--- a/server/tests/transport/timekpr-mirror/refresh.test.ts
+++ b/server/tests/transport/timekpr-mirror/refresh.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for the timekpr-mirror fetch/refresh (#392).
+ *
+ * Network (`fetch`), filesystem, and the retry clock (`sleep`) are injected, so
+ * no test touches the real network or disk: a fake `fetch` serves the Launchpad
+ * `getPublishedBinaries` + `binaryFileUrls` responses and a `.deb` body, and an
+ * in-memory file map stands in for the data volume. Covers latest/pinned
+ * resolution, skip-when-current idempotency, the structural `.deb` check, and the
+ * download/parse/retry failure paths.
+ */
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  TimekprMirrorDownloadError,
+  TimekprMirrorInvalidPackageError,
+  VERSION_SENTINEL,
+  refreshTimekprMirror,
+  type DownloadFetch,
+  type RefreshDeps,
+} from "../../../src/transport/timekpr-mirror/refresh.js";
+import { TimekprMirrorResolveError } from "../../../src/transport/timekpr-mirror/release.js";
+
+const DATA_DIR = "/data/apt/timekpr";
+const PKG = "timekpr-next";
+const SELF = "https://api.launchpad.net/devel/~mjasnik/+archive/ubuntu/ppa/+binarypub/1";
+const FILES = "https://launchpad.net/~mjasnik/+archive/ubuntu/ppa/+files";
+
+/** A minimal valid `.deb`: the Debian ar global header followed by content. */
+function debBody(): Buffer {
+  return Buffer.concat([Buffer.from("!<arch>\n", "ascii"), Buffer.from("payload")]);
+}
+
+interface Routes {
+  /** Versions to publish, newest first (drives getPublishedBinaries). */
+  versions?: string[];
+  /** File URLs returned by binaryFileUrls (defaults to the _all.deb for versions[0]). */
+  fileUrls?: string[];
+  /** Body returned for a .deb download (defaults to a valid .deb). */
+  deb?: Buffer;
+  /** URL substrings that should fail with a status instead of succeeding. */
+  fail?: { match: string; status: number; statusText: string };
+}
+
+function fakeFetch(routes: Routes): { fetch: DownloadFetch; calls: string[] } {
+  const calls: string[] = [];
+  const versions = routes.versions ?? ["0.5.7-1"];
+  const fileUrls = routes.fileUrls ?? [`${FILES}/${PKG}_${versions[0]}_all.deb`];
+  const deb = routes.deb ?? debBody();
+
+  const fetch: DownloadFetch = async (url) => {
+    calls.push(url);
+    const notFound = {
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      arrayBuffer: async () => new ArrayBuffer(0),
+      text: async () => "",
+      json: async () => ({}),
+    };
+    if (routes.fail && url.includes(routes.fail.match)) {
+      return { ...notFound, status: routes.fail.status, statusText: routes.fail.statusText };
+    }
+    if (url.includes("ws.op=getPublishedBinaries")) {
+      return {
+        ...notFound,
+        ok: true,
+        status: 200,
+        json: async () => ({
+          entries: versions.map((version) => ({
+            binary_package_name: PKG,
+            binary_package_version: version,
+            self_link: SELF,
+          })),
+        }),
+      };
+    }
+    if (url.includes("ws.op=binaryFileUrls")) {
+      return { ...notFound, ok: true, status: 200, json: async () => fileUrls };
+    }
+    if (url.endsWith(".deb")) {
+      return {
+        ...notFound,
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => {
+          const ab = new ArrayBuffer(deb.byteLength);
+          new Uint8Array(ab).set(deb);
+          return ab;
+        },
+      };
+    }
+    return notFound;
+  };
+  return { fetch, calls };
+}
+
+/** In-memory filesystem seams over a `Map<path, contents>`. */
+function memFs(initial: Record<string, string> = {}): {
+  files: Map<string, Buffer | string>;
+  deps: Pick<RefreshDeps, "fileExists" | "readSentinel" | "makeDir" | "writeDeb" | "writeSentinel">;
+} {
+  const files = new Map<string, Buffer | string>(Object.entries(initial));
+  return {
+    files,
+    deps: {
+      fileExists: (path) => files.has(path),
+      readSentinel: (path) => {
+        const value = files.get(path);
+        return typeof value === "string" ? value.trim() : null;
+      },
+      makeDir: () => undefined,
+      writeDeb: (path, contents) => void files.set(path, contents),
+      writeSentinel: (path, value) => void files.set(path, `${value}\n`),
+    },
+  };
+}
+
+/** Deps with no real timers: `sleep` resolves immediately. */
+function seams(routes: Routes, fs = memFs()): { deps: RefreshDeps; calls: string[] } {
+  const { fetch, calls } = fakeFetch(routes);
+  return { deps: { fetch, sleep: async () => undefined, ...fs.deps }, calls };
+}
+
+describe("refreshTimekprMirror", () => {
+  it("downloads the newest .deb and records the sentinel on first run", async () => {
+    const fs = memFs();
+    const { deps } = seams({ versions: ["0.5.7-1", "0.5.6-1"] }, fs);
+
+    const result = await refreshTimekprMirror({ dataDir: DATA_DIR, package: PKG }, deps);
+
+    expect(result).toEqual({
+      version: "0.5.7-1",
+      filename: "timekpr-next_0.5.7-1_all.deb",
+      path: join(DATA_DIR, "timekpr-next_0.5.7-1_all.deb"),
+      fetched: true,
+    });
+    expect(fs.files.get(join(DATA_DIR, "timekpr-next_0.5.7-1_all.deb"))).toBeInstanceOf(Buffer);
+    expect(fs.files.get(join(DATA_DIR, VERSION_SENTINEL))).toBe("0.5.7-1\n");
+  });
+
+  it("is a no-op when the resolved version is already current", async () => {
+    const path = join(DATA_DIR, "timekpr-next_0.5.7-1_all.deb");
+    const fs = memFs({ [path]: "existing", [join(DATA_DIR, VERSION_SENTINEL)]: "0.5.7-1\n" });
+    const { deps, calls } = seams({ versions: ["0.5.7-1"] }, fs);
+
+    const result = await refreshTimekprMirror({ dataDir: DATA_DIR, package: PKG }, deps);
+
+    expect(result.fetched).toBe(false);
+    expect(result.version).toBe("0.5.7-1");
+    // Only the getPublishedBinaries lookup ran — no binaryFileUrls, no download.
+    expect(calls.some((u) => u.includes("ws.op=binaryFileUrls"))).toBe(false);
+    expect(calls.some((u) => u.endsWith(".deb"))).toBe(false);
+  });
+
+  it("re-fetches when the sentinel drifts from the resolved version", async () => {
+    const oldPath = join(DATA_DIR, "timekpr-next_0.5.6-1_all.deb");
+    const fs = memFs({ [oldPath]: "old", [join(DATA_DIR, VERSION_SENTINEL)]: "0.5.6-1\n" });
+    const { deps } = seams({ versions: ["0.5.7-1"] }, fs);
+
+    const result = await refreshTimekprMirror({ dataDir: DATA_DIR, package: PKG }, deps);
+
+    expect(result).toMatchObject({ version: "0.5.7-1", fetched: true });
+    expect(fs.files.get(join(DATA_DIR, VERSION_SENTINEL))).toBe("0.5.7-1\n");
+  });
+
+  it("re-fetches when the sentinel matches but the .deb file is missing", async () => {
+    const fs = memFs({ [join(DATA_DIR, VERSION_SENTINEL)]: "0.5.7-1\n" });
+    const { deps } = seams({ versions: ["0.5.7-1"] }, fs);
+
+    const result = await refreshTimekprMirror({ dataDir: DATA_DIR, package: PKG }, deps);
+
+    expect(result.fetched).toBe(true);
+  });
+
+  it("honours a pinned version instead of the newest", async () => {
+    const fs = memFs();
+    const { deps } = seams(
+      {
+        versions: ["0.5.7-1", "0.5.6-1"],
+        fileUrls: [`${FILES}/${PKG}_0.5.6-1_all.deb`],
+      },
+      fs,
+    );
+
+    const result = await refreshTimekprMirror(
+      { dataDir: DATA_DIR, package: PKG, version: "0.5.6-1" },
+      deps,
+    );
+
+    expect(result.version).toBe("0.5.6-1");
+    expect(result.filename).toBe("timekpr-next_0.5.6-1_all.deb");
+  });
+
+  it("throws a resolve error when a pinned version is not published", async () => {
+    const { deps } = seams({ versions: ["0.5.7-1"] });
+    await expect(
+      refreshTimekprMirror({ dataDir: DATA_DIR, package: PKG, version: "0.1.0-1" }, deps),
+    ).rejects.toThrow(TimekprMirrorResolveError);
+  });
+
+  it("wraps a non-2xx download in TimekprMirrorDownloadError", async () => {
+    const { deps } = seams({
+      versions: ["0.5.7-1"],
+      fail: { match: ".deb", status: 503, statusText: "Unavailable" },
+    });
+    await expect(
+      refreshTimekprMirror({ dataDir: DATA_DIR, package: PKG }, deps),
+    ).rejects.toBeInstanceOf(TimekprMirrorDownloadError);
+  });
+
+  it("rejects a body that is not a Debian package", async () => {
+    const { deps } = seams({ versions: ["0.5.7-1"], deb: Buffer.from("<html>oops</html>") });
+    await expect(
+      refreshTimekprMirror({ dataDir: DATA_DIR, package: PKG }, deps),
+    ).rejects.toBeInstanceOf(TimekprMirrorInvalidPackageError);
+  });
+
+  it("retries a transient failure and eventually succeeds", async () => {
+    let attempts = 0;
+    const inner = fakeFetch({ versions: ["0.5.7-1"] }).fetch;
+    const fetchImpl: DownloadFetch = async (url, init) => {
+      if (url.includes("ws.op=getPublishedBinaries")) {
+        attempts += 1;
+        if (attempts < 3) throw new Error("connection reset");
+      }
+      return inner(url, init);
+    };
+    const sleep = vi.fn(async () => undefined);
+    const result = await refreshTimekprMirror(
+      { dataDir: DATA_DIR, package: PKG },
+      { fetch: fetchImpl, sleep, ...memFs().deps },
+    );
+    expect(result.fetched).toBe(true);
+    expect(attempts).toBe(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates the last error when retries are exhausted", async () => {
+    const fetchImpl: DownloadFetch = async () => {
+      throw new Error("connection reset");
+    };
+    await expect(
+      refreshTimekprMirror(
+        { dataDir: DATA_DIR, package: PKG },
+        { fetch: fetchImpl, sleep: async () => undefined, retryAttempts: 2, ...memFs().deps },
+      ),
+    ).rejects.toThrow("connection reset");
+  });
+});

--- a/server/tests/transport/timekpr-mirror/release.test.ts
+++ b/server/tests/transport/timekpr-mirror/release.test.ts
@@ -117,6 +117,10 @@ describe("debFilename", () => {
   it("builds the arch-independent .deb name", () => {
     expect(debFilename(PKG, "0.5.7-1")).toBe("timekpr-next_0.5.7-1_all.deb");
   });
+
+  it("strips a Debian epoch (the filename never carries it)", () => {
+    expect(debFilename(PKG, "1:0.5.7-1")).toBe("timekpr-next_0.5.7-1_all.deb");
+  });
 });
 
 describe("selectDebUrl", () => {

--- a/server/tests/transport/timekpr-mirror/release.test.ts
+++ b/server/tests/transport/timekpr-mirror/release.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the pure Launchpad-PPA release coordinates (#392): URL builders,
+ * zod validation of the `getPublishedBinaries` / `binaryFileUrls` responses, and
+ * the latest/pinned/`.deb`-URL selection helpers. No I/O — the fetch module is
+ * tested separately with injected seams.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  DEB_AR_MAGIC,
+  TIMEKPR_PPA_NAME,
+  TIMEKPR_PPA_OWNER,
+  TimekprMirrorResolveError,
+  binaryFileUrlsSchema,
+  binaryFileUrlsUrl,
+  debFilename,
+  parseLatestPublication,
+  publishedBinariesSchema,
+  publishedBinariesUrl,
+  selectDebUrl,
+  selectPinnedPublication,
+} from "../../../src/transport/timekpr-mirror/release.js";
+
+const PKG = "timekpr-next";
+const SELF = "https://api.launchpad.net/devel/~mjasnik/+archive/ubuntu/ppa/+binarypub/1";
+
+function collection(entries: { version: string; self?: string }[]) {
+  return publishedBinariesSchema.parse({
+    entries: entries.map((e) => ({
+      binary_package_name: PKG,
+      binary_package_version: e.version,
+      self_link: e.self ?? SELF,
+    })),
+  });
+}
+
+describe("publishedBinariesUrl", () => {
+  it("targets the mjasnik PPA with the scoping query params", () => {
+    const url = publishedBinariesUrl(PKG);
+    expect(url).toContain(`~${TIMEKPR_PPA_OWNER}/+archive/ubuntu/${TIMEKPR_PPA_NAME}`);
+    expect(url).toContain("ws.op=getPublishedBinaries");
+    expect(url).toContain(`binary_name=${PKG}`);
+    expect(url).toContain("status=Published");
+    expect(url).toContain("exact_match=true");
+    expect(url).toContain("order_by_date=true");
+    expect(url).toContain("ws.size=");
+  });
+});
+
+describe("binaryFileUrlsUrl", () => {
+  it("appends the op with ? when the self link has no query", () => {
+    expect(binaryFileUrlsUrl(SELF)).toBe(`${SELF}?ws.op=binaryFileUrls`);
+  });
+
+  it("appends the op with & when the self link already has a query", () => {
+    expect(binaryFileUrlsUrl(`${SELF}?foo=bar`)).toBe(`${SELF}?foo=bar&ws.op=binaryFileUrls`);
+  });
+});
+
+describe("publishedBinariesSchema", () => {
+  it("strips unknown Launchpad fields and keeps the ones we use", () => {
+    const parsed = publishedBinariesSchema.parse({
+      entries: [
+        {
+          binary_package_name: PKG,
+          binary_package_version: "0.5.7-1",
+          self_link: SELF,
+          component_name: "main",
+          status: "Published",
+        },
+      ],
+    });
+    expect(parsed.entries[0]).toEqual({
+      binary_package_name: PKG,
+      binary_package_version: "0.5.7-1",
+      self_link: SELF,
+    });
+  });
+
+  it("rejects a body missing a required field", () => {
+    expect(() =>
+      publishedBinariesSchema.parse({ entries: [{ binary_package_version: "0.5.7-1" }] }),
+    ).toThrow();
+  });
+});
+
+describe("parseLatestPublication", () => {
+  it("returns the first (most recently published) entry", () => {
+    const latest = parseLatestPublication(
+      collection([{ version: "0.5.7-1" }, { version: "0.5.6-1" }]),
+    );
+    expect(latest.binary_package_version).toBe("0.5.7-1");
+  });
+
+  it("throws a resolve error when the collection is empty", () => {
+    expect(() => parseLatestPublication(collection([]))).toThrow(TimekprMirrorResolveError);
+  });
+});
+
+describe("selectPinnedPublication", () => {
+  it("returns the entry matching the pinned version", () => {
+    const pinned = selectPinnedPublication(
+      collection([{ version: "0.5.7-1" }, { version: "0.5.6-1" }]),
+      "0.5.6-1",
+    );
+    expect(pinned.binary_package_version).toBe("0.5.6-1");
+  });
+
+  it("throws a resolve error when the pin is not published", () => {
+    expect(() => selectPinnedPublication(collection([{ version: "0.5.7-1" }]), "0.4.0-1")).toThrow(
+      TimekprMirrorResolveError,
+    );
+  });
+});
+
+describe("debFilename", () => {
+  it("builds the arch-independent .deb name", () => {
+    expect(debFilename(PKG, "0.5.7-1")).toBe("timekpr-next_0.5.7-1_all.deb");
+  });
+});
+
+describe("selectDebUrl", () => {
+  const base = "https://launchpad.net/~mjasnik/+archive/ubuntu/ppa/+files";
+
+  it("picks the _all.deb URL for the exact version", () => {
+    const urls = binaryFileUrlsSchema.parse([
+      `${base}/timekpr-next_0.5.7-1.dsc`,
+      `${base}/timekpr-next_0.5.7-1_all.deb`,
+    ]);
+    expect(selectDebUrl(urls, PKG, "0.5.7-1")).toBe(`${base}/timekpr-next_0.5.7-1_all.deb`);
+  });
+
+  it("matches by basename even when the URL carries a query string", () => {
+    const urls = binaryFileUrlsSchema.parse([`${base}/timekpr-next_0.5.7-1_all.deb?token=abc`]);
+    expect(selectDebUrl(urls, PKG, "0.5.7-1")).toBe(
+      `${base}/timekpr-next_0.5.7-1_all.deb?token=abc`,
+    );
+  });
+
+  it("throws a resolve error when no matching .deb is present", () => {
+    const urls = binaryFileUrlsSchema.parse([`${base}/timekpr-next_0.5.6-1_all.deb`]);
+    expect(() => selectDebUrl(urls, PKG, "0.5.7-1")).toThrow(TimekprMirrorResolveError);
+  });
+});
+
+describe("DEB_AR_MAGIC", () => {
+  it("is the Debian ar global header", () => {
+    expect(DEB_AR_MAGIC).toBe("!<arch>\n");
+  });
+});

--- a/server/tests/transport/timekpr-mirror/scheduler.test.ts
+++ b/server/tests/transport/timekpr-mirror/scheduler.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the timekpr-mirror refresh scheduler (#392): the tick that runs
+ * a refresh pass, logs its outcome, catches + backs off failures (so a tick
+ * never throws), clears backoff on success, and the start/stop lifecycle. The
+ * cron schedule itself isn't fired — `tick()` (the same function each cron tick
+ * invokes) is driven directly, exactly like the reapply scheduler tests.
+ */
+import type { FastifyBaseLogger } from "fastify";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { DownloadFetch, RefreshDeps } from "../../../src/transport/timekpr-mirror/index.js";
+import {
+  DEFAULT_REFRESH_BACKOFF,
+  DEFAULT_REFRESH_PATTERN,
+  REFRESH_LOG_COMPONENT,
+  startTimekprMirrorRefresh,
+  type TimekprMirrorRefreshHandle,
+  type TimekprMirrorRefreshOptions,
+} from "../../../src/transport/timekpr-mirror/index.js";
+
+const CONFIG = { dataDir: "/data/apt/timekpr", package: "timekpr-next" };
+const SELF = "https://api.launchpad.net/devel/~mjasnik/+archive/ubuntu/ppa/+binarypub/1";
+const DEB =
+  "https://launchpad.net/~mjasnik/+archive/ubuntu/ppa/+files/timekpr-next_0.5.7-1_all.deb";
+
+/** A capturing logger that records every line by level. */
+function capturingLog(): { log: FastifyBaseLogger; lines: { level: string; obj: unknown }[] } {
+  const lines: { level: string; obj: unknown }[] = [];
+  const record =
+    (level: string) =>
+    (obj: unknown): void =>
+      void lines.push({ level, obj });
+  const log = {
+    child: () => log,
+    info: record("info"),
+    warn: record("warn"),
+    debug: record("debug"),
+    error: record("error"),
+    fatal: record("fatal"),
+    trace: record("trace"),
+  } as unknown as FastifyBaseLogger;
+  return { log, lines };
+}
+
+/** A `fetch` that serves the Launchpad lookups + a valid `.deb` body. */
+function buildOkFetch(): DownloadFetch {
+  const deb = Buffer.concat([Buffer.from("!<arch>\n", "ascii"), Buffer.from("x")]);
+  return async (url) => {
+    const base = {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      arrayBuffer: async () => {
+        const ab = new ArrayBuffer(deb.byteLength);
+        new Uint8Array(ab).set(deb);
+        return ab;
+      },
+      text: async () => "",
+      json: async () => ({}),
+    };
+    if (url.includes("ws.op=getPublishedBinaries")) {
+      return {
+        ...base,
+        json: async () => ({
+          entries: [
+            {
+              binary_package_name: "timekpr-next",
+              binary_package_version: "0.5.7-1",
+              self_link: SELF,
+            },
+          ],
+        }),
+      };
+    }
+    if (url.includes("ws.op=binaryFileUrls")) {
+      return { ...base, json: async () => [DEB] };
+    }
+    return base;
+  };
+}
+
+/** In-memory refresh seams: a `.deb` body, controllable per-URL, no real timers. */
+function refreshSeams(overrides: Partial<RefreshDeps> = {}): RefreshDeps {
+  return {
+    fetch: buildOkFetch(),
+    fileExists: () => false,
+    readSentinel: () => null,
+    makeDir: () => undefined,
+    writeDeb: () => undefined,
+    writeSentinel: () => undefined,
+    sleep: async () => undefined,
+    ...overrides,
+  };
+}
+
+function start(options: Partial<TimekprMirrorRefreshOptions>, log: FastifyBaseLogger) {
+  return startTimekprMirrorRefresh({ config: CONFIG, log, ...options });
+}
+
+describe("startTimekprMirrorRefresh", () => {
+  const handles: TimekprMirrorRefreshHandle[] = [];
+  const track = (h: TimekprMirrorRefreshHandle): TimekprMirrorRefreshHandle => {
+    handles.push(h);
+    return h;
+  };
+  // Stop every scheduler a test started so no cron timer leaks between tests.
+  afterEach(() => {
+    while (handles.length > 0) handles.pop()?.stop();
+  });
+
+  it("exposes the default pattern, backoff, and log component", () => {
+    expect(DEFAULT_REFRESH_PATTERN).toBe("0 3 * * *");
+    expect(DEFAULT_REFRESH_BACKOFF.baseMs).toBeGreaterThan(0);
+    expect(DEFAULT_REFRESH_BACKOFF.maxMs).toBeGreaterThan(DEFAULT_REFRESH_BACKOFF.baseMs);
+    expect(REFRESH_LOG_COMPONENT).toBe("transport/timekpr-mirror");
+  });
+
+  it("runs a refresh on tick and logs the fetched version", async () => {
+    const { log, lines } = capturingLog();
+    const handle = track(start({ refreshDeps: refreshSeams() }, log));
+
+    await handle.tick();
+
+    const info = lines.find((l) => l.level === "info");
+    expect(info?.obj).toMatchObject({ version: "0.5.7-1" });
+    handle.stop();
+  });
+
+  it("logs debug (not info) when the mirror is already current", async () => {
+    const { log, lines } = capturingLog();
+    const deps = refreshSeams({
+      fileExists: () => true,
+      readSentinel: () => "0.5.7-1",
+    });
+    const handle = track(start({ refreshDeps: deps }, log));
+
+    await handle.tick();
+
+    expect(lines.some((l) => l.level === "info")).toBe(false);
+    expect(lines.some((l) => l.level === "debug")).toBe(true);
+    handle.stop();
+  });
+
+  it("catches a failed refresh, never throws, and backs off", async () => {
+    const { log, lines } = capturingLog();
+    const clock = 1000;
+    const deps = refreshSeams({
+      fetch: async () => {
+        throw new Error("launchpad unreachable");
+      },
+      retryAttempts: 1,
+    });
+    const handle = track(start({ refreshDeps: deps, now: () => clock }, log));
+
+    await expect(handle.tick()).resolves.toBeUndefined();
+    const warn = lines.find((l) => l.level === "warn");
+    expect(warn?.obj).toMatchObject({ failures: 1 });
+
+    // The next tick, still within the backoff window, is skipped (no new warn).
+    const warnsBefore = lines.filter((l) => l.level === "warn").length;
+    await handle.tick();
+    expect(lines.filter((l) => l.level === "warn").length).toBe(warnsBefore);
+    handle.stop();
+  });
+
+  it("clears the backoff after a later success", async () => {
+    const { log, lines } = capturingLog();
+    let clock = 1000;
+    let failNext = true;
+    const okFetch = buildOkFetch();
+    const deps = refreshSeams({
+      fetch: async (url, init) => {
+        if (failNext) throw new Error("transient");
+        return okFetch(url, init);
+      },
+      retryAttempts: 1,
+    });
+    const handle = track(start({ refreshDeps: deps, now: () => clock }, log));
+
+    await handle.tick(); // fails, backs off
+    clock += DEFAULT_REFRESH_BACKOFF.maxMs; // jump past the backoff window
+    failNext = false;
+    await handle.tick(); // succeeds, clears backoff
+
+    expect(lines.some((l) => l.level === "info")).toBe(true);
+    handle.stop();
+  });
+
+  it("stop() halts the schedule without throwing", () => {
+    const { log } = capturingLog();
+    const handle = start({ refreshDeps: refreshSeams() }, log);
+    expect(() => handle.stop()).not.toThrow();
+  });
+});

--- a/server/tests/web/app.test.ts
+++ b/server/tests/web/app.test.ts
@@ -50,6 +50,16 @@ describe("web app routes", () => {
 
     expect(res.statusCode).toBe(404);
   });
+
+  it("defaults the timekpr mirror refresh handle to null and stops it on close (#392)", async () => {
+    const local = buildTestApp();
+    // Null until main.ts wires it in managed mode — building the app starts no timer.
+    expect(local.app.timekprMirrorRefresh).toBeNull();
+    const stop = vi.fn();
+    local.app.timekprMirrorRefresh = { tick: async () => undefined, stop };
+    await local.close();
+    expect(stop).toHaveBeenCalledOnce();
+  });
 });
 
 // trustProxy redefines `request.ip`, which is the key the per-IP


### PR DESCRIPTION
## Summary

- The **fetch half** of the managed `timekpr-next` mirror (epic #389): a background job that keeps `/data/apt/timekpr/` current with the upstream `.deb`, off every client's install/enrol critical path — where the Launchpad latency goes to die.
- Modelled directly on managed-mode AdGuard Home acquisition (`transport/adguard/{release,acquire}.ts`, #96): pure Launchpad-PPA coordinate/parse helpers + a fetch/refresh function whose every network/filesystem/clock boundary is an injected seam + a croner scheduler with overlap protection and per-failure backoff.
- Resolves the newest published version from the `~mjasnik/ppa` Launchpad API (`getPublishedBinaries` → `binaryFileUrls`), or honours a pinned `PCT_TIMEKPR_MIRROR_VERSION`, downloads the arch-independent `_all.deb` with retry/backoff, skips when already current via a version sentinel, and structurally verifies the Debian `ar` header. Started only in `managed` mirror mode.

## Plan

Linked plan: `docs/plans/392-timekpr-mirror-fetch-refresh.md`
ADR: `docs/adr/0011-server-hosted-upstream-package-mirror.md`
Roadmap: `docs/roadmap.md` → Phase 3 (config seam #391 merged; this is #392 in the epic's `#392 → #393 → #394; #395 last` chain)

## License-boundary note

Within the boundary by construction (ADR 0011, the AdGuard managed-mode precedent). Pure TypeScript that **fetches** a GPL `.deb` at runtime and **writes it to the `/data` volume** — nothing links, imports, or vendors GPL code, and no GPL binary is baked into the image (no packaging/image change here; `license-guard` unaffected, and the Docker-image-build check is green). Signed apt index generation, serving `/apt/timekpr/*`, enrol advertisement, and cryptographic (apt `Release`/`Packages`) verification are the **#393** slice; this MVP trusts HTTPS + a structural `.deb` check, called out in the module docstrings.

## No new dependencies

Uses `croner`, `zod`, and Node built-ins already in the tree.

## Test plan

- [x] `release.ts`: URL builders; zod strips/validates the LP responses; latest vs. pinned selection; empty/absent → typed error; `_all.deb` URL selection (incl. query-string basenames).
- [x] `refresh.ts`: first-run download + sentinel; skip-when-current; re-fetch on sentinel drift / missing file; pinned version; non-2xx → `TimekprMirrorDownloadError`; non-`.deb` body → `TimekprMirrorInvalidPackageError`; retry-then-succeed and retry-exhaustion.
- [x] `scheduler.ts`: tick runs refresh + logs; a thrown refresh is caught, logged, backed off (never escapes the tick); backoff clears on success; start/stop lifecycle; default pattern/backoff/log-component exports.
- [x] Config `refreshCron` default + custom + invalid (fails fast naming the field); `buildApp` null-default + `onClose` teardown.
- [x] Full gate green: server 1988 passing, coverage gate satisfied; format/lint/typecheck clean; all 16 CI checks green.

## Deferred (tracked)

- Signed apt index + serve `/apt/timekpr/*` + enrol advertisement + cryptographic verification → **#393**.
- Client `install-baseline-tools.sh` mirror repo path + orchestrator/enrol plumbing → **#394**.
- Docs + `license-guard` confirmation → **#395**.
- Optional upstream source-package mirroring → epic #389 enhancement.

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)