### PR TITLE
feat(integrations): POST /api/integrations/grants — idempotent grant endpoint v1 (#113)

### DIFF
--- a/docs/adr/0014-integration-grant-contract-v1.md
+++ b/docs/adr/0014-integration-grant-contract-v1.md
@@ -1,0 +1,191 @@
+# ADR 0014 — External integration grant contract (v1)
+
+- **Status:** Accepted (2026-08-23) — dashboard-side v1; pending confirmation
+  with next-digital-wall-calendar (NDWC).
+- **Issue:** [#118](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/118)
+  (the contract spike), gating
+  [#113](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/113)
+  (the endpoint). Composes with the integration-token work
+  ([#114](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/114))
+  and the immutable grant ledger.
+- **Phase:** 10
+
+## Context
+
+`docs/architecture.md` → "External integrations" specifies the inbound
+grant endpoint an external integrator calls to award screen-time rewards, with
+this worked example:
+
+```http
+POST /api/integrations/grants
+Authorization: Bearer <integration-token>
+Content-Type: application/json
+
+{
+  "user_ref": "alice",
+  "scope": "overall",
+  "seconds": 1800,
+  "expires_at": "2026-06-05T23:59:59-04:00",
+  "source_ref": "calendar:chore-completion:42a9...",
+  "reason": "Cleaned room (chore reward)"
+}
+```
+
+Most of the contract is already fixed by decisions on `main`:
+
+- The `grants` table (`policy/schema.ts`) is an immutable, additive ledger with
+  a `UNIQUE(source_ref)` index (idempotency), a `seconds_granted > 0` CHECK, a
+  `source` CHECK (`'admin'` or `'integration:%'`), and a scope/target coherence
+  CHECK (`overall` ⇒ null target; `activity`/`group` ⇒ non-null target).
+- Grant scopes mirror policy scopes: `["overall", "activity", "group"]`
+  (`policy/enums.ts`).
+- The token vocabulary fixes `grants:write` as the scope this endpoint requires
+  (`integrations/scopes.ts`), enforced by `integrations/guard.ts`.
+
+What #118 must still **pin** before #113 can exist is everything the schema
+does *not* determine — chiefly how an integrator names a user, since `User` has
+only `id` + `display_name` today (no stable human slug), and the request/reply
+casing, target grammar, and idempotent-replay/error semantics.
+
+## Decision
+
+### 1. `user_ref` → `User.id` (decimal string) for v1
+
+`user_ref` is the dashboard `User.id` in **decimal-string** form (e.g.
+`"7"`). The parent configures the mapping once in NDWC (which dashboard user is
+"Alice"); the dashboard resolves `user_ref` to a `User` and returns `404` if
+none exists.
+
+The field is typed on the wire as a JSON **`string`**, not a number, even
+though v1 only accepts a decimal id. This is deliberate forward-compatibility: a
+later release can also accept a human-assigned alias (`"alice"`, as the
+architecture example imagines) as an *additional* accepted form **without a
+`v2`** — widening the set of accepted strings is backward-compatible, whereas
+changing a numeric field to a string would not be. The architecture example's
+`"alice"` is therefore honoured as the *shape* (a string) now, with the *alias
+resolution* deferred to a future additive change.
+
+`User` gains no new column in this ADR — introducing a stable external alias is
+a separate, additive decision (a migration + admin UI) and is out of scope for
+the record-and-dedupe endpoint.
+
+### 2. snake_case wire contract
+
+The request and response bodies use **snake_case** (`user_ref`, `source_ref`,
+`expires_at`, `granted_at`, …), matching the architecture example verbatim.
+This is the deliberate convention for the external machine-to-machine
+`/api/integrations/*` surface and is intentionally distinct from the internal
+camelCase `/api/*` DTOs the built-in frontends consume. The route maps
+snake_case wire fields to the camelCase repository input at the boundary, so the
+storage layer keeps the house convention.
+
+(The client-enrolment endpoints use camelCase despite being external, because
+they are called by *our own* install script. The grant endpoint is a contract
+with a *third-party* repo, where matching the documented shape reduces
+integration friction and avoids contradicting the authoritative design doc.)
+
+### 3. `scope` / `target` grammar
+
+`scope` completes the architecture example (which showed only `overall`):
+
+| `scope`    | `target`                          |
+| ---------- | --------------------------------- |
+| `overall`  | omitted / `null` (forbidden)      |
+| `activity` | required — an `activities.id`     |
+| `group`    | required — an `activity_groups.id`|
+
+`target` must resolve to an existing row (`404` otherwise). This mirrors the
+table's coherence CHECK and the resolver's `"scope:targetId"` keying
+(`policy/resolve.ts`), where `group` means an **activity group** (ADR 0008),
+not a user group. A grant on a target with no daily budget is a no-op in the
+resolver (an unlimited base stays unlimited) — accepted and recorded, but it
+adjusts nothing; the ledger stays the audit record either way.
+
+### 4. `seconds`, `expires_at`, `source_ref`, `reason`
+
+- `seconds` — integer > 0 (matches the table CHECK).
+- `expires_at` — an ISO-8601 datetime string, required, and **must be in the
+  future** at request time (a grant that has already expired is a client error,
+  `400`, not a silently-dead row). Grants always carry an expiry to prevent
+  unbounded accumulation (architecture doc).
+- `source_ref` — a required, non-empty string; the integrator-owned idempotency
+  key. (Admin-issued grants, which carry no `source_ref`, are a separate path
+  and unaffected by the `UNIQUE` index — SQLite treats NULLs as distinct.)
+- `reason` — optional free text for the audit trail / ledger UI (#116).
+
+### 5. Idempotency & replay
+
+`source_ref` is the idempotency key. The **first** request for a given
+`source_ref` creates the grant and returns `201 Created` with the new row. A
+**replay** (same `source_ref`) returns `200 OK` with the **already-recorded**
+grant and creates no second row — a retried webhook never double-grants. The
+replay reply is the stored grant as-is (the endpoint does not compare the replay
+body against the original; the `source_ref` is the integrator's promise that the
+request is the same). A race between two concurrent first-sightings is resolved
+by the `UNIQUE` constraint: the loser catches the unique-violation and returns
+the winner's row with `200`.
+
+### 6. `source` stamping
+
+`source` is stamped server-side as `integration:<token-name>` from the
+authenticated token (`request.integration.name`), never taken from the body, so
+the ledger truthfully records which integration made each grant and the table's
+`source` CHECK is always satisfied.
+
+### 7. Errors
+
+| Code | When |
+| ---- | ---- |
+| `400 validation_error` | malformed body, `seconds <= 0`, non-future `expires_at`, `target` present for `overall` / absent for `activity`\|`group` |
+| `401 unauthorized` | missing / malformed / invalid / revoked token |
+| `403 insufficient_scope` | valid token lacking `grants:write` |
+| `404 not_found` | unknown `user_ref`, or unknown `target` |
+
+### 8. Versioning
+
+The path is `/api/integrations/grants`; these are its **v1** semantics. Because
+grants are idempotent and additive, and `user_ref` is a widenable string, the
+contract can evolve additively (new optional fields, new accepted `user_ref`
+forms) without a breaking `v2`. A genuinely incompatible change would introduce
+a parallel `/v2` path rather than mutating this one.
+
+## Scope of the endpoint (record + dedupe only)
+
+This endpoint **records and de-dupes** a grant. It deliberately does **not**:
+
+- emit `grant.applied` or recompute/push the effective budget to the client
+  ([#117](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/117));
+- rate-limit per token
+  ([#115](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/115));
+- surface the ledger in the admin UI
+  ([#116](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/116)).
+
+Each is a separate Phase-10 issue that builds on the row this endpoint writes.
+
+## Consequences
+
+- #113 is unblocked and implementable against `main` with no schema change.
+- The immutable/additive ledger properties are preserved: this endpoint only
+  ever inserts (or reads back an existing row); revocation stays a separate
+  `revoked_at` write, never an in-place edit.
+- **NDWC confirmation is still owed.** This ADR is the dashboard's v1 proposal;
+  the reciprocal agreement with next-digital-wall-calendar (especially that it
+  will store and send the dashboard `User.id` as `user_ref`, and how it
+  constructs `source_ref`) remains #118's cross-repo half. The versioned,
+  additive contract keeps that confirmation cheap: if NDWC needs a human alias,
+  it is a widening, not a redesign.
+
+## Alternatives considered
+
+- **`user_ref` = `display_name`.** Rejected: not unique, mutable, and would
+  break silently when a parent renames a child.
+- **`user_ref` = numeric JSON id.** Rejected in favour of a string for the
+  forward-compatibility reason in §1.
+- **camelCase wire body.** Rejected: it would contradict the authoritative
+  architecture example and add friction for the third-party integrator, for no
+  benefit the boundary mapping doesn't already provide internally.
+- **Overall-only v1.** Rejected: the table and resolver already support
+  activity/group grants; validating a `target` is cheap, and completing the
+  grammar now avoids a churny follow-up. Reward→scope mapping *policy* (which
+  reward grants what) still lives with NDWC / #335 — this ADR only fixes the
+  wire primitive.

--- a/docs/adr/0014-integration-grant-contract-v1.md
+++ b/docs/adr/0014-integration-grant-contract-v1.md
@@ -168,6 +168,15 @@ Each is a separate Phase-10 issue that builds on the row this endpoint writes.
 - The immutable/additive ledger properties are preserved: this endpoint only
   ever inserts (or reads back an existing row); revocation stays a separate
   `revoked_at` write, never an in-place edit.
+- **`source_ref` uniqueness is global, not per-integration.** The
+  `UNIQUE(source_ref)` index and the replay lookup span the whole ledger, not a
+  `(token, source_ref)` pair. With a single integrator and self-namespaced keys
+  (the `calendar:…` prefix in the example) this is a non-issue, but if a second
+  integrator ever reused a `source_ref` string an earlier one used, its grant
+  would be swallowed as a "replay" and it would receive the other integration's
+  row. When a second integrator is onboarded, either require namespaced
+  `source_ref`s by contract or make the uniqueness `(token_id, source_ref)` — a
+  point to settle alongside the NDWC confirmation below.
 - **NDWC confirmation is still owed.** This ADR is the dashboard's v1 proposal;
   the reciprocal agreement with next-digital-wall-calendar (especially that it
   will store and send the dashboard `User.id` as `user_ref`, and how it

--- a/docs/plans/113-integration-grants-endpoint.md
+++ b/docs/plans/113-integration-grants-endpoint.md
@@ -1,0 +1,89 @@
+# Plan — `POST /api/integrations/grants` (v1 grant endpoint) — #113 (+ #118 contract ADR)
+
+Roadmap: `docs/roadmap.md` → Phase 10 (first bullet + idempotency).
+Design: `docs/architecture.md` → "External integrations"; new ADR 0014.
+
+## Goal
+
+The inbound grant endpoint that external integrators (first
+next-digital-wall-calendar, "NDWC") call to grant screen-time rewards. Records
+an immutable, additive `Grant` row, idempotent by the integrator-supplied
+`source_ref`. Scope is deliberately **record + dedupe only** — emitting
+`grant.applied` and recomputing/pushing the effective budget is #117; per-token
+rate limiting is #115; the ledger admin UI is #116.
+
+## Prerequisite decision (#118) — pinned in ADR 0014
+
+#113 is gated by #118 ("agree the v1 request/response contract"). The one part
+that is a genuine unresolved decision (not already fixed by the schema) is the
+**`user_ref` mapping**: `User` has only `id` + `displayName` today — no stable
+human slug. ADR 0014 pins:
+
+- **`user_ref`** — the dashboard `User.id` in **decimal-string** form for v1.
+  Typed as a JSON `string` (not a number) so a later release can also accept a
+  human-assigned alias without a `v2` (forward-compatible widening). Resolved to
+  a `User`; unknown ⇒ `404`.
+- **Wire casing** — **snake_case** (`user_ref`, `source_ref`, `expires_at`),
+  matching the `docs/architecture.md` example verbatim. This is the deliberate
+  external-integration convention, distinct from the internal camelCase `/api`
+  DTOs; the route maps snake_case → camelCase repository input at the boundary.
+- **`scope` / `target`** — `overall` (no `target`), `activity` (`target` =
+  `activities.id`), `group` (`target` = `activityGroups.id`). `target` is
+  required for activity/group, forbidden for overall, and must resolve to an
+  existing row (`404` otherwise). Completes the architecture example, which only
+  showed the `overall` case.
+- **`seconds`** — integer > 0.
+- **`expires_at`** — ISO-8601 datetime; must be in the future at request time.
+- **`source_ref`** — required non-empty string; the idempotency key
+  (`UNIQUE(source_ref)` already on the table). A replay with a seen `source_ref`
+  returns the **existing** grant with `200` (no new row); a first sighting
+  creates it with `201`.
+- **`reason`** — optional free text.
+- **`source`** — stamped server-side as `integration:<token-name>` (the
+  authenticated token's name), never client-supplied. Satisfies the table's
+  `source` CHECK.
+- **Errors** — `400` validation / bad target coherence, `401` missing/invalid
+  token, `403` token lacking `grants:write`, `404` unknown `user_ref`/`target`.
+
+The ADR is explicit that this is the **dashboard-side v1 proposal, pending
+confirmation with NDWC**; the versioned path + idempotency make it safe to
+evolve.
+
+## Phases
+
+### Phase 1 — repository + ADR
+- `docs/adr/0014-integration-grant-contract-v1.md` (above).
+- `server/src/policy/grants.ts`:
+  - `GrantRow` re-export / `NewGrant` input type.
+  - `createGrant(db, input)` — insert, return row.
+  - `findGrantBySourceRef(db, sourceRef)` — for idempotent replay.
+  - Export from `policy/index.ts`.
+- Tests: `server/tests/policy/grants.test.ts` (insert round-trip, source_ref
+  lookup, unique-violation surfaces, overall/activity/group coherence).
+
+### Phase 2 — DTOs + route + wiring
+- `server/src/api/integrations/grant-dtos.ts` — snake_case zod request +
+  response schemas; inferred types.
+- `server/src/api/integrations/grants-routes.ts` —
+  `registerIntegrationGrantRoutes(scope)`: `POST /integrations/grants` behind
+  `scope.requireIntegrationToken("grants:write")`; resolve `user_ref`, validate
+  `target`, idempotent create keyed on `source_ref` (catch unique-violation race
+  → return existing), stamp `source`, serialise dates.
+- Register from `api/plugin.ts` (after `registerIntegrationRoutes`, which
+  decorates `requireIntegrationToken`).
+- Re-export DTO types from `api/integrations/index.ts`.
+- Tests: `server/tests/api/integrations/grants-routes.test.ts` — anonymous
+  `401`; wrong-scope token `403`; happy overall/activity/group `201`; idempotent
+  replay `200` + no second row; `400` on past `expires_at`, bad target coherence,
+  `seconds <= 0`; `404` on unknown user / target; `source` stamped from token.
+
+## License boundary
+
+N/A — pure TypeScript + zod + Drizzle over the policy store. No subprocess /
+REST / GPL boundary; no packaging or Docker-image change.
+
+## Out of scope (deferred, tracked)
+
+- `grant.applied` event + effective-budget recompute + SSH push → #117.
+- Per-token rate limiting → #115.
+- Grant-ledger admin UI (view / filter / revoke) → #116.

--- a/server/src/api/integrations/grant-dtos.ts
+++ b/server/src/api/integrations/grant-dtos.ts
@@ -47,8 +47,14 @@ export const createGrantSchema = z
     target: positiveIdSchema.optional(),
     /** Seconds granted; must be a positive integer (table CHECK: > 0). */
     seconds: positiveIdSchema,
-    /** ISO-8601 datetime; must be in the future (checked in the route). */
-    expires_at: z.string().datetime(),
+    /**
+     * ISO-8601 datetime; must be in the future (checked in the route).
+     * `offset: true` accepts a timezone **offset** (e.g. `-04:00`), not just
+     * `Z`, so the documented contract value from `docs/architecture.md` / ADR
+     * 0014 (`2026-06-05T23:59:59-04:00`) — the natural end-of-day expiry a
+     * calendar integrator emits in local time — is accepted, not 400'd.
+     */
+    expires_at: z.string().datetime({ offset: true }),
     /** The integrator-owned idempotency key; unique across the ledger. */
     source_ref: z.string().trim().min(1).max(512),
     /** Optional free-text reason for the audit trail / ledger UI (#116). */

--- a/server/src/api/integrations/grant-dtos.ts
+++ b/server/src/api/integrations/grant-dtos.ts
@@ -1,0 +1,99 @@
+/**
+ * zod DTOs for the inbound integration grant endpoint (#113), pinned by
+ * ADR 0014.
+ *
+ * Unlike the internal `/api/*` DTOs (camelCase, consumed by the built-in
+ * frontends), this is the **external** machine-to-machine contract with a
+ * third-party integrator (first: next-digital-wall-calendar), so its wire shape
+ * is **snake_case**, matching `docs/architecture.md` → "External integrations"
+ * verbatim. The route maps these snake_case fields onto the camelCase
+ * repository input at the boundary, keeping the storage layer on the house
+ * convention.
+ *
+ * Scope vocabulary is derived from the canonical {@link scopeValues} tuple so
+ * the request validation can never drift from what the ledger accepts.
+ *
+ * License boundary: none touched — plain TypeScript + zod.
+ */
+import { z } from "zod";
+
+import { scopeValues } from "../../policy/enums.js";
+
+/** A positive integer id (activity / activity-group target, resolved user). */
+const positiveIdSchema = z.number().int().positive();
+
+// --- Request ---------------------------------------------------------------
+
+/**
+ * `POST /api/integrations/grants` body (ADR 0014 §1–§4).
+ *
+ * `user_ref` is a string (v1: the dashboard `User.id` in decimal form) so a
+ * future release can also accept a human alias without a `v2`. `target` is
+ * required for `activity`/`group` and forbidden for `overall` — the
+ * `superRefine` enforces that coherence here (a clear `400`) ahead of the
+ * table's coherence CHECK. Target **existence** and `expires_at` being in the
+ * future are checked in the route (they need a DB read / the current instant).
+ */
+export const createGrantSchema = z
+  .object({
+    /** The subject user; v1 = the dashboard `User.id` in decimal-string form. */
+    user_ref: z.string().trim().min(1).max(64),
+    /** Grant scope; mirrors policy scopes. */
+    scope: z.enum(scopeValues),
+    /**
+     * Target id: an `activities.id` (`activity`) or `activity_groups.id`
+     * (`group`). Omit for `overall`.
+     */
+    target: positiveIdSchema.optional(),
+    /** Seconds granted; must be a positive integer (table CHECK: > 0). */
+    seconds: positiveIdSchema,
+    /** ISO-8601 datetime; must be in the future (checked in the route). */
+    expires_at: z.string().datetime(),
+    /** The integrator-owned idempotency key; unique across the ledger. */
+    source_ref: z.string().trim().min(1).max(512),
+    /** Optional free-text reason for the audit trail / ledger UI (#116). */
+    reason: z.string().trim().min(1).max(500).optional(),
+  })
+  .strict()
+  .superRefine((body, ctx) => {
+    if (body.scope === "overall" && body.target !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["target"],
+        message: "target must be omitted for the 'overall' scope",
+      });
+    }
+    if (body.scope !== "overall" && body.target === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["target"],
+        message: `target is required for the '${body.scope}' scope`,
+      });
+    }
+  });
+
+export type CreateGrantRequest = z.infer<typeof createGrantSchema>;
+
+// --- Response --------------------------------------------------------------
+
+/**
+ * A recorded grant as returned to the integrator (snake_case wire). Returned
+ * with `201` on first creation and `200` on an idempotent `source_ref` replay
+ * (ADR 0014 §5). `revoked_at` is always `null` on creation; it is included so
+ * the shape matches a later ledger read.
+ */
+export const grantResponseSchema = z.object({
+  id: z.number().int(),
+  user_id: z.number().int(),
+  scope: z.enum(scopeValues),
+  target: z.number().int().nullable(),
+  seconds: z.number().int(),
+  expires_at: z.string(),
+  source: z.string(),
+  source_ref: z.string().nullable(),
+  reason: z.string().nullable(),
+  granted_at: z.string(),
+  revoked_at: z.string().nullable(),
+});
+
+export type GrantResponse = z.infer<typeof grantResponseSchema>;

--- a/server/src/api/integrations/grants-routes.ts
+++ b/server/src/api/integrations/grants-routes.ts
@@ -1,0 +1,186 @@
+/**
+ * The inbound integration grant endpoint (#113), pinned by ADR 0014.
+ *
+ * `POST /api/integrations/grants` — an external integrator (first:
+ * next-digital-wall-calendar) records a screen-time grant. Registered inside the
+ * `/api` plugin scope **after** {@link registerIntegrationRoutes} (which
+ * decorates `scope.requireIntegrationToken`), so it can gate itself on a scoped
+ * bearer token with `{ preHandler: scope.requireIntegrationToken("grants:write") }`.
+ *
+ * Scope is **record + dedupe only** (ADR 0014): it writes an immutable, additive
+ * `Grant` row, idempotent by the integrator-supplied `source_ref`. Emitting
+ * `grant.applied` + recomputing/pushing the effective budget is #117; per-token
+ * rate limiting is #115; the ledger admin UI is #116.
+ *
+ * The handler maps the snake_case external wire DTO onto the camelCase policy
+ * repository at the boundary, resolves `user_ref` → `User`, validates the
+ * `target` against existing rows, checks `expires_at` is in the future, and
+ * stamps `source` from the authenticated token — none of which the DTO can do on
+ * its own.
+ *
+ * License boundary: none touched — plain TypeScript + zod + Fastify + Drizzle.
+ */
+import type { FastifyInstance } from "fastify";
+
+import { ApiError } from "../errors.js";
+import type { PolicyDb } from "../../policy/db.js";
+import type { Scope } from "../../policy/enums.js";
+import { createGrant, findGrantBySourceRef, type GrantRow } from "../../policy/grants.js";
+import { isCheckViolation, isUniqueViolation } from "../../policy/repository.js";
+import * as repo from "../../policy/repository.js";
+import type { ZodTypeProvider } from "../validation.js";
+import { createGrantSchema, type GrantResponse } from "./grant-dtos.js";
+
+/** Serialise a stored grant row to its snake_case wire response. */
+function toGrantResponse(row: GrantRow): GrantResponse {
+  return {
+    id: row.id,
+    user_id: row.userId,
+    scope: row.scope,
+    target: row.targetId,
+    seconds: row.secondsGranted,
+    expires_at: row.expiresAt.toISOString(),
+    source: row.source,
+    source_ref: row.sourceRef,
+    reason: row.reason,
+    granted_at: row.grantedAt.toISOString(),
+    revoked_at: row.revokedAt?.toISOString() ?? null,
+  };
+}
+
+/**
+ * Resolve the wire `user_ref` to a dashboard `User.id`. v1: `user_ref` is the
+ * id in decimal-string form (ADR 0014 §1). A non-decimal or unknown ref is a
+ * `404` — the same code either way so the contract stays forward-compatible when
+ * a future release also accepts a human alias.
+ */
+function resolveUserRef(db: PolicyDb, userRef: string): number {
+  const isDecimal = /^\d+$/.test(userRef);
+  const id = isDecimal ? Number(userRef) : NaN;
+  if (!Number.isSafeInteger(id) || id <= 0 || repo.getUser(db, id) === undefined) {
+    throw new ApiError(404, "not_found", `No user matches user_ref "${userRef}"`);
+  }
+  return id;
+}
+
+/**
+ * Resolve the `target` for a scoped grant to its `target_id`, validating that
+ * the referenced row exists. `overall` ⇒ `null`; `activity` ⇒ `activities.id`;
+ * `group` ⇒ `activity_groups.id`. The DTO has already enforced target
+ * presence/absence coherence, so `target` is defined here iff scope needs it.
+ */
+function resolveTargetId(db: PolicyDb, scope: Scope, target: number | undefined): number | null {
+  if (scope === "overall") return null;
+  // Coherence guaranteed by the DTO's superRefine (non-overall ⇒ target set);
+  // this guard narrows the type without an unchecked cast and is a defensive
+  // 400 should that invariant ever change.
+  if (target === undefined) {
+    throw new ApiError(400, "validation_error", `target is required for the '${scope}' scope`);
+  }
+  const exists =
+    scope === "activity"
+      ? repo.getActivity(db, target) !== undefined
+      : repo.getActivityGroup(db, target) !== undefined;
+  if (!exists) {
+    const kind = scope === "activity" ? "activity" : "activity group";
+    throw new ApiError(404, "not_found", `No ${kind} matches target ${target}`);
+  }
+  return target;
+}
+
+/**
+ * Register the inbound integration grant route on an already-`/api`-prefixed
+ * scope. Call **after** {@link registerIntegrationRoutes} so
+ * `scope.requireIntegrationToken` is decorated.
+ */
+export function registerIntegrationGrantRoutes(scope: FastifyInstance): void {
+  const typed = scope.withTypeProvider<ZodTypeProvider>();
+
+  typed.post(
+    "/integrations/grants",
+    {
+      preHandler: scope.requireIntegrationToken("grants:write"),
+      schema: { body: createGrantSchema },
+    },
+    async (request, reply): Promise<GrantResponse> => {
+      const {
+        user_ref,
+        scope: grantScope,
+        target,
+        seconds,
+        expires_at,
+        source_ref,
+        reason,
+      } = request.body;
+
+      // The guard sets `request.integration` on success; null is defensive.
+      const integration = request.integration;
+      if (integration === null) {
+        throw new ApiError(401, "unauthorized", "Integration token did not authenticate");
+      }
+
+      // Idempotent replay: a source_ref already in the ledger returns the
+      // recorded grant unchanged, with 200 (ADR 0014 §5).
+      const existing = findGrantBySourceRef(scope.db, source_ref);
+      if (existing !== undefined) {
+        request.log.info(
+          { event: "integration_grant_replayed", grantId: existing.id, sourceRef: source_ref },
+          "integration grant replayed (idempotent)",
+        );
+        reply.code(200);
+        return toGrantResponse(existing);
+      }
+
+      const userId = resolveUserRef(scope.db, user_ref);
+      const targetId = resolveTargetId(scope.db, grantScope, target);
+
+      if (new Date(expires_at).getTime() <= Date.now()) {
+        throw new ApiError(400, "validation_error", "expires_at must be in the future");
+      }
+
+      let created: GrantRow;
+      try {
+        created = createGrant(scope.db, {
+          userId,
+          scope: grantScope,
+          targetId,
+          secondsGranted: seconds,
+          expiresAt: new Date(expires_at),
+          source: `integration:${integration.name}`,
+          sourceRef: source_ref,
+          reason: reason ?? null,
+        });
+      } catch (err) {
+        // Lost a race to a concurrent first-sighting of the same source_ref:
+        // the UNIQUE index rejected the insert — return the winner's row (200).
+        if (isUniqueViolation(err)) {
+          const winner = findGrantBySourceRef(scope.db, source_ref);
+          if (winner !== undefined) {
+            reply.code(200);
+            return toGrantResponse(winner);
+          }
+        }
+        // A storage invariant (seconds > 0, target coherence, source shape) the
+        // DTO didn't catch → 400 rather than a leaked 500.
+        if (isCheckViolation(err)) {
+          throw new ApiError(400, "validation_error", "Grant violates a storage constraint");
+        }
+        throw err;
+      }
+
+      request.log.info(
+        {
+          event: "integration_grant_created",
+          grantId: created.id,
+          userId,
+          scope: grantScope,
+          source: created.source,
+          sourceRef: source_ref,
+        },
+        "integration grant recorded",
+      );
+      reply.code(201);
+      return toGrantResponse(created);
+    },
+  );
+}

--- a/server/src/api/integrations/index.ts
+++ b/server/src/api/integrations/index.ts
@@ -5,6 +5,13 @@
  * License boundary: none touched.
  */
 export { registerIntegrationRoutes } from "./routes.js";
+export { registerIntegrationGrantRoutes } from "./grants-routes.js";
+export {
+  createGrantSchema,
+  grantResponseSchema,
+  type CreateGrantRequest,
+  type GrantResponse,
+} from "./grant-dtos.js";
 export {
   createIntegrationTokenSchema,
   integrationScopeSchema,

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -18,7 +18,7 @@ import { registerAppAuthRoutes } from "./app/index.js";
 import { registerAuditRoutes } from "./audit/index.js";
 import { registerClientEnrolmentRoutes, registerClientHealthRoutes } from "./clients/index.js";
 import { registerDnsRoutes } from "./dns/index.js";
-import { registerIntegrationRoutes } from "./integrations/index.js";
+import { registerIntegrationGrantRoutes, registerIntegrationRoutes } from "./integrations/index.js";
 import { registerMetaRoute } from "./meta.js";
 import {
   registerEffectiveRoutes,
@@ -161,6 +161,10 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   // bearer tokens, and the `scope.requireIntegrationToken` guard the inbound
   // `/api/integrations/*` endpoints (#113) authenticate with.
   registerIntegrationRoutes(scope);
+  // Inbound integration grants (#113, ADR 0014): external integrators record
+  // screen-time grants via a `grants:write` bearer token. Must follow
+  // `registerIntegrationRoutes`, which decorates `scope.requireIntegrationToken`.
+  registerIntegrationGrantRoutes(scope);
 };
 
 /** Mount the JSON API under `/api` on the given app. */

--- a/server/src/policy/grants.ts
+++ b/server/src/policy/grants.ts
@@ -1,0 +1,95 @@
+/**
+ * Policy-store data access for the immutable grant ledger (#113).
+ *
+ * Companion to {@link ./integration-tokens.ts}: thin, synchronous functions
+ * over the shared {@link PolicyDb} for the `grants` table. HTTP concerns (status
+ * codes, the error envelope, `user_ref` resolution, `source` stamping) live in
+ * the `api/integrations/` route layer; this module only touches the database.
+ *
+ * The ledger is **append-plus-revoke only** (`policy/schema.ts`): business
+ * columns are never UPDATEd in place, and idempotency is structural — a
+ * `UNIQUE(source_ref)` index means a retried integrator webhook cannot
+ * double-grant. This module exposes exactly the two operations the grant
+ * endpoint needs — create, and look up by `source_ref` for the idempotent
+ * replay — and never an update of a grant's business columns.
+ *
+ * License boundary: none touched — Drizzle (Apache-2.0) + better-sqlite3 (MIT).
+ */
+import { eq } from "drizzle-orm";
+
+import type { PolicyDb } from "./db.js";
+import type { Scope } from "./enums.js";
+import { grants } from "./schema.js";
+
+/** A persisted {@link grants} row. */
+export type GrantRow = typeof grants.$inferSelect;
+
+/**
+ * Fields accepted when creating a {@link grants} row. Validated by the route's
+ * DTO + coherence checks before this call; the table's CHECK constraints
+ * (`seconds_granted > 0`, scope/target coherence, `source` shape) backstop it.
+ */
+export interface GrantCreate {
+  /** The subject user (already resolved from the wire `user_ref`). */
+  userId: number;
+  /** Grant scope; mirrors policy scopes (`overall` | `activity` | `group`). */
+  scope: Scope;
+  /**
+   * `activities.id` for `activity`, `activity_groups.id` for `group`, `null`
+   * for `overall` (the schema's coherence CHECK enforces the null-ness).
+   */
+  targetId: number | null;
+  /** Seconds granted; must be > 0 (table CHECK). */
+  secondsGranted: number;
+  /** Exclusive end of the grant's life. */
+  expiresAt: Date;
+  /** Provenance: `admin` or `integration:<name>` (table CHECK). */
+  source: string;
+  /**
+   * The integrator-owned idempotency key; `UNIQUE` across the table so a
+   * retried request cannot double-grant. `null` for admin-issued grants.
+   */
+  sourceRef: string | null;
+  /** Optional free-text reason for the audit trail / ledger UI (#116). */
+  reason: string | null;
+}
+
+/**
+ * Insert a grant and return the stored row. `source_ref` is unique; a duplicate
+ * raises a SQLite unique violation the caller maps to an idempotent replay via
+ * {@link import("./repository.js").isUniqueViolation} + {@link findGrantBySourceRef}.
+ * The table's CHECK constraints (seconds, target coherence, source shape) raise
+ * a check violation the caller maps to a 400 via
+ * {@link import("./repository.js").isCheckViolation}.
+ *
+ * `granted_at` defaults to now (schema `timestampNow`); `revoked_at` stays NULL
+ * — revocation is a separate write, never part of creation.
+ */
+export function createGrant(db: PolicyDb, input: GrantCreate): GrantRow {
+  return db
+    .insert(grants)
+    .values({
+      userId: input.userId,
+      scope: input.scope,
+      targetId: input.targetId,
+      secondsGranted: input.secondsGranted,
+      expiresAt: input.expiresAt,
+      source: input.source,
+      sourceRef: input.sourceRef,
+      reason: input.reason,
+    })
+    .returning()
+    .get();
+}
+
+/**
+ * Look up a grant by its `source_ref`, or `undefined` if none exists. Used for
+ * the idempotent replay: a second request carrying a `source_ref` already in
+ * the ledger returns the stored row rather than creating a new one. Passing a
+ * `null`/absent `source_ref` is never valid here — admin grants (which have no
+ * `source_ref`) do not go through this path — so the caller only calls this with
+ * a concrete key.
+ */
+export function findGrantBySourceRef(db: PolicyDb, sourceRef: string): GrantRow | undefined {
+  return db.select().from(grants).where(eq(grants.sourceRef, sourceRef)).get();
+}

--- a/server/tests/api/integrations/grants-routes.test.ts
+++ b/server/tests/api/integrations/grants-routes.test.ts
@@ -1,0 +1,238 @@
+/**
+ * HTTP tests for the inbound integration grant endpoint (#113, ADR 0014),
+ * driven through the real app via `app.inject()` — per `docs/testing.md` →
+ * "HTTP routes". Covers the happy paths (overall / activity / group), the
+ * idempotent `source_ref` replay, and the full failure matrix (auth, scope,
+ * validation, unknown user / target).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SESSION_COOKIE } from "../../../src/auth/session.js";
+import { loadSettings, type Settings } from "../../../src/config.js";
+import { createActivity, createActivityGroup, createUser } from "../../../src/policy/repository.js";
+import { grants } from "../../../src/policy/schema.js";
+import { buildTestApp, type TestApp } from "../../helpers/app.js";
+
+function settings(): Settings {
+  return loadSettings({
+    PCT_LOG_LEVEL: "silent",
+    PCT_SECRET_KEY: "grants-test-secret",
+    PCT_ADMIN_USERNAME: "ben",
+    PCT_ADMIN_PASSWORD: "hunter2",
+  });
+}
+
+function sessionCookie(res: { headers: Record<string, unknown> }): string {
+  const raw = res.headers["set-cookie"];
+  const headers = Array.isArray(raw) ? (raw as string[]) : [String(raw ?? "")];
+  const match = headers.find((h) => h.startsWith(`${SESSION_COOKIE}=`));
+  if (match === undefined) throw new Error("no session cookie set");
+  return match.split(";")[0] ?? "";
+}
+
+const FUTURE = "2999-01-01T00:00:00.000Z";
+
+describe("integration grant endpoint", () => {
+  let harness: TestApp;
+  let cookie: string;
+  let userId: number;
+  let grantsWriteSecret: string;
+  let readOnlySecret: string;
+
+  beforeEach(async () => {
+    harness = buildTestApp({ appOptions: { settings: settings() } });
+    await harness.app.ready();
+
+    const login = await harness.app.inject({
+      method: "POST",
+      url: "/api/auth/login",
+      payload: { username: "ben", password: "hunter2" },
+    });
+    cookie = sessionCookie(login);
+
+    grantsWriteSecret = (await mintToken("calendar", ["grants:write"])).secret;
+    readOnlySecret = (await mintToken("viewer", ["policy:read"])).secret;
+
+    userId = createUser(harness.db, { displayName: "Alice" }).id;
+  });
+
+  afterEach(async () => {
+    await harness.close();
+  });
+
+  async function mintToken(
+    name: string,
+    scopes: string[],
+  ): Promise<{ id: number; secret: string }> {
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/integrations/tokens",
+      headers: { cookie },
+      payload: { name, scopes },
+    });
+    if (res.statusCode !== 201) throw new Error(`mint failed: ${res.statusCode} ${res.body}`);
+    const body = res.json();
+    return { id: body.id as number, secret: body.secret as string };
+  }
+
+  /** POST a grant with the given bearer secret (default: the grants:write token). */
+  function postGrant(payload: Record<string, unknown>, secret: string = grantsWriteSecret) {
+    return harness.app.inject({
+      method: "POST",
+      url: "/api/integrations/grants",
+      headers: { authorization: `Bearer ${secret}` },
+      payload,
+    });
+  }
+
+  function overallBody(overrides: Record<string, unknown> = {}) {
+    return {
+      user_ref: String(userId),
+      scope: "overall",
+      seconds: 1800,
+      expires_at: FUTURE,
+      source_ref: "calendar:chore:1",
+      reason: "Cleaned room",
+      ...overrides,
+    };
+  }
+
+  function countGrants(): number {
+    return harness.db.select().from(grants).all().length;
+  }
+
+  it("records an overall grant with a 201 and snake_case body", async () => {
+    const res = await postGrant(overallBody());
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.id).toBeGreaterThan(0);
+    expect(body.user_id).toBe(userId);
+    expect(body.scope).toBe("overall");
+    expect(body.target).toBeNull();
+    expect(body.seconds).toBe(1800);
+    expect(body.expires_at).toBe(FUTURE);
+    expect(body.source).toBe("integration:calendar");
+    expect(body.source_ref).toBe("calendar:chore:1");
+    expect(body.reason).toBe("Cleaned room");
+    expect(body.revoked_at).toBeNull();
+    expect(typeof body.granted_at).toBe("string");
+    expect(countGrants()).toBe(1);
+  });
+
+  it("defaults an omitted reason to null", async () => {
+    const res = await postGrant(overallBody({ reason: undefined }));
+    expect(res.statusCode).toBe(201);
+    expect(res.json().reason).toBeNull();
+  });
+
+  it("records activity- and group-scoped grants against an existing target", async () => {
+    const activityId = createActivity(harness.db, { kind: "app", matcher: "firefox" }).id;
+    const groupId = createActivityGroup(harness.db, { name: "Games" }).id;
+
+    const activity = await postGrant(
+      overallBody({
+        scope: "activity",
+        target: activityId,
+        source_ref: "calendar:activity:1",
+      }),
+    );
+    expect(activity.statusCode).toBe(201);
+    expect(activity.json().scope).toBe("activity");
+    expect(activity.json().target).toBe(activityId);
+
+    const group = await postGrant(
+      overallBody({ scope: "group", target: groupId, source_ref: "calendar:group:1" }),
+    );
+    expect(group.statusCode).toBe(201);
+    expect(group.json().target).toBe(groupId);
+  });
+
+  it("is idempotent on source_ref: a replay returns 200 with the original row, no new grant", async () => {
+    const first = await postGrant(overallBody());
+    expect(first.statusCode).toBe(201);
+    const firstId = first.json().id as number;
+
+    // Replay with the same source_ref but a *different* seconds — the recorded
+    // grant is returned unchanged (ADR 0014 §5: source_ref is the promise).
+    const replay = await postGrant(overallBody({ seconds: 9999 }));
+    expect(replay.statusCode).toBe(200);
+    expect(replay.json().id).toBe(firstId);
+    expect(replay.json().seconds).toBe(1800);
+    expect(countGrants()).toBe(1);
+  });
+
+  it("401s an anonymous request (no bearer token)", async () => {
+    const res = await harness.app.inject({
+      method: "POST",
+      url: "/api/integrations/grants",
+      payload: overallBody(),
+    });
+    expect(res.statusCode).toBe(401);
+    expect(countGrants()).toBe(0);
+  });
+
+  it("401s an invalid bearer token", async () => {
+    const res = await postGrant(overallBody(), "not-a-real-token");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("403s a token lacking the grants:write scope", async () => {
+    const res = await postGrant(overallBody(), readOnlySecret);
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error.code).toBe("insufficient_scope");
+    expect(countGrants()).toBe(0);
+  });
+
+  it("400s a grant whose expires_at is in the past", async () => {
+    const res = await postGrant(overallBody({ expires_at: "2000-01-01T00:00:00.000Z" }));
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+    expect(countGrants()).toBe(0);
+  });
+
+  it("400s non-positive seconds", async () => {
+    const res = await postGrant(overallBody({ seconds: 0 }));
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("400s a target supplied for the overall scope", async () => {
+    const res = await postGrant(overallBody({ target: 5 }));
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("400s a missing target for the activity scope", async () => {
+    const res = await postGrant(overallBody({ scope: "activity", source_ref: "x" }));
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("400s a malformed body (missing seconds)", async () => {
+    const res = await postGrant(overallBody({ seconds: undefined }));
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("404s an unknown user_ref", async () => {
+    const res = await postGrant(overallBody({ user_ref: "999999" }));
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+    expect(countGrants()).toBe(0);
+  });
+
+  it("404s a non-decimal user_ref (v1 accepts only the decimal id)", async () => {
+    const res = await postGrant(overallBody({ user_ref: "alice" }));
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+  });
+
+  it("404s an unknown activity target", async () => {
+    const res = await postGrant(
+      overallBody({ scope: "activity", target: 999999, source_ref: "x" }),
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+    expect(countGrants()).toBe(0);
+  });
+});

--- a/server/tests/api/integrations/grants-routes.test.ts
+++ b/server/tests/api/integrations/grants-routes.test.ts
@@ -125,6 +125,17 @@ describe("integration grant endpoint", () => {
     expect(res.json().reason).toBeNull();
   });
 
+  it("accepts an expires_at carrying a timezone offset (the documented contract shape)", async () => {
+    // ADR 0014 / docs/architecture.md show `...T23:59:59-04:00` (an offset, not
+    // Z). The endpoint must accept it, not 400 it.
+    const res = await postGrant(
+      overallBody({ expires_at: "2999-06-05T23:59:59-04:00", source_ref: "calendar:offset:1" }),
+    );
+    expect(res.statusCode).toBe(201);
+    // Echoed back normalised to UTC Z form (stored as a Unix timestamp).
+    expect(res.json().expires_at).toBe(new Date("2999-06-05T23:59:59-04:00").toISOString());
+  });
+
   it("records activity- and group-scoped grants against an existing target", async () => {
     const activityId = createActivity(harness.db, { kind: "app", matcher: "firefox" }).id;
     const groupId = createActivityGroup(harness.db, { name: "Games" }).id;
@@ -234,5 +245,18 @@ describe("integration grant endpoint", () => {
     expect(res.statusCode).toBe(404);
     expect(res.json().error.code).toBe("not_found");
     expect(countGrants()).toBe(0);
+  });
+
+  it("404s an unknown group target", async () => {
+    const res = await postGrant(overallBody({ scope: "group", target: 999999, source_ref: "x" }));
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("not_found");
+    expect(countGrants()).toBe(0);
+  });
+
+  it("400s an unknown field in the body (strict)", async () => {
+    const res = await postGrant(overallBody({ surprise: true }));
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
   });
 });

--- a/server/tests/policy/grants.test.ts
+++ b/server/tests/policy/grants.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for the grant-ledger data access (#113), against a fresh in-memory
+ * policy DB — see `docs/testing.md` → "Policy model". Covers the create /
+ * source_ref-lookup pair the grant endpoint uses, plus the structural
+ * invariants the schema's CHECK / UNIQUE constraints backstop (ADR 0014).
+ */
+import { describe, expect, it } from "vitest";
+
+import { createGrant, findGrantBySourceRef } from "../../src/policy/grants.js";
+import {
+  createActivity,
+  createActivityGroup,
+  createUser,
+  isCheckViolation,
+  isUniqueViolation,
+} from "../../src/policy/repository.js";
+import { testDb } from "../helpers/db.js";
+
+/** A user id to hang grants off (grants.user_id is a FK with ON DELETE cascade). */
+function seedUser(db: ReturnType<typeof testDb>): number {
+  return createUser(db, { displayName: "Alice" }).id;
+}
+
+const FUTURE = new Date("2999-01-01T00:00:00.000Z");
+
+describe("grant repository", () => {
+  it("creates an overall grant and reads it back by source_ref", () => {
+    const db = testDb();
+    const userId = seedUser(db);
+
+    const row = createGrant(db, {
+      userId,
+      scope: "overall",
+      targetId: null,
+      secondsGranted: 1800,
+      expiresAt: FUTURE,
+      source: "integration:calendar",
+      sourceRef: "calendar:chore:1",
+      reason: "Cleaned room",
+    });
+
+    expect(row.id).toBeGreaterThan(0);
+    expect(row.userId).toBe(userId);
+    expect(row.scope).toBe("overall");
+    expect(row.targetId).toBeNull();
+    expect(row.secondsGranted).toBe(1800);
+    expect(row.source).toBe("integration:calendar");
+    expect(row.sourceRef).toBe("calendar:chore:1");
+    expect(row.reason).toBe("Cleaned room");
+    expect(row.revokedAt).toBeNull();
+    // granted_at is defaulted by the schema (timestampNow) to a real instant.
+    expect(row.grantedAt).toBeInstanceOf(Date);
+
+    const found = findGrantBySourceRef(db, "calendar:chore:1");
+    expect(found?.id).toBe(row.id);
+    expect(findGrantBySourceRef(db, "no-such-ref")).toBeUndefined();
+  });
+
+  it("supports activity- and group-scoped grants with a target", () => {
+    const db = testDb();
+    const userId = seedUser(db);
+    const activityId = createActivity(db, { kind: "app", matcher: "firefox" }).id;
+    const groupId = createActivityGroup(db, { name: "Games" }).id;
+
+    const activityGrant = createGrant(db, {
+      userId,
+      scope: "activity",
+      targetId: activityId,
+      secondsGranted: 600,
+      expiresAt: FUTURE,
+      source: "integration:calendar",
+      sourceRef: "calendar:activity:1",
+      reason: null,
+    });
+    expect(activityGrant.scope).toBe("activity");
+    expect(activityGrant.targetId).toBe(activityId);
+
+    const groupGrant = createGrant(db, {
+      userId,
+      scope: "group",
+      targetId: groupId,
+      secondsGranted: 900,
+      expiresAt: FUTURE,
+      source: "integration:calendar",
+      sourceRef: "calendar:group:1",
+      reason: null,
+    });
+    expect(groupGrant.scope).toBe("group");
+    expect(groupGrant.targetId).toBe(groupId);
+  });
+
+  it("rejects a duplicate source_ref with a unique violation", () => {
+    const db = testDb();
+    const userId = seedUser(db);
+    const base = {
+      userId,
+      scope: "overall" as const,
+      targetId: null,
+      secondsGranted: 60,
+      expiresAt: FUTURE,
+      source: "integration:calendar",
+      reason: null,
+    };
+    createGrant(db, { ...base, sourceRef: "dup" });
+
+    let caught: unknown;
+    try {
+      createGrant(db, { ...base, sourceRef: "dup" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(isUniqueViolation(caught)).toBe(true);
+    // The first row is still the one on record.
+    expect(findGrantBySourceRef(db, "dup")).not.toBeUndefined();
+  });
+
+  it("allows distinct grants that both omit source_ref (NULLs are distinct)", () => {
+    const db = testDb();
+    const userId = seedUser(db);
+    const base = {
+      userId,
+      scope: "overall" as const,
+      targetId: null,
+      secondsGranted: 60,
+      expiresAt: FUTURE,
+      source: "admin",
+      sourceRef: null,
+      reason: null,
+    };
+    expect(() => createGrant(db, base)).not.toThrow();
+    expect(() => createGrant(db, base)).not.toThrow();
+  });
+
+  it("enforces the schema invariants as CHECK violations", () => {
+    const db = testDb();
+    const userId = seedUser(db);
+    const valid = {
+      userId,
+      scope: "overall" as const,
+      targetId: null,
+      secondsGranted: 60,
+      expiresAt: FUTURE,
+      source: "integration:calendar",
+      sourceRef: null,
+      reason: null,
+    };
+
+    // seconds must be > 0
+    let secondsErr: unknown;
+    try {
+      createGrant(db, { ...valid, secondsGranted: 0 });
+    } catch (err) {
+      secondsErr = err;
+    }
+    expect(isCheckViolation(secondsErr)).toBe(true);
+
+    // overall must not carry a target
+    let coherenceErr: unknown;
+    try {
+      createGrant(db, { ...valid, targetId: 5 });
+    } catch (err) {
+      coherenceErr = err;
+    }
+    expect(isCheckViolation(coherenceErr)).toBe(true);
+
+    // source must be 'admin' or 'integration:%'
+    let sourceErr: unknown;
+    try {
+      createGrant(db, { ...valid, source: "bogus" });
+    } catch (err) {
+      sourceErr = err;
+    }
+    expect(isCheckViolation(sourceErr)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements **`POST /api/integrations/grants`** (#113) — the inbound endpoint external integrators (first: [next-digital-wall-calendar](https://github.com/BenSeymourODB/next-digital-wall-calendar), "NDWC") call to record screen-time rewards, exactly as `docs/architecture.md` → "External integrations" specifies. It writes an **immutable, additive** `Grant` row, **idempotent by the integrator-supplied `source_ref`**.
- Ships **ADR 0014**, which pins the v1 request/response contract that #118 called for and that gated #113 — so the design decision has a concrete consumer rather than being a paper contract.
- **Record + dedupe only**, per the issue's own note: emitting `grant.applied` + effective-budget recompute/push is #117; per-token rate limiting is #115; the ledger admin UI is #116.

## The #118 contract decision (ADR 0014)

#113 was gated by #118 ("agree the v1 grant request/response contract"). The one genuinely open decision — everything else is already fixed by the `grants` table + integration-token infra on `main` — was the **`user_ref` mapping**, because `User` has only `id` + `display_name` today (no stable human slug). ADR 0014 pins:

- **`user_ref`** → the dashboard `User.id` in **decimal-string** form. Typed on the wire as a `string` (not a number) so a future release can *also* accept a human alias (`"alice"`, as the architecture example imagines) without a breaking `v2` — a forward-compatible widening.
- **snake_case wire** (`user_ref`, `source_ref`, `expires_at`, …), matching the architecture example verbatim. This is the deliberate external machine-to-machine convention, distinct from the internal camelCase `/api` DTOs; the route maps snake→camel at the boundary.
- **`scope` / `target`** — `overall` (no target), `activity` (`activities.id`), `group` (`activity_groups.id`); target required for the latter two, forbidden for `overall`, must resolve to an existing row.
- **`seconds`** > 0; **`expires_at`** ISO-8601 and must be in the future; **`source_ref`** the required idempotency key; **`reason`** optional.
- **Idempotency** — first sighting → `201` with the new row; a `source_ref` replay → `200` with the recorded row, no second insert (a lost race resolves via the `UNIQUE(source_ref)` index).
- **`source`** stamped server-side as `integration:<token-name>`, never client-supplied.
- **Errors** — `400` validation, `401` no/invalid token, `403` missing `grants:write`, `404` unknown `user_ref`/`target`.

ADR 0014 is explicit that this is the **dashboard-side v1 proposal, pending confirmation with NDWC**; the versioned path + string-typed `user_ref` + idempotency keep it safe to evolve. That cross-repo confirmation is the remaining half of #118 and is called out in the ADR.

## Changes

- `docs/adr/0014-integration-grant-contract-v1.md` — the v1 contract decision.
- `server/src/policy/grants.ts` — `createGrant` / `findGrantBySourceRef` over the existing immutable ledger (append-plus-revoke only; no update of business columns).
- `server/src/api/integrations/grant-dtos.ts` — snake_case zod request/response DTOs (scope vocabulary derived from the canonical `scopeValues` tuple).
- `server/src/api/integrations/grants-routes.ts` — the route, gated by `requireIntegrationToken("grants:write")`.
- `server/src/api/integrations/index.ts`, `server/src/api/plugin.ts` — register + re-export.

## Plan

Linked plan: `docs/plans/113-integration-grants-endpoint.md`
Roadmap: `docs/roadmap.md` → Phase 10 (first bullet + idempotency)

## License-boundary note

N/A — pure TypeScript + zod + Drizzle over the policy store. No subprocess / REST / GPL boundary; no packaging or Docker-image change (`license-guard` unaffected).

## No new dependencies

Uses `zod`, `drizzle-orm`, Fastify, and Node built-ins already in the tree.

## Test plan

- [x] Repository: create round-trip (overall/activity/group), `source_ref` lookup, unique-violation on duplicate `source_ref`, NULL `source_ref`s stay distinct, CHECK-constraint backstops (seconds > 0, target coherence, source shape).
- [x] HTTP matrix: `201` overall with snake_case body + `source` stamped; activity/group with target; idempotent replay → `200`, no new row; `401` anonymous / invalid token; `403` wrong scope; `400` past `expires_at` / non-positive seconds / target-coherence / malformed body; `404` unknown user_ref (incl. non-decimal) / unknown target.
- [x] Server gate green: `format:check` / `lint` / `typecheck` clean; **1997** unit tests; coverage **98.81%** (≥ 80%).

## Deferred (tracked)

- `grant.applied` event + effective-budget recompute + SSH push → **#117**.
- Per-token rate limiting on `/api/integrations/*` → **#115**.
- Grant-ledger admin UI (view / filter / revoke) → **#116**.
- Cross-repo confirmation of the v1 contract with NDWC → the remaining half of **#118**.

Closes #113
Addresses #118 (records the v1 contract ADR; NDWC-side confirmation pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nz86WMKUah812jkqr7HpjV)_