### PR TITLE
feat(integrations): per-token rate limiting on /api/integrations/* (#115)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -437,10 +437,13 @@ parental-controls toolkit. Example flow:
   (`PCT_INTEGRATIONS_RATE_LIMIT_MAX` requests per
   `PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS`, default 120 / 60 s). It is
   enforced in the integration guard right after authentication, so a noisy
-  integrator is throttled regardless of the endpoint or scope it targets.
-  Every response carries `RateLimit-Limit` / `RateLimit-Remaining` /
-  `RateLimit-Reset`; an over-limit request is rejected `429` with the standard
-  `{ error: { code: "rate_limited", … } }` envelope and a `Retry-After` header.
+  integrator is throttled regardless of the endpoint or scope it targets (an
+  over-limit request is rejected before the scope check, so a wrong-scope flood
+  is throttled too). Every **authenticated** response carries `RateLimit-Limit`
+  / `RateLimit-Remaining` / `RateLimit-Reset` (an unauthenticated `401` carries
+  none — no token is known yet); an over-limit request is rejected `429` with
+  the standard `{ error: { code: "rate_limited", … } }` envelope and a
+  `Retry-After` header.
 - Grant requests are **idempotent by `source_ref`**. The integrator owns
   the dedupe key; the dashboard enforces uniqueness.
 - The `Grant` ledger is immutable: revocations are a separate row, not an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -433,6 +433,14 @@ parental-controls toolkit. Example flow:
 - All external traffic enters via `/api/integrations/*`. No side channels.
 - Per-integration tokens are scoped (e.g. `grants:write`,
   `policy:read`), revocable from the admin UI, and rate-limited per token.
+  The limit is a fixed in-process window keyed by the authenticated token
+  (`PCT_INTEGRATIONS_RATE_LIMIT_MAX` requests per
+  `PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS`, default 120 / 60 s). It is
+  enforced in the integration guard right after authentication, so a noisy
+  integrator is throttled regardless of the endpoint or scope it targets.
+  Every response carries `RateLimit-Limit` / `RateLimit-Remaining` /
+  `RateLimit-Reset`; an over-limit request is rejected `429` with the standard
+  `{ error: { code: "rate_limited", … } }` envelope and a `Retry-After` header.
 - Grant requests are **idempotent by `source_ref`**. The integrator owns
   the dedupe key; the dashboard enforces uniqueness.
 - The `Grant` ledger is immutable: revocations are a separate row, not an

--- a/docs/plans/115-integrations-rate-limit.md
+++ b/docs/plans/115-integrations-rate-limit.md
@@ -1,0 +1,92 @@
+# Plan: Per-token rate limiting on `/api/integrations/*` (#115)
+
+Roadmap: `docs/roadmap.md` → Phase 10 ("rate limiting per token").
+Design: `docs/architecture.md` → "External integrations" (per-integration
+tokens are "scoped, revocable, rate-limited").
+
+## Problem
+
+A noisy or misbehaving external integrator (the family-calendar rewards system,
+etc.) authenticating on `/api/integrations/*` can flood the single-process
+dashboard. `CLAUDE.md` and `docs/architecture.md` both require per-integration
+tokens to be **rate-limited**; the token model (#114), the
+`requireIntegrationToken` guard, and the scope vocabulary already exist on
+`main`, but nothing throttles a token's request rate yet.
+
+## Why this is independent of the grant endpoint (#113 / PR #422)
+
+Rate limiting lives in the **guard** (`integrations/guard.ts`), applied the
+moment a token authenticates — not in any one route handler. It therefore
+protects the (future) grants endpoint and every other integration endpoint
+automatically, and needs only the guard, which is already on `main`.
+
+## Design decisions
+
+1. **Request-count, not failed-attempt.** `auth/rate-limit.ts` is a
+   *failed-attempt* limiter (records failures, clears on success) for login /
+   enrol throttling. Per-token API throttling needs a *request-count* fixed
+   window: every authenticated request counts. These are different semantics,
+   so a small dedicated limiter (`integrations/rate-limit.ts`) is the right
+   move rather than overloading the auth one. No new dependency — same
+   rationale the `auth/rate-limit.ts` docstring already records for not pulling
+   in `@fastify/rate-limit`.
+
+2. **Keyed by token id.** "Per token" per the issue — so one integrator's
+   burst never starves another's budget. The guard resolves
+   `request.integration.id` on authentication; that is the key.
+
+3. **Checked after authentication, before the scope check.** An unauthenticated
+   request is `401` before any token is known (it must not consume a token's
+   budget). A token spamming with the wrong scope still counts against its
+   limit — so the check sits between `authenticateIntegrationToken` and the
+   scope test.
+
+4. **Standard envelope + metadata headers.** Over-limit → `ApiError(429,
+   "rate_limited", …)` rendered as the shared `{ error: { code, message } }`
+   envelope. Set `Retry-After` (seconds) and the IETF-draft `RateLimit-Limit` /
+   `RateLimit-Remaining` / `RateLimit-Reset` headers on both the throttled
+   response and admitted responses ("surface limit metadata if practical").
+
+5. **Config seam** mirroring `telemetry` / `clientHealth`:
+   `PCT_INTEGRATIONS_RATE_LIMIT_MAX` (default 120) and
+   `PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS` (default 60) → one request per
+   ~0.5 s sustained, generous for webhook-driven grants while cutting off a
+   runaway loop. A single long-lived limiter instance is created in
+   `registerIntegrationRoutes` and closed over by the guard (in-process memory,
+   one process — same posture as `auth/rate-limit.ts`).
+
+## Phases
+
+### Phase 1 — limiter core + config + unit tests
+- `server/src/integrations/rate-limit.ts`: `FixedWindowQuota` class with an
+  injectable clock; `consume(key) → { limited, limit, remaining, resetAtMs,
+  retryAfterMs }`. Lazy prune of elapsed windows on access.
+- `server/src/config.ts`: `integrations.rateLimit.{maxRequests, windowSeconds}`
+  block + `PCT_INTEGRATIONS_RATE_LIMIT_*` wiring.
+- Unit tests: window fill/reset, per-key isolation, metadata maths, disabled
+  (`max = 0` → never limits, opt-out) if we support it.
+
+### Phase 2 — guard wiring + headers + integration tests + docs
+- `integrations/guard.ts`: `makeRequireIntegrationToken(db, rateLimiter?)` — the
+  limiter is optional so existing callers/tests keep working; when present, the
+  guard consumes a slot post-auth, sets `RateLimit-*` headers, and throws `429`
+  when limited.
+- `api/integrations/routes.ts`: build the limiter from settings and pass it into
+  the guard factory. Thread `settings` into `registerIntegrationRoutes` and the
+  `apiPlugin` call.
+- Tests: guard integration test (429 after N requests within the window; headers
+  present; per-token isolation; a fresh window admits again via an injected
+  clock).
+- Docs: `docs/architecture.md` / `docs/server-deployment.md` note the config
+  knobs and the 429 contract.
+
+## Out of scope (not this PR)
+
+- Distributed / cross-process limiting (single process by design).
+- Per-scope or per-endpoint differentiated limits (one bucket per token for
+  now; revisit if a real integrator needs burst vs. sustained tiers).
+
+## License boundary
+
+None touched — plain TypeScript + Fastify + `node`'s own clock. No GPL linkage,
+no GPL binary added to the image.

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -432,6 +432,17 @@ failed-attempt limiter" (#235).
 - Client SSH access uses a single dedicated key generated on first run;
   rotation is a one-click action in the dashboard that pushes a new key
   via the existing connection.
+- **Integration-token throttling.** The machine-to-machine `/api/integrations/*`
+  surface (per-integration bearer tokens minted from `/admin`, #114) is
+  rate-limited **per token** so a noisy or misbehaving integrator can't
+  overwhelm the single-process dashboard. The limit is a fixed in-process
+  window keyed by the authenticated token: `PCT_INTEGRATIONS_RATE_LIMIT_MAX`
+  requests (default 120) per `PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS`
+  (default 60). An over-limit request gets `429 rate_limited` with a
+  `Retry-After` header; every response carries `RateLimit-Limit` /
+  `RateLimit-Remaining` / `RateLimit-Reset`. Raise the limit for a chatty
+  integrator, or lower it to tighten a shared LAN. This is per-IP-independent —
+  it throttles the credential, not the source address.
 
 ## Backup and restore
 

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -439,8 +439,9 @@ failed-attempt limiter" (#235).
   window keyed by the authenticated token: `PCT_INTEGRATIONS_RATE_LIMIT_MAX`
   requests (default 120) per `PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS`
   (default 60). An over-limit request gets `429 rate_limited` with a
-  `Retry-After` header; every response carries `RateLimit-Limit` /
-  `RateLimit-Remaining` / `RateLimit-Reset`. Raise the limit for a chatty
+  `Retry-After` header; every **authenticated** response carries
+  `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset` (an
+  unauthenticated `401` carries none). Raise the limit for a chatty
   integrator, or lower it to tighten a shared LAN. This is per-IP-independent —
   it throttles the credential, not the source address.
 

--- a/server/src/api/integrations/routes.ts
+++ b/server/src/api/integrations/routes.ts
@@ -16,7 +16,9 @@
  */
 import type { FastifyInstance } from "fastify";
 
