### PR TITLE
feat(bridge): client-side ADR-0007 event-stream version handshake (#303)

### DIFF
--- a/client/agent/src/bridge/bridge.ts
+++ b/client/agent/src/bridge/bridge.ts
@@ -20,6 +20,7 @@
  */
 import { socketPathForUid, type BridgeConfig } from "./config.js";
 import { Dispatcher } from "./dispatch.js";
+import type { AcceptFrame, RefuseFrame } from "./handshake.js";
 import type { Logger } from "./logger.js";
 import { WsClient, type Timers, type WebSocketFactory } from "./ws-client.js";
 
@@ -32,8 +33,12 @@ export interface BridgeDeps {
   timers?: Timers;
   /** Override the backoff jitter RNG. */
   rng?: () => number;
-  /** Optional handshake seam fired on each successful connect (ADR-0007, #165). */
+  /** Optional seam fired on each successful socket open (before `hello`). */
   onOpen?: () => void;
+  /** Optional seam fired when the server accepts the ADR-0007 handshake (#303). */
+  onAccept?: (frame: AcceptFrame) => void;
+  /** Optional seam fired when the server refuses the handshake as incompatible (#303). */
+  onRefuse?: (frame: RefuseFrame) => void;
 }
 
 /** The composed bridge: an event-stream client feeding an AF_UNIX dispatcher. */
@@ -53,6 +58,7 @@ export class Bridge {
     this.#wsClient = new WsClient({
       url: config.serverUrl,
       token: config.token,
+      agentVersion: config.agentVersion,
       onFrame: (frame) => this.#dispatcher.dispatch(frame),
       backoff: config.backoff,
       logger: deps.logger,
@@ -60,6 +66,8 @@ export class Bridge {
       ...(deps.timers ? { timers: deps.timers } : {}),
       ...(deps.rng ? { rng: deps.rng } : {}),
       ...(deps.onOpen ? { onOpen: deps.onOpen } : {}),
+      ...(deps.onAccept ? { onAccept: deps.onAccept } : {}),
+      ...(deps.onRefuse ? { onRefuse: deps.onRefuse } : {}),
     });
   }
 

--- a/client/agent/src/bridge/config.ts
+++ b/client/agent/src/bridge/config.ts
@@ -23,6 +23,14 @@ import { DEFAULT_BACKOFF } from "./backoff.js";
 /** Default directory the bridge owns its per-user AF_UNIX sockets under. */
 export const DEFAULT_SOCKET_DIR = "/run/pct";
 
+/**
+ * Fallback agent version advertised in the ADR-0007 `hello` when the packaging
+ * has not stamped `PCT_BRIDGE_AGENT_VERSION`. Matches the placeholder in
+ * `package.json`; the real `.deb` build sets the env to the release version
+ * (client-packaging work, #106).
+ */
+export const DEFAULT_AGENT_VERSION = "0.0.0";
+
 /** Default mode for a per-user socket (owner read/write only). */
 export const DEFAULT_SOCKET_MODE = 0o600;
 
