### PR TITLE
feat(frontend): surface inherited group budgets in the cadence picker (#403)

### DIFF
--- a/docs/plans/403-cadence-picker-inherited-group-budgets.md
+++ b/docs/plans/403-cadence-picker-inherited-group-budgets.md
@@ -1,0 +1,74 @@
+# Plan — #403: Cadence picker surfaces inherited group budgets
+
+Roadmap: `docs/roadmap.md` → Phase 8b. Follow-up to #388 (own-budget cadence
+picker); composes with #363 (resolved / group budgets, `listResolvedBudgets`).
+
+## Problem
+
+`NotificationsView`'s per-budget warning-cadence picker (`/admin/notifications`,
+#388) sources its options from the selected user's **own** budgets
+(`listBudgets(userId)`). It does **not** offer a cadence-override target for a
+budget the user only **inherits** via a `UserGroup` (a `GroupBudget`, surfaced
+by `listResolvedBudgets(userId)` with `source.kind === "group"`) — unless the
+user also happens to have an own budget for that same `(scope, target)`.
+
+A stored override for such an inherited-only budget already round-trips (its
+key is folded in as a stale-key option), so this is a **discoverability** gap,
+not data loss: you can't *add* a cadence override for an inherited group budget
+from the picker today.
+
+## Approach (frontend-only)
+
+Extend the picker's option source to include inherited resolved budgets,
+keeping the existing `(scope, target)` collapse and own-wins de-duplication.
+
+1. **Load resolved budgets alongside own budgets.** In `loadBudgets(userId)`
+   also call `listResolvedBudgets(userId)` (best-effort, same failure posture as
+   the own-budget load — a failure degrades the picker to Overall + stored keys,
+   never blocks editing). Store in new `resolvedBudgets` state; reset it on
+   user de-select exactly like `budgets`.
+
+2. **Fold inherited keys into `budgetOptions`.** Compute the own-budget key set
+   as today. Then walk `resolvedBudgets`, and for each entry with
+   `source.kind === "group"` and a non-null `targetId`, derive the same cadence
+   key (`activity:<id>` / `group:<id>`) and collect it into an `inheritedKeys`
+   set. (Inherited *overall* needs no handling — `overall` is always present and
+   never marked.)
+
+3. **Own budgets win.** A key that is both an own budget and inherited is *not*
+   marked — only purely-inherited keys (`inheritedKeys \ ownKeys`) get the
+   `(inherited)` suffix, matching #363/#343's own-vs-inherited presentation and
+   the issue's "unless the user also has an own budget" wording.
+
+4. **Mark inherited-only options.** Append ` (inherited)` to the label of a
+   purely-inherited option in `budgetOptions`; `labelForKey` stays the shared
+   name resolver. Stored-key folding and ordering (overall → activities →
+   groups, then by label) are unchanged.
+
+No storage-grammar change: the stored key is still `overall|activity:<id>|
+group:<id>` — an inherited group budget is keyed identically to an own one, so
+save/hydrate is untouched. No API/DTO change: `listResolvedBudgets` and
+`ResolvedBudgetResponse` already exist (#363).
+
+## Tests (frontend vitest, `tests/components/notifications-view.test.ts`)
+
+Extend the existing `$lib/api/budgets` mock to also expose
+`listResolvedBudgets` (defaulting to `[]` so every existing case is unaffected),
+then add:
+
+- An inherited-only group budget (`source.kind: "group"`) surfaces as a
+  pickable `group:<id>` option labelled `Group — <name> (inherited)`, and an
+  override picked from it keys/saves as `group:<id>`.
+- An inherited budget the user *also* owns is offered **once**, **without** the
+  `(inherited)` suffix (own wins).
+- A `listResolvedBudgets` failure degrades gracefully (Overall still offered;
+  editing still works), mirroring the existing own-budget-failure test.
+
+## Out of scope (unchanged from #403)
+
+- The combined per-user editor / effective-schedule view (#343).
+- Any change to how inherited budgets are resolved server-side (#363 owns that).
+
+## License boundary
+
+None touched — frontend-only TypeScript/Svelte over the existing JSON API.

--- a/server/frontend/src/lib/views/NotificationsView.svelte
+++ b/server/frontend/src/lib/views/NotificationsView.svelte
@@ -18,11 +18,14 @@
   budget. This view edits them as rows (a budget picker + a comma-separated
   minute list), plus a "Clear all" that reverts to the built-in cadence.
 
-  The budget picker (#388) is sourced from the user's own budgets and labelled
-  with the activity/activity-group names (`Activity — firefox`, `Group — Games`)
-  rather than asking the admin to type a numeric target id. Options are keyed by
-  `(scope, target)` — the same key the grammar stores — and de-duplicated across
-  a target's daily / weekly / monthly rollover windows into a single entry. A
+  The budget picker (#388) is sourced from the user's own budgets — plus the
+  group budgets they only **inherit** via a `UserGroup` (#363/#403) — and
+  labelled with the activity/activity-group names (`Activity — firefox`,
+  `Group — Games`) rather than asking the admin to type a numeric target id.
+  Options are keyed by `(scope, target)` — the same key the grammar stores — and
+  de-duplicated across a target's daily / weekly / monthly rollover windows into
+  a single entry. Own budgets win: a target that is both owned and inherited is
+  offered once, unmarked; a purely-inherited target is marked "(inherited)". A
   stored override whose budget no longer exists stays pickable (its key is added
   to the option list) so hydrate→save is a faithful round-trip.
 -->
@@ -34,6 +37,7 @@
     ActivityResponse,
     BudgetResponse,
     NotificationPolicyResponse,
+    ResolvedBudgetResponse,
     SoundProfile,
     UserResponse,
   } from "$lib/api/contract.js";
@@ -43,7 +47,7 @@
     deleteNotificationPolicy,
   } from "$lib/api/notifications.js";
   import { listUsers } from "$lib/api/users.js";
-  import { listBudgets } from "$lib/api/budgets.js";
+  import { listBudgets, listResolvedBudgets } from "$lib/api/budgets.js";
   import { listActivities } from "$lib/api/activities.js";
   import { listActivityGroups } from "$lib/api/activity-groups.js";
 
@@ -85,6 +89,10 @@
   let loadingPolicy = $state(false);
   // The selected user's budgets — the source of the cadence picker options.
   let budgets = $state<BudgetResponse[]>([]);
+  // The selected user's resolved budget baseline (own + inherited group budgets,
+  // #363). Its `source.kind === "group"` slots feed the picker's inherited-only
+  // options (#403); own slots are already covered by `budgets`.
+  let resolvedBudgets = $state<ResolvedBudgetResponse[]>([]);
 
   // Editable form fields, hydrated from the loaded policy.
   let formEnabled = $state(true);
@@ -163,14 +171,22 @@
     }
   }
 
-  // Load the selected user's budgets to source the cadence picker options.
-  // Best-effort: a failure leaves the picker with the always-present "Overall"
-  // entry plus any keys the stored overrides already carry.
+  // Load the selected user's own + resolved budgets to source the cadence picker
+  // options. Best-effort: a failure leaves the picker with the always-present
+  // "Overall" entry plus any keys the stored overrides already carry. Both loads
+  // share one try so a failure of either degrades the picker identically and
+  // never blocks editing (#388, #403).
   async function loadBudgets(userId: number): Promise<void> {
     try {
-      budgets = await listBudgets(userId);
+      const [own, resolved] = await Promise.all([
+        listBudgets(userId),
+        listResolvedBudgets(userId),
+      ]);
+      budgets = own;
+      resolvedBudgets = resolved;
     } catch (err) {
       budgets = [];
+      resolvedBudgets = [];
       error ??= messageOf(err);
     }
   }
@@ -179,6 +195,7 @@
     if (selectedUserId === null) {
       policy = null;
       budgets = [];
+      resolvedBudgets = [];
       return;
     }
     void loadUserData(selectedUserId);
@@ -245,32 +262,67 @@
     return group ? `Group — ${group.name}` : `Group ${id}`;
   }
 
+  // The cadence key for a budget-shaped `(scope, targetId)`, or `null` for
+  // scopes that carry no per-target key (`overall`, which is always offered, and
+  // any non-`activity`/`group` scope defensively). Shared by the own-budget and
+  // inherited-budget passes so both derive the identical key.
+  function budgetKey(scope: string, targetId: number | null): string | null {
+    if (targetId === null) {
+      return null;
+    }
+    if (scope === "activity") {
+      return `activity:${targetId}`;
+    }
+    if (scope === "group") {
+      return `group:${targetId}`;
+    }
+    return null;
+  }
+
   // The picker options: always "Overall", plus one entry per distinct
-  // non-overall `(scope, target)` in the user's budgets — de-duplicated across
-  // the target's daily/weekly/monthly windows (the cadence key is keyed by
-  // target, not window). Keys already used by a row are folded in too, so a
-  // stored override for a since-deleted budget stays pickable (a faithful
-  // hydrate→save round-trip). Ordered overall → activities → groups, then by
-  // label.
+  // non-overall `(scope, target)` in the user's own budgets and the group
+  // budgets they only **inherit** (#403) — de-duplicated across the target's
+  // daily/weekly/monthly windows (the cadence key is keyed by target, not
+  // window). Own budgets win: a key that is both owned and inherited is offered
+  // once, unmarked; a purely-inherited key is marked "(inherited)". Keys already
+  // used by a row are folded in too, so a stored override for a since-deleted
+  // budget stays pickable (a faithful hydrate→save round-trip). Ordered
+  // overall → activities → groups, then by label.
   let budgetOptions = $derived.by<BudgetOption[]>(() => {
-    const keys = new Set<string>(["overall"]);
+    const ownKeys = new Set<string>(["overall"]);
     for (const budget of budgets) {
-      if (budget.targetId === null) {
-        continue;
-      }
-      if (budget.scope === "activity") {
-        keys.add(`activity:${budget.targetId}`);
-      } else if (budget.scope === "group") {
-        keys.add(`group:${budget.targetId}`);
+      const key = budgetKey(budget.scope, budget.targetId);
+      if (key !== null) {
+        ownKeys.add(key);
       }
     }
+    // Keys the user only inherits via a UserGroup (#363's `source.kind`
+    // === "group" slots). Overall-scoped inherited budgets need no entry — the
+    // always-present "Overall" option already covers them.
+    const inheritedKeys = new Set<string>();
+    for (const resolved of resolvedBudgets) {
+      if (resolved.source.kind !== "group") {
+        continue;
+      }
+      const key = budgetKey(resolved.scope, resolved.targetId);
+      if (key !== null) {
+        inheritedKeys.add(key);
+      }
+    }
+    const keys = new Set<string>([...ownKeys, ...inheritedKeys]);
     for (const row of cadenceRows) {
       keys.add(row.key);
     }
+    // Only a purely-inherited key is marked; an own budget for the same key wins.
+    const isInheritedOnly = (key: string): boolean =>
+      inheritedKeys.has(key) && !ownKeys.has(key);
     const rank = (key: string): number =>
       key === "overall" ? 0 : key.startsWith("activity:") ? 1 : 2;
     return [...keys]
-      .map((key) => ({ key, label: labelForKey(key) }))
+      .map((key) => ({
+        key,
+        label: isInheritedOnly(key) ? `${labelForKey(key)} (inherited)` : labelForKey(key),
+      }))
       .sort((a, b) => rank(a.key) - rank(b.key) || a.label.localeCompare(b.label));
   });
 

--- a/server/frontend/tests/components/notifications-view.test.ts
+++ b/server/frontend/tests/components/notifications-view.test.ts
@@ -24,6 +24,7 @@ import type {
   ActivityResponse,
   BudgetResponse,
   NotificationPolicyResponse,
+  ResolvedBudgetResponse,
   UserResponse,
 } from "../../src/lib/api/contract.js";
 
@@ -33,6 +34,7 @@ const upsertNotificationPolicy =
   vi.fn<(userId: number, input: unknown) => Promise<NotificationPolicyResponse>>();
 const deleteNotificationPolicy = vi.fn<(userId: number) => Promise<void>>();
 const listBudgets = vi.fn<(userId?: number) => Promise<BudgetResponse[]>>();
+const listResolvedBudgets = vi.fn<(userId: number) => Promise<ResolvedBudgetResponse[]>>();
 const listActivities = vi.fn<() => Promise<ActivityResponse[]>>();
 const listActivityGroups = vi.fn<() => Promise<ActivityGroupResponse[]>>();
 
@@ -43,7 +45,10 @@ vi.mock("$lib/api/notifications", () => ({
     upsertNotificationPolicy(userId, input),
   deleteNotificationPolicy: (userId: number) => deleteNotificationPolicy(userId),
 }));
-vi.mock("$lib/api/budgets", () => ({ listBudgets: (userId?: number) => listBudgets(userId) }));
+vi.mock("$lib/api/budgets", () => ({
+  listBudgets: (userId?: number) => listBudgets(userId),
+  listResolvedBudgets: (userId: number) => listResolvedBudgets(userId),
+}));
 vi.mock("$lib/api/activities", () => ({ listActivities: () => listActivities() }));
 vi.mock("$lib/api/activity-groups", () => ({ listActivityGroups: () => listActivityGroups() }));
 
@@ -89,6 +94,20 @@ function activity(overrides: Partial<ActivityResponse> = {}): ActivityResponse {
   return { id: 1, kind: "app", matcher: "firefox", matchType: "exact", ...overrides };
 }
 
+// A resolved budget slot (#363). `source` decides own-vs-inherited; the default
+// is a group-inherited slot since that is the case #403 adds to the picker.
+function resolvedBudget(overrides: Partial<ResolvedBudgetResponse> = {}): ResolvedBudgetResponse {
+  return {
+    scope: "group",
+    targetId: 2,
+    window: "daily",
+    secondsAllowed: 3600,
+    recurrenceDays: null,
+    source: { kind: "group", groupId: 5 },
+    ...overrides,
+  };
+}
+
 function group(overrides: Partial<ActivityGroupResponse> = {}): ActivityGroupResponse {
   return { id: 1, name: "Games", ...overrides };
 }
@@ -99,6 +118,7 @@ beforeEach(() => {
   upsertNotificationPolicy.mockReset().mockResolvedValue(policy());
   deleteNotificationPolicy.mockReset().mockResolvedValue();
   listBudgets.mockReset().mockResolvedValue([]);
+  listResolvedBudgets.mockReset().mockResolvedValue([]);
   listActivities.mockReset().mockResolvedValue([]);
   listActivityGroups.mockReset().mockResolvedValue([]);
   vi.spyOn(globalThis, "confirm").mockReturnValue(true);
@@ -404,6 +424,76 @@ describe("NotificationsView", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Save cadence" }));
 
     expect(upsertNotificationPolicy).toHaveBeenCalledWith(1, { cadenceOverrides: null });
+  });
+
+  it("offers an inherited-only group budget as an '(inherited)'-marked, pickable option (#403)", async () => {
+    // The user owns no group:2 budget, but inherits one via a UserGroup.
+    listBudgets.mockResolvedValue([]);
+    listResolvedBudgets.mockResolvedValue([
+      resolvedBudget({ scope: "group", targetId: 2, source: { kind: "group", groupId: 5 } }),
+    ]);
+    listActivityGroups.mockResolvedValue([group({ id: 2, name: "Games" })]);
+    upsertNotificationPolicy.mockResolvedValue(
+      policy({ cadenceOverrides: { "group:2": { warningMinutes: [5] } } }),
+    );
+
+    render(NotificationsView);
+    await selectUser();
+    await waitFor(() => expect(listResolvedBudgets).toHaveBeenCalledWith(1));
+    await fireEvent.click(await screen.findByRole("button", { name: "Add override" }));
+
+    // The inherited group budget surfaces, labelled and flagged as inherited.
+    const option = await screen.findByRole("option", { name: "Group — Games (inherited)" });
+    expect(option).toBeInTheDocument();
+
+    // Picking it still keys/saves as the plain "group:<id>" grammar (no marker leaks).
+    await fireEvent.change(screen.getByLabelText("Budget"), { target: { value: "group:2" } });
+    await fireEvent.input(screen.getByLabelText("Warning minutes"), { target: { value: "5" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Save cadence" }));
+
+    expect(upsertNotificationPolicy).toHaveBeenCalledWith(1, {
+      cadenceOverrides: { "group:2": { warningMinutes: [5] } },
+    });
+  });
+
+  it("offers a budget the user both owns and inherits once, unmarked (own wins) (#403)", async () => {
+    listBudgets.mockResolvedValue([budget({ id: 1, scope: "group", targetId: 2 })]);
+    listResolvedBudgets.mockResolvedValue([
+      // Same (scope, target) also reachable via a group — but the user owns it.
+      resolvedBudget({ scope: "group", targetId: 2, source: { kind: "group", groupId: 5 } }),
+    ]);
+    listActivityGroups.mockResolvedValue([group({ id: 2, name: "Games" })]);
+
+    render(NotificationsView);
+    await selectUser();
+    await fireEvent.click(await screen.findByRole("button", { name: "Add override" }));
+
+    // Offered once, without the "(inherited)" suffix (the own budget wins).
+    expect(await screen.findByRole("option", { name: "Group — Games" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Group — Games (inherited)" }),
+    ).not.toBeInTheDocument();
+    const groupOptions = screen
+      .getAllByRole("option")
+      .filter((option) => (option as HTMLOptionElement).value === "group:2");
+    expect(groupOptions).toHaveLength(1);
+  });
+
+  it("keeps the editor usable when the resolved-budgets load fails (best-effort) (#403)", async () => {
+    getNotificationPolicy.mockResolvedValue(
+      policy({ cadenceOverrides: { "activity:7": { warningMinutes: [10] } } }),
+    );
+    listResolvedBudgets.mockRejectedValue(new ApiError(500, "server_error", "boom"));
+
+    render(NotificationsView);
+    await selectUser();
+
+    // A resolved-budgets failure degrades the picker exactly like an own-budget
+    // failure: Overall plus the hydrated stored key stay selectable.
+    const picker = (await screen.findByLabelText("Budget")) as HTMLSelectElement;
+    expect(picker.value).toBe("activity:7");
+    expect(screen.getByRole("option", { name: "Overall screen time" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Activity 7" })).toBeInTheDocument();
   });
 
   it("clears all overrides with an explicit null via Clear all", async () => {

--- a/server/frontend/tests/components/notifications-view.test.ts
+++ b/server/frontend/tests/components/notifications-view.test.ts
@@ -456,10 +456,33 @@ describe("NotificationsView", () => {
     });
   });
 
+  it("marks an inherited activity-scoped group budget as '(inherited)' too (#403)", async () => {
+    // A UserGroup can carry an activity-scoped budget; the same inherited
+    // marking applies, keyed by "activity:<id>".
+    listBudgets.mockResolvedValue([]);
+    listResolvedBudgets.mockResolvedValue([
+      resolvedBudget({ scope: "activity", targetId: 3, source: { kind: "group", groupId: 5 } }),
+    ]);
+    listActivities.mockResolvedValue([activity({ id: 3, matcher: "firefox" })]);
+
+    render(NotificationsView);
+    await selectUser();
+    await fireEvent.click(await screen.findByRole("button", { name: "Add override" }));
+
+    expect(
+      await screen.findByRole("option", { name: "Activity — firefox (inherited)" }),
+    ).toBeInTheDocument();
+  });
+
   it("offers a budget the user both owns and inherits once, unmarked (own wins) (#403)", async () => {
     listBudgets.mockResolvedValue([budget({ id: 1, scope: "group", targetId: 2 })]);
     listResolvedBudgets.mockResolvedValue([
-      // Same (scope, target) also reachable via a group — but the user owns it.
+      // Same (scope, target) also carried as a group slot. In real server output
+      // the resolver's own-wins precedence would return this target as a
+      // `source.kind: "user"` slot, so `inheritedKeys` wouldn't contain it; this
+      // fixture forces the group slot to exercise the client's defensive
+      // `!ownKeys.has(key)` guard directly (belt-and-braces if the server ever
+      // emits both).
       resolvedBudget({ scope: "group", targetId: 2, source: { kind: "group", groupId: 5 } }),
     ]);
     listActivityGroups.mockResolvedValue([group({ id: 2, name: "Games" })]);


### PR DESCRIPTION
## Summary

- The per-budget warning-cadence picker in `NotificationsView` (`/admin/notifications`, #388) sourced its options only from the user's **own** budgets, so a group budget the user **inherits** via a `UserGroup` couldn't be picked as a cadence-override target unless they also had an own budget for it — a discoverability gap (#403).
- Now the picker also offers inherited group budgets from `listResolvedBudgets(userId)` (#363), keyed by the same `(scope, target)` grammar and de-duplicated across rollover windows.
- **Own budgets win:** a target both owned and inherited is offered once, unmarked; a purely-inherited target is marked `(inherited)`, consistent with how #363/#343 present own-vs-inherited budget slots.

## Plan

Linked plan: `docs/plans/403-cadence-picker-inherited-group-budgets.md`
Roadmap: `docs/roadmap.md` → Phase 8b (follow-up to #388; composes with #363).

## Design notes

- **No grammar/DTO change.** The stored key stays `overall | activity:<id> | group:<id>`, so an inherited group budget is keyed identically to an own one and hydrate→save is a faithful round-trip. `listResolvedBudgets` / `ResolvedBudgetResponse` already exist (#363); this only reads them.
- **Shared key derivation.** Own and inherited passes both go through one `budgetKey(scope, targetId)` helper so they can never derive divergent keys. Inherited *overall* needs no entry — the always-present "Overall" option covers it.
- **Best-effort load.** The resolved-budgets fetch shares the own-budget load's `try`; either failure degrades the picker to Overall + stored keys and never blocks editing.

## License-boundary note

N/A — frontend-only TypeScript/Svelte over the existing JSON API. No transport, packaging, or Docker-image changes; no GPL linkage.

## No new dependencies

Uses the existing `$lib/api/budgets` client and Svelte 5 runes already in the tree.

## Test plan

- [x] An inherited-only group budget surfaces as a `(inherited)`-marked, pickable option that keys/saves as `group:<id>`.
- [x] A target the user both owns and inherits is offered **once**, **unmarked** (own wins).
- [x] A `listResolvedBudgets` load failure degrades gracefully (Overall + stored key stay selectable).
- [x] Frontend gate green: `svelte-check` 0 errors / 0 warnings, **378** tests pass, static build OK.
- [x] Server gate clean: `format:check`, `lint`, `typecheck` all pass (no backend change).

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJ1Ex99xcGwjJfuLjN97PV)_