+import type { Settings } from "../../config.js";
 import { makeRequireIntegrationToken } from "../../integrations/guard.js";
+import { FixedWindowQuota } from "../../integrations/rate-limit.js";
 import {
   issueIntegrationToken,
   listIntegrationTokenSummaries,
@@ -50,14 +52,26 @@ function toSummaryResponse(summary: IntegrationTokenSummary): IntegrationTokenSu
  * `scope.requireAdmin` is decorated. Also decorates
  * `scope.requireIntegrationToken` so the inbound integration endpoints (#113)
  * can gate themselves on a scoped bearer token.
+ *
+ * `settings` carries the per-token rate-limit window (#115): a single
+ * long-lived {@link FixedWindowQuota} is built here and closed over by the
+ * guard, so every inbound integration endpoint shares one bucket per token.
  */
-export function registerIntegrationRoutes(scope: FastifyInstance): void {
+export function registerIntegrationRoutes(scope: FastifyInstance, settings: Settings): void {
   const typed = scope.withTypeProvider<ZodTypeProvider>();
 
+  // One process-lifetime limiter shared by every request the guard admits, keyed
+  // inside the guard by the authenticated token id (#115). In-memory + fixed
+  // window — one process, so it needs nothing more (mirrors `auth/rate-limit.ts`).
+  const rateLimiter = new FixedWindowQuota({
+    maxRequests: settings.integrations.rateLimitMax,
+    windowMs: settings.integrations.rateLimitWindowSeconds * 1000,
+  });
+
   // The bearer guard used by the (future) inbound integration endpoints (#113).
-  // Decorated here, bound to this scope's db, so those endpoints apply it with
-  // `{ preHandler: scope.requireIntegrationToken("grants:write") }`.
-  scope.decorate("requireIntegrationToken", makeRequireIntegrationToken(scope.db));
+  // Decorated here, bound to this scope's db + limiter, so those endpoints apply
+  // it with `{ preHandler: scope.requireIntegrationToken("grants:write") }`.
+  scope.decorate("requireIntegrationToken", makeRequireIntegrationToken(scope.db, rateLimiter));
 
   typed.post(
     "/integrations/tokens",

--- a/server/src/api/plugin.ts
+++ b/server/src/api/plugin.ts
@@ -159,8 +159,9 @@ export const apiPlugin: FastifyPluginAsync<ApiPluginOptions> = async (scope, opt
   registerSystemRoutes(scope);
   // Integration tokens (#114): admin-only mint/list/revoke of per-integration
   // bearer tokens, and the `scope.requireIntegrationToken` guard the inbound
-  // `/api/integrations/*` endpoints (#113) authenticate with.
-  registerIntegrationRoutes(scope);
+  // `/api/integrations/*` endpoints (#113) authenticate with. `settings` carries
+  // the per-token rate-limit window (#115).
+  registerIntegrationRoutes(scope, opts.settings);
 };
 
 /** Mount the JSON API under `/api` on the given app. */

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -512,6 +512,28 @@ const settingsSchema = z
      * {@link timekprMirrorSchema}.
      */
     timekprMirror: timekprMirrorSchema,
+    /**
+     * Inbound integration API throttling (#115): a per-token request-rate
+     * ceiling on `/api/integrations/*` so a noisy or misbehaving integrator
+     * can't overwhelm the single-process dashboard (`docs/architecture.md` →
+     * "External integrations": per-integration tokens are "rate-limited"). Like
+     * the `telemetry`/`clientHealth` blocks above, a fixed in-process window;
+     * the guard (`integrations/guard.ts`) keys it by the authenticated token id.
+     */
+    integrations: z.object({
+      /**
+       * Max requests one token may make per window before it is throttled
+       * (`PCT_INTEGRATIONS_RATE_LIMIT_MAX`). Defaults to 120 — generous for a
+       * webhook-driven integrator at the default 60 s window (≈2 req/s
+       * sustained) while still cutting a runaway loop short.
+       */
+      rateLimitMax: z.coerce.number().int().positive().default(120),
+      /**
+       * Fixed-window length in seconds (`PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS`).
+       * Defaults to 60.
+       */
+      rateLimitWindowSeconds: z.coerce.number().int().positive().default(60),
+    }),
   })
   .superRefine((settings, ctx) => {
     if (settings.adguard.mode !== "external") return;
@@ -617,6 +639,10 @@ export function loadSettings(env: NodeJS.ProcessEnv = process.env): Settings {
       dataDir: env.PCT_TIMEKPR_MIRROR_DIR,
       package: env.PCT_TIMEKPR_MIRROR_PACKAGE,
       version: env.PCT_TIMEKPR_MIRROR_VERSION,
+    },
+    integrations: {
+      rateLimitMax: env.PCT_INTEGRATIONS_RATE_LIMIT_MAX,
+      rateLimitWindowSeconds: env.PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS,
     },
   });
 

--- a/server/src/integrations/guard.ts
+++ b/server/src/integrations/guard.ts
@@ -21,6 +21,7 @@ import type { preHandlerHookHandler } from "fastify";
 import { ApiError } from "../api/errors.js";
 import { parseBearer } from "../auth/bearer.js";
 import type { PolicyDb } from "../policy/db.js";
+import type { IntegrationRateLimiter } from "./rate-limit.js";
 import { authenticateIntegrationToken, type AuthenticatedIntegration } from "./tokens.js";
 import type { IntegrationScope } from "./scopes.js";
 
@@ -44,12 +45,22 @@ declare module "fastify" {
  * Build the integration-token guard factory bound to a policy database. The
  * returned factory takes the scopes a route requires (none = authentication
  * only) and yields the `preHandler` enforcing them.
+ *
+ * When a {@link IntegrationRateLimiter} is supplied (#115) the guard counts one
+ * request against the authenticated **token id** right after authentication and
+ * before the scope check — so a noisy integrator is throttled regardless of
+ * whether it also has the right scope. Every admitted response carries the
+ * `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset` headers; an
+ * over-limit request is rejected `429 rate_limited` with a `Retry-After`. Omit
+ * the limiter (the default) to disable throttling — the shape existing tests
+ * and callers already use.
  */
 export function makeRequireIntegrationToken(
   db: PolicyDb,
+  rateLimiter?: IntegrationRateLimiter,
 ): (...scopes: IntegrationScope[]) => preHandlerHookHandler {
   return function requireIntegrationToken(...required: IntegrationScope[]): preHandlerHookHandler {
-    return async function integrationGuard(request) {
+    return async function integrationGuard(request, reply) {
       const secret = parseBearer(request.headers.authorization);
       if (secret === null) {
         throw new ApiError(
@@ -61,6 +72,26 @@ export function makeRequireIntegrationToken(
 
       const integration = authenticateIntegrationToken(db, secret);
       request.integration = integration;
+
+      // Per-token throttling (#115): count this request and surface the window
+      // state. Keyed by the token id so one integrator's burst never starves
+      // another's budget. Done after authentication (an unauthenticated request
+      // is already `401` and must not consume a token's budget) and before the
+      // scope check (a token spamming with the wrong scope is still throttled).
+      if (rateLimiter !== undefined) {
+        const decision = rateLimiter.consume(String(integration.id));
+        reply.header("RateLimit-Limit", decision.limit);
+        reply.header("RateLimit-Remaining", decision.remaining);
+        reply.header("RateLimit-Reset", decision.resetSeconds);
+        if (decision.limited) {
+          reply.header("Retry-After", decision.resetSeconds);
+          throw new ApiError(
+            429,
+            "rate_limited",
+            `This integration token has exceeded its request rate limit; retry in ${decision.resetSeconds}s`,
+          );
+        }
+      }
 
       const missing = required.filter((scope) => !integration.scopes.includes(scope));
       if (missing.length > 0) {

--- a/server/src/integrations/rate-limit.ts
+++ b/server/src/integrations/rate-limit.ts
@@ -1,0 +1,129 @@
+/**
+ * A minimal in-memory fixed-window **request-count** limiter for the inbound
+ * integration surface (#115).
+ *
+ * `/api/integrations/*` authenticates external systems by a per-integration
+ * bearer token (#114). `docs/architecture.md` → "External integrations"
+ * requires those tokens to be rate-limited so a noisy or misbehaving integrator
+ * (a retry storm from the family-calendar rewards webhook, a runaway loop)
+ * can't overwhelm the single-process dashboard. This is that limiter: a
+ * fixed-window count of *every* authenticated request per key (the token id),
+ * held in process memory.
+ *
+ * It is deliberately **not** the failed-attempt limiter in `auth/rate-limit.ts`
+ * — that one counts *failures* and clears on success (login / enrol
+ * throttling). Per-token API throttling is the opposite shape: every request
+ * counts, and the window resets only by elapsing. Two small mechanisms with
+ * clear, separate semantics beat one overloaded class, and neither needs a
+ * dependency — the same reasoning `auth/rate-limit.ts` records for not reaching
+ * for `@fastify/rate-limit` (there is one process, so a distributed limiter is
+ * more than this surface calls for).
+ *
+ * The clock is injectable so the window behaviour is testable without real
+ * time.
+ *
+ * License boundary: none touched — plain TypeScript + `node`'s own clock.
+ */
+
+/** The outcome of consuming one request slot for a key. */
+export interface RateLimitDecision {
+  /** True when this request is over the limit and should be rejected `429`. */
+  readonly limited: boolean;
+  /** The window's request ceiling (the `RateLimit-Limit` header value). */
+  readonly limit: number;
+  /** Requests still allowed in the current window (`RateLimit-Remaining`). */
+  readonly remaining: number;
+  /**
+   * Whole seconds until the current window resets — the `RateLimit-Reset`
+   * value, and the `Retry-After` value when {@link limited}. Never negative.
+   */
+  readonly resetSeconds: number;
+}
+
+/**
+ * The narrow slice of the limiter the integration guard drives — one method, so
+ * a test can inject a spy and the real {@link FixedWindowQuota} drops in unchanged.
+ */
+export interface IntegrationRateLimiter {
+  /** Count one request against `key` and report the resulting decision. */
+  consume(key: string): RateLimitDecision;
+}
+
+/** One fixed window for a single key. */
+interface Window {
+  /** Requests seen in this window (capped one past the limit; see `consume`). */
+  count: number;
+  /** Epoch ms when the window opened. */
+  startedAt: number;
+}
+
+/** Options for {@link FixedWindowQuota}. */
+export interface FixedWindowQuotaOptions {
+  /** Requests allowed per key within a window before further ones are limited. */
+  readonly maxRequests: number;
+  /** Window length in milliseconds. */
+  readonly windowMs: number;
+  /** Clock seam for tests; defaults to `Date.now`. */
+  readonly now?: () => number;
+}
+
+/**
+ * Fixed-window request-count limiter keyed by an arbitrary string (here, the
+ * integration-token id). Each {@link consume} counts one request; a key is
+ * limited once its window count exceeds {@link FixedWindowQuotaOptions.maxRequests}.
+ * Elapsed windows are dropped lazily on access, so an idle key costs nothing.
+ */
+export class FixedWindowQuota implements IntegrationRateLimiter {
+  private readonly maxRequests: number;
+  private readonly windowMs: number;
+  private readonly now: () => number;
+  private readonly windows = new Map<string, Window>();
+
+  constructor(options: FixedWindowQuotaOptions) {
+    if (!Number.isInteger(options.maxRequests) || options.maxRequests < 1) {
+      throw new RangeError("FixedWindowQuota maxRequests must be a positive integer");
+    }
+    if (!Number.isInteger(options.windowMs) || options.windowMs < 1) {
+      throw new RangeError("FixedWindowQuota windowMs must be a positive integer");
+    }
+    this.maxRequests = options.maxRequests;
+    this.windowMs = options.windowMs;
+    this.now = options.now ?? Date.now;
+  }
+
+  /** Return the live window for `key`, dropping it first if it has elapsed. */
+  private current(key: string, at: number): Window | undefined {
+    const window = this.windows.get(key);
+    if (window === undefined) return undefined;
+    if (at - window.startedAt >= this.windowMs) {
+      this.windows.delete(key);
+      return undefined;
+    }
+    return window;
+  }
+
+  /**
+   * Count one request against `key` and report the decision. The counter is
+   * capped one past the limit so a sustained flood within a window can't grow
+   * it without bound — the extra requests are all uniformly `limited`, which is
+   * all the caller needs.
+   */
+  consume(key: string): RateLimitDecision {
+    const at = this.now();
+    let window = this.current(key, at);
+    if (window === undefined) {
+      window = { count: 0, startedAt: at };
+      this.windows.set(key, window);
+    }
+    // Only increment while at or below the ceiling; once over, hold the count so
+    // a long flood in one window stays bounded.
+    if (window.count <= this.maxRequests) {
+      window.count += 1;
+    }
+    const count = window.count;
+    const limited = count > this.maxRequests;
+    const remaining = Math.max(0, this.maxRequests - count);
+    const resetSeconds = Math.max(0, Math.ceil((window.startedAt + this.windowMs - at) / 1000));
+    return { limited, limit: this.maxRequests, remaining, resetSeconds };
+  }
+}

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -28,6 +28,7 @@ describe("loadSettings", () => {
     expect(settings.retention).toEqual({ defaultDays: 365 });
     expect(settings.reapply).toEqual({ cron: "0 * * * *", playbooks: [] });
     expect(settings.clientHealth).toEqual({ probeConcurrency: 4, probeDeadlineMs: 15000 });
+    expect(settings.integrations).toEqual({ rateLimitMax: 120, rateLimitWindowSeconds: 60 });
     expect(settings.preMigrationBackup).toEqual({ enabled: true, retain: 5 });
     expect(settings.serverVersion).toBeUndefined();
     expect(settings.protocolCompatWindow).toBe(1);
@@ -452,6 +453,26 @@ describe("loadSettings", () => {
         SettingsError,
       );
       expect(() => loadSettings({ PCT_ENFORCEMENT_INITIAL_LOOKBACK_SECONDS: "nope" })).toThrow(
+        SettingsError,
+      );
+    });
+  });
+
+  describe("PCT_INTEGRATIONS_RATE_LIMIT_*", () => {
+    it("honours an explicit per-token rate limit and window", () => {
+      const settings = loadSettings({
+        PCT_INTEGRATIONS_RATE_LIMIT_MAX: "30",
+        PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS: "10",
+      });
+      expect(settings.integrations).toEqual({ rateLimitMax: 30, rateLimitWindowSeconds: 10 });
+    });
+
+    it("rejects a non-positive or non-numeric limit or window", () => {
+      expect(() => loadSettings({ PCT_INTEGRATIONS_RATE_LIMIT_MAX: "0" })).toThrow(SettingsError);
+      expect(() => loadSettings({ PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS: "-5" })).toThrow(
+        SettingsError,
+      );
+      expect(() => loadSettings({ PCT_INTEGRATIONS_RATE_LIMIT_MAX: "lots" })).toThrow(
         SettingsError,
       );
     });

--- a/server/tests/integrations/guard.test.ts
+++ b/server/tests/integrations/guard.test.ts
@@ -131,4 +131,19 @@ describe("integration-token guard", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().name).toBe("readonly");
   });
+
+  it("emits no RateLimit-* headers when the guard is built without a limiter", async () => {
+    // This suite constructs the guard with no limiter (`makeRequireIntegrationToken(db)`),
+    // so throttling is disabled — the documented opt-out. No rate-limit metadata leaks.
+    const issued = issueIntegrationToken(db, { name: "readonly", scopes: ["policy:read"] });
+    const res = await app.inject({
+      method: "GET",
+      url: "/needs-auth",
+      headers: bearer(issued.secret),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["ratelimit-limit"]).toBeUndefined();
+    expect(res.headers["ratelimit-remaining"]).toBeUndefined();
+    expect(res.headers["retry-after"]).toBeUndefined();
+  });
 });

--- a/server/tests/integrations/rate-limit-guard.test.ts
+++ b/server/tests/integrations/rate-limit-guard.test.ts
@@ -39,6 +39,11 @@ describe("integration guard — per-token rate limiting (#115)", () => {
     app.get("/ping", { preHandler: guard() }, async (request) => ({
       id: request.integration?.id,
     }));
+    // A scope-guarded route, to prove the rate limit is applied *before* the
+    // scope check (a wrong-scope flood is still throttled).
+    app.get("/needs-grants", { preHandler: guard("grants:write") }, async (request) => ({
+      id: request.integration?.id,
+    }));
     await app.ready();
   });
 
@@ -51,6 +56,14 @@ describe("integration guard — per-token rate limiting (#115)", () => {
     return app.inject({
       method: "GET",
       url: "/ping",
+      headers: { authorization: `Bearer ${secret}` },
+    });
+  }
+
+  function pingGrants(secret: string) {
+    return app.inject({
+      method: "GET",
+      url: "/needs-grants",
       headers: { authorization: `Bearer ${secret}` },
     });
   }
@@ -99,6 +112,28 @@ describe("integration guard — per-token rate limiting (#115)", () => {
     const afterReset = await ping(token.secret);
     expect(afterReset.statusCode).toBe(200);
     expect(afterReset.headers["ratelimit-remaining"]).toBe("1");
+  });
+
+  it("throttles a wrong-scope caller: budget is spent, and the limit wins over the scope check", async () => {
+    // A token that authenticates but lacks `grants:write`.
+    const token = issueIntegrationToken(db, { name: "readonly", scopes: ["policy:read"] });
+
+    // Under the limit, the scope check runs and rejects 403 — but the request
+    // still counted (remaining decrements), proving rate-limit sits before scope.
+    const first = await pingGrants(token.secret);
+    expect(first.statusCode).toBe(403);
+    expect(first.json().error.code).toBe("insufficient_scope");
+    expect(first.headers["ratelimit-remaining"]).toBe("1");
+
+    const second = await pingGrants(token.secret);
+    expect(second.statusCode).toBe(403);
+    expect(second.headers["ratelimit-remaining"]).toBe("0");
+
+    // Now over the limit: the rate limiter rejects 429 *before* the scope check,
+    // so a wrong-scope flood is throttled rather than endlessly 403-ing.
+    const third = await pingGrants(token.secret);
+    expect(third.statusCode).toBe(429);
+    expect(third.json().error.code).toBe("rate_limited");
   });
 
   it("does not spend a token's budget on an unauthenticated request", async () => {

--- a/server/tests/integrations/rate-limit-guard.test.ts
+++ b/server/tests/integrations/rate-limit-guard.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Integration tests for per-token rate limiting in the integration guard (#115).
+ *
+ * Driven through the exact runtime Fastify uses (validator + shared error
+ * envelope + a probe route), like `guard.test.ts`, but with a
+ * {@link FixedWindowQuota} injected into the guard on a hand-cranked clock — so
+ * the throttle, the `429 rate_limited` envelope, the `RateLimit-*` /
+ * `Retry-After` headers, per-token isolation, and the window reset are all
+ * exercised without real time.
+ */
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installApiConventions } from "../../src/api/validation.js";
+import { makeRequireIntegrationToken } from "../../src/integrations/guard.js";
+import { FixedWindowQuota } from "../../src/integrations/rate-limit.js";
+import { issueIntegrationToken } from "../../src/integrations/tokens.js";
+import { testDb, type TestDb } from "../helpers/db.js";
+
+describe("integration guard — per-token rate limiting (#115)", () => {
+  let app: FastifyInstance;
+  let db: TestDb;
+  let nowMs: number;
+
+  beforeEach(async () => {
+    db = testDb();
+    nowMs = 10_000;
+    app = Fastify({ logger: false });
+    installApiConventions(app);
+
+    // Two requests per 60 s window, on the injected clock.
+    const limiter = new FixedWindowQuota({
+      maxRequests: 2,
+      windowMs: 60_000,
+      now: () => nowMs,
+    });
+    const guard = makeRequireIntegrationToken(db, limiter);
+
+    app.get("/ping", { preHandler: guard() }, async (request) => ({
+      id: request.integration?.id,
+    }));
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.$client.close();
+  });
+
+  function ping(secret: string) {
+    return app.inject({
+      method: "GET",
+      url: "/ping",
+      headers: { authorization: `Bearer ${secret}` },
+    });
+  }
+
+  it("admits up to the limit, annotates every response, then rejects 429", async () => {
+    const token = issueIntegrationToken(db, { name: "calendar", scopes: ["policy:read"] });
+
+    const first = await ping(token.secret);
+    expect(first.statusCode).toBe(200);
+    expect(first.headers["ratelimit-limit"]).toBe("2");
+    expect(first.headers["ratelimit-remaining"]).toBe("1");
+    expect(first.headers["ratelimit-reset"]).toBe("60");
+
+    const second = await ping(token.secret);
+    expect(second.statusCode).toBe(200);
+    expect(second.headers["ratelimit-remaining"]).toBe("0");
+
+    const third = await ping(token.secret);
+    expect(third.statusCode).toBe(429);
+    expect(third.json().error.code).toBe("rate_limited");
+    expect(third.headers["retry-after"]).toBe("60");
+    expect(third.headers["ratelimit-remaining"]).toBe("0");
+  });
+
+  it("keeps each token's budget independent", async () => {
+    const a = issueIntegrationToken(db, { name: "a", scopes: ["policy:read"] });
+    const b = issueIntegrationToken(db, { name: "b", scopes: ["policy:read"] });
+
+    await ping(a.secret);
+    await ping(a.secret);
+    expect((await ping(a.secret)).statusCode).toBe(429);
+
+    // A different token is unaffected by the first's exhaustion.
+    expect((await ping(b.secret)).statusCode).toBe(200);
+  });
+
+  it("admits again once the window elapses", async () => {
+    const token = issueIntegrationToken(db, { name: "calendar", scopes: ["policy:read"] });
+
+    await ping(token.secret);
+    await ping(token.secret);
+    expect((await ping(token.secret)).statusCode).toBe(429);
+
+    // Advance past the window boundary → the token recovers its full budget.
+    nowMs += 60_000;
+    const afterReset = await ping(token.secret);
+    expect(afterReset.statusCode).toBe(200);
+    expect(afterReset.headers["ratelimit-remaining"]).toBe("1");
+  });
+
+  it("does not spend a token's budget on an unauthenticated request", async () => {
+    const token = issueIntegrationToken(db, { name: "calendar", scopes: ["policy:read"] });
+
+    // Anonymous hits are 401 before any token is known — they must not count.
+    for (let i = 0; i < 5; i += 1) {
+      expect((await app.inject({ method: "GET", url: "/ping" })).statusCode).toBe(401);
+    }
+
+    // The token still has its full budget.
+    expect((await ping(token.secret)).statusCode).toBe(200);
+    expect((await ping(token.secret)).statusCode).toBe(200);
+    expect((await ping(token.secret)).statusCode).toBe(429);
+  });
+});

--- a/server/tests/integrations/rate-limit.test.ts
+++ b/server/tests/integrations/rate-limit.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the inbound-integration request-count limiter (#115).
+ *
+ * The window behaviour is driven by an injected clock so no real time passes:
+ * a fill-to-limit, the first over-limit request, per-key isolation, the window
+ * reset once it elapses, and the reported metadata (limit / remaining / reset).
+ */
+import { describe, expect, it } from "vitest";
+
+import { FixedWindowQuota } from "../../src/integrations/rate-limit.js";
+
+/** A hand-cranked clock: `tick(ms)` advances it; `read` is the seam callback. */
+function fakeClock(startMs = 1_000): { read: () => number; tick: (ms: number) => void } {
+  let nowMs = startMs;
+  return {
+    read: () => nowMs,
+    tick: (ms: number) => {
+      nowMs += ms;
+    },
+  };
+}
+
+describe("FixedWindowQuota", () => {
+  it("admits requests up to the limit, then limits further ones in the window", () => {
+    const clock = fakeClock();
+    const quota = new FixedWindowQuota({ maxRequests: 3, windowMs: 60_000, now: clock.read });
+
+    const first = quota.consume("token-1");
+    expect(first).toEqual({ limited: false, limit: 3, remaining: 2, resetSeconds: 60 });
+    expect(quota.consume("token-1").remaining).toBe(1);
+
+    const third = quota.consume("token-1");
+    expect(third).toMatchObject({ limited: false, remaining: 0 });
+
+    const fourth = quota.consume("token-1");
+    expect(fourth).toMatchObject({ limited: true, limit: 3, remaining: 0 });
+    // Reset is still reported so the caller can send Retry-After.
+    expect(fourth.resetSeconds).toBeGreaterThan(0);
+  });
+
+  it("keeps each key's budget independent", () => {
+    const clock = fakeClock();
+    const quota = new FixedWindowQuota({ maxRequests: 1, windowMs: 60_000, now: clock.read });
+
+    expect(quota.consume("a").limited).toBe(false);
+    expect(quota.consume("a").limited).toBe(true);
+    // A different token still has its full budget.
+    expect(quota.consume("b").limited).toBe(false);
+  });
+
+  it("resets the count once the window elapses", () => {
+    const clock = fakeClock();
+    const quota = new FixedWindowQuota({ maxRequests: 2, windowMs: 60_000, now: clock.read });
+
+    expect(quota.consume("t").limited).toBe(false);
+    expect(quota.consume("t").limited).toBe(false);
+    expect(quota.consume("t").limited).toBe(true);
+
+    // Just before the boundary the window is still live → still limited.
+    clock.tick(59_999);
+    expect(quota.consume("t").limited).toBe(true);
+
+    // At the boundary the window has elapsed → a fresh budget.
+    clock.tick(1);
+    const afterReset = quota.consume("t");
+    expect(afterReset).toMatchObject({ limited: false, remaining: 1 });
+  });
+
+  it("reports whole seconds remaining until the window resets", () => {
+    const clock = fakeClock();
+    const quota = new FixedWindowQuota({ maxRequests: 5, windowMs: 30_000, now: clock.read });
+
+    expect(quota.consume("t").resetSeconds).toBe(30);
+    clock.tick(10_500);
+    // 19.5 s left → rounded up to 20.
+    expect(quota.consume("t").resetSeconds).toBe(20);
+  });
+
+  it("holds the counter bounded during a sustained over-limit flood", () => {
+    const clock = fakeClock();
+    const quota = new FixedWindowQuota({ maxRequests: 1, windowMs: 60_000, now: clock.read });
+
+    quota.consume("t"); // allowed
+    for (let i = 0; i < 1_000; i += 1) {
+      expect(quota.consume("t").limited).toBe(true);
+    }
+    // Once the window elapses the key recovers cleanly (no leaked over-count).
+    clock.tick(60_000);
+    expect(quota.consume("t")).toMatchObject({ limited: false, remaining: 0 });
+  });
+
+  it("rejects a non-positive limit or window at construction", () => {
+    expect(() => new FixedWindowQuota({ maxRequests: 0, windowMs: 1_000 })).toThrow(RangeError);
+    expect(() => new FixedWindowQuota({ maxRequests: 5, windowMs: 0 })).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
## Summary

- Throttle inbound `/api/integrations/*` traffic **per bearer token** so a noisy or misbehaving integrator can't overwhelm the single-process dashboard (`docs/architecture.md` → "External integrations": per-integration tokens are "rate-limited"; `CLAUDE.md` → "Per-integration API tokens (scoped, revocable, rate-limited)").
- A small in-process fixed-window **request-count** limiter (`integrations/rate-limit.ts`) — deliberately distinct from the *failed-attempt* `auth/rate-limit.ts`, no new dependency — wired into the `requireIntegrationToken` guard, keyed by the authenticated **token id**, checked after authentication and before the scope check.
- Over-limit → `429 rate_limited` in the standard `{ error: { code, message } }` envelope with `Retry-After`; every response carries `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset`. Config: `PCT_INTEGRATIONS_RATE_LIMIT_MAX` / `PCT_INTEGRATIONS_RATE_LIMIT_WINDOW_SECONDS` (default 120 / 60 s).

**Independent of the grants endpoint (#113 / #422):** the limiter lives in the guard layer, so it protects every current and future `/api/integrations/*` endpoint the moment it authenticates a token — it does not need #113 merged. This was the first cleanly-implementable open issue (every lower-phase item is currently blocked, stale, needs an ADR, or requires live infra).

## Plan

Linked plan: `docs/plans/115-integrations-rate-limit.md`
Roadmap: `docs/roadmap.md` → Phase 10 ("rate limiting per token")

## License-boundary note

N/A — no transport or packaging changes. Plain TypeScript + Fastify + `node`'s own clock; no GPL linkage, no GPL binary added to the image.

## Test plan

- [x] `integrations/rate-limit.test.ts` — limiter unit tests: fill-to-limit, per-key isolation, window reset on an injected clock, `resetSeconds` maths, bounded counter under a sustained flood, construction guards.
- [x] `integrations/rate-limit-guard.test.ts` — guard integration tests through the real Fastify error envelope: admit → 200 with `RateLimit-*` headers, over-limit → `429 rate_limited` + `Retry-After`, per-token isolation, window-reset re-admit, and that an unauthenticated `401` never spends a token's budget.
- [x] `config.test.ts` — default (`120 / 60`), explicit override, and rejection of non-positive/non-numeric values.
- [x] Full gate green: `format:check`, `lint`, `typecheck`, `npm test` (1989 passing, 98.9% coverage; 100% on both new files).

## Deferred

- Distributed / cross-process limiting — out of scope by design (single process, same posture as `auth/rate-limit.ts`).
- Per-scope or per-endpoint differentiated limits (one bucket per token for now).

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcUrzL2koWc8ax3BU8cvUn)_