@@ -54,6 +62,13 @@ export const bridgeConfigSchema = z.object({
   serverUrl: z.url({ protocol: /^wss?$/ }),
   /** The per-client bearer token from enrolment (#77). */
   token: z.string().min(1),
+  /**
+   * The `pct-client` agent version advertised in the ADR-0007 `hello` (#303),
+   * which refreshes the server's `agent_version` inventory on every connect
+   * (#164). Defaults to {@link DEFAULT_AGENT_VERSION}; the packaging stamps the
+   * real `.deb` version via `PCT_BRIDGE_AGENT_VERSION`.
+   */
+  agentVersion: z.string().min(1).max(100).default(DEFAULT_AGENT_VERSION),
   /** Directory the bridge creates its per-user sockets in. */
   socketDir: z.string().min(1).default(DEFAULT_SOCKET_DIR),
   /** Filesystem mode applied to each per-user socket. */
@@ -105,6 +120,7 @@ export function socketPathForUid(config: BridgeConfig, linuxUid: number): string
 export interface BridgeEnv {
   PCT_BRIDGE_SERVER_URL?: string;
   PCT_BRIDGE_TOKEN?: string;
+  PCT_BRIDGE_AGENT_VERSION?: string;
   PCT_BRIDGE_SOCKET_DIR?: string;
   PCT_BRIDGE_SOCKET_MODE?: string;
   /** JSON array of `{ userId, linuxUid }` objects. */
@@ -133,6 +149,7 @@ export function loadConfigFromEnv(env: BridgeEnv = process.env): BridgeConfig {
   const raw = {
     serverUrl: env.PCT_BRIDGE_SERVER_URL,
     token: env.PCT_BRIDGE_TOKEN,
+    agentVersion: env.PCT_BRIDGE_AGENT_VERSION,
     socketDir: env.PCT_BRIDGE_SOCKET_DIR,
     socketMode: parseOptionalInt(env.PCT_BRIDGE_SOCKET_MODE, "PCT_BRIDGE_SOCKET_MODE"),
     users,

--- a/client/agent/src/bridge/handshake.ts
+++ b/client/agent/src/bridge/handshake.ts
@@ -1,0 +1,153 @@
+/**
+ * The bridge's client side of the ADR-0007 event-stream version handshake
+ * (#303, Phase 8b).
+ *
+ * On every (re)connect the bridge **speaks first** with a `hello`
+ * (`agentVersion`, `eventProtocol`, `capabilities`) and proceeds only on the
+ * server's `accept`; on `refuse` (`code: "incompatible_protocol"`) it surfaces
+ * the `update_required` condition and stops retrying (ADR 0007 §2). This module
+ * is the pure, I/O-free contract — the frame builder + the reply parser —
+ * mirroring the server's `server/src/events/protocol.ts` (`negotiate` /
+ * `helloFrameSchema` / `acceptFrameSchema` / `refuseFrameSchema`).
+ *
+ * Why re-declare rather than import: the bridge ships as its own `.deb` with a
+ * bundled Node runtime (`docs/client-notifications.md`) — there is no workspace
+ * to import `server/src` across, exactly as `protocol.ts` already re-declares
+ * the *event* envelope for the same reason. `tests/bridge/handshake.test.ts`
+ * pins these shapes against the server contract so the two declarations cannot
+ * silently drift.
+ *
+ * License boundary: none touched — plain TypeScript + zod (MIT).
+ */
+import { z } from "zod";
+
+/**
+ * The frame-envelope/handshake protocol version this bridge speaks (ADR 0007
+ * §1) — a positive integer, kept in lockstep with the server's `EVENT_PROTOCOL`
+ * and bumped only on a *breaking* envelope/handshake change (additive changes
+ * ride on {@link BRIDGE_CAPABILITIES}).
+ */
+export const EVENT_PROTOCOL = 1;
+
+/**
+ * The enforcement primitives this (Linux) bridge honours, advertised in `hello`
+ * (ADR 0007 §4). The bridge forwards all five server events, so it advertises
+ * both capabilities the server gates on today (mirrors the server's
+ * `events/capabilities.ts` `CLIENT_CAPABILITIES`):
+ *
+ * - `session_budget` — overall-screen-time lock/unlock (`enforce.session_lock`,
+ *   `lockout.cleared`).
+ * - `per_app_close` — per-app/group process force-close (`enforce.force_close`).
+ *
+ * `grant.applied` / `policy.changed` are baseline (ungated) frames every client
+ * receives regardless. Capability strings are additively extensible — adding one
+ * is never a breaking change.
+ */
+export const BRIDGE_CAPABILITIES: readonly string[] = ["session_budget", "per_app_close"];
+
+/**
+ * Client → server opening frame (ADR 0007 §2). Mirrors the server's
+ * `helloFrameSchema`; used to validate {@link buildHello}'s own output in tests.
+ */
+export const helloFrameSchema = z.object({
+  type: z.literal("hello"),
+  /** The `pct-client` agent `.deb` version (refreshes the server inventory, #164). */
+  agentVersion: z.string().min(1).max(100),
+  /** The integer frame-protocol version this client speaks. */
+  eventProtocol: z.number().int().positive(),
+  /** Additive feature flags the client supports (§4). */
+  capabilities: z.array(z.string().min(1).max(100)).max(64),
+});
+
+/** The client's opening `hello` frame. */
+export type HelloFrame = z.infer<typeof helloFrameSchema>;
+
+/** Inputs for {@link buildHello}. */
+export interface HelloInput {
+  /** The agent `.deb` version to report (the packaging stamps this). */
+  agentVersion: string;
+  /** The protocol version to advertise (defaults to {@link EVENT_PROTOCOL}). */
+  eventProtocol?: number;
+  /** The capabilities to advertise (defaults to {@link BRIDGE_CAPABILITIES}). */
+  capabilities?: readonly string[];
+}
+
+/** Build the opening `hello` frame the bridge sends on each (re)connect. */
+export function buildHello(input: HelloInput): HelloFrame {
+  return {
+    type: "hello",
+    agentVersion: input.agentVersion,
+    eventProtocol: input.eventProtocol ?? EVENT_PROTOCOL,
+    capabilities: [...(input.capabilities ?? BRIDGE_CAPABILITIES)],
+  };
+}
+
+/**
+ * Server → client `accept` frame: the stream proceeds in the agreed dialect
+ * (`eventProtocol` is the version the server will *speak* — the client's own
+ * when within the N-1 window). Mirrors the server's `acceptFrameSchema`.
+ */
+export const acceptFrameSchema = z.object({
+  type: z.literal("accept"),
+  eventProtocol: z.number().int().positive(),
+  apiVersion: z.number().int().positive(),
+});
+
+/** A decoded `accept` frame. */
+export type AcceptFrame = z.infer<typeof acceptFrameSchema>;
+
+/** The single refusal code (the `/api/*` error-envelope vocabulary, ADR 0007 §2). */
+export const INCOMPATIBLE_PROTOCOL_CODE = "incompatible_protocol";
+
+/**
+ * Server → client `refuse` frame: the connection is incompatible and the server
+ * will close the socket. Mirrors the server's `refuseFrameSchema`.
+ */
+export const refuseFrameSchema = z.object({
+  type: z.literal("refuse"),
+  error: z.object({
+    code: z.literal(INCOMPATIBLE_PROTOCOL_CODE),
+    message: z.string(),
+  }),
+});
+
+/** A decoded `refuse` frame. */
+export type RefuseFrame = z.infer<typeof refuseFrameSchema>;
+
+/** The server's reply to a `hello`: either an accept or a refuse frame. */
+export const handshakeReplySchema = z.discriminatedUnion("type", [
+  acceptFrameSchema,
+  refuseFrameSchema,
+]);
+
+/** The outcome of {@link parseHandshakeReply}. */
+export type HandshakeReply =
+  | { readonly kind: "accept"; readonly frame: AcceptFrame }
+  | { readonly kind: "refuse"; readonly frame: RefuseFrame };
+
+/**
+ * Parse an untrusted incoming WebSocket message as the server's handshake reply.
+ *
+ * Returns `null` for anything that is not a valid `accept`/`refuse` frame (bad
+ * JSON, wrong shape, or an event frame arriving where a reply was expected) so
+ * the caller can treat a non-handshake opener as a protocol violation without
+ * throwing — mirroring how {@link ./protocol.ts decodeFrame}'s server-side twin
+ * (`parseHello`) tolerates a malformed opener.
+ */
+export function parseHandshakeReply(raw: string | Uint8Array): HandshakeReply | null {
+  const text = typeof raw === "string" ? raw : Buffer.from(raw).toString("utf8");
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return null;
+  }
+
+  const parsed = handshakeReplySchema.safeParse(json);
+  if (!parsed.success) return null;
+
+  return parsed.data.type === "accept"
+    ? { kind: "accept", frame: parsed.data }
+    : { kind: "refuse", frame: parsed.data };
+}

--- a/client/agent/src/bridge/handshake.ts
+++ b/client/agent/src/bridge/handshake.ts
@@ -56,7 +56,7 @@ export const helloFrameSchema = z.object({
   /** The integer frame-protocol version this client speaks. */
   eventProtocol: z.number().int().positive(),
   /** Additive feature flags the client supports (§4). */
-  capabilities: z.array(z.string().min(1).max(100)).max(64),
+  capabilities: z.array(z.string().min(1).max(100)).max(64).default([]),
 });
 
 /** The client's opening `hello` frame. */

--- a/client/agent/src/bridge/ws-client.ts
+++ b/client/agent/src/bridge/ws-client.ts
@@ -8,27 +8,47 @@
  * exponential backoff** whenever the socket drops. Outbound-only because the
  * client is typically behind NAT.
  *
- * Liveness is the standard `ws` ping/pong: the server pings
+ * ## Version handshake (ADR 0007, #303)
+ *
+ * On every (re)connect the bridge **speaks first**: it sends a `hello`
+ * (`agentVersion`, `eventProtocol`, `capabilities`) and forwards **no** event
+ * frames to {@link WsClientOptions.onFrame} until the server's `accept`. The
+ * server always sends its `accept`/`refuse` as the first message (before it
+ * starts the event fan-out), so the first inbound message is treated as the
+ * handshake reply and everything after it as an event frame.
+ *
+ * - `accept` → the stream proceeds in the agreed dialect.
+ * - `refuse` (`code: "incompatible_protocol"`) → the server closes the socket;
+ *   the bridge surfaces the `update_required` condition (via
+ *   {@link WsClientOptions.onRefuse}) and **stops reconnecting**, since retrying
+ *   the same protocol against the same server cannot succeed until the agent is
+ *   updated (ADR 0007 §2, §5).
+ * - A bounded {@link WsClientOptions.handshakeTimeoutMs} closes and reconnects
+ *   if no reply arrives (backstop for a server that never replies).
+ *
+ * Liveness (post-accept) is the standard `ws` ping/pong: the server pings
  * (`server/src/events/heartbeat.ts`) and the `ws` runtime auto-replies with a
  * pong, so the bridge needs no heartbeat logic of its own — a dead peer is
  * surfaced to us as a `close`, which drives the reconnect.
  *
  * The actual `WebSocket` is created through an injected {@link WebSocketFactory}
- * so the lifecycle (open → frames → close → backoff → reconnect) is unit-tested
- * with a fake socket and no network. A malformed frame is logged and dropped —
- * one poison frame must never tear down the connection.
- *
- * Deferred: the ADR-0007 `hello`/`accept`/`refuse` version handshake. Its
- * server side + shared schemas land with #165 (PR #286); {@link WsClient}
- * exposes the {@link WsClientOptions.onOpen} seam where it will slot in. Against
- * `main`'s current handshake-less stream the connection proceeds straight to
- * frames.
+ * so the lifecycle (open → hello → accept → frames → close → backoff →
+ * reconnect) is unit-tested with a fake socket and no network. A malformed event
+ * frame is logged and dropped — one poison frame must never tear down the
+ * connection.
  *
  * License boundary: none touched — `ws` (MIT) behind an injected factory.
  */
 import { WebSocket } from "ws";
 
 import { computeBackoffDelayMs, type BackoffOptions } from "./backoff.js";
+import {
+  BRIDGE_CAPABILITIES,
+  buildHello,
+  parseHandshakeReply,
+  type AcceptFrame,
+  type RefuseFrame,
+} from "./handshake.js";
 import type { Logger } from "./logger.js";
 import { decodeFrame, FrameDecodeError, type EventFrame } from "./protocol.js";
 
@@ -40,6 +60,8 @@ export interface WebSocketLike {
   on(event: "open" | "close", listener: () => void): unknown;
   on(event: "message", listener: (data: RawMessage) => void): unknown;
   on(event: "error", listener: (err: Error) => void): unknown;
+  /** Send a text frame (the opening `hello`). */
+  send(data: string): void;
   /** Begin a clean close handshake. */
   close(): void;
   /** Forcibly drop the socket (used on stop()). */
@@ -65,17 +87,42 @@ const defaultTimers: Timers = {
 
 const defaultFactory: WebSocketFactory = (url, options) => new WebSocket(url, options);
 
+/**
+ * How long to wait for the server's `accept`/`refuse` after sending `hello`
+ * before closing and reconnecting. Above the server's own hello-timeout (10s,
+ * `server/src/events/stream.ts`), so in the normal too-slow case the server's
+ * close drives the reconnect and this is only the backstop for a server that
+ * accepts internally but never replies.
+ */
+export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 15_000;
+
 /** Options for {@link WsClient}. */
 export interface WsClientOptions {
   /** Dashboard event-stream URL (`ws(s)://…/api/events/stream`). */
   url: string;
   /** Per-client bearer token sent as `Authorization: Bearer <token>`. */
   token: string;
-  /** Called with each decoded, validated frame. */
+  /** The `pct-client` agent version advertised in `hello` (refreshes the inventory). */
+  agentVersion: string;
+  /** Called with each decoded, validated event frame (only after `accept`). */
   onFrame: (frame: EventFrame) => void;
   backoff: BackoffOptions;
   logger: Logger;
-  /** Optional hook fired on each successful open (the handshake seam). */
+  /** Capabilities advertised in `hello` (defaults to {@link BRIDGE_CAPABILITIES}). */
+  capabilities?: readonly string[];
+  /** Protocol version advertised in `hello` (defaults to the handshake module's). */
+  eventProtocol?: number;
+  /** Fired when the server accepts the handshake. */
+  onAccept?: (frame: AcceptFrame) => void;
+  /**
+   * Fired when the server refuses the handshake as incompatible. The bridge has
+   * already stopped reconnecting; the hook surfaces the `update_required`
+   * condition (ADR 0007 §5).
+   */
+  onRefuse?: (frame: RefuseFrame) => void;
+  /** How long to wait for the handshake reply (defaults to {@link DEFAULT_HANDSHAKE_TIMEOUT_MS}). */
+  handshakeTimeoutMs?: number;
+  /** Optional hook fired on each successful socket open (before `hello` is sent). */
   onOpen?: () => void;
   /** Override the WebSocket constructor (tests inject a fake). */
   factory?: WebSocketFactory;
@@ -86,36 +133,46 @@ export interface WsClientOptions {
 }
 
 /**
- * Manages the event-stream connection: connect, decode-and-forward frames, and
- * reconnect with backoff on every drop until {@link stop} is called.
+ * Manages the event-stream connection: connect, run the version handshake,
+ * decode-and-forward frames, and reconnect with backoff on every drop until
+ * {@link stop} is called (or the server refuses the handshake as incompatible).
  */
 export class WsClient {
   readonly #options: WsClientOptions;
   readonly #factory: WebSocketFactory;
   readonly #timers: Timers;
   readonly #rng: () => number;
+  readonly #handshakeTimeoutMs: number;
 
   #socket: WebSocketLike | null = null;
   #reconnectTimer: { unref?: () => void } | null = null;
+  #handshakeTimer: { unref?: () => void } | null = null;
   #attempt = 0;
   #stopped = false;
+  /** True once the server has refused this bridge's protocol; suppresses reconnect. */
+  #refused = false;
+  /** True between sending `hello` and receiving the `accept`/`refuse` reply. */
+  #awaitingHandshake = false;
 
   constructor(options: WsClientOptions) {
     this.#options = options;
     this.#factory = options.factory ?? defaultFactory;
     this.#timers = options.timers ?? defaultTimers;
     this.#rng = options.rng ?? Math.random;
+    this.#handshakeTimeoutMs = options.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
   }
 
   /** Open the connection. Subsequent drops reconnect automatically. */
   start(): void {
     this.#stopped = false;
+    this.#refused = false;
     this.#connect();
   }
 
   /** Stop reconnecting and close the current socket. Idempotent. */
   stop(): void {
     this.#stopped = true;
+    this.#clearHandshakeTimer();
     if (this.#reconnectTimer !== null) {
       this.#timers.clear(this.#reconnectTimer);
       this.#reconnectTimer = null;
@@ -126,6 +183,7 @@ export class WsClient {
 
   #connect(): void {
     this.#reconnectTimer = null;
+    this.#awaitingHandshake = false;
     const socket = this.#factory(this.#options.url, {
       headers: { Authorization: `Bearer ${this.#options.token}` },
     });
@@ -135,6 +193,7 @@ export class WsClient {
       this.#attempt = 0;
       this.#options.logger.info({ url: this.#options.url }, "event stream connected");
       this.#options.onOpen?.();
+      this.#sendHello(socket);
     });
 
     socket.on("message", (data) => this.#onMessage(data));
@@ -147,12 +206,38 @@ export class WsClient {
 
     socket.on("close", () => {
       this.#socket = null;
-      if (this.#stopped) return;
+      this.#clearHandshakeTimer();
+      this.#awaitingHandshake = false;
+      if (this.#stopped || this.#refused) return;
       this.#scheduleReconnect();
     });
   }
 
+  /** Speak first: send `hello` and await the server's `accept`/`refuse`. */
+  #sendHello(socket: WebSocketLike): void {
+    const hello = buildHello({
+      agentVersion: this.#options.agentVersion,
+      ...(this.#options.eventProtocol !== undefined
+        ? { eventProtocol: this.#options.eventProtocol }
+        : {}),
+      capabilities: this.#options.capabilities ?? BRIDGE_CAPABILITIES,
+    });
+    this.#awaitingHandshake = true;
+    socket.send(JSON.stringify(hello));
+    this.#options.logger.info(
+      { eventProtocol: hello.eventProtocol, capabilities: hello.capabilities },
+      "sent event-stream hello",
+    );
+    const handle = this.#timers.set(() => this.#onHandshakeTimeout(), this.#handshakeTimeoutMs);
+    handle.unref?.();
+    this.#handshakeTimer = handle;
+  }
+
   #onMessage(data: RawMessage): void {
+    if (this.#awaitingHandshake) {
+      this.#onHandshakeReply(data);
+      return;
+    }
     let frame: EventFrame;
     try {
       frame = decodeFrame(toFrameInput(data));
@@ -166,6 +251,61 @@ export class WsClient {
     this.#options.onFrame(frame);
   }
 
+  #onHandshakeReply(data: RawMessage): void {
+    const reply = parseHandshakeReply(toFrameInput(data));
+
+    if (reply === null) {
+      // The server should send accept/refuse first; anything else pre-handshake
+      // is a protocol violation. Close and reconnect (with backoff) rather than
+      // forwarding a frame we can't trust the negotiation for.
+      this.#clearHandshakeTimer();
+      this.#awaitingHandshake = false;
+      this.#options.logger.warn({}, "unexpected pre-handshake frame; closing to retry");
+      this.#socket?.close();
+      return;
+    }
+
+    this.#clearHandshakeTimer();
+    this.#awaitingHandshake = false;
+
+    if (reply.kind === "refuse") {
+      this.#refused = true;
+      this.#options.logger.error(
+        { code: reply.frame.error.code, message: reply.frame.error.message },
+        "event-stream handshake refused; client update required — not reconnecting",
+      );
+      this.#options.onRefuse?.(reply.frame);
+      // The server closes the socket on refuse; terminate defensively so we do
+      // not linger if it does not, and the close handler (with #refused set) will
+      // not reconnect.
+      this.#socket?.terminate();
+      this.#socket = null;
+      return;
+    }
+
+    this.#options.logger.info(
+      { eventProtocol: reply.frame.eventProtocol, apiVersion: reply.frame.apiVersion },
+      "event-stream handshake accepted",
+    );
+    this.#options.onAccept?.(reply.frame);
+  }
+
+  #onHandshakeTimeout(): void {
+    if (!this.#awaitingHandshake) return;
+    this.#handshakeTimer = null;
+    this.#awaitingHandshake = false;
+    this.#options.logger.warn({}, "no handshake reply before timeout; closing to retry");
+    // Close → the close handler schedules a backoff reconnect.
+    this.#socket?.close();
+  }
+
+  #clearHandshakeTimer(): void {
+    if (this.#handshakeTimer !== null) {
+      this.#timers.clear(this.#handshakeTimer);
+      this.#handshakeTimer = null;
+    }
+  }
+
   #scheduleReconnect(): void {
     const delay = computeBackoffDelayMs(this.#attempt, this.#options.backoff, this.#rng);
     this.#attempt += 1;
@@ -174,7 +314,7 @@ export class WsClient {
       "scheduling event stream reconnect",
     );
     const handle = this.#timers.set(() => {
-      if (!this.#stopped) this.#connect();
+      if (!this.#stopped && !this.#refused) this.#connect();
     }, delay);
     // Don't let a pending reconnect keep the process alive on its own.
     handle.unref?.();

--- a/client/agent/src/bridge/ws-client.ts
+++ b/client/agent/src/bridge/ws-client.ts
@@ -162,10 +162,19 @@ export class WsClient {
     this.#handshakeTimeoutMs = options.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
   }
 
-  /** Open the connection. Subsequent drops reconnect automatically. */
+  /**
+   * Open the connection. Subsequent drops reconnect automatically. Safe to call
+   * again after {@link stop} or a refuse to restart; if called while a reconnect
+   * is already pending it cancels that pending attempt first so a restart never
+   * leaves two connect loops racing.
+   */
   start(): void {
     this.#stopped = false;
     this.#refused = false;
+    if (this.#reconnectTimer !== null) {
+      this.#timers.clear(this.#reconnectTimer);
+      this.#reconnectTimer = null;
+    }
     this.#connect();
   }
 

--- a/client/agent/tests/bridge/bridge.test.ts
+++ b/client/agent/tests/bridge/bridge.test.ts
@@ -43,6 +43,10 @@ class FakeSocket implements WebSocketLike {
     else if (event === "close") this.#close = listener as () => void;
     return this;
   }
+  readonly sent: string[] = [];
+  send(data: string): void {
+    this.sent.push(data);
+  }
   closed = false;
   close(): void {
     this.closed = true;
@@ -88,6 +92,9 @@ function nextLine(socket: net.Socket): Promise<string> {
 }
 
 const tick = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+/** The server's accept reply — the bridge withholds event frames until it lands. */
+const acceptFrame = JSON.stringify({ type: "accept", eventProtocol: 1, apiVersion: 1 });
 
 function frame(userId: number, seq = 1): EventFrame {
   return {
@@ -152,6 +159,9 @@ describe("Bridge (fake WS → real AF_UNIX)", () => {
     const fakeWs = sockets[0];
     expect(fakeWs).toBeDefined();
     fakeWs?.emitOpen();
+    // The bridge speaks first (hello) and only streams after the server accepts.
+    expect(fakeWs?.sent).toHaveLength(1);
+    fakeWs?.emitMessage(acceptFrame);
 
     const line = nextLine(agent);
     fakeWs?.emitMessage(JSON.stringify(frame(7, 42)));
@@ -203,6 +213,7 @@ describe("Bridge (fake WS → real AF_UNIX)", () => {
     const bridge = new Bridge(config, { logger: testLogger(), wsFactory: factory });
     await bridge.start();
     fakeWs?.emitOpen();
+    fakeWs?.emitMessage(acceptFrame);
 
     // userId 999 is not in the config; this must be a silent no-op, not a throw.
     expect(() => fakeWs?.emitMessage(JSON.stringify(frame(999)))).not.toThrow();

--- a/client/agent/tests/bridge/config.test.ts
+++ b/client/agent/tests/bridge/config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   bridgeConfigSchema,
   ConfigError,
+  DEFAULT_AGENT_VERSION,
   DEFAULT_SOCKET_DIR,
   DEFAULT_SOCKET_MODE,
   loadConfigFromEnv,
@@ -27,6 +28,17 @@ describe("bridgeConfigSchema", () => {
     expect(parsed.socketDir).toBe(DEFAULT_SOCKET_DIR);
     expect(parsed.socketMode).toBe(DEFAULT_SOCKET_MODE);
     expect(parsed.backoff).toEqual({ baseMs: 1_000, maxMs: 60_000 });
+    expect(parsed.agentVersion).toBe(DEFAULT_AGENT_VERSION);
+  });
+
+  it("accepts an explicit agentVersion", () => {
+    const parsed = bridgeConfigSchema.parse({
+      serverUrl: "wss://d/api/events/stream",
+      token: "t",
+      agentVersion: "1.4.2",
+      users: [{ userId: 1, linuxUid: 1000 }],
+    });
+    expect(parsed.agentVersion).toBe("1.4.2");
   });
 
   it("accepts ws:// and wss:// but rejects other schemes", () => {
@@ -98,6 +110,12 @@ describe("loadConfigFromEnv", () => {
     expect(cfg.serverUrl).toBe(VALID_ENV.PCT_BRIDGE_SERVER_URL);
     expect(cfg.token).toBe("tok_abc123");
     expect(cfg.users).toEqual([{ userId: 7, linuxUid: 1001 }]);
+    expect(cfg.agentVersion).toBe(DEFAULT_AGENT_VERSION);
+  });
+
+  it("reads PCT_BRIDGE_AGENT_VERSION when the packaging stamps it", () => {
+    const cfg = loadConfigFromEnv({ ...VALID_ENV, PCT_BRIDGE_AGENT_VERSION: "2.0.1" });
+    expect(cfg.agentVersion).toBe("2.0.1");
   });
 
   it("reads optional socketDir, octal socketMode, and backoff overrides", () => {

--- a/client/agent/tests/bridge/handshake.test.ts
+++ b/client/agent/tests/bridge/handshake.test.ts
@@ -104,10 +104,13 @@ describe("handshake — parsing the server reply", () => {
   });
 });
 
-describe("handshake — drift guard against the server contract", () => {
-  // These payloads are copied from server/src/events/protocol.ts. If the server
-  // contract changes, one of these assertions fails, forcing the client copy to
-  // be re-synced (mirrors tests/bridge/protocol.test.ts for the event envelope).
+describe("handshake — client schema pinned to the server-contract copy", () => {
+  // The bridge cannot import server/src, so these payloads are copied verbatim
+  // from server/src/events/protocol.ts to pin the *client's* schema shapes to
+  // that contract. This cannot detect a server-side rename by itself (nothing
+  // here imports the server schema); it fixes the client copy so a hand-edit
+  // that diverges from the copied samples fails — the same limitation and intent
+  // as tests/bridge/protocol.test.ts for the event envelope.
   it("the hello shape matches the server's helloFrameSchema fields", () => {
     const serverShapedHello = {
       type: "hello",

--- a/client/agent/tests/bridge/handshake.test.ts
+++ b/client/agent/tests/bridge/handshake.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  acceptFrameSchema,
+  BRIDGE_CAPABILITIES,
+  buildHello,
+  EVENT_PROTOCOL,
+  helloFrameSchema,
+  INCOMPATIBLE_PROTOCOL_CODE,
+  parseHandshakeReply,
+  refuseFrameSchema,
+} from "../../src/bridge/handshake.js";
+
+describe("handshake — the client hello", () => {
+  it("builds a schema-valid hello advertising the protocol and both capabilities", () => {
+    const hello = buildHello({ agentVersion: "1.2.3" });
+    expect(helloFrameSchema.safeParse(hello).success).toBe(true);
+    expect(hello).toEqual({
+      type: "hello",
+      agentVersion: "1.2.3",
+      eventProtocol: EVENT_PROTOCOL,
+      capabilities: ["session_budget", "per_app_close"],
+    });
+  });
+
+  it("advertises the Linux enforcement primitives the server gates on", () => {
+    // Mirror of server/src/events/capabilities.ts CLIENT_CAPABILITIES: the bridge
+    // forwards all five events, so it advertises both gated primitives.
+    expect(BRIDGE_CAPABILITIES).toEqual(["session_budget", "per_app_close"]);
+  });
+
+  it("copies the capabilities array (no shared mutable reference to the constant)", () => {
+    const hello = buildHello({ agentVersion: "1.0.0" });
+    expect(hello.capabilities).not.toBe(BRIDGE_CAPABILITIES);
+    hello.capabilities.push("mutated");
+    expect(BRIDGE_CAPABILITIES).toEqual(["session_budget", "per_app_close"]);
+  });
+
+  it("honours explicit protocol and capability overrides", () => {
+    const hello = buildHello({
+      agentVersion: "9.9.9",
+      eventProtocol: 2,
+      capabilities: ["session_budget"],
+    });
+    expect(hello.eventProtocol).toBe(2);
+    expect(hello.capabilities).toEqual(["session_budget"]);
+  });
+});
+
+describe("handshake — parsing the server reply", () => {
+  it("parses an accept frame", () => {
+    const reply = parseHandshakeReply(
+      JSON.stringify({ type: "accept", eventProtocol: 1, apiVersion: 3 }),
+    );
+    expect(reply).toEqual({
+      kind: "accept",
+      frame: { type: "accept", eventProtocol: 1, apiVersion: 3 },
+    });
+  });
+
+  it("parses a refuse frame carrying the incompatible-protocol code", () => {
+    const reply = parseHandshakeReply(
+      JSON.stringify({
+        type: "refuse",
+        error: { code: INCOMPATIBLE_PROTOCOL_CODE, message: "update the client" },
+      }),
+    );
+    expect(reply?.kind).toBe("refuse");
+    if (reply?.kind === "refuse") {
+      expect(reply.frame.error.code).toBe("incompatible_protocol");
+      expect(reply.frame.error.message).toBe("update the client");
+    }
+  });
+
+  it("decodes a Buffer reply identically to a string", () => {
+    const raw = Buffer.from(JSON.stringify({ type: "accept", eventProtocol: 1, apiVersion: 1 }));
+    expect(parseHandshakeReply(raw)?.kind).toBe("accept");
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseHandshakeReply("{not json")).toBeNull();
+  });
+
+  it("returns null for an event frame arriving where a reply was expected", () => {
+    // The server always sends accept/refuse first; an event frame here is a
+    // protocol violation the caller must not mistake for a handshake reply.
+    const eventFrame = JSON.stringify({
+      seq: 1,
+      at: "2026-06-24T02:00:00.000Z",
+      event: { type: "policy.changed", userId: 7 },
+    });
+    expect(parseHandshakeReply(eventFrame)).toBeNull();
+  });
+
+  it("returns null for a refuse frame with an unknown error code", () => {
+    const reply = parseHandshakeReply(
+      JSON.stringify({ type: "refuse", error: { code: "something_else", message: "x" } }),
+    );
+    expect(reply).toBeNull();
+  });
+
+  it("returns null for an accept frame missing apiVersion", () => {
+    expect(parseHandshakeReply(JSON.stringify({ type: "accept", eventProtocol: 1 }))).toBeNull();
+  });
+});
+
+describe("handshake — drift guard against the server contract", () => {
+  // These payloads are copied from server/src/events/protocol.ts. If the server
+  // contract changes, one of these assertions fails, forcing the client copy to
+  // be re-synced (mirrors tests/bridge/protocol.test.ts for the event envelope).
+  it("the hello shape matches the server's helloFrameSchema fields", () => {
+    const serverShapedHello = {
+      type: "hello",
+      agentVersion: "0.0.0",
+      eventProtocol: 1,
+      capabilities: ["session_budget", "per_app_close"],
+    };
+    expect(helloFrameSchema.safeParse(serverShapedHello).success).toBe(true);
+  });
+
+  it("rejects a hello with a non-positive eventProtocol", () => {
+    expect(
+      helloFrameSchema.safeParse({
+        type: "hello",
+        agentVersion: "1",
+        eventProtocol: 0,
+        capabilities: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("the accept/refuse shapes match the server's frame schemas", () => {
+    expect(
+      acceptFrameSchema.safeParse({ type: "accept", eventProtocol: 1, apiVersion: 1 }).success,
+    ).toBe(true);
+    expect(
+      refuseFrameSchema.safeParse({
+        type: "refuse",
+        error: { code: "incompatible_protocol", message: "m" },
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/client/agent/tests/bridge/ws-client.test.ts
+++ b/client/agent/tests/bridge/ws-client.test.ts
@@ -193,13 +193,16 @@ describe("WsClient", () => {
     );
   });
 
-  it("forwards event frames once the handshake is accepted", () => {
+  it("forwards event frames once the handshake is accepted (and clears the handshake timer)", () => {
     const onAccept = vi.fn();
-    const { client, sockets, frames } = setup({ onAccept });
+    const { client, sockets, frames, timers } = setup({ onAccept });
     client.start();
     sockets[0]?.emitOpen();
     sockets[0]?.emitMessage(acceptFrame);
     expect(onAccept).toHaveBeenCalledTimes(1);
+    // The handshake timeout must not fire after a successful accept.
+    const handshakeTimer = timers.scheduled.find((s) => s.ms === DEFAULT_HANDSHAKE_TIMEOUT_MS);
+    expect(handshakeTimer?.cleared).toBe(true);
     sockets[0]?.emitMessage(JSON.stringify(sampleFrame(9)));
     expect(frames).toEqual([sampleFrame(9)]);
   });
@@ -239,6 +242,9 @@ describe("WsClient", () => {
       expect.stringContaining("not reconnecting"),
     );
     expect(sockets[0]?.terminated).toBe(true);
+    // The handshake timeout must not fire after a refuse either.
+    const handshakeTimer = timers.scheduled.find((s) => s.ms === DEFAULT_HANDSHAKE_TIMEOUT_MS);
+    expect(handshakeTimer?.cleared).toBe(true);
 
     // Even the server-driven close after a refuse must not schedule a reconnect.
     sockets[0]?.emitClose();
@@ -316,6 +322,18 @@ describe("WsClient", () => {
     sockets[2]?.emitOpen(); // success resets the counter (also sends hello)
     sockets[2]?.emitClose(); // attempt 0 again -> 999
     expect(timers.reconnectDelays()).toEqual([999, 1999, 999]);
+  });
+
+  it("start() while a reconnect is pending cancels it (no duplicate connect loop)", () => {
+    const { client, sockets, timers } = setup();
+    client.start();
+    sockets[0]?.emitClose(); // schedules a reconnect
+    const pending = timers.scheduled.find((s) => s.ms === 999);
+    expect(pending?.cleared).toBe(false);
+
+    client.start(); // restart must cancel the pending reconnect and connect fresh
+    expect(pending?.cleared).toBe(true);
+    expect(sockets).toHaveLength(2);
   });
 
   it("stop() cancels a pending reconnect and does not reconnect", () => {

--- a/client/agent/tests/bridge/ws-client.test.ts
+++ b/client/agent/tests/bridge/ws-client.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { buildHello, type AcceptFrame, type RefuseFrame } from "../../src/bridge/handshake.js";
 import type { Logger } from "../../src/bridge/logger.js";
 import type { EventFrame } from "../../src/bridge/protocol.js";
 import {
+  DEFAULT_HANDSHAKE_TIMEOUT_MS,
   WsClient,
   type Timers,
   type WebSocketFactory,
@@ -11,12 +13,13 @@ import {
 
 type RawMessage = string | Buffer | ArrayBuffer | Buffer[];
 
-/** A controllable fake socket that records listeners and exposes emitters. */
+/** A controllable fake socket that records listeners + sends and exposes emitters. */
 class FakeSocket implements WebSocketLike {
   #open?: () => void;
   #message?: (data: RawMessage) => void;
   #close?: () => void;
   #error?: (err: Error) => void;
+  readonly sent: string[] = [];
   closed = false;
   terminated = false;
 
@@ -42,6 +45,9 @@ class FakeSocket implements WebSocketLike {
         break;
     }
     return this;
+  }
+  send(data: string): void {
+    this.sent.push(data);
   }
   close(): void {
     this.closed = true;
@@ -82,6 +88,10 @@ class FakeTimers implements Timers {
     const last = this.scheduled.at(-1);
     if (last && !last.cleared) last.handler();
   }
+  /** The delays of the reconnect timers (excluding the handshake timeout). */
+  reconnectDelays(): number[] {
+    return this.scheduled.filter((s) => s.ms !== DEFAULT_HANDSHAKE_TIMEOUT_MS).map((s) => s.ms);
+  }
 }
 
 const noopLogger: Logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
@@ -113,24 +123,41 @@ function makeClient(opts: {
   timers: Timers;
   rng: () => number;
   logger?: Logger;
+  onAccept?: (f: AcceptFrame) => void;
+  onRefuse?: (f: RefuseFrame) => void;
 }): WsClient {
   return new WsClient({
     url: "wss://dash.example/api/events/stream",
     token: "tok_abc",
+    agentVersion: "1.0.0",
     onFrame: opts.onFrame,
     backoff: { baseMs: 1_000, maxMs: 60_000 },
     logger: opts.logger ?? noopLogger,
     factory: opts.factory,
     timers: opts.timers,
     rng: opts.rng,
+    ...(opts.onAccept ? { onAccept: opts.onAccept } : {}),
+    ...(opts.onRefuse ? { onRefuse: opts.onRefuse } : {}),
   });
 }
+
+const acceptFrame = JSON.stringify({ type: "accept", eventProtocol: 1, apiVersion: 1 });
+const refuseFrame = JSON.stringify({
+  type: "refuse",
+  error: { code: "incompatible_protocol", message: "update the client" },
+});
 
 const sampleFrame = (seq = 1): EventFrame => ({
   seq,
   at: "2026-06-24T02:00:00.000Z",
   event: { type: "policy.changed", userId: 7, summary: "1h now" },
 });
+
+/** Drive a socket through open → hello → accept so it is in the streaming state. */
+function completeHandshake(socket: FakeSocket): void {
+  socket.emitOpen();
+  socket.emitMessage(acceptFrame);
+}
 
 describe("WsClient", () => {
   it("connects with the Authorization: Bearer header", () => {
@@ -140,30 +167,120 @@ describe("WsClient", () => {
     expect(headers[0]).toEqual({ Authorization: "Bearer tok_abc" });
   });
 
-  it("decodes an inbound message and forwards the frame", () => {
-    const { client, sockets, frames } = setup();
+  it("speaks first: sends a hello advertising version + capabilities on open", () => {
+    const { client, sockets } = setup();
     client.start();
     sockets[0]?.emitOpen();
+    expect(sockets[0]?.sent).toHaveLength(1);
+    expect(JSON.parse(sockets[0]?.sent[0] ?? "null")).toEqual(
+      buildHello({ agentVersion: "1.0.0" }),
+    );
+  });
+
+  it("does not forward event frames before the handshake is accepted", () => {
+    const warn = vi.fn();
+    const { client, sockets, frames } = setup({ logger: { ...noopLogger, warn } });
+    client.start();
+    sockets[0]?.emitOpen();
+    // An event frame arriving before accept is a protocol violation: dropped, and
+    // the socket is closed to retry rather than forwarded.
+    sockets[0]?.emitMessage(JSON.stringify(sampleFrame(9)));
+    expect(frames).toEqual([]);
+    expect(sockets[0]?.closed).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      expect.anything(),
+      "unexpected pre-handshake frame; closing to retry",
+    );
+  });
+
+  it("forwards event frames once the handshake is accepted", () => {
+    const onAccept = vi.fn();
+    const { client, sockets, frames } = setup({ onAccept });
+    client.start();
+    sockets[0]?.emitOpen();
+    sockets[0]?.emitMessage(acceptFrame);
+    expect(onAccept).toHaveBeenCalledTimes(1);
     sockets[0]?.emitMessage(JSON.stringify(sampleFrame(9)));
     expect(frames).toEqual([sampleFrame(9)]);
   });
 
-  it("decodes a Buffer message the same as a string", () => {
+  it("decodes a Buffer event message the same as a string (post-accept)", () => {
     const { client, sockets, frames } = setup();
     client.start();
+    completeHandshake(sockets[0] as FakeSocket);
     sockets[0]?.emitMessage(Buffer.from(JSON.stringify(sampleFrame(3)), "utf8"));
     expect(frames).toEqual([sampleFrame(3)]);
   });
 
-  it("drops a malformed frame without throwing or forwarding", () => {
+  it("drops a malformed event frame without throwing or forwarding (post-accept)", () => {
     const warn = vi.fn();
-    const { client, sockets, frames } = setup({
-      logger: { ...noopLogger, warn },
-    });
+    const { client, sockets, frames } = setup({ logger: { ...noopLogger, warn } });
     client.start();
+    completeHandshake(sockets[0] as FakeSocket);
     expect(() => sockets[0]?.emitMessage("{not json")).not.toThrow();
     expect(frames).toEqual([]);
     expect(warn).toHaveBeenCalledWith(expect.anything(), "dropping undecodable frame");
+  });
+
+  it("on refuse: surfaces update_required and does NOT reconnect", () => {
+    const error = vi.fn();
+    const onRefuse = vi.fn();
+    const { client, sockets, timers } = setup({ logger: { ...noopLogger, error }, onRefuse });
+    client.start();
+    sockets[0]?.emitOpen();
+    sockets[0]?.emitMessage(refuseFrame);
+
+    expect(onRefuse).toHaveBeenCalledWith({
+      type: "refuse",
+      error: { code: "incompatible_protocol", message: "update the client" },
+    });
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "incompatible_protocol" }),
+      expect.stringContaining("not reconnecting"),
+    );
+    expect(sockets[0]?.terminated).toBe(true);
+
+    // Even the server-driven close after a refuse must not schedule a reconnect.
+    sockets[0]?.emitClose();
+    expect(timers.reconnectDelays()).toEqual([]);
+    // A stale reconnect attempt would create a second socket; none should exist.
+    expect(sockets).toHaveLength(1);
+  });
+
+  it("re-enables reconnect after start() following a refuse", () => {
+    const { client, sockets } = setup();
+    client.start();
+    sockets[0]?.emitOpen();
+    sockets[0]?.emitMessage(refuseFrame); // refused, no reconnect
+    client.start(); // operator/unit restart clears the refusal
+    expect(sockets).toHaveLength(2);
+  });
+
+  it("closes and reconnects if no handshake reply arrives before the timeout", () => {
+    const { client, sockets, timers } = setup();
+    client.start();
+    sockets[0]?.emitOpen();
+    // The last scheduled timer is the handshake timeout; firing it closes the socket.
+    const handshakeTimer = timers.scheduled.at(-1);
+    expect(handshakeTimer?.ms).toBe(DEFAULT_HANDSHAKE_TIMEOUT_MS);
+    handshakeTimer?.handler();
+    expect(sockets[0]?.closed).toBe(true);
+
+    sockets[0]?.emitClose();
+    expect(timers.reconnectDelays()).toEqual([999]);
+    timers.fireLast();
+    expect(sockets).toHaveLength(2); // reconnected
+  });
+
+  it("re-runs the handshake on every reconnect", () => {
+    const { client, sockets, timers } = setup();
+    client.start();
+    completeHandshake(sockets[0] as FakeSocket);
+    expect(sockets[0]?.sent).toHaveLength(1); // hello #1
+    sockets[0]?.emitClose();
+    timers.fireLast(); // reconnect
+    sockets[1]?.emitOpen();
+    expect(sockets[1]?.sent).toHaveLength(1); // hello #2 on the fresh socket
   });
 
   it("reconnects after a close, creating a fresh socket when the timer fires", () => {
@@ -172,8 +289,7 @@ describe("WsClient", () => {
     expect(sockets).toHaveLength(1);
 
     sockets[0]?.emitClose();
-    expect(timers.scheduled).toHaveLength(1);
-    expect(timers.scheduled[0]?.ms).toBe(999); // attempt 0: ~baseMs ceiling
+    expect(timers.reconnectDelays()).toEqual([999]); // attempt 0: ~baseMs ceiling
 
     timers.fireLast();
     expect(sockets).toHaveLength(2); // reconnected
@@ -187,7 +303,7 @@ describe("WsClient", () => {
     sockets[1]?.emitClose(); // attempt 1
     timers.fireLast();
     sockets[2]?.emitClose(); // attempt 2
-    expect(timers.scheduled.map((s) => s.ms)).toEqual([999, 1999, 3999]);
+    expect(timers.reconnectDelays()).toEqual([999, 1999, 3999]);
   });
 
   it("resets the backoff after a successful open", () => {
@@ -197,41 +313,45 @@ describe("WsClient", () => {
     timers.fireLast();
     sockets[1]?.emitClose(); // attempt 1 -> 1999
     timers.fireLast();
-    sockets[2]?.emitOpen(); // success resets the counter
+    sockets[2]?.emitOpen(); // success resets the counter (also sends hello)
     sockets[2]?.emitClose(); // attempt 0 again -> 999
-    expect(timers.scheduled.map((s) => s.ms)).toEqual([999, 1999, 999]);
+    expect(timers.reconnectDelays()).toEqual([999, 1999, 999]);
   });
 
   it("stop() cancels a pending reconnect and does not reconnect", () => {
     const { client, sockets, timers } = setup();
     client.start();
     sockets[0]?.emitClose();
-    expect(timers.scheduled).toHaveLength(1);
+    expect(timers.reconnectDelays()).toEqual([999]);
 
     client.stop();
-    expect(timers.scheduled[0]?.cleared).toBe(true);
+    const reconnectTimer = timers.scheduled.find((s) => s.ms === 999);
+    expect(reconnectTimer?.cleared).toBe(true);
     // A stale timer that somehow still fires is a no-op after stop().
-    timers.scheduled[0]?.handler();
+    reconnectTimer?.handler();
     expect(sockets).toHaveLength(1);
   });
 
-  it("stop() terminates the current socket", () => {
-    const { client, sockets } = setup();
+  it("stop() terminates the current socket and clears the handshake timer", () => {
+    const { client, sockets, timers } = setup();
     client.start();
+    sockets[0]?.emitOpen(); // schedules the handshake timer
     client.stop();
     expect(sockets[0]?.terminated).toBe(true);
+    const handshakeTimer = timers.scheduled.find((s) => s.ms === DEFAULT_HANDSHAKE_TIMEOUT_MS);
+    expect(handshakeTimer?.cleared).toBe(true);
   });
 
   it("logs but does not reconnect on error alone (close drives reconnect)", () => {
     const { client, sockets, timers } = setup();
     client.start();
     sockets[0]?.emitError(new Error("ECONNREFUSED"));
-    expect(timers.scheduled).toHaveLength(0);
+    expect(timers.reconnectDelays()).toEqual([]);
     sockets[0]?.emitClose();
-    expect(timers.scheduled).toHaveLength(1);
+    expect(timers.reconnectDelays()).toEqual([999]);
   });
 
-  it("fires the onOpen handshake seam on connect", () => {
+  it("fires the onOpen seam on connect (before hello)", () => {
     const onOpen = vi.fn();
     const sockets: FakeSocket[] = [];
     const factory: WebSocketFactory = () => {
@@ -242,6 +362,7 @@ describe("WsClient", () => {
     const client = new WsClient({
       url: "wss://d/api/events/stream",
       token: "t",
+      agentVersion: "1.0.0",
       onFrame: () => undefined,
       backoff: { baseMs: 1_000, maxMs: 60_000 },
       logger: noopLogger,
@@ -252,5 +373,6 @@ describe("WsClient", () => {
     client.start();
     sockets[0]?.emitOpen();
     expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(sockets[0]?.sent).toHaveLength(1); // hello follows the seam
   });
 });

--- a/docs/plans/303-client-version-handshake.md
+++ b/docs/plans/303-client-version-handshake.md
@@ -1,0 +1,76 @@
+# Plan — #303 pct-client-bridge client-side ADR-0007 version handshake
+
+Roadmap: `docs/roadmap.md` → Phase 8b. ADR: `docs/adr/0007-event-stream-version-compatibility.md`.
+
+## Why now
+
+The server side of the handshake (#165) is merged: `server/src/events/protocol.ts`
+holds `EVENT_PROTOCOL`, `negotiate()`, and the `hello` / `accept` / `refuse` zod
+schemas, and `server/src/events/stream.ts` waits for the client's opening `hello`
+(a 10s `DEFAULT_HELLO_TIMEOUT_MS`) before registering the socket.
+
+The bridge's `WsClient` (#101) still ships the deferred stub: on open it connects
+straight to frames and never speaks. Against the current server that means the
+bridge **is refused after the 10s hello-timeout on every connect and receives no
+events at all** — so this is a correctness fix, not just forward-compat plumbing.
+
+## Contract (from ADR 0007 §2–§4, mirrored from the server)
+
+- Client speaks first on every (re)connect with `hello`:
+  `{ type:"hello", agentVersion, eventProtocol, capabilities: string[] }`.
+- Server replies with exactly one of:
+  - `accept` `{ type:"accept", eventProtocol, apiVersion }` → stream proceeds;
+    event frames follow.
+  - `refuse` `{ type:"refuse", error:{ code:"incompatible_protocol", message } }`
+    → server closes the socket.
+- The `accept`/`refuse` is always the **first** inbound message (the server sends
+  it before `hub.register`), so the first message after `hello` is the handshake
+  reply and everything after is an event frame.
+- Capabilities are additive flags naming the enforcement primitives the client
+  honours. The Linux bridge forwards all five events, so it advertises both
+  server-recognised primitives: `session_budget` and `per_app_close`
+  (`server/src/events/capabilities.ts` → `CLIENT_CAPABILITIES`).
+
+## Single-sourcing the schema
+
+The bridge ships as a separate `.deb` with its own bundled Node runtime — there
+is no workspace to import `server/src` across (see the existing note in
+`client/agent/src/bridge/protocol.ts`, which re-declares the *event* envelope for
+the same reason and pins it with a drift test). This slice follows that exact
+precedent: it re-declares the `hello`/`accept`/`refuse` shapes in a new
+`bridge/handshake.ts` and pins them against the server contract with a drift
+test. Noted as a deliberate, precedent-following deviation from the issue's
+"do not re-declare a second copy" ideal, which the package split makes impossible.
+
+## Phases
+
+### Phase 1 — the handshake contract module + tests
+- `client/agent/src/bridge/handshake.ts`: `EVENT_PROTOCOL` (=1), `BRIDGE_CAPABILITIES`
+  (`["session_budget","per_app_close"]`), `helloFrameSchema` + `buildHello(...)`,
+  `acceptFrameSchema`, `refuseFrameSchema`, `INCOMPATIBLE_PROTOCOL_CODE`, and
+  `parseHandshakeReply(raw) → {kind:"accept"|"refuse", frame} | null`.
+- `tests/bridge/handshake.test.ts`: hello shape + capabilities; parse accept /
+  refuse / malformed / non-handshake → null; drift guard vs. the server contract.
+
+### Phase 2 — wire the handshake into `WsClient` + config + tests
+- `WebSocketLike` gains `send(data: string)`.
+- `WsClient` sends `hello` on open, withholds event frames until `accept`, and on
+  `refuse` logs + surfaces `update_required` and **stops reconnecting** (no
+  hot-loop). A bounded client-side handshake timeout closes → reconnects if no
+  reply arrives. Re-handshakes on every reconnect.
+- `bridge/config.ts` gains `agentVersion` (`PCT_BRIDGE_AGENT_VERSION`, default
+  `"0.0.0"` — the packaging stamps the real `.deb` version).
+- `bridge/bridge.ts` passes `agentVersion` + `BRIDGE_CAPABILITIES` and a default
+  `onRefuse` that logs the update-required condition.
+- Update `ws-client.test.ts` / `bridge.test.ts` / `config.test.ts` for the new
+  handshake-first flow; add refuse / timeout / re-handshake coverage.
+
+## License boundary / tamper resistance
+
+None touched — plain TypeScript + zod (`ws` MIT behind the injected factory).
+No GPL linkage; no packaging/image change. Not a hardening feature.
+
+## Deferred
+
+- Populating `PCT_BRIDGE_AGENT_VERSION` from the real `.deb` version at install
+  time is client-packaging work (#106).


### PR DESCRIPTION
## Summary

The **client side** of the ADR-0007 event-stream version handshake in
`pct-client-bridge` (#303, Phase 8b). Its only blocker — the server-side
handshake (#165: `negotiate()` + the shared `hello`/`accept`/`refuse` schemas +
`EVENT_PROTOCOL`) — is now on `main` (`server/src/events/protocol.ts`,
`stream.ts`).

**This is a correctness fix, not just forward-compat plumbing.** The server now
waits for the client's opening `hello` and refuses + closes after a 10s timeout
if none arrives. The bridge's `WsClient` still shipped the deferred stub
(connect straight to frames, never speak), so against the current server it was
**refused on every connect and received no events at all**.

- **`bridge/handshake.ts`** (new) — the pure, I/O-free client contract mirrored
  from `server/src/events/protocol.ts`: `buildHello` (`agentVersion`,
  `eventProtocol`, `capabilities`), the `accept`/`refuse` schemas, and
  `parseHandshakeReply`. `BRIDGE_CAPABILITIES` advertises the two Linux
  enforcement primitives the server gates on — `session_budget` +
  `per_app_close` (mirrors `server/src/events/capabilities.ts`).
- **`bridge/ws-client.ts`** — speaks first on every (re)connect; withholds event
  frames until `accept`; on `refuse` surfaces the `update_required` condition and
  **stops reconnecting** (no hot-loop, ADR 0007 §2/§5); a bounded handshake
  timeout closes → reconnects if no reply arrives; re-handshakes on every
  reconnect; `start()` cancels any pending reconnect so a restart can't race two
  connect loops.
- **`bridge/config.ts`** — adds `agentVersion` (`PCT_BRIDGE_AGENT_VERSION`,
  default `"0.0.0"`); carried in `hello` to refresh the server's `agent_version`
  inventory (#164) on each connect.
- **`bridge/bridge.ts`** — passes `agentVersion` + capabilities and forwards the
  `onAccept` / `onRefuse` seams.

## Single-sourcing note

The bridge ships as its own `.deb` with a bundled Node runtime — there is no
workspace to import `server/src` across, so the handshake schemas are
**re-declared** on the client, exactly as `bridge/protocol.ts` already
re-declares the event envelope. This is the precedent-following path, not the
issue's literal "do not re-declare a second copy" ideal, which the package split
makes impossible. A test (`tests/bridge/handshake.test.ts`) pins the client
shapes against the copied server contract so a client-side hand-edit that
diverges fails (mirrors `tests/bridge/protocol.test.ts`; it cannot import + diff
the server schema from this package — noted honestly in the test).

## Plan

Linked plan: `docs/plans/303-client-version-handshake.md`
ADR: `docs/adr/0007-event-stream-version-compatibility.md`
Roadmap: `docs/roadmap.md` → Phase 8b

## First-pass review

A first-pass adversarial review found no blockers/majors and verified interop,
license/tamper boundaries, and type safety. The minor/nit items were applied
(`start()` reconnect-timer hardening; mirror the server's `capabilities`
`.default([])`; honest drift-guard naming; timer-clear-on-accept/refuse tests).

## License-boundary note

None touched — plain TypeScript + zod (`ws` MIT behind the injected factory). No
GPL linkage, no subprocess/REST boundary, no packaging or Docker-image change
(`license-guard` unaffected). Not a hardening feature (tamper-resistance ceiling
unchanged).

## No new dependencies

Uses `ws` and `zod` already in the client-agent tree.

## Test plan

- [x] `handshake.ts` — hello shape + both capabilities; array copied (no shared
      mutable ref); protocol/capability overrides; parse accept / refuse /
      malformed JSON / event-frame-as-reply / unknown-code / missing-field →
      null; client schema pinned to the server-contract copy.
- [x] `ws-client.ts` — sends hello on open; withholds & closes on a
      pre-handshake event frame; forwards frames after accept; Buffer parity;
      drops a malformed *event* frame post-accept; on refuse surfaces
      `update_required` + does not reconnect (timer cleared); re-enables after
      `start()`; `start()` cancels a pending reconnect; handshake-timeout →
      close → reconnect; re-handshake on reconnect; backoff unchanged; `onOpen`
      fires before hello.
- [x] `config.ts` — `agentVersion` default + `PCT_BRIDGE_AGENT_VERSION` override.
- [x] `bridge.ts` — end-to-end fake-WS → real AF_UNIX now completes the handshake
      before routing.
- [x] Client-agent gate green: `format:check` / `lint` / `typecheck` clean; 159
      unit tests; coverage 99% (gate 80%; `handshake.ts` 100%).

## Deferred (tracked)

- Stamping `PCT_BRIDGE_AGENT_VERSION` from the real `.deb` version at install
  time is client-packaging work → **#106**.
- A machine-readable refusal `reason` so the client can distinguish
  `server_too_old` / `malformed_hello` from `client_too_old` (the ADR's single
  `incompatible_protocol` code, faithfully implemented here, collapses them) →
  **#427**.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)