### PR TITLE
feat(app): per-child status screen — GET /api/app/status + /app view (#110)

### DIFF
--- a/docs/plans/110-app-child-status-screen.md
+++ b/docs/plans/110-app-child-status-screen.md
@@ -1,0 +1,108 @@
+# Plan — #110 App (PWA): per-child status screen
+
+**Roadmap:** Phase 9 (PWA / `/app`). **Depends on:** #112 per-user PIN auth
+(merged — `api/app/*`, `auth/pin-session.ts`, `requirePinSession`,
+`GET /api/app/me`). **Reused by:** Phase 12 "My Time" client dashboard (#61) —
+keep the payload and the render component reusable.
+
+## Goal
+
+The PIN-scoped `/app` status screen a supervised user sees after logging in:
+how much overall time is left today, what's been used, their per-activity
+limits, and the next schedule transition — all in their effective timezone,
+non-punitive framing (`design/app/child-status.html`, `design/README.md`).
+
+## Deliberately deferred (tracked)
+
+- **Recent grants / rewards strip** (the "🎁 +30 min for cleaning your room"
+  card and the "earn more time" CTA). The immutable `Grant` ledger is Phase 10
+  (#113 endpoint, #116 ledger UI, #117 recompute). The `grants` **table**
+  exists (the resolver reads it) but there is no creation path or display
+  contract yet. The status payload is shaped so a `rewards` field can be added
+  additively later without a breaking change. Out of this slice.
+- **"No limit" activity rows** (design shows `School ∞`). This slice's
+  "My limits today" list is exactly the *budgeted* set (the resolver's
+  `perActivitySeconds`), which is the honest, enforceable list. Surfacing
+  unbudgeted-but-used activities is a follow-up.
+- **Schedule / Rewards tabs** — shell tabs stay inert (#109); only "My time"
+  lands here.
+
+## Design decisions
+
+- **One scoped read, deny-by-default.** New `GET /api/app/status`, gated by
+  `scope.requirePinSession`, scoped strictly to `request.pinUser.userId` —
+  never a caller-supplied id, exactly like `GET /api/app/me`. No admin route
+  is touched; the PIN session reaches only this allowlisted read.
+- **Thin route over pure resolvers.** The handler composes what already exists
+  (mirrors `api/usage/routes.ts` and `api/policy/effective.ts`):
+  - effective tz via `resolveEffectiveTz(user.tz, settings.defaultTz)` (ADR 0001);
+  - today's effective policy via `effectivePolicy({ date, tz, schedules,
+    budgets, grants, exceptions })` using the `gatherUser*` loaders +
+    `grants` rows — giving grant-adjusted, weekday-varying `overallSeconds`
+    and `perActivitySeconds`, plus `allowedWindows`;
+  - today's consumption via `usageByActivityInWindow` (overall = Σ) and
+    `groupSecondsInWindow` for group targets — same one-pass rollup the admin
+    burndown uses.
+- **Time left = effective quota − consumed**, clamped at 0; `null` remaining
+  when the quota is `null` (no limit — unlimited base makes a grant moot).
+- **Next transition is wall-clock.** A schedule boundary ("bedtime at 21:00")
+  is inherently a local wall-clock concept, so it is transmitted as
+  `{ kind, localDate, atMinuteOfDay }` (the client formats `21:00`), not a UTC
+  instant — the client renders wall-clock in tz, faithful to ADR 0001's
+  intent. Computed by a **pure, unit-tested** helper
+  `policy/next-transition.ts` over the resolver's `allowedWindows`:
+  - inside an allowed window that is not the whole day → `access_ends` at that
+    window's `end`;
+  - in a gap before a later window today → `access_resumes` at that window's
+    `start`;
+  - no boundary left today → resolve *tomorrow's* effective policy and report
+    `access_resumes` at tomorrow's first window `start` (matches the mockup's
+    "turns back on tomorrow at 11:00"); if tomorrow is unrestricted or fully
+    denied with no window, `null`.
+
+## Payload (`AppStatusResponse`)
+
+```
+user: { id, displayName }
+tz: string
+now: string (ISO)            // server clock, for the client's "resets at midnight"
+date: string (YYYY-MM-DD)    // today, local
+overall: {
+  allowedSeconds: number | null
+  consumedSeconds: number
+  remainingSeconds: number | null
+}
+activities: Array<{
+  scope: "activity" | "group"
+  targetId: number
+  label: string              // group name, or activity matcher
+  activityKind: string | null  // activity kind (app/domain/…); null for group
+  allowedSeconds: number
+  consumedSeconds: number
+  remainingSeconds: number
+}>
+access: {
+  allowedNow: boolean
+  nextTransition: {
+    kind: "access_ends" | "access_resumes"
+    localDate: string        // YYYY-MM-DD
+    atMinuteOfDay: number     // 0..1440
+  } | null
+}
+```
+
+## Phases
+
+1. **Server.** `policy/next-transition.ts` (pure) + unit tests;
+   `AppStatusResponse` zod DTO in `api/app/dtos.ts` + re-export from `api/index.ts`;
+   `GET /api/app/status` in `api/app/routes.ts`; API tests (scoping, empty
+   policy, budgets+usage, next-transition today/tomorrow). Full server gate.
+2. **Frontend.** `$lib/api/app-status.ts` client; contract re-export;
+   `StatusView.svelte` (time-left ring + "My limits today" + next-transition
+   banner, non-punitive copy) rendered into the signed-in branch of
+   `routes/app/+page.svelte`; component test; `svelte-check` + build.
+
+## License boundary
+
+None touched — plain TypeScript + zod + Drizzle on the server, Svelte over the
+same-origin JSON API on the client. No subprocess/REST/GPL boundary involved.

--- a/server/frontend/src/lib/api/app-status.ts
+++ b/server/frontend/src/lib/api/app-status.ts
@@ -1,0 +1,19 @@
+/**
+ * The `/app` per-child status read (#110), consumed by the signed-in status
+ * screen. A thin typed wrapper over {@link apiFetch}, mirroring the other
+ * `$lib/api/*` clients: the response type comes from the shared `/api` contract
+ * so the frontend never re-declares a DTO.
+ *
+ * The call is PIN-session-scoped — it needs no user id in the URL because the
+ * server serves only `request.pinUser`'s own data. The same-origin PIN cookie
+ * rides along automatically (see `$lib/api/client`).
+ *
+ * License boundary: none — JSON API only.
+ */
+import { apiFetch } from "./client.js";
+import type { AppStatusResponse } from "./contract.js";
+
+/** Fetch the signed-in child's own status (time left, limits, next transition). */
+export function fetchAppStatus(): Promise<AppStatusResponse> {
+  return apiFetch<AppStatusResponse>("/app/status");
+}

--- a/server/frontend/src/lib/api/contract.ts
+++ b/server/frontend/src/lib/api/contract.ts
@@ -27,6 +27,10 @@ export type {
   SetUserPinRequest,
   UserPinStatusResponse,
   AppMeResponse,
+  AppOverallStatus,
+  AppActivityStatus,
+  AppNextTransition,
+  AppStatusResponse,
 } from "../../../../src/api/app/dtos.js";
 export type {
   UserResponse,

--- a/server/frontend/src/lib/views/AppStatusView.svelte
+++ b/server/frontend/src/lib/views/AppStatusView.svelte
@@ -37,8 +37,8 @@
     } catch (err) {
       error =
         err instanceof ApiError
-          ? "We couldn't load your time right now. Pull to refresh in a moment."
-          : "Something went wrong loading your time. Try again in a moment.";
+          ? "We couldn't load your time right now. Please try again in a moment."
+          : "Something went wrong loading your time. Please try again in a moment.";
     } finally {
       loading = false;
     }

--- a/server/frontend/src/lib/views/AppStatusView.svelte
+++ b/server/frontend/src/lib/views/AppStatusView.svelte
@@ -1,0 +1,316 @@
+<!--
+  The /app per-child status screen (#110) — the signed-in "My time" view.
+
+  Reads `GET /api/app/status` (PIN-scoped, own data only) through the typed
+  `$lib/api/app-status` wrapper and renders, in the child's effective timezone:
+  the overall time left today, a per-activity "My limits today" list, and the
+  next scheduled access change. Non-punitive framing throughout
+  (design/app/child-status.html, design/README.md) — this is a calm status
+  glance, not a warning.
+
+  Read-only and browser-only. Times arrive as the resolver computed them in the
+  user's zone (ADR 0001): durations in seconds, the next transition as a local
+  wall-clock minute-of-day; this component only formats them.
+
+  Deferred (tracked): the "rewards" strip (recent grants) rides with the
+  Phase-10 grant ledger (#113/#116/#117).
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  import { ApiError } from "$lib/api/client.js";
+  import { fetchAppStatus } from "$lib/api/app-status.js";
+  import type { AppNextTransition, AppStatusResponse } from "$lib/api/contract.js";
+  import { formatDuration } from "$lib/format/duration.js";
+
+  let status = $state<AppStatusResponse | null>(null);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  onMount(load);
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      status = await fetchAppStatus();
+    } catch (err) {
+      error =
+        err instanceof ApiError
+          ? "We couldn't load your time right now. Pull to refresh in a moment."
+          : "Something went wrong loading your time. Try again in a moment.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  /** A local minute-of-day (`0..1440`) as a `H:MM` wall-clock string. */
+  function formatClock(minuteOfDay: number): string {
+    const h = Math.floor(minuteOfDay / 60) % 24;
+    const m = minuteOfDay % 60;
+    return `${h}:${m.toString().padStart(2, "0")}`;
+  }
+
+  /** A friendly "when" for the next transition, relative to today. */
+  function whenLabel(t: AppNextTransition, today: string): string {
+    const clock = formatClock(t.atMinuteOfDay);
+    return t.localDate === today ? `at ${clock}` : `tomorrow at ${clock}`;
+  }
+
+  /** Percentage of a budget consumed, clamped to `[0, 100]`. */
+  function usedPercent(consumed: number, allowed: number): number {
+    if (allowed <= 0) {
+      return 100;
+    }
+    return Math.max(0, Math.min(100, Math.round((consumed / allowed) * 100)));
+  }
+
+  /** Bar tone by how much is left — a gentle low/almost-gone cue, not alarm. */
+  function tone(remaining: number, allowed: number): "ok" | "low" | "gone" {
+    if (remaining <= 0) {
+      return "gone";
+    }
+    if (allowed > 0 && remaining / allowed <= 0.15) {
+      return "low";
+    }
+    return "ok";
+  }
+</script>
+
+{#if loading}
+  <p class="state" role="status">Loading your time…</p>
+{:else if error}
+  <p class="state error" role="alert">{error}</p>
+{:else if status !== null}
+  {@const s = status}
+  <section class="status" aria-labelledby="status-title">
+    <h1 id="status-title">Hi, {s.user.displayName} 👋</h1>
+
+    <!-- Overall time left today -->
+    <div class="card overall">
+      {#if s.overall.remainingSeconds === null}
+        <p class="big">No time limit today</p>
+        <p class="muted">Enjoy — there's no overall screen-time limit set for today.</p>
+      {:else}
+        <p class="big">{formatDuration(s.overall.remainingSeconds)} left today</p>
+        {#if s.overall.allowedSeconds !== null}
+          <p class="muted">
+            You've used {formatDuration(s.overall.consumedSeconds)} of
+            {formatDuration(s.overall.allowedSeconds)}. Resets at midnight 🌙
+          </p>
+        {/if}
+        <div
+          class="bar tone-{tone(s.overall.remainingSeconds, s.overall.allowedSeconds ?? 0)}"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={usedPercent(s.overall.consumedSeconds, s.overall.allowedSeconds ?? 0)}
+          aria-label="Overall screen time used today"
+        >
+          <span
+            style="width:{usedPercent(s.overall.consumedSeconds, s.overall.allowedSeconds ?? 0)}%"
+          ></span>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Next scheduled access change -->
+    {#if !s.access.allowedNow}
+      <div class="next paused">
+        ⏸️
+        <div>
+          <strong>Screen time is paused right now</strong>
+          {#if s.access.nextTransition && s.access.nextTransition.kind === "access_resumes"}
+            <div class="muted small">
+              It comes back {whenLabel(s.access.nextTransition, s.date)}.
+            </div>
+          {/if}
+        </div>
+      </div>
+    {:else if s.access.nextTransition && s.access.nextTransition.kind === "access_ends"}
+      <div class="next">
+        ⏰
+        <div>
+          <strong>Screen time until {formatClock(s.access.nextTransition.atMinuteOfDay)}</strong>
+          {#if s.access.nextTransition.localDate !== s.date}
+            <div class="muted small">That's tomorrow's bedtime.</div>
+          {/if}
+        </div>
+      </div>
+    {/if}
+
+    <!-- Per-activity limits today -->
+    {#if s.activities.length > 0}
+      <h2 class="section-title">My limits today</h2>
+      <div class="card">
+        <ul class="limits">
+          {#each s.activities as a (a.scope + ":" + a.targetId)}
+            <li class="limit">
+              <div class="grow">
+                <div class="name">{a.label}</div>
+                <div
+                  class="bar tone-{tone(a.remainingSeconds, a.allowedSeconds)}"
+                  role="progressbar"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={usedPercent(a.consumedSeconds, a.allowedSeconds)}
+                  aria-label="{a.label} time used today"
+                >
+                  <span style="width:{usedPercent(a.consumedSeconds, a.allowedSeconds)}%"></span>
+                </div>
+              </div>
+              <div class="amount">
+                <strong>{formatDuration(a.remainingSeconds)}</strong>
+                <div class="muted small">of {formatDuration(a.allowedSeconds)}</div>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+
+    <p class="muted center foot">Questions about your limits? Talk to a parent 💬</p>
+  </section>
+{/if}
+
+<style>
+  .state {
+    text-align: center;
+    color: var(--muted);
+    padding: 32px 8px;
+  }
+  .state.error {
+    color: var(--red);
+    font-weight: 600;
+  }
+
+  .status {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  h1 {
+    margin: 4px 0 0;
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 16px;
+  }
+
+  .overall {
+    text-align: center;
+  }
+
+  .big {
+    margin: 0;
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  .muted {
+    color: var(--muted);
+  }
+  .muted.small {
+    font-size: 12px;
+  }
+  .muted.center {
+    text-align: center;
+  }
+
+  .overall .muted {
+    margin: 6px 0 0;
+    font-size: 13px;
+  }
+
+  .bar {
+    height: 8px;
+    border-radius: 999px;
+    background: var(--surface-3);
+    overflow: hidden;
+    margin-top: 10px;
+  }
+  .bar span {
+    display: block;
+    height: 100%;
+    border-radius: 999px;
+    background: var(--green);
+  }
+  .bar.tone-low span {
+    background: var(--amber);
+  }
+  .bar.tone-gone span {
+    background: var(--red);
+  }
+
+  .next {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    background: var(--surface-3);
+    border-radius: 12px;
+    padding: 12px 14px;
+    font-size: 14px;
+  }
+  .next.paused {
+    background: #fbeecb;
+  }
+  .next strong {
+    font-weight: 600;
+  }
+
+  .section-title {
+    margin: 6px 0 0;
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+  }
+
+  .limits {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .limit {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 11px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .limit:last-child {
+    border-bottom: none;
+  }
+  .grow {
+    flex: 1;
+  }
+  .name {
+    font-weight: 600;
+    font-size: 14px;
+  }
+  .amount {
+    text-align: right;
+    white-space: nowrap;
+  }
+  .amount strong {
+    font-size: 15px;
+    font-weight: 700;
+  }
+
+  .foot {
+    font-size: 11.5px;
+    margin-top: 6px;
+  }
+</style>

--- a/server/frontend/src/routes/app/+page.svelte
+++ b/server/frontend/src/routes/app/+page.svelte
@@ -19,6 +19,7 @@
   import { ApiError } from "$lib/api/client.js";
   import { fetchAppSession, pinLogin, pinLogout } from "$lib/api/app-session.js";
   import type { PinSessionResponse } from "$lib/api/contract.js";
+  import AppStatusView from "$lib/views/AppStatusView.svelte";
 
   // `null` while the initial session probe is in flight.
   let session = $state<PinSessionResponse | null>(null);
@@ -89,15 +90,10 @@
 {#if session === null}
   <p class="loading" role="status">Loading…</p>
 {:else if authenticated}
-  <section class="signed-in" aria-labelledby="signed-in-title">
-    <div class="ring" aria-hidden="true"></div>
-    <h1 id="signed-in-title">Hi, {session.user?.displayName}</h1>
-    <p>
-      You're signed in. Your time left, today's limits and the rewards you've
-      earned will show up here soon.
-    </p>
+  <AppStatusView />
+  <div class="signout-row">
     <button type="button" class="link" onclick={handleLogout}>Sign out</button>
-  </section>
+  </div>
 {:else}
   <section class="login" aria-labelledby="login-title">
     <h1 id="login-title">Sign in</h1>
@@ -142,7 +138,6 @@
     padding: 32px 8px;
   }
 
-  .signed-in,
   .login {
     display: flex;
     flex-direction: column;
@@ -154,17 +149,10 @@
     box-shadow: var(--shadow);
   }
 
-  .signed-in {
-    align-items: center;
-    text-align: center;
-  }
-
-  .ring {
-    width: 84px;
-    height: 84px;
-    border-radius: 50%;
-    border: 11px solid var(--surface-3);
-    border-top-color: var(--primary);
+  .signout-row {
+    display: flex;
+    justify-content: center;
+    margin-top: 16px;
   }
 
   h1 {
@@ -172,13 +160,6 @@
     font-size: 22px;
     font-weight: 700;
     letter-spacing: -0.01em;
-  }
-
-  .signed-in p {
-    margin: 0;
-    max-width: 30ch;
-    font-size: 14px;
-    color: var(--muted);
   }
 
   .sub {

--- a/server/frontend/tests/components/app-pin-login.test.ts
+++ b/server/frontend/tests/components/app-pin-login.test.ts
@@ -28,6 +28,14 @@ vi.mock("$lib/api/app-session", () => ({
   pinLogout: () => pinLogout(),
 }));
 
+// The signed-in state renders `AppStatusView` (#110), which fetches its own
+// status. Stub it so this page-orchestrator test stays about the session cycle,
+// not the status content (that has its own component test). A never-resolving
+// stub keeps the child in its harmless loading state.
+vi.mock("$lib/api/app-status", () => ({
+  fetchAppStatus: () => new Promise(() => {}),
+}));
+
 // Imported after the mocks are registered so the page picks up the mocked client.
 const { default: AppPage } = await import("../../src/routes/app/+page.svelte");
 
@@ -58,7 +66,9 @@ describe("/app PIN login", () => {
 
     render(AppPage);
 
-    expect(await screen.findByText("Hi, Alice")).toBeInTheDocument();
+    // Signed-in state is the page's own "Sign out" control (the greeting now
+    // lives inside AppStatusView, covered by its own test).
+    expect(await screen.findByRole("button", { name: "Sign out" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Sign in" })).not.toBeInTheDocument();
   });
 
@@ -73,7 +83,7 @@ describe("/app PIN login", () => {
     await fireEvent.input(screen.getByLabelText("PIN"), { target: { value: "1234" } });
     await fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
 
-    expect(await screen.findByText("Hi, Alice")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Sign out" })).toBeInTheDocument();
     expect(pinLogin).toHaveBeenCalledWith({ userId: 7, pin: "1234" });
     expect(screen.queryByRole("button", { name: "Sign in" })).not.toBeInTheDocument();
   });
@@ -112,7 +122,7 @@ describe("/app PIN login", () => {
     pinLogout.mockResolvedValue({ authenticated: false });
 
     render(AppPage);
-    await screen.findByText("Hi, Alice");
+    await screen.findByRole("button", { name: "Sign out" });
 
     await fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
 

--- a/server/frontend/tests/components/app-status-view.test.ts
+++ b/server/frontend/tests/components/app-status-view.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Component test for the `/app` per-child status screen (#110).
+ *
+ * Renders `AppStatusView` against a mocked `$lib/api/app-status` (no live
+ * backend) and asserts the accessible textual surface: overall time left / no
+ * limit, the per-activity "My limits today" rows, the paused vs. bedtime
+ * next-transition banner, and the load-error state.
+ */
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppStatusResponse } from "../../src/lib/api/contract.js";
+
+const fetchAppStatus = vi.fn<() => Promise<AppStatusResponse>>();
+
+vi.mock("$lib/api/app-status", () => ({
+  fetchAppStatus: () => fetchAppStatus(),
+}));
+
+const { default: AppStatusView } = await import("../../src/lib/views/AppStatusView.svelte");
+
+function status(overrides: Partial<AppStatusResponse> = {}): AppStatusResponse {
+  return {
+    user: { id: 1, displayName: "Alice" },
+    tz: "UTC",
+    now: "2026-08-23T13:00:00.000Z",
+    date: "2026-08-23",
+    overall: { allowedSeconds: 9000, consumedSeconds: 6900, remainingSeconds: 2100 },
+    activities: [
+      {
+        scope: "activity",
+        targetId: 10,
+        label: "steam",
+        activityKind: "app",
+        allowedSeconds: 3600,
+        consumedSeconds: 3420,
+        remainingSeconds: 180,
+      },
+      {
+        scope: "group",
+        targetId: 20,
+        label: "Fun",
+        activityKind: null,
+        allowedSeconds: 2700,
+        consumedSeconds: 1080,
+        remainingSeconds: 1620,
+      },
+    ],
+    access: { allowedNow: true, nextTransition: null },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fetchAppStatus.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AppStatusView", () => {
+  it("renders the greeting, overall time left, and per-activity rows", async () => {
+    fetchAppStatus.mockResolvedValue(status());
+    render(AppStatusView);
+
+    expect(await screen.findByText("Hi, Alice 👋")).toBeInTheDocument();
+    expect(screen.getByText("35m left today")).toBeInTheDocument();
+    expect(screen.getByText(/You've used 1h 55m of 2h 30m/)).toBeInTheDocument();
+    // Per-activity limits: label + remaining/allowed.
+    expect(screen.getByText("steam")).toBeInTheDocument();
+    expect(screen.getByText("Fun")).toBeInTheDocument();
+    expect(screen.getByText("3m")).toBeInTheDocument(); // steam remaining
+    expect(screen.getByText("of 1h")).toBeInTheDocument(); // steam allowed
+  });
+
+  it("shows a no-limit state when there is no overall budget", async () => {
+    fetchAppStatus.mockResolvedValue(
+      status({
+        overall: { allowedSeconds: null, consumedSeconds: 0, remainingSeconds: null },
+        activities: [],
+      }),
+    );
+    render(AppStatusView);
+
+    expect(await screen.findByText("No time limit today")).toBeInTheDocument();
+    // No "My limits today" list when there are no budgeted activities.
+    expect(screen.queryByText("My limits today")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a paused state with the resume time", async () => {
+    fetchAppStatus.mockResolvedValue(
+      status({
+        access: {
+          allowedNow: false,
+          nextTransition: { kind: "access_resumes", localDate: "2026-08-24", atMinuteOfDay: 420 },
+        },
+      }),
+    );
+    render(AppStatusView);
+
+    expect(await screen.findByText("Screen time is paused right now")).toBeInTheDocument();
+    expect(screen.getByText(/comes back tomorrow at 7:00/)).toBeInTheDocument();
+  });
+
+  it("surfaces the next bedtime while access is open", async () => {
+    fetchAppStatus.mockResolvedValue(
+      status({
+        access: {
+          allowedNow: true,
+          nextTransition: { kind: "access_ends", localDate: "2026-08-23", atMinuteOfDay: 1260 },
+        },
+      }),
+    );
+    render(AppStatusView);
+
+    expect(await screen.findByText("Screen time until 21:00")).toBeInTheDocument();
+  });
+
+  it("shows a friendly error when the status fails to load", async () => {
+    fetchAppStatus.mockRejectedValue(new Error("boom"));
+    render(AppStatusView);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+});

--- a/server/src/api/app/dtos.ts
+++ b/server/src/api/app/dtos.ts
@@ -72,3 +72,75 @@ export const appMeResponseSchema = z.object({
   tz: z.string().nullable(),
 });
 export type AppMeResponse = z.infer<typeof appMeResponseSchema>;
+
+/**
+ * The overall daily screen-time picture for the status screen (#110).
+ *
+ * `allowedSeconds` / `remainingSeconds` are `null` when the user has **no**
+ * overall daily budget (no limit — the ring renders as unlimited rather than
+ * empty). Otherwise `remainingSeconds` is `max(0, allowed − consumed)`, so a
+ * rounding artefact or an over-run never prints a negative time.
+ */
+export const appOverallStatusSchema = z.object({
+  allowedSeconds: z.number().int().nullable(),
+  consumedSeconds: z.number().int(),
+  remainingSeconds: z.number().int().nullable(),
+});
+export type AppOverallStatus = z.infer<typeof appOverallStatusSchema>;
+
+/**
+ * One row of the "My limits today" list — an effective per-activity or
+ * per-group daily quota with today's consumption against it. `label` is the
+ * user-facing name (a group's `name`, or an activity's `matcher`); the client
+ * renders it, never re-deriving the vocabulary. `activityKind` carries the
+ * activity's kind (`app` / `domain` / …) for icon selection, and is `null` for
+ * a group row. Only *budgeted* targets appear — the enforceable set.
+ */
+export const appActivityStatusSchema = z.object({
+  scope: z.enum(["activity", "group"]),
+  targetId: z.number().int(),
+  label: z.string(),
+  activityKind: z.string().nullable(),
+  allowedSeconds: z.number().int(),
+  consumedSeconds: z.number().int(),
+  remainingSeconds: z.number().int(),
+});
+export type AppActivityStatus = z.infer<typeof appActivityStatusSchema>;
+
+/**
+ * The next overall-access transition, as a local wall-clock time (a schedule
+ * boundary is a wall-clock concept — see `policy/next-transition.ts`).
+ * `access_ends` = access pauses (a lock begins); `access_resumes` = it returns.
+ * `null` when access does not change between now and the end of tomorrow.
+ */
+export const appNextTransitionSchema = z.object({
+  kind: z.enum(["access_ends", "access_resumes"]),
+  localDate: z.string(),
+  atMinuteOfDay: z.number().int(),
+});
+export type AppNextTransition = z.infer<typeof appNextTransitionSchema>;
+
+/**
+ * Response of `GET /api/app/status` — the PIN-scoped per-child status screen
+ * (#110). Composed from the effective-policy resolver (grant-adjusted,
+ * weekday-varying quotas + allowed windows) and today's usage rollup, all in
+ * the user's effective timezone (ADR 0001); the client renders. Deny-by-
+ * default: served only for the PIN session's own user.
+ *
+ * A `rewards` field (recent grants) will be added additively once the Phase-10
+ * grant ledger (#113/#116/#117) lands; the shape here is forward-compatible
+ * with that addition.
+ */
+export const appStatusResponseSchema = z.object({
+  user: pinSessionUserSchema,
+  tz: z.string(),
+  now: z.string(),
+  date: z.string(),
+  overall: appOverallStatusSchema,
+  activities: z.array(appActivityStatusSchema),
+  access: z.object({
+    allowedNow: z.boolean(),
+    nextTransition: appNextTransitionSchema.nullable(),
+  }),
+});
+export type AppStatusResponse = z.infer<typeof appStatusResponseSchema>;

--- a/server/src/api/app/index.ts
+++ b/server/src/api/app/index.ts
@@ -5,6 +5,7 @@
  * License boundary: none touched.
  */
 export { registerAppAuthRoutes } from "./routes.js";
+export { registerAppStatusRoutes } from "./status-routes.js";
 export {
   setUserPinSchema,
   userPinStatusResponseSchema,
@@ -12,9 +13,17 @@ export {
   pinSessionUserSchema,
   pinSessionResponseSchema,
   appMeResponseSchema,
+  appOverallStatusSchema,
+  appActivityStatusSchema,
+  appNextTransitionSchema,
+  appStatusResponseSchema,
   type SetUserPinRequest,
   type UserPinStatusResponse,
   type PinLoginRequest,
   type PinSessionResponse,
   type AppMeResponse,
+  type AppOverallStatus,
+  type AppActivityStatus,
+  type AppNextTransition,
+  type AppStatusResponse,
 } from "./dtos.js";

--- a/server/src/api/app/status-routes.ts
+++ b/server/src/api/app/status-routes.ts
@@ -1,0 +1,202 @@
+/**
+ * The PIN-scoped per-child status read (#110, Phase 9):
+ * `GET /api/app/status`.
+ *
+ * The `/app` "My time" screen a supervised user sees after logging in: how much
+ * overall time is left today, what they've used, their per-activity limits, and
+ * the next schedule transition — all in their effective timezone (ADR 0001);
+ * the client renders. **Deny-by-default**, gated by `scope.requirePinSession`
+ * and scoped strictly to `request.pinUser.userId` — never a caller-supplied id,
+ * exactly like `GET /api/app/me`.
+ *
+ * The handler stays thin, composing what already exists (mirrors
+ * `api/usage/routes.ts` and `api/policy/effective.ts`): the effective-policy
+ * resolver for grant-adjusted, weekday-varying quotas + the day's allowed
+ * windows, and the `policy/usage.ts` rollups for today's consumption. The
+ * next-transition boundary walk lives in the pure `policy/next-transition.ts`.
+ *
+ * Recent grants ("rewards") are deliberately out of this slice — the Phase-10
+ * `Grant` ledger (#113/#116/#117) has no creation path yet; the DTO is shaped
+ * so a `rewards` field can be added additively later.
+ *
+ * License boundary: none touched — plain TypeScript + zod + Drizzle over the
+ * policy store.
+ */
+import { eq, inArray } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+
+import type { Settings } from "../../config.js";
+import {
+  localCalendarDate,
+  localDayBounds,
+  localTimeOfDayMinutes,
+  resolveEffectiveTz,
+} from "../../policy/budget-window.js";
+import {
+  gatherUserBudgets,
+  gatherUserExceptions,
+  gatherUserScheduleRules,
+} from "../../policy/group-resolution.js";
+import { isAccessAllowedAt, nextOverallTransition } from "../../policy/next-transition.js";
+import { getUser } from "../../policy/repository.js";
+import { effectivePolicy, type GrantInput } from "../../policy/resolve.js";
+import { activities, activityGroups, grants } from "../../policy/schema.js";
+import { groupSecondsInWindow, usageByActivityInWindow } from "../../policy/usage.js";
+import { ApiError } from "../errors.js";
+import type { AppActivityStatus, AppStatusResponse } from "./dtos.js";
+
+/**
+ * Register `GET /api/app/status` on an already-`/api`-prefixed scope. Call after
+ * {@link import("../../auth/index.js").registerAuth} so `scope.requirePinSession`
+ * is decorated; `settings` supplies the server-default timezone for users with
+ * no `tz`.
+ */
+export function registerAppStatusRoutes(
+  scope: FastifyInstance,
+  settings: Pick<Settings, "defaultTz">,
+): void {
+  scope.get(
+    "/app/status",
+    { preHandler: scope.requirePinSession },
+    async (request): Promise<AppStatusResponse> => {
+      const pinUser = request.pinUser;
+      if (pinUser === null) {
+        // Unreachable — the guard sets pinUser or throws — but keeps the
+        // handler total without an unchecked assertion (mirrors `/app/me`).
+        throw new ApiError(401, "unauthorized", "Authentication required");
+      }
+      const user = getUser(scope.db, pinUser.userId);
+      if (user === undefined) {
+        throw new ApiError(401, "unauthorized", "Authentication required");
+      }
+      const userId = user.id;
+
+      const tz = resolveEffectiveTz(user.tz, settings.defaultTz);
+      const now = new Date();
+      const todayCal = localCalendarDate(now, tz);
+      // Tomorrow's local calendar date: the instant of the *next* local
+      // midnight, resolved back to its calendar fields (DST-correct, since
+      // `localDayBounds` uses local-midnight wall times).
+      const tomorrowCal = localCalendarDate(
+        localDayBounds(todayCal.year, todayCal.month, todayCal.day, tz).end,
+        tz,
+      );
+
+      // The user's full rule set (own + inherited group), loaded once and shared
+      // by both the today and tomorrow resolutions (the resolver date-gates).
+      const schedules = gatherUserScheduleRules(scope.db, userId);
+      const budgets = gatherUserBudgets(scope.db, userId);
+      const exceptions = gatherUserExceptions(scope.db, userId);
+      const grantRows: GrantInput[] = scope.db
+        .select()
+        .from(grants)
+        .where(eq(grants.userId, userId))
+        .all();
+
+      const today = effectivePolicy({
+        date: todayCal,
+        tz,
+        schedules,
+        budgets,
+        grants: grantRows,
+        exceptions,
+      });
+      const tomorrow = effectivePolicy({
+        date: tomorrowCal,
+        tz,
+        schedules,
+        budgets,
+        grants: grantRows,
+        exceptions,
+      });
+
+      // One pass of per-activity consumption over today's effective-TZ window
+      // serves both the overall total (Σ) and each per-activity row.
+      const byActivity = usageByActivityInWindow(scope.db, {
+        userId,
+        window: "daily",
+        now,
+        tz,
+      });
+      const overallConsumed = Math.round(
+        [...byActivity.values()].reduce((sum, secs) => sum + secs, 0),
+      );
+
+      // Friendly labels for the "My limits today" rows: an activity's matcher +
+      // kind, or a group's name. Loaded in one query per target kind.
+      const activityIds = today.perActivitySeconds
+        .filter((q) => q.scope === "activity")
+        .map((q) => q.targetId);
+      const groupIds = today.perActivitySeconds
+        .filter((q) => q.scope === "group")
+        .map((q) => q.targetId);
+      const activityById = new Map(
+        (activityIds.length > 0
+          ? scope.db.select().from(activities).where(inArray(activities.id, activityIds)).all()
+          : []
+        ).map((row) => [row.id, row]),
+      );
+      const groupById = new Map(
+        (groupIds.length > 0
+          ? scope.db.select().from(activityGroups).where(inArray(activityGroups.id, groupIds)).all()
+          : []
+        ).map((row) => [row.id, row]),
+      );
+
+      const activityRows: AppActivityStatus[] = today.perActivitySeconds.map((quota) => {
+        const consumed =
+          quota.scope === "activity"
+            ? Math.round(byActivity.get(quota.targetId) ?? 0)
+            : Math.round(
+                groupSecondsInWindow(scope.db, {
+                  userId,
+                  window: "daily",
+                  now,
+                  tz,
+                  groupId: quota.targetId,
+                }),
+              );
+        const activity = quota.scope === "activity" ? activityById.get(quota.targetId) : undefined;
+        const group = quota.scope === "group" ? groupById.get(quota.targetId) : undefined;
+        const label = activity?.matcher ?? group?.name ?? `${quota.scope} ${quota.targetId}`;
+        return {
+          scope: quota.scope,
+          targetId: quota.targetId,
+          label,
+          activityKind: activity?.kind ?? null,
+          allowedSeconds: quota.seconds,
+          consumedSeconds: consumed,
+          remainingSeconds: Math.max(0, quota.seconds - consumed),
+        };
+      });
+
+      const nowMinute = localTimeOfDayMinutes(now, tz);
+
+      return {
+        user: { id: user.id, displayName: user.displayName },
+        tz,
+        now: now.toISOString(),
+        date: today.date,
+        overall: {
+          allowedSeconds: today.overallSeconds,
+          consumedSeconds: overallConsumed,
+          remainingSeconds:
+            today.overallSeconds === null
+              ? null
+              : Math.max(0, today.overallSeconds - overallConsumed),
+        },
+        activities: activityRows,
+        access: {
+          allowedNow: isAccessAllowedAt(nowMinute, today.allowedWindows),
+          nextTransition: nextOverallTransition(
+            today.allowedWindows,
+            nowMinute,
+            today.date,
+            tomorrow.allowedWindows,
+            tomorrow.date,
+          ),
+        },
+      };
+    },
+  );
+}

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -241,11 +241,19 @@ export {
   pinSessionUserSchema,
   pinSessionResponseSchema,
   appMeResponseSchema,
+  appOverallStatusSchema,
+  appActivityStatusSchema,
+  appNextTransitionSchema,
+  appStatusResponseSchema,
   type SetUserPinRequest,
   type UserPinStatusResponse,
   type PinLoginRequest,
   type PinSessionResponse,
   type AppMeResponse,
+  type AppOverallStatus,
+  type AppActivityStatus,
+  type AppNextTransition,
+  type AppStatusResponse,
 } from "./app/index.js";
 
 // Event-stream taxonomy (#100): the `/api/events/stream` wire contract — the

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -14,7 +14,7 @@ import { registerEventStream, type EventHub, type EventStreamOptions } from "../
 import type { ClientProber } from "../transport/health/index.js";
 import type { PolicyPushNow, TimeTodayAdjuster } from "../transport/policy-push/index.js";
 import type { PolicyPushStub } from "../transport/stub.js";
-import { registerAppAuthRoutes } from "./app/index.js";
+import { registerAppAuthRoutes, registerAppStatusRoutes } from "./app/index.js";
 import { registerAuditRoutes } from "./audit/index.js";
 import { registerClientEnrolmentRoutes, registerClientHealthRoutes } from "./clients/index.js";
 import { registerDnsRoutes } from "./dns/index.js";
@@ -92,6 +92,11 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   // (`GET /api/app/me`). Registered after auth so `scope.requireAdmin` /
   // `scope.requirePinSession` exist and the cookie plugin is installed.
   registerAppAuthRoutes(scope, opts.settings);
+  // Per-child status screen (#110): GET /api/app/status — the PIN-scoped
+  // "My time" read (overall + per-activity time left, next transition).
+  // Registered after auth so `scope.requirePinSession` exists; needs
+  // `settings` for the server-default timezone of users with no `tz`.
+  registerAppStatusRoutes(scope, opts.settings);
   registerMetaRoute(scope);
   // Policy CRUD (#51) — registered after auth so `scope.requireAdmin` exists.
   // The live SSH dispatcher (#201) is injected from buildApp; absent it, the

--- a/server/src/policy/next-transition.ts
+++ b/server/src/policy/next-transition.ts
@@ -1,0 +1,120 @@
+/**
+ * "When does overall access next change?" — the pure boundary walk behind the
+ * `/app` per-child status screen's next-transition banner (#110, Phase 9).
+ *
+ * The effective-policy resolver ({@link import("./resolve.js").effectivePolicy})
+ * already reduces a day's `overall`-scoped schedule rules to
+ * {@link AllowedWindow}s — ascending, non-overlapping half-open `[start, end)`
+ * ranges in **local minutes-from-midnight**, where an empty list means access
+ * is denied all day and a single `{ 0, 1440 }` means unrestricted. This module
+ * answers the follow-on question the status screen asks: *given it is now
+ * `nowMinute` local, when does access next flip, and which way?*
+ *
+ * A schedule boundary ("bedtime at 21:00") is inherently a local wall-clock
+ * concept, so the result is expressed as `{ kind, localDate, atMinuteOfDay }`
+ * — the client renders the wall-clock time in the user's effective timezone,
+ * faithful to ADR 0001's "store/compute in UTC, render local" split without
+ * inventing a UTC instant for a value that is really a wall-clock time.
+ *
+ * Pure: no clock, no DB, no timezone math (the caller supplies the already-
+ * resolved windows and the local minute). License boundary: none touched.
+ */
+
+/** A half-open allowed-access window in local minutes-from-midnight `[start, end)`. */
+export interface AllowedWindow {
+  readonly start: number;
+  readonly end: number;
+}
+
+/** Which way overall access flips at a transition. */
+export type TransitionKind = "access_ends" | "access_resumes";
+
+/** The next overall-access transition, as a local wall-clock time. */
+export interface NextTransition {
+  /** `access_ends` = access pauses (a lock begins); `access_resumes` = it comes back. */
+  readonly kind: TransitionKind;
+  /** The local calendar date the transition falls on, `YYYY-MM-DD`. */
+  readonly localDate: string;
+  /** Minutes-from-midnight of the transition, `[0, 1440)`. */
+  readonly atMinuteOfDay: number;
+}
+
+/** Minutes in a day; `1440` is midnight (the day boundary, never a surfaced flip). */
+const MINUTES_PER_DAY = 1440;
+
+/**
+ * Is overall access allowed at `minute` given `windows`? A minute is allowed
+ * iff it falls in some half-open window `[start, end)`. Exported so the status
+ * route can report `allowedNow` from the same predicate this walk uses.
+ */
+export function isAccessAllowedAt(minute: number, windows: readonly AllowedWindow[]): boolean {
+  return windows.some((w) => minute >= w.start && minute < w.end);
+}
+
+/**
+ * Ascending, de-duplicated window-boundary minutes within `[lo, hi)`. These are
+ * the only minutes at which {@link isAccessAllowedAt} can change value, so scanning them
+ * finds every state flip without walking all 1440 minutes.
+ */
+function boundariesIn(windows: readonly AllowedWindow[], lo: number, hi: number): number[] {
+  const set = new Set<number>();
+  for (const w of windows) {
+    if (w.start >= lo && w.start < hi) set.add(w.start);
+    if (w.end >= lo && w.end < hi) set.add(w.end);
+  }
+  return [...set].sort((a, b) => a - b);
+}
+
+/**
+ * The next overall-access transition at or after `nowMinute`, or `null` when
+ * access never changes between now and the end of tomorrow (unrestricted or
+ * denied straight through).
+ *
+ * Looks at **today** first — the earliest window boundary after `nowMinute`
+ * (before midnight) at which access flips — then, if today holds steady to
+ * midnight, at **tomorrow**, including the midnight crossing itself (so a
+ * "denied all day today, resumes at 07:00 tomorrow" or a "unrestricted today,
+ * bedtime at 21:00 tomorrow" both surface). Days beyond tomorrow are not
+ * scanned: a status glance needs the *next* change, not a full calendar.
+ *
+ * @param today       today's overall allowed windows (local minutes).
+ * @param nowMinute   the current local minute-of-day, `[0, 1440)`.
+ * @param todayDate   today's local calendar date, `YYYY-MM-DD`.
+ * @param tomorrow    tomorrow's overall allowed windows (local minutes).
+ * @param tomorrowDate tomorrow's local calendar date, `YYYY-MM-DD`.
+ */
+export function nextOverallTransition(
+  today: readonly AllowedWindow[],
+  nowMinute: number,
+  todayDate: string,
+  tomorrow: readonly AllowedWindow[],
+  tomorrowDate: string,
+): NextTransition | null {
+  const state = isAccessAllowedAt(nowMinute, today);
+
+  // Today: the first boundary strictly after now (never midnight) that flips.
+  for (const minute of boundariesIn(today, nowMinute + 1, MINUTES_PER_DAY)) {
+    if (isAccessAllowedAt(minute, today) !== state) {
+      return {
+        kind: isAccessAllowedAt(minute, today) ? "access_resumes" : "access_ends",
+        localDate: todayDate,
+        atMinuteOfDay: minute,
+      };
+    }
+  }
+
+  // Tomorrow: midnight (0) is always a candidate — the state may flip on the
+  // day crossing even when tomorrow has no intra-day boundaries (e.g. denied
+  // all day) — followed by tomorrow's own boundaries.
+  for (const minute of [0, ...boundariesIn(tomorrow, 1, MINUTES_PER_DAY)]) {
+    if (isAccessAllowedAt(minute, tomorrow) !== state) {
+      return {
+        kind: isAccessAllowedAt(minute, tomorrow) ? "access_resumes" : "access_ends",
+        localDate: tomorrowDate,
+        atMinuteOfDay: minute,
+      };
+    }
+  }
+
+  return null;
+}

--- a/server/tests/api/app-status.test.ts
+++ b/server/tests/api/app-status.test.ts
@@ -1,0 +1,308 @@
+/**
+ * HTTP tests for the PIN-scoped per-child status read (#110):
+ * `GET /api/app/status`.
+ *
+ * Covers the deny-by-default scoping (anonymous and admin sessions are both
+ * refused; a PIN session reaches only its own data), the composed overall +
+ * per-activity time-left numbers against today's usage, the no-budget empty
+ * state, and the two clock-robust access shapes — unrestricted (`allowedNow`
+ * true, no upcoming transition) and an all-day deny (`allowedNow` false). The
+ * transition *boundary* logic is exhaustively unit-tested in
+ * `tests/policy/next-transition.test.ts`; here we only assert it is wired in.
+ */
+import type { InjectOptions } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadSettings } from "../../src/config.js";
+import { PIN_SESSION_COOKIE } from "../../src/auth/pin-session.js";
+import { SESSION_COOKIE } from "../../src/auth/session.js";
+import {
+  activities,
+  activityGroups,
+  activitiesToGroups,
+  budgets,
+  clients,
+  schedules,
+  usageSamples,
+} from "../../src/policy/schema.js";
+import { buildTestApp, type TestApp } from "../helpers/app.js";
+
+function configuredSettings() {
+  return loadSettings({
+    PCT_LOG_LEVEL: "silent",
+    PCT_SECRET_KEY: "app-status-test-secret",
+    PCT_ADMIN_USERNAME: "ben",
+    PCT_ADMIN_PASSWORD: "hunter2",
+  });
+}
+
+/** Pull a named cookie's `name=value` pair out of a response's set-cookie header. */
+function cookieFrom(res: { headers: Record<string, unknown> }, name: string): string {
+  const raw = res.headers["set-cookie"];
+  const headers = Array.isArray(raw) ? (raw as string[]) : [String(raw ?? "")];
+  const match = headers.find((h) => h.startsWith(`${name}=`));
+  if (match === undefined) throw new Error(`no ${name} cookie set`);
+  return match.split(";")[0] ?? "";
+}
+
+/** Today's UTC midnight — the start of the `daily` window for a UTC user. */
+function utcMidnight(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+/** A Date `offsetMinutes` after today's UTC midnight (always within today). */
+function todayAt(offsetMinutes: number): Date {
+  return new Date(utcMidnight().getTime() + offsetMinutes * 60_000);
+}
+
+describe("GET /api/app/status", () => {
+  let harness: TestApp;
+  let adminCookie: string;
+
+  beforeEach(async () => {
+    harness = buildTestApp({ appOptions: { settings: configuredSettings() } });
+    await harness.app.ready();
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    adminCookie = cookieFrom(login, SESSION_COOKIE);
+  });
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  function asAdmin(opts: InjectOptions) {
+    return harness.app.inject({ ...opts, headers: { ...opts.headers, cookie: adminCookie } });
+  }
+
+  async function createUser(displayName: string, tz?: string): Promise<number> {
+    const res = await asAdmin({
+      method: "POST",
+      url: "/api/users",
+      payload: tz === undefined ? { displayName } : { displayName, tz },
+    });
+    expect(res.statusCode).toBe(201);
+    return res.json().id as number;
+  }
+
+  /** Set a PIN via admin, then log the child in and return their session cookie. */
+  async function pinLogin(userId: number, pin: string): Promise<string> {
+    const set = await asAdmin({ method: "PUT", url: `/api/users/${userId}/pin`, payload: { pin } });
+    expect(set.statusCode).toBe(200);
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/app/session",
+      payload: { userId, pin },
+    });
+    expect(login.statusCode).toBe(200);
+    return cookieFrom(login, PIN_SESSION_COOKIE);
+  }
+
+  function asChild(cookie: string, opts: InjectOptions) {
+    return harness.app.inject({ ...opts, headers: { ...opts.headers, cookie } });
+  }
+
+  function createClient(hostname: string): number {
+    const row = harness.db
+      .insert(clients)
+      .values({ hostname, sshUser: "pct-agent" })
+      .returning({ id: clients.id })
+      .get();
+    if (row === undefined) throw new Error("client insert returned no row");
+    return row.id;
+  }
+
+  function createActivity(matcher: string): number {
+    const row = harness.db
+      .insert(activities)
+      .values({ kind: "app", matcher })
+      .returning({ id: activities.id })
+      .get();
+    if (row === undefined) throw new Error("activity insert returned no row");
+    return row.id;
+  }
+
+  // --- deny-by-default scoping ----------------------------------------------
+
+  it("refuses an anonymous caller with a 401", async () => {
+    const res = await harness.app.inject({ method: "GET", url: "/api/app/status" });
+    expect(res.statusCode).toBe(401);
+    expect(res.json().error.code).toBe("unauthorized");
+  });
+
+  it("refuses an admin session (PIN scope only)", async () => {
+    const res = await asAdmin({ method: "GET", url: "/api/app/status" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  // --- composed status ------------------------------------------------------
+
+  it("composes overall and per-activity time-left against today's usage", async () => {
+    const userId = await createUser("Alice"); // tz null → UTC
+    const cookie = await pinLogin(userId, "4242");
+    const clientId = createClient("mint-01");
+    const games = createActivity("steam");
+    const social = createActivity("discord");
+
+    // Group "Fun" containing only the Games activity.
+    const group = harness.db
+      .insert(activityGroups)
+      .values({ name: "Fun" })
+      .returning({ id: activityGroups.id })
+      .get();
+    if (group === undefined) throw new Error("group insert returned no row");
+    harness.db.insert(activitiesToGroups).values({ activityId: games, groupId: group.id }).run();
+
+    harness.db
+      .insert(budgets)
+      .values([
+        { userId, scope: "overall", targetId: null, window: "daily", secondsAllowed: 7200 },
+        { userId, scope: "activity", targetId: games, window: "daily", secondsAllowed: 3600 },
+        { userId, scope: "group", targetId: group.id, window: "daily", secondsAllowed: 5400 },
+      ])
+      .run();
+
+    // 30 min of Games + 10 min of Social, both squarely within today (UTC).
+    harness.db
+      .insert(usageSamples)
+      .values([
+        { userId, clientId, activityId: games, startedAt: todayAt(60), endedAt: todayAt(90) },
+        { userId, clientId, activityId: social, startedAt: todayAt(120), endedAt: todayAt(130) },
+      ])
+      .run();
+
+    const res = await asChild(cookie, { method: "GET", url: "/api/app/status" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.user).toEqual({ id: userId, displayName: "Alice" });
+    expect(body.tz).toBe("UTC");
+    expect(typeof body.now).toBe("string");
+
+    // Overall consumed = 30m Games + 10m Social = 2400s; of 7200s ⇒ 4800 left.
+    expect(body.overall).toEqual({
+      allowedSeconds: 7200,
+      consumedSeconds: 2400,
+      remainingSeconds: 4800,
+    });
+
+    // Per-activity rows are the budgeted set, labelled and with time left.
+    const gamesRow = body.activities.find(
+      (a: { scope: string; targetId: number }) => a.scope === "activity" && a.targetId === games,
+    );
+    expect(gamesRow).toEqual({
+      scope: "activity",
+      targetId: games,
+      label: "steam",
+      activityKind: "app",
+      allowedSeconds: 3600,
+      consumedSeconds: 1800,
+      remainingSeconds: 1800,
+    });
+
+    const groupRow = body.activities.find(
+      (a: { scope: string; targetId: number }) => a.scope === "group" && a.targetId === group.id,
+    );
+    expect(groupRow).toEqual({
+      scope: "group",
+      targetId: group.id,
+      label: "Fun",
+      activityKind: null,
+      allowedSeconds: 5400,
+      consumedSeconds: 1800, // only Games is in the group
+      remainingSeconds: 3600,
+    });
+
+    // No overall schedule ⇒ unrestricted access, no upcoming transition.
+    expect(body.access.allowedNow).toBe(true);
+    expect(body.access.nextTransition).toBeNull();
+  });
+
+  it("reports no limit and no rows when the user has no budgets", async () => {
+    const userId = await createUser("Bob");
+    const cookie = await pinLogin(userId, "1357");
+
+    const res = await asChild(cookie, { method: "GET", url: "/api/app/status" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.overall).toEqual({
+      allowedSeconds: null,
+      consumedSeconds: 0,
+      remainingSeconds: null,
+    });
+    expect(body.activities).toEqual([]);
+  });
+
+  it("clamps remaining to zero when the budget is over-run", async () => {
+    const userId = await createUser("Cara");
+    const cookie = await pinLogin(userId, "2468");
+    const clientId = createClient("mint-02");
+    const games = createActivity("minecraft");
+
+    harness.db
+      .insert(budgets)
+      .values([{ userId, scope: "overall", targetId: null, window: "daily", secondsAllowed: 600 }])
+      .run();
+    // 30 min used against a 10 min budget.
+    harness.db
+      .insert(usageSamples)
+      .values([
+        { userId, clientId, activityId: games, startedAt: todayAt(60), endedAt: todayAt(90) },
+      ])
+      .run();
+
+    const res = await asChild(cookie, { method: "GET", url: "/api/app/status" });
+    const body = res.json();
+    expect(body.overall).toEqual({
+      allowedSeconds: 600,
+      consumedSeconds: 1800,
+      remainingSeconds: 0,
+    });
+  });
+
+  it("reports access denied now when an all-day deny is in effect", async () => {
+    const userId = await createUser("Dan");
+    const cookie = await pinLogin(userId, "9753");
+
+    // An always-on overall deny ⇒ no allowed windows any day.
+    harness.db
+      .insert(schedules)
+      .values([{ userId, targetKind: "overall", targetId: null, action: "deny", ordinal: 0 }])
+      .run();
+
+    const res = await asChild(cookie, { method: "GET", url: "/api/app/status" });
+    const body = res.json();
+    expect(body.access.allowedNow).toBe(false);
+    // Denied straight through today and tomorrow ⇒ no upcoming transition.
+    expect(body.access.nextTransition).toBeNull();
+  });
+
+  it("scopes strictly to the session's own user", async () => {
+    const alice = await createUser("Alice");
+    const bob = await createUser("Bob");
+    const bobCookie = await pinLogin(bob, "1111");
+    // Give Alice a budget; Bob's status must not reflect it.
+    harness.db
+      .insert(budgets)
+      .values([
+        { userId: alice, scope: "overall", targetId: null, window: "daily", secondsAllowed: 7200 },
+      ])
+      .run();
+
+    const res = await asChild(bobCookie, { method: "GET", url: "/api/app/status" });
+    const body = res.json();
+    expect(body.user.id).toBe(bob);
+    expect(body.overall.allowedSeconds).toBeNull(); // Bob has no budget of his own
+  });
+
+  it("resolves the user's effective timezone", async () => {
+    const userId = await createUser("Eve", "America/New_York");
+    const cookie = await pinLogin(userId, "3141");
+    const res = await asChild(cookie, { method: "GET", url: "/api/app/status" });
+    expect(res.json().tz).toBe("America/New_York");
+  });
+});

--- a/server/tests/api/app-status.test.ts
+++ b/server/tests/api/app-status.test.ts
@@ -264,6 +264,47 @@ describe("GET /api/app/status", () => {
     });
   });
 
+  it("wires a real next transition from a bedtime schedule", async () => {
+    const userId = await createUser("Fay"); // UTC
+    const cookie = await pinLogin(userId, "8642");
+
+    // Every-day overall deny 21:00–24:00 ⇒ allowed 00:00–21:00 (1260) each day.
+    harness.db
+      .insert(schedules)
+      .values([
+        {
+          userId,
+          targetKind: "overall",
+          targetId: null,
+          recurrenceDays: 127, // all ISO weekdays
+          recurrenceStartMinute: 1260,
+          recurrenceEndMinute: 1440,
+          action: "deny",
+          ordinal: 0,
+        },
+      ])
+      .run();
+
+    const res = await asChild(cookie, { method: "GET", url: "/api/app/status" });
+    const body = res.json();
+    // A schedule is in play, so there is always an upcoming transition. The
+    // branch is clock-dependent, so assert each side deterministically: this
+    // catches a route-wiring regression (wrong today/tomorrow arg order, wrong
+    // now-minute or date) that the isolated unit tests can't.
+    expect(body.access.nextTransition).not.toBeNull();
+    if (body.access.allowedNow) {
+      // Before 21:00 local: inside today's window ⇒ access ends at 21:00 today.
+      expect(body.access.nextTransition).toEqual({
+        kind: "access_ends",
+        localDate: body.date,
+        atMinuteOfDay: 1260,
+      });
+    } else {
+      // In the 21:00–24:00 deny: access resumes at the midnight roll (tomorrow).
+      expect(body.access.nextTransition.kind).toBe("access_resumes");
+    }
+  });
+
   it("reports access denied now when an all-day deny is in effect", async () => {
     const userId = await createUser("Dan");
     const cookie = await pinLogin(userId, "9753");

--- a/server/tests/policy/next-transition.test.ts
+++ b/server/tests/policy/next-transition.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the pure next-transition boundary walk (#110).
+ *
+ * Exercises `isAccessAllowedAt` and `nextOverallTransition` against the window
+ * shapes the effective-policy resolver produces — unrestricted (`{0,1440}`),
+ * denied-all-day (`[]`), a single bedtime cut-off, a mid-day gap — and the
+ * today→tomorrow hand-off including the midnight crossing.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  isAccessAllowedAt,
+  nextOverallTransition,
+  type AllowedWindow,
+} from "../../src/policy/next-transition.js";
+
+const FULL_DAY: AllowedWindow[] = [{ start: 0, end: 1440 }];
+const DENIED: AllowedWindow[] = [];
+const TODAY = "2026-08-23";
+const TOMORROW = "2026-08-24";
+
+describe("isAccessAllowedAt", () => {
+  it("treats windows as half-open [start, end)", () => {
+    const windows: AllowedWindow[] = [{ start: 540, end: 1260 }]; // 09:00–21:00
+    expect(isAccessAllowedAt(539, windows)).toBe(false);
+    expect(isAccessAllowedAt(540, windows)).toBe(true);
+    expect(isAccessAllowedAt(1259, windows)).toBe(true);
+    expect(isAccessAllowedAt(1260, windows)).toBe(false); // end is exclusive
+  });
+
+  it("is always true unrestricted and always false denied", () => {
+    expect(isAccessAllowedAt(0, FULL_DAY)).toBe(true);
+    expect(isAccessAllowedAt(1439, FULL_DAY)).toBe(true);
+    expect(isAccessAllowedAt(720, DENIED)).toBe(false);
+  });
+});
+
+describe("nextOverallTransition — within today", () => {
+  it("reports access_ends at a bedtime cut-off while access is open", () => {
+    const today: AllowedWindow[] = [{ start: 0, end: 1260 }]; // allowed until 21:00
+    // now 20:00 (1200), inside the window.
+    expect(nextOverallTransition(today, 1200, TODAY, FULL_DAY, TOMORROW)).toEqual({
+      kind: "access_ends",
+      localDate: TODAY,
+      atMinuteOfDay: 1260,
+    });
+  });
+
+  it("reports access_resumes at the next window start while in a gap", () => {
+    const today: AllowedWindow[] = [
+      { start: 0, end: 540 }, // 00:00–09:00
+      { start: 900, end: 1440 }, // 15:00–24:00 (school-hours gap 09:00–15:00)
+    ];
+    // now 10:00 (600), in the gap.
+    expect(nextOverallTransition(today, 600, TODAY, FULL_DAY, TOMORROW)).toEqual({
+      kind: "access_resumes",
+      localDate: TODAY,
+      atMinuteOfDay: 900,
+    });
+  });
+
+  it("picks the earliest boundary after now, not a later one", () => {
+    const today: AllowedWindow[] = [
+      { start: 0, end: 540 },
+      { start: 900, end: 1260 },
+    ];
+    // now 05:00 (300), inside the first window: the next flip is its end at 540.
+    expect(nextOverallTransition(today, 300, TODAY, FULL_DAY, TOMORROW)).toEqual({
+      kind: "access_ends",
+      localDate: TODAY,
+      atMinuteOfDay: 540,
+    });
+  });
+
+  it("never surfaces the midnight end (1440) as a today transition", () => {
+    const today: AllowedWindow[] = [{ start: 720, end: 1440 }]; // allowed noon→midnight
+    // now 13:00 (780), inside; the only later boundary is 1440 → look to tomorrow.
+    const result = nextOverallTransition(today, 780, TODAY, DENIED, TOMORROW);
+    // tomorrow denied all day ⇒ access ends at the midnight crossing.
+    expect(result).toEqual({ kind: "access_ends", localDate: TOMORROW, atMinuteOfDay: 0 });
+  });
+});
+
+describe("nextOverallTransition — spilling into tomorrow", () => {
+  it("reports tomorrow's first resume when denied for the rest of today", () => {
+    // today denied all day; tomorrow allowed 07:00–21:00.
+    const tomorrow: AllowedWindow[] = [{ start: 420, end: 1260 }];
+    expect(nextOverallTransition(DENIED, 600, TODAY, tomorrow, TOMORROW)).toEqual({
+      kind: "access_resumes",
+      localDate: TOMORROW,
+      atMinuteOfDay: 420,
+    });
+  });
+
+  it("reports a resume at midnight when access comes back exactly at the day roll", () => {
+    // today denied all day; tomorrow unrestricted ⇒ access resumes at 00:00.
+    expect(nextOverallTransition(DENIED, 600, TODAY, FULL_DAY, TOMORROW)).toEqual({
+      kind: "access_resumes",
+      localDate: TOMORROW,
+      atMinuteOfDay: 0,
+    });
+  });
+
+  it("reports tomorrow's bedtime when today is unrestricted", () => {
+    // today unrestricted (no today boundary), tomorrow allowed until 21:00.
+    const tomorrow: AllowedWindow[] = [{ start: 0, end: 1260 }];
+    expect(nextOverallTransition(FULL_DAY, 800, TODAY, tomorrow, TOMORROW)).toEqual({
+      kind: "access_ends",
+      localDate: TOMORROW,
+      atMinuteOfDay: 1260,
+    });
+  });
+
+  it("returns null when access never changes (both days unrestricted)", () => {
+    expect(nextOverallTransition(FULL_DAY, 720, TODAY, FULL_DAY, TOMORROW)).toBeNull();
+  });
+
+  it("returns null when access is denied straight through both days", () => {
+    expect(nextOverallTransition(DENIED, 720, TODAY, DENIED, TOMORROW)).toBeNull();
+  });
+
+  it("skips a no-op boundary where two windows touch", () => {
+    // touching windows: access is continuous 00:00→21:00 across the 09:00 seam.
+    const today: AllowedWindow[] = [
+      { start: 0, end: 540 },
+      { start: 540, end: 1260 },
+    ];
+    // now 08:00 (480): the 540 seam is not a flip; the next real flip is 1260.
+    expect(nextOverallTransition(today, 480, TODAY, FULL_DAY, TOMORROW)).toEqual({
+      kind: "access_ends",
+      localDate: TODAY,
+      atMinuteOfDay: 1260,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The PWA per-child status screen (#110, Phase 9): the PIN-scoped `/app` "My time"
view a supervised user sees after logging in — how much overall time is left
today, what they've used, their per-activity limits, and the next schedule
transition, all in their effective timezone.

- **Server** — `GET /api/app/status`, **deny-by-default** (gated by
  `requirePinSession`, scoped strictly to `request.pinUser` — never a
  caller-supplied id, mirroring `GET /api/app/me`). Composes the existing
  effective-policy resolver (grant-adjusted, weekday-varying quotas + allowed
  windows) with the `policy/usage.ts` today rollup into the status payload.
- **`policy/next-transition.ts`** — a pure, exhaustively-tested boundary walk
  answering "when does overall access next flip, and which way?" over the
  resolver's allowed windows, spilling into tomorrow including the midnight
  crossing. A schedule boundary is a wall-clock concept, so it is transmitted
  as `{ kind, localDate, atMinuteOfDay }` and rendered client-side.
- **Frontend** — `AppStatusView.svelte` (overall time-left summary, a "My
  limits today" per-activity list with gentle low/almost-gone bar tones, and a
  paused-now vs. upcoming-bedtime next-transition banner; non-punitive framing
  per `design/app/child-status.html`), rendered into the signed-in branch of
  `routes/app/+page.svelte`, replacing the #112 placeholder.

## Plan

Linked plan: `docs/plans/110-app-child-status-screen.md`
Roadmap: `docs/roadmap.md` → Phase 9. Depends on #112 (per-user PIN auth,
merged); reused by the Phase-12 "My Time" client dashboard (#61).

## Deferred (tracked)

- **Recent grants / rewards strip** — the immutable `Grant` ledger is Phase 10
  (#113 endpoint, #116 ledger UI, #117 recompute); the `grants` table exists
  (the resolver reads it) but has no creation path or display contract yet. The
  status payload is shaped so a `rewards` field can be added additively later.
- **"No-limit" activity rows** (the design's `School ∞` — unbudgeted-but-used
  activities) — this slice's "My limits today" list is the *budgeted*
  (enforceable) set. Tracked in **#417**.

## License-boundary note

N/A — pure TypeScript + zod + Drizzle over the policy store on the server, and
Svelte over the same-origin JSON API on the client. No subprocess / REST / GPL
boundary involved; no packaging or Docker-image change (`license-guard`
unaffected).

## No new dependencies

Uses `drizzle-orm`, `zod`, Fastify, and Svelte 5 already in the tree.

## Test plan

- [x] `policy/next-transition.ts` unit tests: half-open windows; bedtime
      cut-off; mid-day gap; earliest-boundary; never surfacing midnight;
      spill-to-tomorrow (resume/bedtime/midnight); denied/unrestricted → null;
      touching-window no-op seam.
- [x] `GET /api/app/status` API tests: anonymous 401; admin session refused
      (PIN scope only); composed overall + per-activity + group time-left vs.
      today's usage; no-budget empty state; over-run clamps to zero; a real
      (non-null) bedtime transition wired end-to-end; all-day deny →
      `allowedNow` false; strict own-user scoping; effective-tz.
- [x] `AppStatusView` component test: greeting + overall + per-activity rows;
      no-limit state; paused + resume banner; upcoming-bedtime banner; error.
- [x] Server gate green: `format:check` / `lint` / `typecheck` clean; **1998**
      unit tests; coverage gate (80%) satisfied.
- [x] Frontend gate green: `svelte-check` 0 errors / 0 warnings; **380** tests;
      static build OK.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)