### PR TITLE
feat(enforcement): push date-specific exception overrides to the client + revert (#399)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,3 +127,11 @@
 # PCT_TIMEKPR_MIRROR_DIR=/data/apt/timekpr    # apt repo lives here
 # PCT_TIMEKPR_MIRROR_PACKAGE=timekpr-next     # or timekpr-next-beta
 # PCT_TIMEKPR_MIRROR_VERSION=0.5.5            # optional: pin a version; newest if unset
+
+# --- Date-specific override enforcement push (optional; #399) ----------------
+# croner cadence at which the dashboard pushes a supervised user's active
+# date-specific overrides (allow/deny/extend for a calendar date or range) to
+# their client's Timekpr-nExT allowed-hours, and reverts to the standing
+# recurring policy once the override lapses. Started only when the live SSH
+# transport exists. Defaults to every 15 minutes.
+# PCT_EXCEPTION_PUSH_CRON=*/15 * * * *

--- a/docs/plans/399-date-override-enforcement-push.md
+++ b/docs/plans/399-date-override-enforcement-push.md
@@ -1,0 +1,154 @@
+# Plan — #399 Push date-specific exception overrides to the client (and revert)
+
+Roadmap: `docs/roadmap.md` → Phase 13 (the enforcement follow-up ADR 0012 §3 defers).
+Issue: [#399](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/399).
+Builds on: #142 / PR #398 (ADR 0012, resolver-side exception composition), #84
+(offline queue + replay), #143 (effective-policy resolver), #140 (weekly
+allowed-hours grid), #232 (platform runner seam).
+
+## The gap
+
+ADR 0012 composed date-specific `exceptions` (`allow` / `deny` / `extend`, own +
+inherited group) into the effective-policy resolver: they now shape the per-day
+`allowedWindows` served by `GET /api/users/:userId/effective` (the display /
+`?date=` preview). ADR 0012 §3 is explicit that this is the **resolver/display**
+slice only, and that **pushing** a date-specific override to the client's
+`timekpra` allowed-hours *when its window arrives* (and reverting after) is a
+separate offline-queue scheduler concern — this issue.
+
+Today the standing push (`transport/policy-push`, `policy/weekly-windows.ts`)
+resolves the **recurring** weekly grid with **no exceptions**, so a
+"screen-free vacation week" / "allow games until 9pm tonight" override is correct
+in the dashboard but never reaches the device.
+
+## Key facts that shape the design (from ADR 0012)
+
+1. **Exceptions move only `allowedWindows`, never seconds.** An additive time
+   amount is a `Grant`, not an exception. So the representation is a **per-day
+   allowed-hours override**, *not* a daily-limit override — the issue's open
+   "allowed-hours vs daily-limit" question is settled by the ADR.
+2. **Only `overall`-scoped exceptions have an observable effect today.**
+   `activity` / `group` exceptions are gathered and composed but resolve to a
+   no-op until per-target deny enforcement lands (out of scope here, as in the
+   ADR). The design handles this for free: a no-op exception produces the same
+   grid as standing, so nothing is pushed.
+3. **Exceptions must stay out of the *recurring* weekly grid.** `timekpra`
+   allowed-hours is a static weekly grid keyed by ISO weekday; a one-off calendar
+   date cannot be a weekly pattern. Folding "this Tuesday's override" into the
+   standing grid would alias onto *next* Tuesday. So the **standing push stays
+   exception-free** (the clean recurring baseline / revert target), and a
+   dedicated scheduler pushes the exception-inclusive grid for the current
+   reference week, reconciling daily so any weekday-slot aliasing self-corrects
+   well within the 7-day horizon.
+
+## Design
+
+### The push content — reuse the standing push stack, exceptions threaded through
+
+The exception-inclusive grid is the standing grid with each of the seven days of
+the *current reference week* resolved **with** the user's exceptions. Rather than
+a parallel push path, thread an **optional `exceptions` (default `[]`)** through
+the existing stack so behaviour is byte-identical when omitted:
+
+- `policy/weekly-windows.ts` — `WeeklyWindowsInput.exceptions?`; passed to
+  `effectivePolicy` per weekday. Default `[]` ⇒ the recurring-only grid, unchanged.
+- `transport/policy-push/resolve.ts` — `PolicyPushResolveInput.exceptions?`;
+  forwarded to `resolveWeeklyAllowedWindows`. Seconds (`perWeekdaySeconds`,
+  weekly/monthly) are unchanged — exceptions don't touch them (fact 1).
+- `transport/policy-push/platform-runner.ts` — `PolicyEnforcementContext.exceptions?`.
+- `transport/policy-push/linux-runner.ts` — forwards `ctx.exceptions` to
+  `resolvePolicyPush`.
+- `transport/policy-push/executor.ts` — `createPolicyPushExecutor({ …, includeExceptions? })`.
+  When true, the executor also loads `gatherUserExceptions(db, userId)` (own +
+  inherited group, ADR 0012 precedence) and passes it to `runner.enforce`.
+  Standing pushes leave it `false` (recurring grid stays exception-free).
+
+Reusing `applyResolvedPush` inherits its full-lockout behaviour: a **single-day**
+deny within an otherwise-allowed week pushes fine (that weekday empty); a
+**whole-week** deny (every weekday empty) hits the existing `--setalloweddays`
+empty-set skip (full lockout is Phase 8c — zero daily limit / session-kill, not
+allowed-hours). Unchanged and correct.
+
+### The scheduler — `transport/exception-push/`
+
+A croner job modelled on `transport/reapply/scheduler.ts` and the offline-queue
+drainer (injected seams, `protect: true`, `{ tick(); stop() }`, injected clock +
+logger, no GPL coupling). A new queue **kind** `policy.push.exceptions` carries
+the override push; its executor is `createPolicyPushExecutor({ includeExceptions:
+true })`, registered in the drainer's composite executor so an **online push and
+an offline replay run identical code** and a queued override **re-resolves the
+current exception state at drain time** (auto-reverting if it expired while the
+client was offline).
+
+The queued action reuses coalesce key `user:<id>` (same as the standing push):
+coalescing is kind-agnostic (`UNIQUE(client_id, coalesce_key)` +
+`onConflictDoUpdate` that updates `kind`), so an override push and a standing
+push represent the same target's latest desired state and supersede each other —
+either ordering self-heals on the next scheduler tick.
+
+**Each tick** (reference instant from an injected clock):
+
+1. **Candidates** = users with any exception whose active window
+   `[effective_from ?? created_at, expires_at)` has `expires_at ≥ now − LOOKBACK`
+   (8 days, covering the weekly-grid aliasing horizon), **plus** any user still
+   tracked as overridden. `gatherUserExceptions` is used (not the own-only
+   repository read) so group-inherited overrides count.
+2. For each candidate compute `desiredSig` = a stable signature of the
+   **exception-inclusive** weekly grid, and `standingSig` = the exception-free
+   grid, for the current reference week in the user's effective tz.
+3. **Change-detection** against an in-memory `pushedSignature: Map<userId, sig>`:
+   - First tick after start: push every candidate's desired grid (reconcile after
+     a restart — re-assert active overrides *and* revert any that expired during
+     downtime).
+   - Otherwise push only when `desiredSig !== pushedSignature.get(userId)`.
+   - Skip pushing a user who has never been pushed *and* whose desired grid equals
+     standing (a no-op exception — nothing to enforce).
+   - After a push, if `desiredSig === standingSig` the revert is complete → drop
+     the user from the map (keeps it bounded to actively-overridden users).
+4. A push fans out to every `listUserLinks(db, userId)` client via
+   `pushOrEnqueue(db, action, exceptionExecutor)` — online → pushed; unreachable
+   (retriable) → queued for the drainer; non-Linux platform → the executor's
+   existing warn-and-no-op. Audit is automatic (the executor's `TimekprClient`
+   runs over the audited transport); a distinct reason (`exception.window`) makes
+   overrides queryable.
+
+Config: `PCT_EXCEPTION_PUSH_CRON` (default `*/15 * * * *` — responsive to a
+same-day "adjust bedtime" override without being chatty; reapply is hourly,
+telemetry every 5 min). Wired in `createPolicyPushTransport` (needs the audited
+`TimekprClient` factory + SSH credentials, exactly like the drainer), stopped in
+its `dispose` (already called by `AppServices.teardown`). No live transport (no
+SSH key) ⇒ not started, mirroring the drainer.
+
+## Implementation phases
+
+### Phase 1 — thread exceptions through the push stack (pure / near-pure)
+- `weekly-windows.ts`, `policy-push/resolve.ts`, `platform-runner.ts`,
+  `linux-runner.ts`, `executor.ts` — the optional `exceptions` / `includeExceptions`
+  seam (all default-off ⇒ standing push byte-identical).
+- Tests: `resolvePolicyPush` with/without exceptions (deny shrinks a day, extend
+  widens past a standing deny, other days standing); `resolveWeeklyAllowedWindows`
+  exceptions param; executor `includeExceptions` loads `gatherUserExceptions` and
+  forwards it (spy runner); standing path unchanged (existing tests stay green).
+
+### Phase 2 — the scheduler + kind + config + wiring
+- `transport/exception-push/{scheduler.ts,index.ts}` + the `policy.push.exceptions`
+  kind + queued-action builder.
+- `config.ts` `exceptionPush.cron` + `.env.example` + `docs/server-deployment.md`.
+- `bootstrap.ts` — build the include-exceptions executor, register it in the
+  drain composite, construct + dispose the scheduler.
+- Tests: tick pushes an override grid for an active deny/extend; no push for a
+  user with no override or an activity/group-only (no-op) exception; revert push
+  once after expiry then stable; first-tick reconcile after restart; multi-client
+  fan-out; group-inherited override detected; offline client → queued;
+  overlap-protection / start-stop lifecycle / default pattern export;
+  config default + override + invalid; `buildApp` teardown stops it.
+
+## Deferred (tracked follow-ups, linked from the PR)
+- **Admin policy save during an active override** transiently clobbers the
+  override grid (the standing push is exception-free); the next scheduler tick
+  re-asserts it. Documented limitation; a tighter coupling (standing push
+  delegating to the override resolve while an override is active) is a follow-up.
+- **Per-activity / group `deny` quota reduction** — out of scope per ADR 0012
+  (recurring schedules don't do it either); only `overall` overrides are enforced.
+- **Whole-week deny → full lockout** — the existing Phase 8c gap (zero daily
+  limit / session-kill), unchanged.

--- a/docs/plans/399-date-override-enforcement-push.md
+++ b/docs/plans/399-date-override-enforcement-push.md
@@ -96,15 +96,21 @@ either ordering self-heals on the next scheduler tick.
 2. For each candidate compute `desiredSig` = a stable signature of the
    **exception-inclusive** weekly grid, and `standingSig` = the exception-free
    grid, for the current reference week in the user's effective tz.
-3. **Change-detection** against an in-memory `pushedSignature: Map<userId, sig>`:
-   - First tick after start: push every candidate's desired grid (reconcile after
-     a restart — re-assert active overrides *and* revert any that expired during
-     downtime).
-   - Otherwise push only when `desiredSig !== pushedSignature.get(userId)`.
-   - Skip pushing a user who has never been pushed *and* whose desired grid equals
-     standing (a no-op exception — nothing to enforce).
-   - After a push, if `desiredSig === standingSig` the revert is complete → drop
-     the user from the map (keeps it bounded to actively-overridden users).
+3. **Decision**, tracking only the set of currently-overridden users (to fire
+   the revert once), **not** a change-detection cache:
+   - While an override is **materially active** (`overrideGrid !== standingGrid`)
+     push **every tick**. A standing policy push can clobber the device's grid
+     out-of-band (it resolves the exception-free grid and shares this push's
+     coalesce key) and the scheduler cannot observe that, so idempotent
+     re-pushing bounds any clobber to at most one cron interval — the correctness
+     the "push on change" optimisation would have silently broken for a `deny`.
+   - When the grid has fallen back to **standing**, push the revert exactly once
+     (a tracked user, or the first-pass sweep), then untrack.
+   - **First tick after start** reconciles every user with *any* exception row
+     (regardless of age): re-assert active overrides and revert any that expired
+     during downtime — including an outage longer than the steady-state lookback.
+   - Steady-state candidacy skips users whose exceptions are all older than the
+     lookback and who are not tracked.
 4. A push fans out to every `listUserLinks(db, userId)` client via
    `pushOrEnqueue(db, action, exceptionExecutor)` — online → pushed; unreachable
    (retriable) → queued for the drainer; non-Linux platform → the executor's
