### PR TITLE
refactor(server): complete integrations/ barrel + readability nits (#311)

### DIFF
--- a/server/src/enforcement/decision.ts
+++ b/server/src/enforcement/decision.ts
@@ -99,7 +99,10 @@ export interface EnforcementOutcome {
  * *window* is the schedule layer's concern, not budget enforcement.
  */
 function isExhausted(quota: QuotaConsumption): boolean {
-  return quota.consumedSeconds > 0 && quota.consumedSeconds >= quota.allowedSeconds;
+  // `hasConsumption` makes the 0/0-idle guard self-evident: a disallowed but
+  // idle target (allowed 0, consumed 0) must not fire with nothing running.
+  const hasConsumption = quota.consumedSeconds > 0;
+  return hasConsumption && quota.consumedSeconds >= quota.allowedSeconds;
 }
 
 /**

--- a/server/src/integrations/index.ts
+++ b/server/src/integrations/index.ts
@@ -1,2 +1,27 @@
-/** External inbound APIs (e.g. family-calendar reward grants). */
+/**
+ * External inbound APIs (e.g. family-calendar reward grants, #114).
+ *
+ * The integration-token service and guard that gate `/api/integrations/*` for
+ * external systems: the scope vocabulary ({@link ./scopes.js}), the token
+ * lifecycle + authentication service ({@link ./tokens.js}), and the Fastify
+ * guard factory ({@link ./guard.js}). Re-exported here as the module's public
+ * surface, matching the barrel pattern used across `api/*` and `transport/*`.
+ * Importing this barrel also registers the `fastify` module augmentation
+ * declared in `./guard.js` (`app.requireIntegrationToken`, `request.integration`).
+ *
+ * License boundary: none touched — plain TypeScript, `node:crypto` (via
+ * `auth/secret-token.ts`), Fastify, and Drizzle.
+ */
 export const moduleName = "integrations";
+
+export { INTEGRATION_SCOPES, type IntegrationScope } from "./scopes.js";
+export { makeRequireIntegrationToken } from "./guard.js";
+export {
+  issueIntegrationToken,
+  listIntegrationTokenSummaries,
+  revokeIntegrationToken,
+  authenticateIntegrationToken,
+  type IssuedIntegrationToken,
+  type IntegrationTokenSummary,
+  type AuthenticatedIntegration,
+} from "./tokens.js";

--- a/server/src/integrations/index.ts
+++ b/server/src/integrations/index.ts
@@ -6,8 +6,9 @@
  * lifecycle + authentication service ({@link ./tokens.js}), and the Fastify
  * guard factory ({@link ./guard.js}). Re-exported here as the module's public
  * surface, matching the barrel pattern used across `api/*` and `transport/*`.
- * Importing this barrel also registers the `fastify` module augmentation
- * declared in `./guard.js` (`app.requireIntegrationToken`, `request.integration`).
+ * Re-exporting `./guard.js` also brings its `fastify` module augmentation
+ * (`app.requireIntegrationToken`, `request.integration`) into scope wherever
+ * this barrel is imported.
  *
  * License boundary: none touched — plain TypeScript, `node:crypto` (via
  * `auth/secret-token.ts`), Fastify, and Drizzle.

--- a/server/src/policy/weekly-windows.ts
+++ b/server/src/policy/weekly-windows.ts
@@ -42,7 +42,12 @@ export interface WeeklyWindowsInput {
   readonly reference: Date;
 }
 
-/** The seven ISO weekdays, Monday (1) … Sunday (7), in order. */
+/**
+ * The seven ISO-8601 weekdays, Monday (1) … Sunday (7), in order — the scheme
+ * used throughout the schedule model. Note this is **not** JS's 0-indexed
+ * `Date.getDay()` (0 = Sunday, 6 = Saturday), so never index this array with a
+ * raw `getDay()` value.
+ */
 const ISO_WEEKDAYS = [1, 2, 3, 4, 5, 6, 7] as const satisfies readonly IsoWeekday[];
 
 /**

--- a/server/src/transport/reapply/scheduler.ts
+++ b/server/src/transport/reapply/scheduler.ts
@@ -83,7 +83,12 @@ export const DEFAULT_REAPPLY_PLATFORMS: ReadonlySet<Platform> = new Set<Platform
 /** Default SSH port recorded in the audit target (clients carry no port column). */
 const DEFAULT_SSH_PORT = 22;
 
-/** Max length of a recorded error message; longer messages are truncated. */
+/**
+ * Max length of a recorded error message; longer messages are truncated. An
+ * arbitrary operational cap, not schema-driven — the audit `error_message`
+ * column is unbounded `TEXT` (`policy/schema.ts`); this just bounds row growth
+ * from a pathological error.
+ */
 const MAX_ERROR_MESSAGE = 2000;
 
 /** Per-client exponential backoff bounds after a failed re-apply. */

--- a/server/tests/integrations/index.test.ts
+++ b/server/tests/integrations/index.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The `integrations` barrel re-exports the module's public surface (the scope
+ * vocabulary, the token lifecycle/auth service, and the guard factory) and tags
+ * the module name. This guards that the intended API stays exported (a rename
+ * or accidental drop fails here) and that the barrel matches the source
+ * modules' own exports (identity, not a stale copy).
+ */
+import { describe, expect, it } from "vitest";
+
+import * as integrations from "../../src/integrations/index.js";
+import * as scopes from "../../src/integrations/scopes.js";
+import * as guard from "../../src/integrations/guard.js";
+import * as tokens from "../../src/integrations/tokens.js";
+
+describe("integrations index", () => {
+  it("tags the module name", () => {
+    expect(integrations.moduleName).toBe("integrations");
+  });
+
+  it("re-exports the scope vocabulary", () => {
+    expect(integrations.INTEGRATION_SCOPES).toBe(scopes.INTEGRATION_SCOPES);
+    expect(integrations.INTEGRATION_SCOPES).toContain("grants:write");
+    expect(integrations.INTEGRATION_SCOPES).toContain("policy:read");
+  });
+
+  it("re-exports the guard factory", () => {
+    expect(integrations.makeRequireIntegrationToken).toBe(guard.makeRequireIntegrationToken);
+    expect(integrations.makeRequireIntegrationToken).toBeTypeOf("function");
+  });
+
+  it("re-exports the token lifecycle + authentication service", () => {
+    expect(integrations.issueIntegrationToken).toBe(tokens.issueIntegrationToken);
+    expect(integrations.listIntegrationTokenSummaries).toBe(tokens.listIntegrationTokenSummaries);
+    expect(integrations.revokeIntegrationToken).toBe(tokens.revokeIntegrationToken);
+    expect(integrations.authenticateIntegrationToken).toBe(tokens.authenticateIntegrationToken);
+    for (const fn of [
+      integrations.issueIntegrationToken,
+      integrations.listIntegrationTokenSummaries,
+      integrations.revokeIntegrationToken,
+      integrations.authenticateIntegrationToken,
+    ]) {
+      expect(fn).toBeTypeOf("function");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Address the low-risk polish grab-bag from the automated review in #311. Every checklist item was re-verified against the current tree (line numbers had drifted since 2026-06-26):

- **Complete the `integrations/` barrel** (`server/src/integrations/index.ts`) — it previously exported only `moduleName`. Now re-exports the public surface of `scopes.ts` (`INTEGRATION_SCOPES`, `IntegrationScope`), `guard.ts` (`makeRequireIntegrationToken`), and `tokens.ts` (the token lifecycle/auth service + its types), matching the barrel pattern used across `api/*` and `transport/*`. Importing the barrel now also registers `guard.ts`'s `fastify` module augmentation (`app.requireIntegrationToken`, `request.integration`). Adds `tests/integrations/index.test.ts` mirroring `transport/timekpr/index.test.ts` (asserts the surface is present **and** identical to the source modules' exports).
- **`policy/weekly-windows.ts`** — expand the `ISO_WEEKDAYS` JSDoc to warn it is ISO-8601 (1=Mon…7=Sun), **not** JS's 0-indexed `Date.getDay()`, which was the item's stated intent.
- **`transport/reapply/scheduler.ts`** — clarify `MAX_ERROR_MESSAGE` is an arbitrary operational cap, **not** schema-driven (the audit `error_message` column is unbounded `TEXT`).
- **`enforcement/decision.ts`** — extract `const hasConsumption` in `isExhausted` so the 0/0-idle guard is self-evident (no behaviour change).

### Already-satisfied checklist items (verified, left unchanged)

Three items had already been addressed by later drift and needed no change:

- `auth/session.ts` `SESSION_TTL_SECONDS` — already carries a "7 days" JSDoc.
- `api/clients/dtos.ts` `MAX/DEFAULT_ENROLMENT_TTL_SECONDS` — already carry "24h" / "1h" JSDoc.
- `policy/notification.ts` `cadenceOverrides` — already tightened from `Record<...>` to the `CadenceOverrides` z-inferred type.

## Plan

No new plan doc — this is a scoped polish issue whose plan is the checklist in #311 itself. Roadmap: no phase label (code-review polish).

## License-boundary note

N/A — no transport, packaging, or Docker-image changes. The barrel only re-exports existing in-process TypeScript; no GPL linkage introduced or altered.

## Test plan

- [x] `npm run format:check` / `lint` / `typecheck` clean
- [x] `npm test` — 1981 unit tests pass; coverage gate (80%) green; `integrations/index.ts` at 100%
- [x] New `tests/integrations/index.test.ts` asserts the barrel re-exports the intended surface and that each export is identical to its source module (guards against a rename/drop)

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012LrxZy9bniGFzhjvinYJox)_