### PR TITLE
feat(api,frontend): future-dated save-and-push preview (#281)

### DIFF
--- a/docs/plans/issue-281-future-dated-preview.md
+++ b/docs/plans/issue-281-future-dated-preview.md
@@ -1,0 +1,83 @@
+# Plan — #281 future-dated save-and-push preview (`?date=` / `now`)
+
+Roadmap: `docs/roadmap.md` → Phase 4 (save-and-push preview; the last non-Ansible
+bullet of the #281 umbrella). Builds on #64 (preview backend), and now-landed
+#141 (weekday-varying budgets, PR #408) + #142 (date-specific overrides, PR #398).
+
+## Goal
+
+Let an admin preview the save-and-push diff **as it resolves on a chosen future
+date**, not only "now". The endpoint already accepts an optional `now` reference
+instant; this slice adds a timezone-correct calendar-date selector on top and
+surfaces it in `/admin`.
+
+## Why it is now meaningful
+
+`transport/policy-push/resolve.ts` (`resolvePolicyPush`) uses the reference
+instant only to pick the **reference week** for the recurring allowed-hours grid
+(`resolveWeeklyAllowedWindows` → `effectivePolicy`, whose `appliesOnDay` applies
+the `effective_from`/`effective_to` **date gate** on schedule rules). So a
+**date-scoped schedule rule** that is dormant today but active in a future week
+changes the future-dated preview. `perWeekdaySeconds` is weekday-based
+(date-invariant), which is correct — there is no date-specific *budget* override
+(an additive time amount is a `Grant`, not a schedule rule; Exceptions carry no
+seconds).
+
+**Faithful to the push.** `resolvePolicyPush` deliberately does *not* compose
+one-off Exceptions (#142) into the pushed allowed-hours grid — pushing an
+exception override to the client is its own path (#399, PR #420). The preview
+mirrors the recurring push, so it too excludes Exceptions and reflects only the
+recurring layer's date gate. Composing Exceptions into the preview but not the
+push would make the preview lie about what the recurring push sends.
+
+## Design
+
+### Backend (`server/src/api/policy/`)
+
+- `preview-dtos.ts`: add an optional `date` (`z.iso.date()`, `YYYY-MM-DD`) to
+  `policyPreviewRequestSchema`. Document precedence: `date` > `now` > current
+  time. `date` is the admin-facing calendar selection; `now` stays the
+  instant-precise seam for tests.
+- `preview-routes.ts`: replace the inline `now` parse with a
+  `referenceInstant(body, tz)` helper. When `date` is set, resolve it to a
+  reference instant at **local noon** of that date in the user's *effective*
+  timezone — `localDayBounds(y, m, d, tz).start + 12h` — so the reference week is
+  selected correctly at week boundaries regardless of the caller's clock (noon is
+  ~12h from either local-midnight edge, DST-safe). Endpoint stays side-effect-free.
+
+The date→instant conversion lives on the **server**, which owns tz resolution
+(`resolveEffectiveTz(user.tz, settings.defaultTz)`); the client only sends the
+picked calendar date.
+
+### Frontend (`server/frontend/src/lib/views/PolicyPreviewView.svelte`)
+
+- A "Preview as of" `<input type="date">`. Empty ⇒ omit `date` (today). Set ⇒
+  pass `date` in the preview request and show an "as of <date>" context note near
+  the change header. Clearing returns to today.
+- Reuses the existing debounced `runPreview` path; the date is part of the
+  proposed request, so a date change re-previews like any other edit.
+
+## Tests
+
+- `server/tests/api/policy-preview.test.ts`:
+  - a date-scoped schedule rule (`effectiveFrom`/`effectiveTo` bounding a future
+    week) yields **no** allowed-hours diff for "today" but **does** for a `date`
+    inside its window;
+  - `date` is timezone-correct (a non-UTC user's week boundary picks the right
+    week);
+  - `date` takes precedence over `now`;
+  - a malformed `date` (`2026-13-40`, or a datetime) is a 400.
+- `server/frontend/tests/components/policy-preview-view.test.ts`: selecting a
+  date re-requests with `date` in the proposed payload; clearing drops it.
+
+## Deferred (remains on the #281 umbrella)
+
+- **Ansible-side filter diff** (e2guardian / iptables) — Phase 6 (#90); nothing
+  to diff against on `main` yet.
+
+## Quality gate
+
+`cd server`: `npm run format` · `npm run lint:fix` · `npm run typecheck` ·
+`npm test`; then `cd server/frontend && npm ci && npm run build` +
+`npm run test` (component). No new dependency; no transport/packaging/Docker
+change → license-guard unaffected.

--- a/server/frontend/src/lib/views/PolicyPreviewView.svelte
+++ b/server/frontend/src/lib/views/PolicyPreviewView.svelte
@@ -412,17 +412,28 @@
             value={previewDate}
             oninput={(e) => onPreviewDateChange(e.currentTarget.value)}
           />
+          <span class="as-of-status" role="status" aria-live="polite">
+            {#if previewDate !== ""}
+              <span class="as-of" data-testid="preview-as-of"
+                >showing {previewDateLabel(previewDate)}</span
+              >
+            {:else}
+              <span class="as-of muted-as-of">showing today</span>
+            {/if}
+          </span>
           {#if previewDate !== ""}
-            <span class="as-of" data-testid="preview-as-of"
-              >showing {previewDateLabel(previewDate)}</span
-            >
             <button type="button" class="clear-date" onclick={clearPreviewDate}>
               Back to today
             </button>
-          {:else}
-            <span class="as-of muted-as-of">showing today</span>
           {/if}
         </div>
+        {#if previewDate !== ""}
+          <p class="date-caveat" data-testid="preview-date-caveat">
+            Shows the <strong>recurring</strong> schedule &amp; budget push resolved for that day.
+            One-off exceptions and time grants that fall on this date are pushed separately and
+            aren't included here.
+          </p>
+        {/if}
 
         <div class="editor">
           <div class="card">
@@ -684,6 +695,15 @@
   }
   .muted-as-of {
     color: #6b7280;
+  }
+  .date-caveat {
+    margin: -0.5rem 0 1rem;
+    color: #6b7280;
+    font-size: 0.78rem;
+    max-width: 44rem;
+  }
+  .date-caveat strong {
+    color: #374151;
   }
   .clear-date {
     background: transparent;

--- a/server/frontend/src/lib/views/PolicyPreviewView.svelte
+++ b/server/frontend/src/lib/views/PolicyPreviewView.svelte
@@ -60,6 +60,15 @@
   let loading = $state(true);
   let error = $state<string | null>(null);
 
+  // Future-dated preview (#281): the calendar date to preview the policy *as of*,
+  // or "" for today. When set it is sent as the request's `date`; the server
+  // resolves it to local noon of that day in the user's timezone, so a date-scoped
+  // rule dormant today but active that week shows up in the diff. Today's date
+  // (local) is the picker's floor — previewing the past isn't a useful "what would
+  // a push do" question.
+  const todayIso = localTodayIso();
+  let previewDate = $state<string>("");
+
   // The persisted baseline for the selected user (the proposed payload is
   // derived from it + the admin's what-if edits).
   let budgets = $state<BudgetResponse[]>([]);
@@ -131,6 +140,7 @@
     previewError = null;
     pushResult = null;
     pushError = null;
+    previewDate = ""; // a fresh user starts previewing "today"
     try {
       const [loadedBudgets, loadedSchedules] = await Promise.all([
         listBudgets(selectedUserId),
@@ -212,6 +222,8 @@
       const result = await previewPolicyPush(selectedUserId, {
         budgets: proposedBudgets(),
         schedules: proposedSchedules(),
+        // Preview as of the picked future date, if any — otherwise "today".
+        ...(previewDate !== "" ? { date: previewDate } : {}),
         ...(probe ? { probe: true } : {}),
       });
       if (seq === previewSeq) preview = result;
@@ -255,6 +267,19 @@
 
   function onMinutesChange(id: number, value: string): void {
     minutesById = { ...minutesById, [id]: value };
+    schedulePreview();
+  }
+
+  /** Change the "preview as of" date (empty string ⇒ back to today) and re-preview. */
+  function onPreviewDateChange(value: string): void {
+    previewDate = value;
+    schedulePreview();
+  }
+
+  /** Clear the future date, returning the preview to today. */
+  function clearPreviewDate(): void {
+    if (previewDate === "") return;
+    previewDate = "";
     schedulePreview();
   }
 
@@ -314,6 +339,29 @@
     if (err instanceof ApiError) return err.message;
     return err instanceof Error ? err.message : "Something went wrong";
   }
+
+  /** Today's local calendar date as `YYYY-MM-DD` — the date picker's floor. */
+  function localTodayIso(): string {
+    const now = new Date();
+    const y = now.getFullYear();
+    const m = String(now.getMonth() + 1).padStart(2, "0");
+    const d = String(now.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+  }
+
+  /** A human-readable label for the picked date, e.g. `Sat, Mar 20, 2027`. */
+  function previewDateLabel(iso: string): string {
+    // Parse as local midnight (append no time ⇒ UTC in some engines), so build
+    // the Date from parts to keep the displayed day stable across timezones.
+    const [y, m, d] = iso.split("-").map(Number);
+    if (y === undefined || m === undefined || d === undefined) return iso;
+    return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+      weekday: "short",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
 </script>
 
 <section>
@@ -353,6 +401,29 @@
       {#if loadingPolicy}
         <p class="muted">Loading policy…</p>
       {:else}
+        <!-- Future-dated preview (#281): preview the policy as it resolves on a
+             chosen day, surfacing date-scoped rules dormant today. -->
+        <div class="datebar">
+          <label for="preview-date">Preview as of</label>
+          <input
+            id="preview-date"
+            type="date"
+            min={todayIso}
+            value={previewDate}
+            oninput={(e) => onPreviewDateChange(e.currentTarget.value)}
+          />
+          {#if previewDate !== ""}
+            <span class="as-of" data-testid="preview-as-of"
+              >showing {previewDateLabel(previewDate)}</span
+            >
+            <button type="button" class="clear-date" onclick={clearPreviewDate}>
+              Back to today
+            </button>
+          {:else}
+            <span class="as-of muted-as-of">showing today</span>
+          {/if}
+        </div>
+
         <div class="editor">
           <div class="card">
             <h2>Overall time budgets</h2>
@@ -588,6 +659,43 @@
     border: 1px solid #d1d5db;
     border-radius: 0.4rem;
     background: #fff;
+  }
+  .datebar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .datebar label {
+    font-weight: 600;
+    color: #374151;
+    font-size: 0.9rem;
+  }
+  .datebar input[type="date"] {
+    padding: 0.4rem 0.5rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.4rem;
+    background: #fff;
+  }
+  .as-of {
+    font-size: 0.82rem;
+    color: #374151;
+  }
+  .muted-as-of {
+    color: #6b7280;
+  }
+  .clear-date {
+    background: transparent;
+    color: #2563eb;
+    border: 1px solid #bfdbfe;
+    border-radius: 0.4rem;
+    padding: 0.25rem 0.55rem;
+    font-size: 0.78rem;
+    cursor: pointer;
+  }
+  .clear-date:hover {
+    background: #eff6ff;
   }
   .editor {
     display: grid;

--- a/server/frontend/tests/components/policy-preview-view.test.ts
+++ b/server/frontend/tests/components/policy-preview-view.test.ts
@@ -371,6 +371,41 @@ describe("PolicyPreviewView", () => {
     expect(screen.queryByTestId("preview-as-of")).not.toBeInTheDocument();
   });
 
+  it("resets the picked date to today when a different user is selected", async () => {
+    listUsers.mockResolvedValue([user({ id: 1 }), user({ id: 2, displayName: "Bob" })]);
+    render(PolicyPreviewView);
+    await selectUser(1);
+    await fireEvent.input(screen.getByLabelText("Preview as of"), {
+      target: { value: "2027-03-17" },
+    });
+    await waitFor(() => expect(lastProposed().date).toBe("2027-03-17"));
+
+    await selectUser(2);
+
+    // The new user's preview resolves for today — the date picker was reset.
+    await waitFor(() => {
+      const call = previewPolicyPush.mock.calls.at(-1)!;
+      expect(call[0]).toBe(2);
+      expect(call[1].date).toBeUndefined();
+    });
+    expect(screen.queryByTestId("preview-as-of")).not.toBeInTheDocument();
+  });
+
+  it("shows the recurring-only caveat while a date is picked", async () => {
+    render(PolicyPreviewView);
+    await selectUser();
+    await fireEvent.input(screen.getByLabelText("Preview as of"), {
+      target: { value: "2027-03-17" },
+    });
+
+    expect(await screen.findByTestId("preview-date-caveat")).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Back to today" }));
+    await waitFor(() =>
+      expect(screen.queryByTestId("preview-date-caveat")).not.toBeInTheDocument(),
+    );
+  });
+
   // --- "Push saved policy now" (#304) ---
 
   it("pushes the saved policy for the selected user and renders per-client results", async () => {

--- a/server/frontend/tests/components/policy-preview-view.test.ts
+++ b/server/frontend/tests/components/policy-preview-view.test.ts
@@ -333,6 +333,44 @@ describe("PolicyPreviewView", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("users load failed");
   });
 
+  // --- future-dated preview (`date`, #281) ---
+
+  it("omits `date` on the default (today) preview", async () => {
+    render(PolicyPreviewView);
+    await selectUser();
+
+    await waitFor(() => expect(previewPolicyPush).toHaveBeenCalled());
+    expect(lastProposed().date).toBeUndefined();
+    expect(screen.queryByTestId("preview-as-of")).not.toBeInTheDocument();
+  });
+
+  it("re-previews as of a picked future date", async () => {
+    render(PolicyPreviewView);
+    await selectUser();
+    await waitFor(() => expect(previewPolicyPush).toHaveBeenCalled());
+
+    await fireEvent.input(screen.getByLabelText("Preview as of"), {
+      target: { value: "2027-03-17" },
+    });
+
+    await waitFor(() => expect(lastProposed().date).toBe("2027-03-17"));
+    expect(screen.getByTestId("preview-as-of")).toBeInTheDocument();
+  });
+
+  it("returns to today when the picked date is cleared", async () => {
+    render(PolicyPreviewView);
+    await selectUser();
+    await fireEvent.input(screen.getByLabelText("Preview as of"), {
+      target: { value: "2027-03-17" },
+    });
+    await waitFor(() => expect(lastProposed().date).toBe("2027-03-17"));
+
+    await fireEvent.click(screen.getByRole("button", { name: "Back to today" }));
+
+    await waitFor(() => expect(lastProposed().date).toBeUndefined());
+    expect(screen.queryByTestId("preview-as-of")).not.toBeInTheDocument();
+  });
+
   // --- "Push saved policy now" (#304) ---
 
   it("pushes the saved policy for the selected user and renders per-client results", async () => {

--- a/server/src/api/policy/preview-dtos.ts
+++ b/server/src/api/policy/preview-dtos.ts
@@ -21,10 +21,21 @@ import { budgetResponseSchema, scheduleResponseSchema } from "./dtos.js";
 /**
  * The proposed-policy preview request body. `budgets`/`schedules` reuse the
  * single-source response DTOs (what the editor holds), so a proposed rule
- * carries its `id`/`ordinal` — which the resolver needs for precedence. `now`
- * is an optional reference instant (ISO-8601) the proposed/current resolution
- * is computed against; it exists for deterministic tests and future-dated
- * previews, and defaults to the current time when absent.
+ * carries its `id`/`ordinal` — which the resolver needs for precedence.
+ *
+ * Two ways to pick the reference the proposed/current resolution is computed
+ * against, in precedence order:
+ *
+ * - `date` — a calendar date (`YYYY-MM-DD`) the admin picks to preview a
+ *   **future-dated** policy (#281). The server resolves it to an instant at
+ *   local noon of that date in the *user's effective timezone*, so the
+ *   recurring resolver selects the right reference week (a date-scoped schedule
+ *   rule dormant today but active that week then shows in the diff). Because the
+ *   tz-aware conversion is the server's to make, the client sends only the date.
+ * - `now` — an instant-precise reference (ISO-8601 date-time), the seam
+ *   deterministic tests pin the clock with.
+ *
+ * When both are present `date` wins; when neither is, the current time is used.
  *
  * Note: `scheduleResponseSchema` validates the recurrence fields only
  * structurally (each `int | null`), not the cross-field invariants the write
@@ -47,6 +58,13 @@ export const policyPreviewRequestSchema = z.object({
   budgets: z.array(budgetResponseSchema).default([]),
   schedules: z.array(scheduleResponseSchema).default([]),
   now: z.string().datetime().optional(),
+  /**
+   * A calendar date (`YYYY-MM-DD`) to preview the policy *as of*. Optional and,
+   * like `now`, deliberately not `.default(...)` so the inferred type keeps
+   * `date?: string` and a caller previewing "today" omits it. Validated as a
+   * real calendar date (rejects `2026-13-40` and any date-time string).
+   */
+  date: z.iso.date().optional(),
   probe: z.boolean().optional(),
 });
 

--- a/server/src/api/policy/preview-routes.ts
+++ b/server/src/api/policy/preview-routes.ts
@@ -96,8 +96,14 @@ const NOON_OFFSET_MS = 12 * 60 * 60 * 1000;
  */
 function referenceInstant(body: PolicyPreviewRequest, tz: string): Date {
   if (body.date !== undefined) {
-    const [year, month, day] = body.date.split("-").map(Number) as [number, number, number];
-    return new Date(localDayBounds(year, month, day, tz).start.getTime() + NOON_OFFSET_MS);
+    // `z.iso.date()` has already guaranteed three real numeric parts, but a
+    // runtime destructure (not an `as` tuple cast, banned by CLAUDE.md) is what
+    // satisfies `noUncheckedIndexedAccess`; the guard below is unreachable and
+    // degrades to "today" only to keep the types honest.
+    const [year, month, day] = body.date.split("-").map(Number);
+    if (year !== undefined && month !== undefined && day !== undefined) {
+      return new Date(localDayBounds(year, month, day, tz).start.getTime() + NOON_OFFSET_MS);
+    }
   }
   return body.now === undefined ? new Date() : new Date(body.now);
 }

--- a/server/src/api/policy/preview-routes.ts
+++ b/server/src/api/policy/preview-routes.ts
@@ -29,6 +29,13 @@
  * effect, and it bumps `last_seen` on a client that answers, exactly like the
  * Clients-page health probe.
  *
+ * **Future-dated.** By default the preview resolves against *now*; a request may
+ * pass a calendar `date` (#281) to preview the policy as it resolves on a chosen
+ * future day, so a date-scoped schedule rule (its `effective_from`/`effective_to`
+ * gate) dormant today but active that week surfaces in the diff. The reference is
+ * the only thing `date` moves; the resolver, diff, and client annotations are
+ * unchanged.
+ *
  * **Scope.** SSH + `timekpra` session limits (what `resolve.ts` models on
  * `main`). The Ansible-side filter diff (e2guardian / iptables) is Phase 6 (#90)
  * and is a tracked follow-up.
@@ -40,7 +47,7 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 
 import type { Settings } from "../../config.js";
-import { resolveEffectiveTz } from "../../policy/budget-window.js";
+import { localDayBounds, resolveEffectiveTz } from "../../policy/budget-window.js";
 import type { PolicyDb } from "../../policy/db.js";
 import {
   gatherUserBudgets,
@@ -68,6 +75,32 @@ import {
 
 /** `:userId` path param for the preview route. */
 const previewParamsSchema = z.object({ userId: z.coerce.number().int().positive() });
+
+/** Local minutes in half a day — the offset from local midnight to local noon. */
+const NOON_OFFSET_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * The reference instant the current/proposed policy is resolved against, from
+ * the request body (precedence `date` > `now` > current time; see
+ * {@link policyPreviewRequestSchema}).
+ *
+ * A `date` (`YYYY-MM-DD`, already validated as a real calendar date) is resolved
+ * to **local noon** of that date in the user's effective `tz`:
+ * `localDayBounds` gives the UTC instant of local midnight, and +12h lands at
+ * local noon. Noon (not midnight) is used so the reference sits ~12h from either
+ * local-day edge — a DST shift (±1h) can never nudge it into an adjacent day —
+ * which keeps the resolver's reference-week selection correct even for a `date`
+ * that falls on a week boundary. The resolver only uses the instant to pick the
+ * week (and, for grants/date gates, the day), so noon-of-day is the faithful
+ * "preview this whole day/week" reference.
+ */
+function referenceInstant(body: PolicyPreviewRequest, tz: string): Date {
+  if (body.date !== undefined) {
+    const [year, month, day] = body.date.split("-").map(Number) as [number, number, number];
+    return new Date(localDayBounds(year, month, day, tz).start.getTime() + NOON_OFFSET_MS);
+  }
+  return body.now === undefined ? new Date() : new Date(body.now);
+}
 
 /** Map a proposed budget DTO onto the resolver's {@link BudgetInput}. */
 function toBudgetInput(b: PolicyPreviewRequest["budgets"][number]): BudgetInput {
@@ -256,7 +289,9 @@ export function registerPreviewRoutes(
       }
 
       const tz = resolveEffectiveTz(user.tz, settings.defaultTz);
-      const now = request.body.now === undefined ? new Date() : new Date(request.body.now);
+      // The reference instant the week / "today" resolve against — the current
+      // time, an explicit `now`, or local noon of a picked future `date` (#281).
+      const now = referenceInstant(request.body, tz);
 
       // Current policy mirrors the live executor: the user's effective rules —
       // own rules merged with inherited group schedules/budgets (#362), resolved

--- a/server/tests/api/policy-preview.test.ts
+++ b/server/tests/api/policy-preview.test.ts
@@ -466,6 +466,136 @@ describe("POST /api/users/:userId/policy-preview", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().affectedClients[0]).toMatchObject({ reachability: null, probedAt: null });
   });
+
+  // --- future-dated preview (`date`, #281) ---
+
+  // A proposed deny 08:00–12:00 daily, scoped to the single ISO week
+  // Mon 2027-03-15 … Sun 2027-03-21 (effectiveTo is the exclusive next Monday).
+  // Dormant every other week, so the diff it produces depends on the reference
+  // date — exactly what the future-dated preview surfaces.
+  function dateScopedDenyRule(overrides: Record<string, unknown> = {}) {
+    return proposedSchedule({
+      action: "deny",
+      recurrenceStartMinute: 480, // 08:00
+      recurrenceEndMinute: 720, // 12:00
+      effectiveFrom: "2027-03-15T00:00:00.000Z",
+      effectiveTo: "2027-03-22T00:00:00.000Z",
+      ...overrides,
+    });
+  }
+
+  it("previews a date-scoped rule as a no-op today but active on a date in its window", async () => {
+    const userId = await createUser("Alice"); // tz null → UTC
+
+    // Today (well before the window): the proposed rule's date gate is closed,
+    // so the resolved push is unchanged from the ruleless baseline — no diff.
+    const today = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [dateScopedDenyRule()], now: "2026-06-17T12:00:00Z" },
+    });
+    expect(today.statusCode).toBe(200);
+    expect(today.json().hasChanges).toBe(false);
+
+    // A date inside the window: the rule is live all seven days of that week, so
+    // every day's allowed hours tighten from all-day to 00:00–08:00, 12:00–24:00.
+    const inWindow = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [dateScopedDenyRule()], date: "2027-03-17" },
+    });
+    expect(inWindow.statusCode).toBe(200);
+    const body = inWindow.json();
+    expect(body.hasChanges).toBe(true);
+    const allowedHours = body.changes.filter((c: { field: string }) => c.field === "allowed-hours");
+    expect(allowedHours).toHaveLength(7);
+    expect(allowedHours[0]).toMatchObject({
+      field: "allowed-hours",
+      kind: "changed",
+      before: "00:00–24:00",
+      after: "00:00–08:00, 12:00–24:00",
+    });
+  });
+
+  it("respects the exclusive effective_to: a date in the next week is a no-op again", async () => {
+    const userId = await createUser("Alice"); // tz null → UTC
+    // 2027-03-22 is the next Monday — the first day the window (exclusive end)
+    // no longer covers — so its whole week is outside the rule and the diff empties.
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [dateScopedDenyRule()], date: "2027-03-22" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().hasChanges).toBe(false);
+  });
+
+  it("interprets `date` in the user's timezone (local noon selects the local week)", async () => {
+    // Honolulu is UTC-10 with no DST. The rule is scoped to local-midnight
+    // boundaries of the same week (10:00Z each day). Previewing date=2027-03-15
+    // resolves to local noon = 2027-03-15T22:00Z, which lands inside the window
+    // and in the local week Mon 03-15 … Sun 03-21. A naive UTC-midnight reading
+    // (2027-03-15T00:00Z = Sun 03-14 14:00 local) would fall in the *previous*
+    // local week, before the window, and miss the rule — so a diff here proves
+    // the reference is built from the user's timezone, at local noon.
+    const userId = await createUser("Kai", "Pacific/Honolulu");
+    const rule = dateScopedDenyRule({
+      effectiveFrom: "2027-03-15T10:00:00.000Z", // local midnight 03-15
+      effectiveTo: "2027-03-22T10:00:00.000Z", // local midnight 03-22 (exclusive)
+    });
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [rule], date: "2027-03-15" },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.hasChanges).toBe(true);
+    expect(body.changes.some((c: { field: string }) => c.field === "allowed-hours")).toBe(true);
+  });
+
+  it("lets `date` take precedence over `now`", async () => {
+    const userId = await createUser("Alice"); // tz null → UTC
+    // `now` is today (rule dormant); `date` is inside the window (rule live).
+    // If `date` wins, the diff reflects the live rule.
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: {
+        budgets: [],
+        schedules: [dateScopedDenyRule()],
+        now: "2026-06-17T12:00:00Z",
+        date: "2027-03-17",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().hasChanges).toBe(true);
+    expect(res.json().changes.some((c: { field: string }) => c.field === "allowed-hours")).toBe(
+      true,
+    );
+  });
+
+  it("rejects a malformed `date` (not a real calendar date) with a 400", async () => {
+    const userId = await createUser("Alice");
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [], date: "2027-13-40" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
+
+  it("rejects a date-time value in `date` (calendar date only) with a 400", async () => {
+    const userId = await createUser("Alice");
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [], date: "2027-03-17T00:00:00Z" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.code).toBe("validation_error");
+  });
 });
 
 /**

--- a/server/tests/api/policy-preview.test.ts
+++ b/server/tests/api/policy-preview.test.ts
@@ -554,6 +554,28 @@ describe("POST /api/users/:userId/policy-preview", () => {
     expect(body.changes.some((c: { field: string }) => c.field === "allowed-hours")).toBe(true);
   });
 
+  it("resolves `date` correctly across a DST transition (local noon stays in-day)", async () => {
+    // America/New_York springs forward on Sun 2027-03-14 (02:00→03:00). The
+    // local-noon reference (`localDayBounds().start` = local midnight, +12h) must
+    // still land on 2027-03-14 despite the missing hour, so a rule scoped to that
+    // month resolves as active. This exercises the DST-safety the +12h offset buys
+    // (a midnight reference could be nudged across a day boundary; noon cannot).
+    const userId = await createUser("Dana", "America/New_York");
+    const rule = dateScopedDenyRule({
+      effectiveFrom: "2027-03-01T05:00:00.000Z", // 2027-03-01 00:00 EST
+      effectiveTo: "2027-04-01T04:00:00.000Z", // 2027-04-01 00:00 EDT (exclusive)
+    });
+    const res = await auth({
+      method: "POST",
+      url: `/api/users/${userId}/policy-preview`,
+      payload: { budgets: [], schedules: [rule], date: "2027-03-14" },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.hasChanges).toBe(true);
+    expect(body.changes.some((c: { field: string }) => c.field === "allowed-hours")).toBe(true);
+  });
+
   it("lets `date` take precedence over `now`", async () => {
     const userId = await createUser("Alice"); // tz null → UTC
     // `now` is today (rule dormant); `date` is inside the window (rule live).


### PR DESCRIPTION
## Summary

- Adds an admin-facing, timezone-aware **future-dated preview** to the save-and-push preview: `POST /api/users/:userId/policy-preview` gains an optional `date` (`YYYY-MM-DD`) so a policy can be previewed *as it resolves on a chosen future day*, not only "now".
- Now meaningful because weekday-varying budgets (#141, PR #408) and date-specific overrides (#142, PR #398) have both landed in the resolver — a **date-scoped schedule rule** dormant today but active in a future week now surfaces in the diff.
- Frontend: a "Preview as of" date selector in `PolicyPreviewView` that re-previews for the chosen date and labels the context; clearing returns to today.

The reference is the only thing `date` moves — the resolver, diff engine, and client annotations are unchanged. `date` is resolved to **local noon** of that date in the user's *effective* timezone (`localDayBounds + 12h`), so the resolver selects the correct reference week even at a week boundary, regardless of the caller's clock. Precedence: `date` > `now` > current time. The endpoint stays side-effect-free.

## Plan

Linked plan: `docs/plans/issue-281-future-dated-preview.md`
Roadmap: `docs/roadmap.md` → Phase 4 (save-and-push preview; the last non-Ansible bullet of the #281 umbrella).

## License-boundary note

N/A — no transport or packaging changes. Pure TypeScript + zod over the read-only policy/resolver seams; no GPL imports, no image changes.

## Faithful-to-the-push note

`resolvePolicyPush` deliberately does **not** compose one-off Exceptions (#142) into the pushed allowed-hours grid — pushing an exception override to the client is its own path (#399, PR #420). The preview mirrors the recurring push, so it too excludes Exceptions and reflects only the recurring layer's `effective_from`/`effective_to` date gate. Composing Exceptions into the preview but not the push would make the preview lie about what the recurring push sends.

## Test plan

- [x] Backend: a date-scoped rule is a no-op today but active on a `date` inside its window (7 per-weekday allowed-hours rows).
- [x] Backend: the exclusive `effective_to` empties the diff the next week.
- [x] Backend: `date` is interpreted in the user's timezone (local noon selects the local week — decisive Honolulu/UTC-10 case).
- [x] Backend: `date` takes precedence over `now`.
- [x] Backend: a malformed (`2027-13-40`) or date-time `date` is a 400.
- [x] Frontend: selecting a date re-requests with `date`; clearing drops it (component test).
- [x] `format:check` · `lint` · `typecheck` · `npm test` (unit + coverage gate) green; frontend `npm run build` + component tests green.

## Deferred (remains tracked on the #281 umbrella)

- **Ansible-side filter diff** (e2guardian / iptables) — Phase 6 (#90); nothing to diff against on `main` yet.

Part of #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018NKrLy8b1cahYMA8ehWATT)_