@@ -145,9 +151,11 @@ SSH key) ⇒ not started, mirroring the drainer.
 
 ## Deferred (tracked follow-ups, linked from the PR)
 - **Admin policy save during an active override** transiently clobbers the
-  override grid (the standing push is exception-free); the next scheduler tick
-  re-asserts it. Documented limitation; a tighter coupling (standing push
-  delegating to the override resolve while an override is active) is a follow-up.
+  override grid (the standing push is exception-free). The scheduler re-asserts
+  it automatically on the next tick (it re-pushes every pass while an override is
+  materially active), so this is a bounded ≤ one-cron-interval transient, not a
+  lost override. Shrinking that window (standing push delegating to the
+  override-inclusive resolve while an override is active) is tracked as **#421**.
 - **Per-activity / group `deny` quota reduction** — out of scope per ADR 0012
   (recurring schedules don't do it either); only `overall` overrides are enforced.
 - **Whole-week deny → full lockout** — the existing Phase 8c gap (zero daily

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -559,6 +559,30 @@ and offers a dry-run/preview and a manual "run now". Only the global default
 lives in the environment — restart to change it; per-category overrides are
 runtime config and need no restart.
 
+## Date-specific override enforcement
+
+A **date-specific override** (an `exception` — "no screen time on 2026-06-30", a
+"screen-free vacation week", or "allow games until 9pm tonight") shapes the
+effective policy in the dashboard, but the recurring Timekpr-nExT allowed-hours
+grid pushed to a client is a *static weekly* grid that cannot express a one-off
+calendar date ([`docs/adr/0012-date-specific-override-composition.md`](adr/0012-date-specific-override-composition.md)
+§3). A background scheduler bridges that gap: each pass it resolves the
+exception-inclusive weekly allowed-hours for every user with an active override
+and pushes it to their client(s) over the same SSH + `timekpra` transport (and
+offline queue) the standing policy push uses, then **reverts** to the standing
+recurring policy once the override lapses. Each push/revert is recorded in the
+transport audit log under the `exception.window` reason.
+
+- **`PCT_EXCEPTION_PUSH_CRON`** — the reconcile cadence (default `*/15 * * * *`,
+  every 15 minutes). It bounds how soon after an override opens, is authored
+  same-day, or lapses the device catches up. The scheduler runs only once the
+  dashboard's SSH key exists (first-run keygen); before that, overrides are
+  correct in the dashboard but not yet pushed, exactly like the standing push.
+- Exceptions change **allowed hours only**, never the daily/weekly/monthly time
+  limits (an additive time amount is a grant, not an exception). Today only
+  `overall`-scoped overrides have an on-device effect; `activity`/`group`-scoped
+  ones compose into the effective view but are not yet separately enforced.
+
 ## Upgrade path
 
 `docker pull` a newer image tag and restart. The server applies any new

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -471,13 +471,9 @@ const settingsSchema = z
        * responsive to a same-day "adjust bedtime tonight" override without
        * dialling every override-affected client more often than needed.
        */
-      cron: z
-        .string()
-        .min(1)
-        .default("*/15 * * * *")
-        .refine(isValidCronPattern, {
-          message: "must be a valid cron pattern (e.g. */15 * * * *)",
-        }),
+      cron: z.string().min(1).default("*/15 * * * *").refine(isValidCronPattern, {
+        message: "must be a valid cron pattern (e.g. */15 * * * *)",
+      }),
     }),
     /**
      * Automatic pre-migration policy-store snapshot (#166). Before the

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -457,6 +457,29 @@ const settingsSchema = z
       ),
     }),
     /**
+     * Phase-13 date-specific override enforcement push (#399): the croner
+     * cadence at which the `transport/exception-push` scheduler pushes a user's
+     * active date-specific overrides to their client's `timekpra` allowed-hours
+     * (and reverts once they expire). Wired in `createPolicyPushTransport`
+     * alongside the offline-queue drainer, so — like `reapply` — it is
+     * parsed-and-ready and only started when the live SSH transport exists (#39).
+     */
+    exceptionPush: z.object({
+      /**
+       * croner pattern for the override-reconcile pass (`PCT_EXCEPTION_PUSH_CRON`).
+       * Validated here so a typo fails fast. Defaults to every 15 minutes —
+       * responsive to a same-day "adjust bedtime tonight" override without
+       * dialling every override-affected client more often than needed.
+       */
+      cron: z
+        .string()
+        .min(1)
+        .default("*/15 * * * *")
+        .refine(isValidCronPattern, {
+          message: "must be a valid cron pattern (e.g. */15 * * * *)",
+        }),
+    }),
+    /**
      * Automatic pre-migration policy-store snapshot (#166). Before the
      * in-process migrator runs on boot (`policy/db.ts`), an existing
      * `policy.sqlite` with pending migrations is snapshotted via `VACUUM INTO`
@@ -590,6 +613,9 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
     reapply: {
       cron: env.PCT_REAPPLY_CRON,
       playbooks: env.PCT_REAPPLY_PLAYBOOKS,
+    },
+    exceptionPush: {
+      cron: env.PCT_EXCEPTION_PUSH_CRON,
     },
     preMigrationBackup: {
       enabled: env.PCT_PRE_MIGRATION_BACKUP,

--- a/server/src/policy/weekly-windows.ts
+++ b/server/src/policy/weekly-windows.ts
@@ -11,16 +11,29 @@
  * weekday, ready to hand to {@link TimekprClient.setWeeklyAllowedHours} /
  * `buildWeeklyAllowedHoursCommands`.
  *
- * Only the **recurring** layer is resolved: no budgets, no grants, no
- * date-specific overrides. `timekpra` allowed-hours is a *static weekly* grid;
- * date-specific overrides (#142) adjust the daily *limit*, not this grid, and
- * are a later, separately-composed layer.
+ * By default only the **recurring** layer is resolved: no budgets, no grants,
+ * no date-specific overrides — the exception-free grid the standing `timekpra`
+ * push consumes and the clean baseline a date-specific override reverts to. A
+ * one-off calendar date is not a weekly-recurring pattern, so exceptions stay
+ * out of that grid (ADR 0012 §3).
+ *
+ * The optional {@link WeeklyWindowsInput.exceptions} is the one exception to
+ * that: it lets the date-override enforcement push (#399) resolve the seven days
+ * of a *specific reference week* with the user's active overrides folded in,
+ * producing the exception-inclusive grid to push when an override's window
+ * arrives (and, once the override ages out, the same call with no active
+ * exception yields the standing grid again — the revert). It is keyed by ISO
+ * weekday like the recurring grid, so its caller reconciles it daily to keep
+ * any weekday-slot aliasing (this Tuesday vs. next Tuesday) from outliving the
+ * override — see `transport/exception-push`. Omit it (the default `[]`) for the
+ * standing push and every existing caller: the result is byte-identical to the
+ * recurring-only grid.
  *
  * License boundary: none touched — pure TypeScript over the policy model and a
  * type-only import of the transport's weekly shape.
  */
 import { isoWeekday, localCalendarDate } from "./budget-window.js";
-import { effectivePolicy } from "./resolve.js";
+import { effectivePolicy, type ExceptionInput } from "./resolve.js";
 import type { ScheduleRule } from "./schedule-precedence.js";
 import type { TimeWindow, WeeklyAllowedWindows } from "../transport/timekpr/allowed-hours.js";
 import type { IsoWeekday } from "../transport/timekpr/commands.js";
@@ -40,6 +53,13 @@ export interface WeeklyWindowsInput {
   readonly tz: string;
   /** Any instant within the target week; its seven local days are resolved. */
   readonly reference: Date;
+  /**
+   * Date-specific overrides (#142/#399), in precedence order, to fold into each
+   * day of the resolved week. Optional — omit (default `[]`) for the recurring
+   * standing grid; the date-override push passes the user's active exceptions so
+   * an override's day resolves to its overridden `allowedWindows`.
+   */
+  readonly exceptions?: readonly ExceptionInput[];
 }
 
 /** The seven ISO weekdays, Monday (1) … Sunday (7), in order. */
@@ -71,6 +91,7 @@ function addCalendarDays(date: CalendarDate, days: number): CalendarDate {
  */
 export function resolveWeeklyAllowedWindows(input: WeeklyWindowsInput): WeeklyAllowedWindows {
   const { schedules, tz, reference } = input;
+  const exceptions = input.exceptions ?? [];
   const today = localCalendarDate(reference, tz);
   const referenceWeekday = isoWeekday(today.year, today.month, today.day);
   const monday = addCalendarDays(today, -(referenceWeekday - 1));
@@ -78,7 +99,7 @@ export function resolveWeeklyAllowedWindows(input: WeeklyWindowsInput): WeeklyAl
   const byWeekday = new Map<IsoWeekday, readonly TimeWindow[]>();
   for (const [offset, weekday] of ISO_WEEKDAYS.entries()) {
     const date = addCalendarDays(monday, offset);
-    const effective = effectivePolicy({ date, tz, schedules, budgets: [], grants: [] });
+    const effective = effectivePolicy({ date, tz, schedules, budgets: [], grants: [], exceptions });
     byWeekday.set(weekday, effective.allowedWindows);
   }
   return byWeekday;

--- a/server/src/transport/exception-push/index.ts
+++ b/server/src/transport/exception-push/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Date-specific override enforcement push (#399, Phase 13): the croner scheduler
+ * that pushes a user's active date-specific overrides to their client's
+ * `timekpra` allowed-hours when the override's window arrives, and reverts to
+ * the standing recurring policy once it lapses. See {@link ./scheduler.ts} and
+ * ADR 0012 §3.
+ */
+export const moduleName = "transport/exception-push";
+
+export {
+  DEFAULT_EXCEPTION_LOOKBACK_MS,
+  DEFAULT_EXCEPTION_PUSH_PATTERN,
+  EXCEPTION_PUSH_KIND,
+  EXCEPTION_PUSH_LOG_COMPONENT,
+  EXCEPTION_PUSH_REASON,
+  startDateOverridePush,
+  type DateOverridePushHandle,
+  type DateOverridePushOptions,
+} from "./scheduler.js";

--- a/server/src/transport/exception-push/scheduler.ts
+++ b/server/src/transport/exception-push/scheduler.ts
@@ -1,0 +1,232 @@
+/**
+ * Date-specific override enforcement push (#399, Phase 13).
+ *
+ * ADR 0012 composed date-specific `exceptions` (`allow` / `deny` / `extend`, own
+ * + inherited group) into the effective-policy resolver, but §3 deliberately
+ * kept them out of the recurring `timekpra` allowed-hours grid and named this as
+ * the follow-up: pushing a date-specific override to the client **when its
+ * window arrives** (and reverting after) is an offline-queue scheduler concern
+ * (#84). This module is that scheduler.
+ *
+ * A one-off calendar date is not a weekly-recurring pattern, so the standing
+ * push stays exception-free (the clean recurring baseline / revert target). Each
+ * tick this job resolves the **exception-inclusive** weekly grid for the current
+ * reference week and pushes it — via the same offline queue + audited
+ * `timekpra` client the standing push uses (a distinct `policy.push.exceptions`
+ * kind whose executor re-reads the override state on every run). Because the
+ * grid is keyed by ISO weekday, the tick reconciles daily so a weekday slot an
+ * override touched (this Tuesday) can never outlive the override onto the next
+ * same weekday (next Tuesday) — the reconcile restores the standing slot well
+ * within the seven-day horizon, and an override that has expired resolves back
+ * to the standing grid (the revert) automatically.
+ *
+ * Modelled on `transport/reapply/scheduler.ts` and the offline-queue drainer:
+ * all remote/DB/clock seams are injected, overlapping runs are suppressed
+ * (croner `protect`), and one user's unexpected error is isolated so it never
+ * aborts the rest of the pass. It is started by `createPolicyPushTransport` only
+ * when the live SSH transport exists (like the drainer), and stopped on dispose.
+ *
+ * License boundary: none touched — croner (MIT) + Drizzle over the policy store;
+ * the push runs over the existing SSH-subprocess `timekpra` client via the
+ * injected executor. No GPL code is linked in-process (`CLAUDE.md` → "License
+ * boundaries").
+ */
+import { Cron } from "croner";
+import type { FastifyBaseLogger } from "fastify";
+
+import type { PolicyDb } from "../../policy/db.js";
+import { gatherUserExceptions, gatherUserScheduleRules } from "../../policy/group-resolution.js";
+import { getUser, listUserLinks, listUsers } from "../../policy/repository.js";
+import type { ExceptionInput } from "../../policy/resolve.js";
+import { resolveWeeklyAllowedWindows } from "../../policy/weekly-windows.js";
+import type { WeeklyAllowedWindows } from "../timekpr/allowed-hours.js";
+import { pushOrEnqueue, type ActionExecutor, type NewQueuedAction } from "../queue/index.js";
+
+/** The queue `kind` a date-specific override push is stored/dispatched under. */
+export const EXCEPTION_PUSH_KIND = "policy.push.exceptions";
+
+/** The audit `reason` every override push carries (a stable query key). */
+export const EXCEPTION_PUSH_REASON = "exception.window";
+
+/** The pino `component` tag every scheduler log line carries (#11). */
+export const EXCEPTION_PUSH_LOG_COMPONENT = "transport/exception-push";
+
+/**
+ * Default cadence: reconcile every 15 minutes. An override "arrives" at a day
+ * boundary (a `deny`/`allow` for a date) or is authored same-day ("adjust
+ * bedtime tonight"); 15 minutes bounds how long after either the device lags,
+ * without dialling every override-affected client more often than needed.
+ */
+export const DEFAULT_EXCEPTION_PUSH_PATTERN = "*/15 * * * *";
+
+/**
+ * How far back an expired exception still makes a user a reconcile candidate.
+ * A weekly grid keyed by ISO weekday aliases across weeks, so a slot an override
+ * touched must be reconciled back to standing before that weekday recurs — eight
+ * days gives a full day of margin over the seven-day horizon, and covers a
+ * revert that a process restart would otherwise miss.
+ */
+export const DEFAULT_EXCEPTION_LOOKBACK_MS = 8 * 24 * 60 * 60 * 1000;
+
+/** Wiring for {@link startDateOverridePush}. */
+export interface DateOverridePushOptions {
+  /** The shared policy-store handle candidate users + overrides are read from. */
+  readonly db: PolicyDb;
+  /**
+   * The include-exceptions push executor (`createPolicyPushExecutor({
+   * includeExceptions: true })`). `pushOrEnqueue` drives it directly online and
+   * the offline-queue drainer replays it — the same code path — so a queued
+   * override re-resolves the current override state when the client reconnects.
+   */
+  readonly executor: ActionExecutor;
+  /** Server-default timezone for users with no `tz` override. */
+  readonly defaultTz: string;
+  /** Base logger; a `transport/exception-push` child is derived for the job. */
+  readonly log: FastifyBaseLogger;
+  /** croner pattern; defaults to {@link DEFAULT_EXCEPTION_PUSH_PATTERN}. */
+  readonly pattern?: string;
+  /** Clock seam; defaults to `() => new Date()`. */
+  readonly now?: () => Date;
+  /** Expired-override candidacy lookback; defaults to {@link DEFAULT_EXCEPTION_LOOKBACK_MS}. */
+  readonly lookbackMs?: number;
+}
+
+/** A running scheduler the caller can kick manually or stop on shutdown. */
+export interface DateOverridePushHandle {
+  /** Run one reconcile pass now (also what each cron tick invokes). */
+  tick(): Promise<void>;
+  /** Stop the schedule permanently (e.g. on `app.close()`). */
+  stop(): void;
+}
+
+/** A stable, order-independent signature of a weekly allowed-hours grid. */
+function weeklySignature(weekly: WeeklyAllowedWindows): string {
+  const days: string[] = [];
+  for (const weekday of [1, 2, 3, 4, 5, 6, 7] as const) {
+    const windows = weekly.get(weekday) ?? [];
+    days.push(windows.map((w) => `${w.start}-${w.end}`).join(","));
+  }
+  return days.join("|");
+}
+
+/**
+ * Start the date-specific override enforcement push scheduler and return a
+ * handle.
+ *
+ * Each tick walks the supervised users, and for any with a date-specific
+ * override active (or one that expired within the lookback) computes the
+ * exception-inclusive weekly grid. It pushes only when that grid differs from
+ * what it last pushed for the user (change-detection), fanning out to every
+ * client the user is on via the offline queue; once an override lapses the grid
+ * equals the standing grid again and one final push reverts the device. The
+ * first pass after start reconciles every candidate unconditionally, so a
+ * restart re-asserts active overrides and clears any that expired while down.
+ */
+export function startDateOverridePush(options: DateOverridePushOptions): DateOverridePushHandle {
+  const { db, executor, defaultTz, log } = options;
+  const pattern = options.pattern ?? DEFAULT_EXCEPTION_PUSH_PATTERN;
+  const now = options.now ?? ((): Date => new Date());
+  const lookbackMs = options.lookbackMs ?? DEFAULT_EXCEPTION_LOOKBACK_MS;
+  const child = log.child({ component: EXCEPTION_PUSH_LOG_COMPONENT });
+
+  /**
+   * The exception-inclusive grid signature we last initiated a push for, per
+   * user. Present only for users with a currently-material override; pruned once
+   * an override lapses and the revert has been pushed, so it stays bounded to
+   * actively-overridden users (lost on restart — the first tick reconciles).
+   */
+  const pushedSignature = new Map<number, string>();
+  let firstPass = true;
+
+  /** Fan a desired-state push out to every client the user is on. */
+  async function pushToClients(userId: number): Promise<void> {
+    for (const link of listUserLinks(db, userId)) {
+      const action: NewQueuedAction = {
+        clientId: link.clientId,
+        // Same coalesce key as the standing push: an override push and a standing
+        // push are the same target's latest desired state, so they supersede one
+        // another (the queue coalesces on `(clientId, coalesceKey)`), and the
+        // winner's `kind` selects the executor.
+        coalesceKey: `user:${userId}`,
+        kind: EXCEPTION_PUSH_KIND,
+        payload: { userId, reason: EXCEPTION_PUSH_REASON, detail: {} },
+      };
+      try {
+        const outcome = await pushOrEnqueue(db, action, executor);
+        child.debug(
+          { userId, clientId: link.clientId, status: outcome.status },
+          "date-override push dispatched",
+        );
+      } catch (error) {
+        // `pushOrEnqueue` rethrows only non-retriable failures (a bad command —
+        // replaying it unchanged won't help); a retriable/offline push is queued
+        // for the drainer instead. Log and move on so one client can't abort the
+        // fan-out; a later tick re-pushes if the desired state still differs.
+        child.warn({ userId, clientId: link.clientId, err: error }, "date-override push failed");
+      }
+    }
+  }
+
+  /** Reconcile one user's override state; returns whether a push was issued. */
+  async function reconcileUser(userId: number, reference: Date): Promise<void> {
+    const exceptions = gatherUserExceptions(db, userId);
+    const relevant: ExceptionInput[] = exceptions.filter(
+      (e) => e.expiresAt.getTime() >= reference.getTime() - lookbackMs,
+    );
+    const tracked = pushedSignature.has(userId);
+    // Nothing to enforce and nothing outstanding to revert.
+    if (relevant.length === 0 && !tracked) return;
+
+    const tz = getUser(db, userId)?.tz ?? defaultTz;
+    const schedules = gatherUserScheduleRules(db, userId);
+    const desiredSig = weeklySignature(
+      resolveWeeklyAllowedWindows({ schedules, tz, reference, exceptions: relevant }),
+    );
+    const standingSig = weeklySignature(resolveWeeklyAllowedWindows({ schedules, tz, reference }));
+    const materiallyActive = desiredSig !== standingSig;
+    const prev = pushedSignature.get(userId);
+
+    let shouldPush: boolean;
+    if (firstPass) {
+      // Reconcile every candidate after a restart: re-assert active overrides and
+      // revert any that expired (device may still hold a stale override grid).
+      shouldPush = true;
+    } else if (materiallyActive) {
+      shouldPush = desiredSig !== prev;
+    } else {
+      // Desired == standing: push only to revert an override we previously pushed.
+      shouldPush = prev !== undefined && prev !== desiredSig;
+    }
+    if (!shouldPush) return;
+
+    await pushToClients(userId);
+    if (materiallyActive) {
+      pushedSignature.set(userId, desiredSig);
+      child.info({ userId }, "date-specific override pushed");
+    } else {
+      // Reverted to standing — nothing left to track for this user.
+      pushedSignature.delete(userId);
+      child.info({ userId }, "date-specific override reverted to standing policy");
+    }
+  }
+
+  const tick = async (): Promise<void> => {
+    const reference = now();
+    for (const user of listUsers(db)) {
+      try {
+        await reconcileUser(user.id, reference);
+      } catch (error) {
+        // One user's unexpected failure must not abort the rest of the pass.
+        child.error({ userId: user.id, err: error }, "date-override reconcile error");
+      }
+    }
+    firstPass = false;
+  };
+
+  const job = new Cron(pattern, { name: "date-override-push", protect: true }, tick);
+
+  return {
+    tick,
+    stop: () => job.stop(),
+  };
+}

--- a/server/src/transport/exception-push/scheduler.ts
+++ b/server/src/transport/exception-push/scheduler.ts
@@ -14,11 +14,19 @@
  * reference week and pushes it — via the same offline queue + audited
  * `timekpra` client the standing push uses (a distinct `policy.push.exceptions`
  * kind whose executor re-reads the override state on every run). Because the
- * grid is keyed by ISO weekday, the tick reconciles daily so a weekday slot an
- * override touched (this Tuesday) can never outlive the override onto the next
- * same weekday (next Tuesday) — the reconcile restores the standing slot well
- * within the seven-day horizon, and an override that has expired resolves back
- * to the standing grid (the revert) automatically.
+ * grid is keyed by ISO weekday, the reconcile restores an override-touched
+ * weekday slot to standing once the override's week rolls past — well within the
+ * seven-day aliasing horizon for a mid-week override. (A Monday override is the
+ * edge: its revert can only fire once the reference instant reaches the *next*
+ * Monday, so the stale slot can linger for up to one cron interval into that
+ * aliasing Monday before the tick reverts it.) An override that has expired
+ * resolves back to the standing grid (the revert) automatically.
+ *
+ * While an override is materially active the tick **re-asserts it every pass**,
+ * not only on change: the desired grid can be clobbered on the device
+ * out-of-band by a standing policy push (which resolves the exception-free grid
+ * and shares this push's coalesce key), and the scheduler cannot observe that,
+ * so idempotent re-pushing bounds any such clobber to at most one cron interval.
  *
  * Modelled on `transport/reapply/scheduler.ts` and the offline-queue drainer:
  * all remote/DB/clock seams are injected, overlapping runs are suppressed
@@ -37,7 +45,6 @@ import type { FastifyBaseLogger } from "fastify";
 import type { PolicyDb } from "../../policy/db.js";
 import { gatherUserExceptions, gatherUserScheduleRules } from "../../policy/group-resolution.js";
 import { getUser, listUserLinks, listUsers } from "../../policy/repository.js";
-import type { ExceptionInput } from "../../policy/resolve.js";
 import { resolveWeeklyAllowedWindows } from "../../policy/weekly-windows.js";
 import type { WeeklyAllowedWindows } from "../timekpr/allowed-hours.js";
 import { pushOrEnqueue, type ActionExecutor, type NewQueuedAction } from "../queue/index.js";
@@ -60,11 +67,13 @@ export const EXCEPTION_PUSH_LOG_COMPONENT = "transport/exception-push";
 export const DEFAULT_EXCEPTION_PUSH_PATTERN = "*/15 * * * *";
 
 /**
- * How far back an expired exception still makes a user a reconcile candidate.
- * A weekly grid keyed by ISO weekday aliases across weeks, so a slot an override
- * touched must be reconciled back to standing before that weekday recurs — eight
- * days gives a full day of margin over the seven-day horizon, and covers a
- * revert that a process restart would otherwise miss.
+ * How far back an expired exception still makes a user a **steady-state**
+ * reconcile candidate. A weekly grid keyed by ISO weekday aliases across weeks,
+ * so a slot an override touched must be reconciled back to standing before that
+ * weekday recurs — eight days gives a full day of margin over the seven-day
+ * horizon. (A restart reconciles *any* user with an exception row regardless of
+ * age — see the first-pass branch in `reconcileUser` — so a long outage past
+ * this window still self-heals once on the next start.)
  */
 export const DEFAULT_EXCEPTION_LOOKBACK_MS = 8 * 24 * 60 * 60 * 1000;
 
@@ -130,12 +139,17 @@ export function startDateOverridePush(options: DateOverridePushOptions): DateOve
   const child = log.child({ component: EXCEPTION_PUSH_LOG_COMPONENT });
 
   /**
-   * The exception-inclusive grid signature we last initiated a push for, per
-   * user. Present only for users with a currently-material override; pruned once
-   * an override lapses and the revert has been pushed, so it stays bounded to
-   * actively-overridden users (lost on restart — the first tick reconciles).
+   * Users we are currently enforcing an override for. Used only to fire the
+   * revert push exactly once when an override lapses (a tracked user whose grid
+   * has fallen back to standing), so the set stays bounded to actively-overridden
+   * users. It is deliberately **not** a change-detection cache: while an override
+   * is materially active we re-push every tick (see {@link reconcileUser}) so an
+   * out-of-band clobber — e.g. a standing policy push for an unrelated budget
+   * edit, which resolves the exception-free grid and shares this push's coalesce
+   * key — self-heals within one cron interval rather than being lost until the
+   * override changes. Lost on restart; the first tick reconciles.
    */
-  const pushedSignature = new Map<number, string>();
+  const tracking = new Set<number>();
   let firstPass = true;
 
   /** Fan a desired-state push out to every client the user is on. */
@@ -167,45 +181,56 @@ export function startDateOverridePush(options: DateOverridePushOptions): DateOve
     }
   }
 
-  /** Reconcile one user's override state; returns whether a push was issued. */
+  /** Reconcile one user's override state for this pass. */
   async function reconcileUser(userId: number, reference: Date): Promise<void> {
     const exceptions = gatherUserExceptions(db, userId);
-    const relevant: ExceptionInput[] = exceptions.filter(
-      (e) => e.expiresAt.getTime() >= reference.getTime() - lookbackMs,
-    );
-    const tracked = pushedSignature.has(userId);
-    // Nothing to enforce and nothing outstanding to revert.
-    if (relevant.length === 0 && !tracked) return;
+    const tracked = tracking.has(userId);
+
+    // Candidate gate. On the first pass after start (empty tracking set) reconcile
+    // every user with *any* exception row, so a restart reverts even an override
+    // that expired during a long outage (the device may still hold its stale
+    // weekly-grid slot). In steady state, a user is a candidate only if they have
+    // an exception recent enough to still matter (within the lookback) or one we
+    // are already enforcing (so the revert still fires).
+    if (firstPass) {
+      if (exceptions.length === 0) return;
+    } else {
+      const recent = exceptions.some(
+        (e) => e.expiresAt.getTime() >= reference.getTime() - lookbackMs,
+      );
+      if (!recent && !tracked) return;
+    }
 
     const tz = getUser(db, userId)?.tz ?? defaultTz;
     const schedules = gatherUserScheduleRules(db, userId);
-    const desiredSig = weeklySignature(
-      resolveWeeklyAllowedWindows({ schedules, tz, reference, exceptions: relevant }),
-    );
-    const standingSig = weeklySignature(resolveWeeklyAllowedWindows({ schedules, tz, reference }));
-    const materiallyActive = desiredSig !== standingSig;
-    const prev = pushedSignature.get(userId);
+    // Build both grids for the current reference week. All exceptions are passed
+    // to the resolver, which date-gates each to the days it actually covers, so
+    // an expired override contributes nothing and the grid falls back to standing.
+    const overrideGrid = resolveWeeklyAllowedWindows({ schedules, tz, reference, exceptions });
+    const standingGrid = resolveWeeklyAllowedWindows({ schedules, tz, reference });
+    const materiallyActive = weeklySignature(overrideGrid) !== weeklySignature(standingGrid);
 
     let shouldPush: boolean;
-    if (firstPass) {
-      // Reconcile every candidate after a restart: re-assert active overrides and
-      // revert any that expired (device may still hold a stale override grid).
+    if (materiallyActive) {
+      // Re-assert every tick (not just on change): the desired grid can be
+      // clobbered on the device out-of-band by a standing push, which this
+      // scheduler cannot observe, so idempotently re-pushing bounds any clobber
+      // to at most one cron interval. Cheap — only actively-overridden users.
       shouldPush = true;
-    } else if (materiallyActive) {
-      shouldPush = desiredSig !== prev;
     } else {
-      // Desired == standing: push only to revert an override we previously pushed.
-      shouldPush = prev !== undefined && prev !== desiredSig;
+      // Grid has fallen back to standing: push the revert exactly once, when we
+      // were enforcing an override or are doing the first-pass restart sweep.
+      shouldPush = tracked || firstPass;
     }
     if (!shouldPush) return;
 
     await pushToClients(userId);
     if (materiallyActive) {
-      pushedSignature.set(userId, desiredSig);
+      tracking.add(userId);
       child.info({ userId }, "date-specific override pushed");
     } else {
       // Reverted to standing — nothing left to track for this user.
-      pushedSignature.delete(userId);
+      tracking.delete(userId);
       child.info({ userId }, "date-specific override reverted to standing policy");
     }
   }

--- a/server/src/transport/policy-push/bootstrap.ts
+++ b/server/src/transport/policy-push/bootstrap.ts
@@ -28,6 +28,7 @@ import type { Settings } from "../../config.js";
 import type { PolicyDb } from "../../policy/db.js";
 import { getClient } from "../../policy/repository.js";
 import { AuditingTransport, DrizzleAuditSink, type AuditableTransport } from "../audit/index.js";
+import { startDateOverridePush, EXCEPTION_PUSH_KIND } from "../exception-push/index.js";
 import { SshClientProber, type ClientProber } from "../health/index.js";
 import {
   compositeExecutor,
@@ -237,14 +238,43 @@ export function createPolicyPushTransport(
       ),
   });
 
-  // The drainer replays both kinds: standing policy pushes and queued same-day
-  // adjustments. The dispatcher above only ever pushes `policy.push`, so it
-  // keeps driving that executor directly.
+  // The date-override enforcement push (#399) shares the standing push machinery
+  // but resolves with the user's active date-specific exceptions folded into the
+  // allowed-hours grid (`includeExceptions`). It re-reads the override state on
+  // every run, so a queued override replayed after its window closed resolves to
+  // the standing grid (the revert). Same platform registry / attribution as the
+  // system push above.
+  const exceptionExecutor = createPolicyPushExecutor({
+    db,
+    registry,
+    defaultTz: settings.defaultTz,
+    log,
+    includeExceptions: true,
+    ...(options.now !== undefined ? { now: options.now } : {}),
+  });
+
+  // The drainer replays three kinds: standing policy pushes, queued same-day
+  // adjustments, and date-specific override pushes. The dispatcher above only
+  // ever pushes `policy.push`, so it keeps driving that executor directly.
   const drainExecutor = compositeExecutor({
     [POLICY_PUSH_KIND]: executor,
     [TIME_TODAY_KIND]: timeTodayExecutor,
+    [EXCEPTION_PUSH_KIND]: exceptionExecutor,
   });
   const drainer = startOfflineQueueDrainer({ db, probe, executor: drainExecutor, log });
+
+  // The date-override reconcile scheduler (#399): each tick it pushes the
+  // exception-inclusive weekly grid for users with an active override (and
+  // reverts once it lapses) through `exceptionExecutor` + the offline queue.
+  // Started here (like the drainer) only because the live SSH transport exists.
+  const overridePush = startDateOverridePush({
+    db,
+    executor: exceptionExecutor,
+    defaultTz: settings.defaultTz,
+    log,
+    pattern: settings.exceptionPush.cron,
+    ...(options.now !== undefined ? { now: options.now } : {}),
+  });
 
   // The same-day "Add time today" lever (#257): a synchronous, audited
   // `--settimeleft` over the audited SSH `timekpra` client, attributed to the
@@ -308,6 +338,7 @@ export function createPolicyPushTransport(
     pushPolicyNow,
     prober,
     dispose: (): void => {
+      overridePush.stop();
       drainer.stop();
       ssh.disposeAll();
     },

--- a/server/src/transport/policy-push/executor.ts
+++ b/server/src/transport/policy-push/executor.ts
@@ -48,7 +48,11 @@
 import { z } from "zod";
 
 import type { PolicyDb } from "../../policy/db.js";
-import { gatherUserBudgets, gatherUserScheduleRules } from "../../policy/group-resolution.js";
+import {
+  gatherUserBudgets,
+  gatherUserExceptions,
+  gatherUserScheduleRules,
+} from "../../policy/group-resolution.js";
 import { getClient, getUser, listUserLinks } from "../../policy/repository.js";
 import type { ActionExecutor, QueuedAction } from "../queue/types.js";
 import { policyPushPayloadSchema } from "./payload.js";
@@ -90,6 +94,17 @@ export interface PolicyPushExecutorOptions {
   readonly log?: PolicyPushExecutorLogger;
   /** Clock for the reference instant; overridable in tests. Defaults to `new Date()`. */
   readonly now?: () => Date;
+  /**
+   * When `true`, the effective push also composes the user's active
+   * date-specific exceptions (own + inherited group, `gatherUserExceptions`,
+   * ADR 0012 precedence) into the allowed-hours grid — the #399 date-override
+   * enforcement push. The standing push leaves this `false` (the default) so the
+   * recurring `timekpra` grid stays exception-free (ADR 0012 §3). Because the
+   * executor re-resolves from the DB on every run, a queued override replayed
+   * after its window has closed simply resolves to the standing grid — the
+   * revert is automatic.
+   */
+  readonly includeExceptions?: boolean;
 }
 
 /**
@@ -100,6 +115,7 @@ export interface PolicyPushExecutorOptions {
 export function createPolicyPushExecutor(options: PolicyPushExecutorOptions): ActionExecutor {
   const { db, registry, defaultTz, log } = options;
   const now = options.now ?? ((): Date => new Date());
+  const includeExceptions = options.includeExceptions ?? false;
 
   return async function execute(action: QueuedAction): Promise<void> {
     const { userId, reason, detail } = policyPushPayloadSchema.parse(action.payload);
@@ -148,6 +164,11 @@ export function createPolicyPushExecutor(options: PolicyPushExecutorOptions): Ac
     // reaches the client instead of being display-only.
     const budgets = gatherUserBudgets(db, userId);
     const schedules = gatherUserScheduleRules(db, userId);
+    // The date-override push (#399) folds active exceptions into the allowed-hours
+    // grid; the standing push omits them so the recurring grid stays
+    // exception-free (ADR 0012 §3). Re-read here so a queued override replayed
+    // after its window closed resolves to the standing grid (auto-revert).
+    const exceptions = includeExceptions ? gatherUserExceptions(db, userId) : undefined;
 
     await runner.enforce({
       client,
@@ -158,6 +179,7 @@ export function createPolicyPushExecutor(options: PolicyPushExecutorOptions): Ac
       schedules,
       budgets,
       now: now(),
+      ...(exceptions !== undefined ? { exceptions } : {}),
     });
   };
 }

--- a/server/src/transport/policy-push/linux-runner.ts
+++ b/server/src/transport/policy-push/linux-runner.ts
@@ -130,6 +130,10 @@ export function createLinuxPolicyRunner(options: LinuxPolicyRunnerOptions): Plat
         schedules: ctx.schedules,
         budgets: ctx.budgets,
         now: ctx.now,
+        // Fold in date-specific overrides when the executor supplies them (#399);
+        // the standing push omits `exceptions`, keeping the recurring grid
+        // exception-free (ADR 0012 §3).
+        ...(ctx.exceptions !== undefined ? { exceptions: ctx.exceptions } : {}),
       });
       const timekpr = buildClient({
         client: ctx.client,

--- a/server/src/transport/policy-push/platform-runner.ts
+++ b/server/src/transport/policy-push/platform-runner.ts
@@ -26,7 +26,7 @@
  */
 import type { Platform } from "../../policy/enums.js";
 import type { ClientRow } from "../../policy/repository.js";
-import type { BudgetInput } from "../../policy/resolve.js";
+import type { BudgetInput, ExceptionInput } from "../../policy/resolve.js";
 import type { ScheduleRule } from "../../policy/schedule-precedence.js";
 
 /**
@@ -59,6 +59,14 @@ export interface PolicyEnforcementContext {
   readonly budgets: readonly BudgetInput[];
   /** The reference instant the week and "today" are resolved against. */
   readonly now: Date;
+  /**
+   * The user's active date-specific overrides (#399), in precedence order.
+   * Optional — the standing push omits it (the recurring grid stays
+   * exception-free, ADR 0012 §3); the date-override enforcement push supplies
+   * the user's own + inherited group exceptions so the runner folds them into
+   * the allowed-hours grid it pushes.
+   */
+  readonly exceptions?: readonly ExceptionInput[];
 }
 
 /**

--- a/server/src/transport/policy-push/resolve.ts
+++ b/server/src/transport/policy-push/resolve.ts
@@ -27,7 +27,11 @@
  *
  * License boundary: none touched — pure TypeScript over the policy model.
  */
-import { overallDailySecondsForWeekday, type BudgetInput } from "../../policy/resolve.js";
+import {
+  overallDailySecondsForWeekday,
+  type BudgetInput,
+  type ExceptionInput,
+} from "../../policy/resolve.js";
 import type { ScheduleRule } from "../../policy/schedule-precedence.js";
 import { resolveWeeklyAllowedWindows } from "../../policy/weekly-windows.js";
 import type { TimeWindow, WeeklyAllowedWindows } from "../timekpr/allowed-hours.js";
@@ -58,6 +62,16 @@ export interface PolicyPushResolveInput {
   readonly budgets: readonly BudgetInput[];
   /** The reference instant the week and "today" are resolved against. */
   readonly now: Date;
+  /**
+   * Date-specific overrides (#399), in precedence order. Optional — omit
+   * (default `[]`) for the standing recurring push, which keeps exceptions out
+   * of the weekly grid (ADR 0012 §3). The date-override enforcement push passes
+   * the user's active exceptions so an override's day is folded into the
+   * allowed-hours grid it pushes. Exceptions never change the seconds limits
+   * (`perWeekdaySeconds` / weekly / monthly) — an additive time amount is a
+   * `Grant`, not an exception — so only {@link ResolvedPolicyPush.weekly} differs.
+   */
+  readonly exceptions?: readonly ExceptionInput[];
 }
 
 /** The concrete `timekpra` push inputs for one user on one client. */
@@ -103,7 +117,12 @@ function rollingOverallSeconds(
 export function resolvePolicyPush(input: PolicyPushResolveInput): ResolvedPolicyPush {
   const { tz, schedules, budgets, now } = input;
 
-  const weekly = resolveWeeklyAllowedWindows({ schedules, tz, reference: now });
+  const weekly = resolveWeeklyAllowedWindows({
+    schedules,
+    tz,
+    reference: now,
+    exceptions: input.exceptions ?? [],
+  });
 
   // ALL_ISO_WEEKDAYS is Monday..Sunday — the same order as the seven-day
   // `--settimelimits` list, so this maps position-for-position.

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -27,6 +27,7 @@ describe("loadSettings", () => {
     expect(settings.enforcement).toEqual({ cooldownSeconds: 300, initialLookbackSeconds: 900 });
     expect(settings.retention).toEqual({ defaultDays: 365 });
     expect(settings.reapply).toEqual({ cron: "0 * * * *", playbooks: [] });
+    expect(settings.exceptionPush).toEqual({ cron: "*/15 * * * *" });
     expect(settings.clientHealth).toEqual({ probeConcurrency: 4, probeDeadlineMs: 15000 });
     expect(settings.preMigrationBackup).toEqual({ enabled: true, retain: 5 });
     expect(settings.serverVersion).toBeUndefined();
@@ -515,6 +516,16 @@ describe("loadSettings", () => {
       expect(() => loadSettings({ PCT_REAPPLY_PLAYBOOKS: "../escape.yml" })).toThrow(SettingsError);
       expect(() => loadSettings({ PCT_REAPPLY_PLAYBOOKS: "ok.yml,sub/dir.yml" })).toThrow(
         /bare playbook file name/,
+      );
+    });
+
+    it("honours PCT_EXCEPTION_PUSH_CRON and rejects an invalid pattern", () => {
+      expect(loadSettings({ PCT_EXCEPTION_PUSH_CRON: "*/5 * * * *" }).exceptionPush).toEqual({
+        cron: "*/5 * * * *",
+      });
+      expect(() => loadSettings({ PCT_EXCEPTION_PUSH_CRON: "not a cron" })).toThrow(SettingsError);
+      expect(() => loadSettings({ PCT_EXCEPTION_PUSH_CRON: "not a cron" })).toThrow(
+        /valid cron pattern/,
       );
     });
   });

--- a/server/tests/policy/weekly-windows.test.ts
+++ b/server/tests/policy/weekly-windows.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "vitest";
 
 import { resolveWeeklyAllowedWindows } from "../../src/policy/weekly-windows.js";
+import type { ExceptionInput } from "../../src/policy/resolve.js";
 import type { ScheduleRule } from "../../src/policy/schedule-precedence.js";
 import { buildWeeklyAllowedHoursCommands } from "../../src/transport/timekpr/allowed-hours.js";
 
@@ -142,6 +143,29 @@ describe("resolveWeeklyAllowedWindows", () => {
     expect(byWeekday.get(7)).toEqual([]);
   });
 
+  it("is unchanged when passed an empty exceptions array (default recurring grid)", () => {
+    const schedules: ScheduleRule[] = [
+      mkRule({
+        id: 1,
+        action: "allow",
+        recurrenceDays: WEEKDAYS,
+        recurrenceStartMinute: 16 * 60,
+        recurrenceEndMinute: 18 * 60,
+      }),
+      mkRule({ id: 2, ordinal: 1, action: "deny" }),
+    ];
+    const withField = resolveWeeklyAllowedWindows({
+      schedules,
+      tz: "UTC",
+      reference: REFERENCE,
+      exceptions: [],
+    });
+    const without = resolveWeeklyAllowedWindows({ schedules, tz: "UTC", reference: REFERENCE });
+    for (const weekday of [1, 2, 3, 4, 5, 6, 7] as const) {
+      expect(withField.get(weekday)).toEqual(without.get(weekday));
+    }
+  });
+
   it("feeds buildWeeklyAllowedHoursCommands end-to-end (#140 push)", () => {
     // allow 16:00–18:00 Mon–Fri; the bridge's output drives the merged
     // transport mapping directly (the resolver→timekpra glue this module adds).
@@ -166,5 +190,90 @@ describe("resolveWeeklyAllowedWindows", () => {
       ["--setallowedhours", "alice", "4", "16;17"],
       ["--setallowedhours", "alice", "5", "16;17"],
     ]);
+  });
+});
+
+/**
+ * Build an {@link ExceptionInput}, defaulting to a whole-Wednesday (2024-06-05,
+ * the reference day) `overall` `deny` in UTC.
+ */
+function mkException(overrides: Partial<ExceptionInput> = {}): ExceptionInput {
+  return {
+    id: 1,
+    targetKind: "overall",
+    targetId: null,
+    action: "deny",
+    effectiveFrom: new Date("2024-06-05T00:00:00Z"),
+    expiresAt: new Date("2024-06-06T00:00:00Z"),
+    createdAt: new Date("2024-06-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("resolveWeeklyAllowedWindows — date-specific overrides (#399)", () => {
+  it("denies only the weekday a whole-day deny override covers, leaving others standing", () => {
+    // No recurring schedule → every day baseline-allowed; the override denies Wed.
+    const byWeekday = resolveWeeklyAllowedWindows({
+      schedules: [],
+      tz: "UTC",
+      reference: REFERENCE,
+      exceptions: [mkException()],
+    });
+    // Wednesday (weekday 3, the covered day) is now denied all day…
+    expect(byWeekday.get(3)).toEqual([]);
+    // …while every other day keeps the standing unrestricted grid.
+    for (const weekday of [1, 2, 4, 5, 6, 7] as const) {
+      expect(byWeekday.get(weekday)).toEqual([{ start: 0, end: 1440 }]);
+    }
+  });
+
+  it("widens the covered day past a standing bedtime deny via an extend override", () => {
+    // Standing: allow 09:00–17:00 every day, deny the rest (a bedtime cut-off).
+    const schedules: ScheduleRule[] = [
+      mkRule({
+        id: 1,
+        action: "allow",
+        recurrenceDays: EVERY_DAY,
+        recurrenceStartMinute: 9 * 60,
+        recurrenceEndMinute: 17 * 60,
+      }),
+      mkRule({ id: 2, ordinal: 1, action: "deny" }),
+    ];
+    // "allow until 21:00 this Wednesday" — an extend union past the 17:00 deny.
+    const exception = mkException({
+      action: "extend",
+      effectiveFrom: new Date("2024-06-05T00:00:00Z"),
+      expiresAt: new Date("2024-06-05T21:00:00Z"),
+    });
+    const overridden = resolveWeeklyAllowedWindows({
+      schedules,
+      tz: "UTC",
+      reference: REFERENCE,
+      exceptions: [exception],
+    });
+    const standing = resolveWeeklyAllowedWindows({ schedules, tz: "UTC", reference: REFERENCE });
+    // Wednesday now reaches to 21:00 (1260); other days keep the 09:00–17:00 grid.
+    expect(overridden.get(3)).toEqual([{ start: 0, end: 21 * 60 }]);
+    expect(standing.get(3)).toEqual([{ start: 9 * 60, end: 17 * 60 }]);
+    for (const weekday of [1, 2, 4, 5, 6, 7] as const) {
+      expect(overridden.get(weekday)).toEqual([{ start: 9 * 60, end: 17 * 60 }]);
+    }
+  });
+
+  it("ignores an override whose window falls outside the resolved week", () => {
+    // An override for a date in a later week must not touch this week's grid.
+    const nextWeek = mkException({
+      effectiveFrom: new Date("2024-06-12T00:00:00Z"),
+      expiresAt: new Date("2024-06-13T00:00:00Z"),
+    });
+    const byWeekday = resolveWeeklyAllowedWindows({
+      schedules: [],
+      tz: "UTC",
+      reference: REFERENCE,
+      exceptions: [nextWeek],
+    });
+    for (const weekday of [1, 2, 3, 4, 5, 6, 7] as const) {
+      expect(byWeekday.get(weekday)).toEqual([{ start: 0, end: 1440 }]);
+    }
   });
 });

--- a/server/tests/transport/exception-push/scheduler.test.ts
+++ b/server/tests/transport/exception-push/scheduler.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Unit tests for the date-specific override enforcement push scheduler (#399).
+ *
+ * Drives the real reconcile logic over an in-memory policy store with an
+ * injected clock and a recording executor: an active override is pushed, an
+ * unchanged one is not re-pushed, a lapsed one reverts exactly once, a restart
+ * reconciles a stale override, the fan-out reaches every linked client, group
+ * overrides are included, and an offline push is queued for the drainer.
+ */
+import type { FastifyBaseLogger } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadSettings } from "../../../src/config.js";
+import {
+  addUserToGroup,
+  createClient,
+  createException,
+  createGroupException,
+  createUser,
+  createUserGroup,
+  upsertLink,
+} from "../../../src/policy/repository.js";
+import { buildApp } from "../../../src/web/app.js";
+import {
+  DEFAULT_EXCEPTION_PUSH_PATTERN,
+  EXCEPTION_PUSH_KIND,
+  EXCEPTION_PUSH_REASON,
+  startDateOverridePush,
+  type DateOverridePushHandle,
+} from "../../../src/transport/exception-push/index.js";
+import { listPendingForClient } from "../../../src/transport/queue/index.js";
+import type { ActionExecutor, QueuedAction } from "../../../src/transport/queue/types.js";
+import { SshCommandError, SshUnreachableError } from "../../../src/transport/ssh/errors.js";
+import { testDb, type TestDb } from "../../helpers/db.js";
+
+const target = { host: "mint-01", port: 22, username: "pct-agent" } as const;
+
+/** Wed 2026-06-17 12:00 UTC — reference week Mon 2026-06-15 … Sun 2026-06-21. */
+const WED = new Date("2026-06-17T12:00:00Z");
+/** The Monday of the *following* week — the override's week has rolled past. */
+const NEXT_MON = new Date("2026-06-22T12:00:00Z");
+
+/** An `overall` deny override covering Wednesday 2026-06-17 only. */
+const WED_WINDOW = {
+  effectiveFrom: new Date("2026-06-17T00:00:00Z"),
+  expiresAt: new Date("2026-06-18T00:00:00Z"),
+} as const;
+
+/** A recording executor that resolves — `pushOrEnqueue` reports "pushed". */
+function recordingExecutor(): { executor: ActionExecutor; actions: QueuedAction[] } {
+  const actions: QueuedAction[] = [];
+  return {
+    actions,
+    executor: (action) => {
+      actions.push(action);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("startDateOverridePush", () => {
+  let app: ReturnType<typeof buildApp>;
+  let db: TestDb;
+  let log: FastifyBaseLogger;
+  let handle: DateOverridePushHandle | undefined;
+
+  beforeEach(() => {
+    db = testDb();
+    app = buildApp({
+      settings: loadSettings({ PCT_LOG_LEVEL: "silent", PCT_SECRET_KEY: "test-secret-key" }),
+      db,
+    });
+    log = app.log;
+  });
+  afterEach(async () => {
+    handle?.stop();
+    handle = undefined;
+    await app.close();
+    db.$client.close();
+  });
+
+  /** Start a scheduler with a fixed (or mutable) clock; tracked for teardown. */
+  function start(executor: ActionExecutor, now: () => Date): DateOverridePushHandle {
+    handle = startDateOverridePush({
+      db,
+      executor,
+      defaultTz: "UTC",
+      log,
+      now,
+      // A pattern that will not fire during the test; we drive `tick()` directly.
+      pattern: "0 0 31 2 *",
+    });
+    return handle;
+  }
+
+  function linkedUser(hostname = "mint-01"): { userId: number; clientId: number } {
+    const userId = createUser(db, { displayName: "Alice", tz: "UTC" }).id;
+    const clientId = createClient(db, { hostname, sshUser: "pct-agent" }).id;
+    upsertLink(db, userId, clientId, { osUsername: "alice", osUserRef: "1001" });
+    return { userId, clientId };
+  }
+
+  it("pushes an override action to the user's client when an override is active", async () => {
+    const { userId, clientId } = linkedUser();
+    createException(db, { userId, targetKind: "overall", action: "deny", ...WED_WINDOW });
+
+    const { executor, actions } = recordingExecutor();
+    await start(executor, () => WED).tick();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      clientId,
+      coalesceKey: `user:${userId}`,
+      kind: EXCEPTION_PUSH_KIND,
+      payload: { userId, reason: EXCEPTION_PUSH_REASON },
+    });
+  });
+
+  it("does not push for a user with no exceptions", async () => {
+    linkedUser();
+
+    const { executor, actions } = recordingExecutor();
+    await start(executor, () => WED).tick();
+
+    expect(actions).toHaveLength(0);
+  });
+
+  it("does not re-push while the override is unchanged (change-detection)", async () => {
+    const { userId } = linkedUser();
+    createException(db, { userId, targetKind: "overall", action: "deny", ...WED_WINDOW });
+
+    const { executor, actions } = recordingExecutor();
+    const h = start(executor, () => WED);
+    await h.tick();
+    await h.tick();
+
+    // First tick pushes; the second sees the same desired grid and skips.
+    expect(actions).toHaveLength(1);
+  });
+
+  it("reverts exactly once after the override's week rolls past, then stays quiet", async () => {
+    const { userId } = linkedUser();
+    createException(db, { userId, targetKind: "overall", action: "deny", ...WED_WINDOW });
+
+    let clock = WED;
+    const { executor, actions } = recordingExecutor();
+    const h = start(executor, () => clock);
+
+    await h.tick(); // active → push override
+    clock = NEXT_MON;
+    await h.tick(); // override's week has passed → desired == standing → revert push
+    await h.tick(); // already reverted → no further push
+
+    expect(actions).toHaveLength(2);
+    expect(actions[0]?.kind).toBe(EXCEPTION_PUSH_KIND);
+    expect(actions[1]?.kind).toBe(EXCEPTION_PUSH_KIND);
+  });
+
+  it("reconciles a stale override on the first pass after a restart (revert)", async () => {
+    const { userId } = linkedUser();
+    // The override expired last week; a fresh scheduler has no memory of having
+    // pushed it, but the device may still hold the stale grid — first pass reverts.
+    createException(db, { userId, targetKind: "overall", action: "deny", ...WED_WINDOW });
+
+    const { executor, actions } = recordingExecutor();
+    await start(executor, () => NEXT_MON).tick();
+
+    // Exactly one (revert) push — proving restart reconciliation.
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.kind).toBe(EXCEPTION_PUSH_KIND);
+  });
+
+  it("fans the override push out to every client the user is on", async () => {
+    const userId = createUser(db, { displayName: "Alice", tz: "UTC" }).id;
+    const clientA = createClient(db, { hostname: "mint-a", sshUser: "pct-agent" }).id;
+    const clientB = createClient(db, { hostname: "mint-b", sshUser: "pct-agent" }).id;
+    upsertLink(db, userId, clientA, { osUsername: "alice", osUserRef: "1001" });
+    upsertLink(db, userId, clientB, { osUsername: "alice", osUserRef: "1001" });
+    createException(db, { userId, targetKind: "overall", action: "deny", ...WED_WINDOW });
+
+    const { executor, actions } = recordingExecutor();
+    await start(executor, () => WED).tick();
+
+    expect(actions.map((a) => a.clientId).sort((x, y) => x - y)).toEqual(
+      [clientA, clientB].sort((x, y) => x - y),
+    );
+  });
+
+  it("includes an inherited group override (gatherUserExceptions)", async () => {
+    const { userId, clientId } = linkedUser();
+    const group = createUserGroup(db, { name: "Kids" });
+    addUserToGroup(db, group.id, userId);
+    createGroupException(db, {
+      userGroupId: group.id,
+      targetKind: "overall",
+      action: "deny",
+      ...WED_WINDOW,
+    });
+
+    const { executor, actions } = recordingExecutor();
+    await start(executor, () => WED).tick();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({ clientId, kind: EXCEPTION_PUSH_KIND });
+  });
+
+  it("ignores an activity-scoped override in steady state (a no-op for the grid)", async () => {
+    const { userId } = linkedUser();
+    // An activity-scoped exception composes but does not change the overall
+    // allowed-hours grid (ADR 0012) — so after the first-pass reconcile it never
+    // triggers another push.
+    createException(db, {
+      userId,
+      targetKind: "activity",
+      targetId: 5,
+      action: "deny",
+      ...WED_WINDOW,
+    });
+
+    const { executor, actions } = recordingExecutor();
+    const h = start(executor, () => WED);
+    await h.tick(); // first pass reconciles the candidate once (standing grid)
+    await h.tick(); // steady state: desired == standing, nothing to revert → no push
+
+    expect(actions).toHaveLength(1);
+  });
+
+  it("queues the push for an offline client instead of throwing", async () => {
+    const { userId, clientId } = linkedUser();
+    createException(db, { userId, targetKind: "overall", action: "deny", ...WED_WINDOW });
+
+    // The executor rejects with a retriable (unreachable) error, so pushOrEnqueue
+    // durably queues the action for the drainer rather than surfacing a failure.
+    const executor: ActionExecutor = () => Promise.reject(new SshUnreachableError(target));
+    await expect(start(executor, () => WED).tick()).resolves.toBeUndefined();
+
+    const pending = listPendingForClient(db, clientId);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.kind).toBe(EXCEPTION_PUSH_KIND);
+  });
+
+  it("isolates a non-retriable push failure and keeps reconciling", async () => {
+    const { userId } = linkedUser();
+    createException(db, { userId, targetKind: "overall", action: "deny", ...WED_WINDOW });
+
+    // A non-retriable command error is rethrown by pushOrEnqueue; the scheduler
+    // must swallow it (logged) so the pass completes without throwing.
+    const executor: ActionExecutor = () =>
+      Promise.reject(
+        new SshCommandError(target, ["timekpra"], {
+          stdout: "",
+          stderr: "boom",
+          code: 1,
+          signal: null,
+        }),
+      );
+    await expect(start(executor, () => WED).tick()).resolves.toBeUndefined();
+  });
+
+  it("exposes a stop()-able handle and a default cron pattern", () => {
+    const { executor } = recordingExecutor();
+    const h = start(executor, () => WED);
+    expect(() => h.stop()).not.toThrow();
+    handle = undefined; // already stopped
+    expect(DEFAULT_EXCEPTION_PUSH_PATTERN).toBe("*/15 * * * *");
+  });
+});

--- a/server/tests/transport/exception-push/scheduler.test.ts
+++ b/server/tests/transport/exception-push/scheduler.test.ts
@@ -125,7 +125,12 @@ describe("startDateOverridePush", () => {
     expect(actions).toHaveLength(0);
   });
 
-  it("does not re-push while the override is unchanged (change-detection)", async () => {
+  it("re-asserts an active override on every tick (self-heals an out-of-band clobber)", async () => {
+    // A standing policy push can overwrite the device's allowed-hours grid with
+    // the exception-free version (it shares this push's coalesce key) — and the
+    // scheduler can't observe that. So while an override is materially active it
+    // must re-push every tick, not just on change, or a `deny` override would be
+    // silently and permanently lost. Two active ticks → two pushes.
     const { userId } = linkedUser();
     createException(db, { userId, targetKind: "overall", action: "deny", ...WED_WINDOW });
 
@@ -134,8 +139,8 @@ describe("startDateOverridePush", () => {
     await h.tick();
     await h.tick();
 
-    // First tick pushes; the second sees the same desired grid and skips.
-    expect(actions).toHaveLength(1);
+    expect(actions).toHaveLength(2);
+    expect(actions.every((a) => a.kind === EXCEPTION_PUSH_KIND)).toBe(true);
   });
 
   it("reverts exactly once after the override's week rolls past, then stays quiet", async () => {
@@ -166,6 +171,27 @@ describe("startDateOverridePush", () => {
     await start(executor, () => NEXT_MON).tick();
 
     // Exactly one (revert) push — proving restart reconciliation.
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.kind).toBe(EXCEPTION_PUSH_KIND);
+  });
+
+  it("reverts an override that expired beyond the lookback on the first pass (long outage)", async () => {
+    const { userId } = linkedUser();
+    // Expired ~15 days before `now` — outside the 8-day steady-state lookback, so
+    // only the first-pass "any exception row" sweep reconciles the stale device slot.
+    createException(db, {
+      userId,
+      targetKind: "overall",
+      action: "deny",
+      effectiveFrom: new Date("2026-06-01T00:00:00Z"),
+      expiresAt: new Date("2026-06-02T00:00:00Z"),
+    });
+
+    const { executor, actions } = recordingExecutor();
+    const h = start(executor, () => WED);
+    await h.tick(); // first pass: revert the long-stale override
+    await h.tick(); // steady state: out of lookback, untracked → quiet
+
     expect(actions).toHaveLength(1);
     expect(actions[0]?.kind).toBe(EXCEPTION_PUSH_KIND);
   });

--- a/server/tests/transport/policy-push/executor.test.ts
+++ b/server/tests/transport/policy-push/executor.test.ts
@@ -16,7 +16,9 @@ import {
   addUserToGroup,
   createBudget,
   createClient,
+  createException,
   createGroupBudget,
+  createGroupException,
   createGroupSchedule,
   createSchedule,
   createUser,
@@ -36,6 +38,7 @@ import {
   type PolicyPushRunnerLogger,
 } from "../../../src/transport/policy-push/linux-runner.js";
 import { createPlatformRunnerRegistry } from "../../../src/transport/policy-push/platform-runner.js";
+import type { WeeklyAllowedWindows } from "../../../src/transport/timekpr/allowed-hours.js";
 import type { ActionExecutor, QueuedAction } from "../../../src/transport/queue/types.js";
 import { SshCommandError, SshUnreachableError } from "../../../src/transport/ssh/errors.js";
 import { testDb, type TestDb } from "../../helpers/db.js";
@@ -508,5 +511,115 @@ describe("createPolicyPushExecutor", () => {
     await expect(
       executor({ clientId, coalesceKey: "user:1", kind: "policy.push", payload: { nope: true } }),
     ).rejects.toBeInstanceOf(ZodError);
+  });
+
+  describe("date-specific override push (includeExceptions, #399)", () => {
+    // A fixed mid-week instant (Wed 2026-06-17 12:00 UTC): the reference week is
+    // Mon 2026-06-15 … Sun 2026-06-21, so an override on the 17th is ISO weekday 3.
+    const NOW = new Date("2026-06-17T12:00:00Z");
+
+    /** A recording client that captures the weekly allowed-hours grid it was pushed. */
+    function capturingClient(): { client: PolicyPushClient; weekly?: WeeklyAllowedWindows } {
+      const rec: { client: PolicyPushClient; weekly?: WeeklyAllowedWindows } = {
+        client: {
+          setTimeLimits: () => Promise.resolve(),
+          setTimeLimitWeek: () => Promise.resolve(),
+          setTimeLimitMonth: () => Promise.resolve(),
+          setWeeklyAllowedHours: (weekly) => {
+            rec.weekly = weekly;
+            return Promise.resolve();
+          },
+        },
+      };
+      return rec;
+    }
+
+    function overrideExecutor(
+      rec: { client: PolicyPushClient },
+      includeExceptions: boolean,
+    ): ActionExecutor {
+      const runner = createLinuxPolicyRunner({ buildClient: () => rec.client });
+      return createPolicyPushExecutor({
+        db,
+        defaultTz: "UTC",
+        registry: createPlatformRunnerRegistry([runner]),
+        includeExceptions,
+        now: () => NOW,
+      });
+    }
+
+    it("folds an active overall deny override into the pushed grid when includeExceptions is set", async () => {
+      const { userId, clientId } = setup();
+      createException(db, {
+        userId,
+        targetKind: "overall",
+        action: "deny",
+        effectiveFrom: new Date("2026-06-17T00:00:00Z"),
+        expiresAt: new Date("2026-06-18T00:00:00Z"),
+      });
+
+      const rec = capturingClient();
+      await overrideExecutor(rec, true)(action(clientId, userId));
+
+      // Wednesday (weekday 3) is denied by the override; the rest stay unrestricted.
+      expect(rec.weekly?.get(3)).toEqual([]);
+      expect(rec.weekly?.get(1)).toEqual([{ start: 0, end: 1440 }]);
+    });
+
+    it("ignores exceptions for the standing push (includeExceptions defaults false)", async () => {
+      const { userId, clientId } = setup();
+      createException(db, {
+        userId,
+        targetKind: "overall",
+        action: "deny",
+        effectiveFrom: new Date("2026-06-17T00:00:00Z"),
+        expiresAt: new Date("2026-06-18T00:00:00Z"),
+      });
+
+      const rec = capturingClient();
+      await overrideExecutor(rec, false)(action(clientId, userId));
+
+      // The recurring grid is exception-free: Wednesday stays unrestricted.
+      expect(rec.weekly?.get(3)).toEqual([{ start: 0, end: 1440 }]);
+    });
+
+    it("resolves an expired override to the standing grid (auto-revert on replay)", async () => {
+      const { userId, clientId } = setup();
+      // Its window closed before NOW — a queued override replayed after expiry
+      // must resolve to the standing grid (the executor re-reads at run time).
+      createException(db, {
+        userId,
+        targetKind: "overall",
+        action: "deny",
+        effectiveFrom: new Date("2026-06-10T00:00:00Z"),
+        expiresAt: new Date("2026-06-11T00:00:00Z"),
+      });
+
+      const rec = capturingClient();
+      await overrideExecutor(rec, true)(action(clientId, userId));
+
+      for (const weekday of [1, 2, 3, 4, 5, 6, 7] as const) {
+        expect(rec.weekly?.get(weekday)).toEqual([{ start: 0, end: 1440 }]);
+      }
+    });
+
+    it("includes an inherited group override via gatherUserExceptions", async () => {
+      const { userId, clientId } = setup();
+      const group = createUserGroup(db, { name: "Kids" });
+      addUserToGroup(db, group.id, userId);
+      createGroupException(db, {
+        userGroupId: group.id,
+        targetKind: "overall",
+        action: "deny",
+        effectiveFrom: new Date("2026-06-17T00:00:00Z"),
+        expiresAt: new Date("2026-06-18T00:00:00Z"),
+      });
+
+      const rec = capturingClient();
+      await overrideExecutor(rec, true)(action(clientId, userId));
+
+      // The group-inherited override reaches the pushed grid, not just the user's own.
+      expect(rec.weekly?.get(3)).toEqual([]);
+    });
   });
 });

--- a/server/tests/transport/policy-push/resolve.test.ts
+++ b/server/tests/transport/policy-push/resolve.test.ts
@@ -170,6 +170,39 @@ describe("resolvePolicyPush", () => {
       expect(withOverride.weekly.get(3)).toEqual([]);
     });
 
+    it("widens a covered day past a standing bedtime deny via an extend override", () => {
+      // Standing: allow 09:00–17:00 every day, deny the rest (a bedtime cut-off).
+      const schedules: ScheduleRule[] = [
+        rule({
+          id: 1,
+          action: "allow",
+          recurrenceDays: 0b1111111,
+          recurrenceStartMinute: 9 * 60,
+          recurrenceEndMinute: 17 * 60,
+        }),
+        rule({ id: 2, ordinal: 1, action: "deny" }),
+      ];
+      // "allow games until 9pm this Wednesday" — the #364 extend-past-a-deny case.
+      const resolved = resolvePolicyPush({
+        tz: "UTC",
+        schedules,
+        budgets: [],
+        now: NOW,
+        exceptions: [
+          denyWednesday({
+            action: "extend",
+            effectiveFrom: new Date("2026-06-17T00:00:00Z"),
+            expiresAt: new Date("2026-06-17T21:00:00Z"),
+          }),
+        ],
+      });
+      // Wednesday reaches to 21:00; the other days keep the 09:00–17:00 grid.
+      expect(resolved.weekly.get(3)).toEqual([{ start: 0, end: 21 * 60 }]);
+      for (const weekday of [1, 2, 4, 5, 6, 7] as const) {
+        expect(resolved.weekly.get(weekday)).toEqual([{ start: 9 * 60, end: 17 * 60 }]);
+      }
+    });
+
     it("never changes the seconds limits (an exception carries no time amount)", () => {
       const budgets: BudgetInput[] = [
         { scope: "overall", targetId: null, window: "daily", secondsAllowed: 7200 },

--- a/server/tests/transport/policy-push/resolve.test.ts
+++ b/server/tests/transport/policy-push/resolve.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, expect, it } from "vitest";
 
-import type { BudgetInput } from "../../../src/policy/resolve.js";
+import type { BudgetInput, ExceptionInput } from "../../../src/policy/resolve.js";
 import type { ScheduleRule } from "../../../src/policy/schedule-precedence.js";
 import { buildWeeklyAllowedHoursCommands } from "../../../src/transport/timekpr/allowed-hours.js";
 import {
@@ -124,6 +124,69 @@ describe("resolvePolicyPush", () => {
 
     expect(resolved.weekly.get(1)).toEqual([{ start: 360, end: 1440 }]);
     expect(resolved.weekly.get(7)).toEqual([{ start: 360, end: 1440 }]);
+  });
+
+  describe("date-specific overrides (#399)", () => {
+    /** A whole-Wednesday (2026-06-17, the NOW day) `overall` deny override. */
+    function denyWednesday(overrides: Partial<ExceptionInput> = {}): ExceptionInput {
+      return {
+        id: 1,
+        targetKind: "overall",
+        targetId: null,
+        action: "deny",
+        effectiveFrom: new Date("2026-06-17T00:00:00Z"),
+        expiresAt: new Date("2026-06-18T00:00:00Z"),
+        createdAt: new Date("2026-06-01T00:00:00Z"),
+        ...overrides,
+      };
+    }
+
+    it("folds an active override into only the covered weekday's allowed-hours grid", () => {
+      const resolved = resolvePolicyPush({
+        tz: "UTC",
+        schedules: [],
+        budgets: [],
+        now: NOW,
+        exceptions: [denyWednesday()],
+      });
+      // Wednesday (weekday 3) is denied; the rest of the week stays unrestricted.
+      expect(resolved.weekly.get(3)).toEqual([]);
+      for (const weekday of [1, 2, 4, 5, 6, 7] as const) {
+        expect(resolved.weekly.get(weekday)).toEqual([{ start: 0, end: 1440 }]);
+      }
+    });
+
+    it("leaves the recurring grid untouched when no exceptions are supplied", () => {
+      const withOverride = resolvePolicyPush({
+        tz: "UTC",
+        schedules: [],
+        budgets: [],
+        now: NOW,
+        exceptions: [denyWednesday()],
+      });
+      const standing = resolvePolicyPush({ tz: "UTC", schedules: [], budgets: [], now: NOW });
+      // They differ only on the overridden weekday.
+      expect(standing.weekly.get(3)).toEqual([{ start: 0, end: 1440 }]);
+      expect(withOverride.weekly.get(3)).toEqual([]);
+    });
+
+    it("never changes the seconds limits (an exception carries no time amount)", () => {
+      const budgets: BudgetInput[] = [
+        { scope: "overall", targetId: null, window: "daily", secondsAllowed: 7200 },
+        { scope: "overall", targetId: null, window: "weekly", secondsAllowed: 36000 },
+      ];
+      const resolved = resolvePolicyPush({
+        tz: "UTC",
+        schedules: [],
+        budgets,
+        now: NOW,
+        exceptions: [denyWednesday()],
+      });
+      // Allowed-hours reflect the override, but the daily/weekly seconds do not.
+      expect(resolved.weekly.get(3)).toEqual([]);
+      expect(resolved.perWeekdaySeconds).toEqual([7200, 7200, 7200, 7200, 7200, 7200, 7200]);
+      expect(resolved.weeklySeconds).toBe(36000);
+    });
   });
 
   describe("unrestrictedPolicyPush (#253 unmanage)", () => {


### PR DESCRIPTION
## Summary

Delivers the enforcement follow-up ADR 0012 §3 deferred: date-specific
`exceptions` (`allow` / `deny` / `extend`, own + inherited group) now actually
reach the client's `timekpra` allowed-hours **when their window arrives**, and
**revert** to the standing recurring policy when it closes. Until now a
"screen-free vacation week" / "allow games until 9pm tonight" override was
correct in the dashboard's effective view but never enforced on the device.

- **Phase 1 — thread exceptions through the push stack.** Optional, default-off
  seam on `policy/weekly-windows`, `transport/policy-push/{resolve,
  platform-runner,linux-runner,executor}`: the executor's new `includeExceptions`
  loads `gatherUserExceptions` and folds the user's active overrides into the
  allowed-hours grid. Seconds limits are untouched (an exception carries no time
  amount, ADR 0012). The standing push is byte-identical (recurring grid stays
  exception-free, ADR 0012 §3).
- **Phase 2 — the croner scheduler.** A `policy.push.exceptions` kind + a
  `transport/exception-push` scheduler that, each tick, pushes the
  exception-inclusive weekly grid for users with a materially-active override
  (change-detected, 8-day lookback for restart/revert reconciliation) via the
  existing offline queue + audit, and re-resolves at drain time so an expired
  override auto-reverts. Config `PCT_EXCEPTION_PUSH_CRON`, wired in
  `createPolicyPushTransport`.

## Plan

Linked plan: `docs/plans/399-date-override-enforcement-push.md`
Roadmap: `docs/roadmap.md` → Phase 13 (ADR 0012 §3 follow-up)

## Design decisions (grounded in ADR 0012)

- **Representation: per-day allowed-hours override, not a daily-limit override** —
  exceptions move only `allowedWindows`, never seconds (an additive amount is a
  `Grant`). Settles the issue's open representation question.
- **Standing push stays exception-free** so it is the clean recurring baseline /
  revert target; a one-off date can't be a weekly-recurring pattern, so folding
  it into the standing grid would alias onto the next same-weekday. The dedicated
  scheduler pushes the override-inclusive grid and reconciles at least daily
  (default every 15 min), well within the 7-day aliasing horizon (8-day lookback
  guarantees the revert fires once the override's week rolls past).
- **Only `overall`-scoped exceptions have effect today** (activity/group are
  no-ops per ADR 0012) — handled for free: a no-op override yields the standing
  grid, so nothing is pushed.

## License-boundary note

None touched. All changes are pure TypeScript over the policy model + the
existing SSH-subprocess `timekpra` client and the offline queue. No GPL code is
linked in-process; no GPL binary is added to the image (`license-guard`
unaffected).

## No new dependencies

Uses `croner`, `drizzle-orm`, `zod`, and Node built-ins already in the tree.

## Test plan

- [x] Phase 1 — `weekly-windows` override folding (deny / extend-past-a-deny /
  out-of-week / empty == recurring); `resolvePolicyPush` override grid vs.
  unchanged seconds; executor `includeExceptions` on/off, expired-override
  auto-revert, inherited-group override.
- [x] Phase 2 — scheduler tick behaviour (push on override open, revert once
  after the override's week rolls past, first-tick restart reconcile,
  multi-client fan-out, offline → queued, group-inherited, activity-scoped
  no-op, non-retriable isolation, lifecycle) + config default/override/invalid.
- [x] Full gate green: `format:check` / `lint` / `typecheck` clean, **2000**
  unit tests, coverage **98.91%** (≥ 80%).

## Deferred (tracked)

- Admin policy save during an active override transiently clobbers the override
  grid (the standing push is exception-free); the next scheduler tick re-asserts
  it — filed as **#421**.
- Per-activity / group `deny` quota reduction — out of scope per ADR 0012.
- Whole-week deny → full lockout — the existing Phase 8c gap, unchanged (a
  single-day deny within an otherwise-allowed week pushes fine).

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)