### PR TITLE
feat(client): restart per-user ActivityWatch units on upgrade re-run (#347)

### DIFF
--- a/client/install-baseline-tools.sh
+++ b/client/install-baseline-tools.sh
@@ -62,6 +62,19 @@ AW_PREFIX="${AW_PREFIX:-/opt/activitywatch}"
 AW_HOST="${AW_HOST:-127.0.0.1}"
 AW_PORT="${AW_PORT:-5600}"
 
+# Set to 1 by pct_baseline_install_activitywatch when it replaces a *different*
+# previously-installed AW version (a genuine upgrade). The configure step reads
+# it to decide whether the running per-user units need a restart to pick up the
+# new binaries. A first install (no prior version) and a same-version no-op
+# re-run both leave it 0 — see #347.
+PCT_AW_VERSION_CHANGED=0
+# systemctl used for the per-user (`--user`) ActivityWatch calls, and the base of
+# the per-user runtime directory whose presence tells us the user's `systemd
+# --user` bus is reachable. Both overridable so the restart-on-upgrade path is
+# unit-testable without root, a real login session, or a real `/run/user`.
+PCT_USER_SYSTEMCTL="${PCT_USER_SYSTEMCTL:-systemctl}"
+PCT_USER_RUNTIME_BASE="${PCT_USER_RUNTIME_BASE:-/run/user}"
+
 # timekpr-next now ships in the Debian/Ubuntu repositories, so by default we
 # install it straight from the distro (a plain `apt-get install timekpr-next`,
 # no external repository). The upstream PPA is kept as an opt-in fallback for
@@ -336,9 +349,21 @@ pct_baseline_configure_sshd() {
 pct_baseline_install_activitywatch() {
   pct_step "Install ActivityWatch ${AW_VERSION} (upstream release bundle)"
   local stamp="${AW_PREFIX}/.pct-aw-version"
-  if [ -f "$stamp" ] && [ "$(cat "$stamp" 2>/dev/null)" = "$AW_VERSION" ]; then
+  local prev=""
+  [ -f "$stamp" ] && prev="$(cat "$stamp" 2>/dev/null || true)"
+  if [ "$prev" = "$AW_VERSION" ]; then
     pct_ok "ActivityWatch ${AW_VERSION} already installed at ${AW_PREFIX}"
     return 0
+  fi
+
+  # A *different* previously-installed version means this is an upgrade: the new
+  # binaries land at ${AW_PREFIX} but the running per-user units still execute the
+  # old ones until restarted. Signal the configure step to bounce them (#347). A
+  # first install (no prior version) does not need this — its units are freshly
+  # enabled and start clean on the user's next login.
+  if [ -n "$prev" ]; then
+    PCT_AW_VERSION_CHANGED=1
+    pct_log "ActivityWatch upgrade detected (${prev} -> ${AW_VERSION})"
   fi
 
   # The pinned upstream bundle is x86_64-only; fail loudly rather than 404 on a
@@ -493,6 +518,35 @@ WantedBy=default.target
 EOF
 }
 
+# Best-effort restart of a supervised user's ActivityWatch `systemd --user`
+# units so an *upgraded* binary takes effect on a re-run. Only acts when the
+# user's `systemd --user` bus is reachable — i.e. a per-user runtime dir
+# (${PCT_USER_RUNTIME_BASE}/<uid>) exists, meaning an active or lingering
+# session. When it is not reachable there is nothing to bounce: the newly
+# installed binaries start clean on the user's next login. `try-restart` is a
+# no-op for an inactive unit, so a lingering-but-logged-out user is handled
+# cleanly too; a genuine failure of an active unit to come back is NOT swallowed.
+# Dry-run prints the conditional intent (mirrors pct_apply_change).
+pct_aw_restart_user_units() {
+  local user="$1" uid="$2"
+  if pct_is_dry_run; then
+    printf '%s ActivityWatch upgraded: try-restart the aw-server/aw-watcher-* --user units for %s (only if their session is reachable)\n' \
+      "$PCT_DRYRUN_PREFIX" "$user" >&2
+    return 0
+  fi
+  local runtime="${PCT_USER_RUNTIME_BASE}/${uid}"
+  if [ -z "$uid" ] || [ ! -d "$runtime" ]; then
+    pct_log "user ${user}'s systemd --user bus not reachable; upgraded ActivityWatch takes effect on next login"
+    return 0
+  fi
+  pct_log "ActivityWatch upgraded; restarting ${user}'s --user units to apply"
+  local svc
+  for svc in aw-server aw-watcher-afk aw-watcher-window; do
+    sudo -u "$user" XDG_RUNTIME_DIR="$runtime" \
+      "$PCT_USER_SYSTEMCTL" --user try-restart "${svc}.service"
+  done
+}
+
 pct_baseline_configure_activitywatch() {
   pct_step "Configure ActivityWatch systemd --user units (per supervised user)"
   local user home
@@ -546,9 +600,15 @@ EOF
     pct_run loginctl enable-linger "$user"
     local svc
     for svc in aw-server aw-watcher-afk aw-watcher-window; do
-      pct_run sudo -u "$user" XDG_RUNTIME_DIR="/run/user/${uid}" \
+      pct_run sudo -u "$user" XDG_RUNTIME_DIR="${PCT_USER_RUNTIME_BASE}/${uid}" \
         systemctl --user enable "${svc}.service"
     done
+
+    # On an upgrade re-run the units above are already enabled and running the
+    # OLD binary; restart them so the just-installed version takes effect (#347).
+    if [ "${PCT_AW_VERSION_CHANGED:-0}" = "1" ]; then
+      pct_aw_restart_user_units "$user" "$uid"
+    fi
   done
 }
 

--- a/client/install-baseline-tools.sh
+++ b/client/install-baseline-tools.sh
@@ -519,14 +519,15 @@ EOF
 }
 
 # Best-effort restart of a supervised user's ActivityWatch `systemd --user`
-# units so an *upgraded* binary takes effect on a re-run. Only acts when the
-# user's `systemd --user` bus is reachable — i.e. a per-user runtime dir
-# (${PCT_USER_RUNTIME_BASE}/<uid>) exists, meaning an active or lingering
-# session. When it is not reachable there is nothing to bounce: the newly
-# installed binaries start clean on the user's next login. `try-restart` is a
-# no-op for an inactive unit, so a lingering-but-logged-out user is handled
-# cleanly too; a genuine failure of an active unit to come back is NOT swallowed.
-# Dry-run prints the conditional intent (mirrors pct_apply_change).
+# units so an *upgraded* binary takes effect on a re-run. Skips cleanly when the
+# user has no per-user runtime dir (${PCT_USER_RUNTIME_BASE}/<uid>) — there is no
+# `systemd --user` bus to talk to, and the new binaries start clean on the user's
+# next login. The configure loop runs `loginctl enable-linger` just before this,
+# so on a re-run the runtime dir is usually already present; `try-restart` is a
+# no-op for an inactive unit, so only actually-running units are bounced. This is
+# per-user best-effort: a unit that will not restart is warned about, never
+# fatal, so one user's failure cannot abort the whole reconcile mid-way. Dry-run
+# prints the conditional intent (mirrors pct_apply_change).
 pct_aw_restart_user_units() {
   local user="$1" uid="$2"
   if pct_is_dry_run; then
@@ -536,14 +537,18 @@ pct_aw_restart_user_units() {
   fi
   local runtime="${PCT_USER_RUNTIME_BASE}/${uid}"
   if [ -z "$uid" ] || [ ! -d "$runtime" ]; then
-    pct_log "user ${user}'s systemd --user bus not reachable; upgraded ActivityWatch takes effect on next login"
+    pct_log "user ${user}'s systemd --user runtime dir is absent; upgraded ActivityWatch takes effect on next login"
     return 0
   fi
-  pct_log "ActivityWatch upgraded; restarting ${user}'s --user units to apply"
+  pct_log "ActivityWatch upgraded; restarting ${user}'s active --user units to apply"
   local svc
   for svc in aw-server aw-watcher-afk aw-watcher-window; do
+    # Warn-and-continue: a single unit failing to bounce (or a not-quite-ready
+    # bus right after enable-linger) must not abort the reconcile under `set -e`
+    # — the upgrade is picked up on next login regardless.
     sudo -u "$user" XDG_RUNTIME_DIR="$runtime" \
-      "$PCT_USER_SYSTEMCTL" --user try-restart "${svc}.service"
+      "$PCT_USER_SYSTEMCTL" --user try-restart "${svc}.service" ||
+      pct_warn "could not restart ${user}'s ${svc}.service; it will pick up the ActivityWatch upgrade on next login"
   done
 }
 

--- a/client/tests/install-baseline-tools.bats
+++ b/client/tests/install-baseline-tools.bats
@@ -193,6 +193,86 @@ EOS
   [ "$(grep -c 'try-restart timekpr.service' "$rec")" -eq 1 ]
 }
 
+@test "a first ActivityWatch install plans no per-user restart (#347)" {
+  # Fresh AW_PREFIX (no version stamp) is a first install: units are enabled
+  # fresh and start clean on next login, so there is nothing to restart.
+  plan --supervised-user alice
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"ActivityWatch upgraded"* ]]
+}
+
+@test "a same-version ActivityWatch re-run plans no restart (#347)" {
+  mkdir -p "$AW_PREFIX"
+  printf '%s\n' "${AW_VERSION:-v0.13.2}" >"${AW_PREFIX}/.pct-aw-version"
+  plan --supervised-user alice
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already installed"* ]]
+  [[ "$output" != *"ActivityWatch upgraded"* ]]
+}
+
+@test "an ActivityWatch upgrade plans a best-effort per-user restart (#347)" {
+  mkdir -p "$AW_PREFIX"
+  # An older version was previously installed -> upgrade -> the running units
+  # hold the old binary and must be bounced (best-effort, per reachable user).
+  printf 'v0.13.1\n' >"${AW_PREFIX}/.pct-aw-version"
+  plan --supervised-user alice --supervised-user bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"upgrade detected (v0.13.1 -> ${AW_VERSION:-v0.13.2})"* ]]
+  echo "$output" | grep -q 'ActivityWatch upgraded: try-restart the aw-server/aw-watcher-\* --user units for alice (only if their session is reachable)'
+  echo "$output" | grep -q 'ActivityWatch upgraded: try-restart the aw-server/aw-watcher-\* --user units for bob (only if their session is reachable)'
+}
+
+@test "aw per-user restart is a clean no-op when the --user bus is unreachable (real)" {
+  local rec="${TMP}/user-systemctl-calls" stub="${TMP}/user-systemctl"
+  cat >"$stub" <<EOS
+#!/usr/bin/env bash
+echo "\$*" >>"${rec}"
+EOS
+  chmod +x "$stub"
+  # No <uid> dir under the runtime base -> the user's bus is not reachable.
+  run env -u PCT_DRY_RUN bash -c '
+    PCT_USER_SYSTEMCTL="'"$stub"'"
+    PCT_USER_RUNTIME_BASE="'"$TMP"'/run"
+    source "'"$SCRIPT"'"
+    pct_aw_restart_user_units alice 4242
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not reachable"* ]]
+  [ ! -f "$rec" ]   # no systemctl --user call was issued
+}
+
+@test "aw per-user restart bounces each --user unit when the session is reachable (real)" {
+  local rec="${TMP}/user-systemctl-calls" stub="${TMP}/user-systemctl"
+  cat >"$stub" <<EOS
+#!/usr/bin/env bash
+echo "\$*" >>"${rec}"
+EOS
+  chmod +x "$stub"
+  # A `sudo` stub that drops `-u <user>` and the inline XDG_RUNTIME_DIR=... and
+  # execs the rest, so the PCT_USER_SYSTEMCTL stub records the real verb/args.
+  local bin="${TMP}/bin"
+  mkdir -p "$bin" "${TMP}/run/4242"
+  cat >"${bin}/sudo" <<'EOS'
+#!/usr/bin/env bash
+shift 2                                   # drop: -u <user>
+while [ "$#" -gt 0 ]; do case "$1" in *=*) shift ;; *) break ;; esac; done
+exec "$@"
+EOS
+  chmod +x "${bin}/sudo"
+  run env -u PCT_DRY_RUN bash -c '
+    export PATH="'"$bin"':$PATH"
+    PCT_USER_SYSTEMCTL="'"$stub"'"
+    PCT_USER_RUNTIME_BASE="'"$TMP"'/run"
+    source "'"$SCRIPT"'"
+    pct_aw_restart_user_units alice 4242
+  '
+  [ "$status" -eq 0 ]
+  [ -f "$rec" ]
+  [ "$(grep -c 'try-restart aw-server.service' "$rec")" -eq 1 ]
+  [ "$(grep -c 'try-restart aw-watcher-afk.service' "$rec")" -eq 1 ]
+  [ "$(grep -c 'try-restart aw-watcher-window.service' "$rec")" -eq 1 ]
+}
+
 @test "installs the openssh-server package (the dashboard connects over SSH)" {
   plan --supervised-user alice
   [ "$status" -eq 0 ]

--- a/client/tests/install-baseline-tools.bats
+++ b/client/tests/install-baseline-tools.bats
@@ -237,7 +237,7 @@ EOS
     pct_aw_restart_user_units alice 4242
   '
   [ "$status" -eq 0 ]
-  [[ "$output" == *"not reachable"* ]]
+  [[ "$output" == *"runtime dir is absent"* ]]
   [ ! -f "$rec" ]   # no systemctl --user call was issued
 }
 
@@ -268,6 +268,42 @@ EOS
   '
   [ "$status" -eq 0 ]
   [ -f "$rec" ]
+  [ "$(grep -c 'try-restart aw-server.service' "$rec")" -eq 1 ]
+  [ "$(grep -c 'try-restart aw-watcher-afk.service' "$rec")" -eq 1 ]
+  [ "$(grep -c 'try-restart aw-watcher-window.service' "$rec")" -eq 1 ]
+}
+
+@test "aw per-user restart is best-effort: one unit failing does not abort (real)" {
+  local rec="${TMP}/user-systemctl-calls" stub="${TMP}/user-systemctl"
+  cat >"$stub" <<EOS
+#!/usr/bin/env bash
+echo "\$*" >>"${rec}"
+# Fail specifically on aw-server to prove the loop continues and the function
+# still succeeds (best-effort) rather than aborting the reconcile under set -e.
+if [[ "\$*" == *aw-server.service* ]]; then exit 1; fi
+EOS
+  chmod +x "$stub"
+  local bin="${TMP}/bin"
+  mkdir -p "$bin" "${TMP}/run/4242"
+  cat >"${bin}/sudo" <<'EOS'
+#!/usr/bin/env bash
+shift 2
+while [ "$#" -gt 0 ]; do case "$1" in *=*) shift ;; *) break ;; esac; done
+exec "$@"
+EOS
+  chmod +x "${bin}/sudo"
+  run env -u PCT_DRY_RUN bash -c '
+    export PATH="'"$bin"':$PATH"
+    PCT_USER_SYSTEMCTL="'"$stub"'"
+    PCT_USER_RUNTIME_BASE="'"$TMP"'/run"
+    source "'"$SCRIPT"'"                 # sourcing activates set -euo pipefail from the script
+    pct_aw_restart_user_units alice 4242
+    echo "RETURNED $?"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"RETURNED 0"* ]]
+  [[ "$output" == *"could not restart"*"aw-server.service; it will pick up the ActivityWatch upgrade"* ]]
+  # All three were still attempted despite aw-server failing.
   [ "$(grep -c 'try-restart aw-server.service' "$rec")" -eq 1 ]
   [ "$(grep -c 'try-restart aw-watcher-afk.service' "$rec")" -eq 1 ]
   [ "$(grep -c 'try-restart aw-watcher-window.service' "$rec")" -eq 1 ]

--- a/docs/plans/347-aw-restart-on-upgrade.md
+++ b/docs/plans/347-aw-restart-on-upgrade.md
@@ -28,11 +28,14 @@ Part (a) of #347 only — the ActivityWatch per-user restart.
   no-op re-run both leave it `0`.
 - **Best-effort per-user restart** (`pct_aw_restart_user_units`): when AW was
   upgraded, `try-restart` each of the user's three `--user` units so they pick
-  up the new binaries. Only acts when the user's `systemd --user` bus is
-  reachable (`${PCT_USER_RUNTIME_BASE}/<uid>` exists — an active or lingering
-  session); otherwise the newly installed binaries start clean on the user's
-  next login, so there is nothing to bounce. `try-restart` is a no-op for an
-  inactive unit, so a lingering-but-logged-out user is handled cleanly too.
+  up the new binaries. Skips cleanly when the user has no per-user runtime dir
+  (`${PCT_USER_RUNTIME_BASE}/<uid>` absent — no `systemd --user` bus to talk to);
+  the newly installed binaries then start clean on next login. The configure
+  loop runs `loginctl enable-linger` just before this, so on a re-run the runtime
+  dir is usually already present; `try-restart` is a no-op for an inactive unit,
+  so only actually-running units are bounced. Failures are per-user best-effort:
+  a unit that will not restart is **warned about, never fatal**, so one user's
+  failure cannot abort the whole (idempotent) reconcile mid-way under `set -e`.
 - Reuses the established change-detection idiom: `try-*` verbs (never swallow a
   genuine failure of an active unit), a dry-run intent line mirroring
   `pct_apply_change`, and env-overridable seams (`PCT_USER_SYSTEMCTL`,
@@ -55,6 +58,8 @@ Part (a) of #347 only — the ActivityWatch per-user restart.
   for each supervised user.
 - Real reachability guard: unreachable bus → logs + issues no `systemctl --user`
   call; reachable bus → exactly one `try-restart` per unit.
+- Real best-effort guarantee: one unit's `try-restart` failing → the function
+  still returns 0, warns, and still attempts the other two units.
 
 Validated with `shellcheck -x` (client + scripts) and `bats client/tests/`.
 

--- a/docs/plans/347-aw-restart-on-upgrade.md
+++ b/docs/plans/347-aw-restart-on-upgrade.md
@@ -1,0 +1,71 @@
+# Plan — #347 (part a): restart per-user ActivityWatch units on upgrade
+
+Roadmap: operations/lifecycle (no numbered phase); follow-up to the
+upgrade-in-place work in PR #344. Closes the ActivityWatch slice of #347.
+
+## Problem
+
+`install-baseline-tools.sh` supports an idempotent upgrade-in-place re-run.
+PR #344 already made the **system** daemons apply changed config on a re-run
+(`pct_apply_change`: `try-restart timekpr.service` when `timekpr.conf` changed,
+`try-reload-or-restart e2guardian.service` when the filter group changed).
+
+The **per-user ActivityWatch** units were left out. `pct_baseline_install_activitywatch`
+extracts the pinned AW bundle to `${AW_PREFIX}` and records the version in a
+stamp; on an upgrade re-run it drops the new binaries, but the running
+`systemd --user` units (`aw-server`, `aw-watcher-afk`, `aw-watcher-window`)
+keep executing the old binary until restarted. So a bumped `AW_VERSION` silently
+does not take effect for an already-logged-in supervised user.
+
+## Scope (this PR)
+
+Part (a) of #347 only — the ActivityWatch per-user restart.
+
+- **Detect a genuine upgrade** in `pct_baseline_install_activitywatch`: read the
+  previously-installed version from the stamp *before* overwriting it. Set a
+  process-global `PCT_AW_VERSION_CHANGED=1` only when a *different* version was
+  previously installed. A first install (no prior version) and a same-version
+  no-op re-run both leave it `0`.
+- **Best-effort per-user restart** (`pct_aw_restart_user_units`): when AW was
+  upgraded, `try-restart` each of the user's three `--user` units so they pick
+  up the new binaries. Only acts when the user's `systemd --user` bus is
+  reachable (`${PCT_USER_RUNTIME_BASE}/<uid>` exists — an active or lingering
+  session); otherwise the newly installed binaries start clean on the user's
+  next login, so there is nothing to bounce. `try-restart` is a no-op for an
+  inactive unit, so a lingering-but-logged-out user is handled cleanly too.
+- Reuses the established change-detection idiom: `try-*` verbs (never swallow a
+  genuine failure of an active unit), a dry-run intent line mirroring
+  `pct_apply_change`, and env-overridable seams (`PCT_USER_SYSTEMCTL`,
+  `PCT_USER_RUNTIME_BASE`) so the path is unit-testable without root, a real
+  login session, or a real `/run/user`.
+
+### Behaviour matrix
+
+| Re-run case                     | `PCT_AW_VERSION_CHANGED` | Restart? |
+| ------------------------------- | ------------------------ | -------- |
+| First install (no stamp)        | 0                        | no       |
+| Same version (stamp == pinned)  | 0 (install short-circuits) | no     |
+| Upgrade (stamp != pinned)       | 1                        | yes, best-effort per reachable user |
+
+## Tests (`client/tests/install-baseline-tools.bats`)
+
+- First install → no restart planned.
+- Same-version re-run → `already installed`, no restart planned.
+- Upgrade re-run → `upgrade detected (old -> new)` + a per-user restart intent
+  for each supervised user.
+- Real reachability guard: unreachable bus → logs + issues no `systemctl --user`
+  call; reachable bus → exactly one `try-restart` per unit.
+
+Validated with `shellcheck -x` (client + scripts) and `bats client/tests/`.
+
+## Deferred (tracked)
+
+- Part (b) of #347 — the `pct-client` agent `.deb` postinst restarting
+  `pct-client-bridge` / the per-user `pct-client-agent` — depends on the agent
+  `.deb` packaging, which does not exist yet (**#106**). Rides with that work;
+  #347 stays open for it.
+
+## License boundary
+
+None touched. Pure Bash + `systemctl` verbs over the existing per-user unit
+model; no GPL source linked, no GPL binary added to the image, no Docker change.


### PR DESCRIPTION
## Summary

- On an upgrade-in-place re-run, `install-baseline-tools.sh` dropped the new ActivityWatch binaries at `${AW_PREFIX}` but the running per-user `systemd --user` units (`aw-server`, `aw-watcher-afk`, `aw-watcher-window`) kept executing the **old** binary until restarted — so a bumped `AW_VERSION` silently did not take effect. This completes the ActivityWatch slice of the change-detection/apply work PR #344 began for the system daemons.
- Detects a **genuine upgrade** in `pct_baseline_install_activitywatch` (a *different* previously-installed version — not a first install, not a same-version no-op) and, when so, does a **best-effort `try-restart`** of each supervised user's `--user` units. It skips cleanly when the user has no `systemd --user` runtime dir at all; `try-restart` is a no-op for an inactive unit, so only actually-running units are bounced. A single unit failing to restart is **warned about, never fatal**, so one user cannot abort the (idempotent) reconcile mid-way.
- Reuses the established `try-*` idiom + dry-run intent line, and adds env seams (`PCT_USER_SYSTEMCTL`, `PCT_USER_RUNTIME_BASE`) so the path is unit-testable without root, a real login session, or a real `/run/user`.

| Re-run case | restart? |
| --- | --- |
| First install (no stamp) | no |
| Same version (no-op) | no |
| Upgrade (different version) | yes — best-effort per reachable user |

## Plan

Linked plan: `docs/plans/347-aw-restart-on-upgrade.md`
Roadmap: operations/lifecycle follow-up to PR #344 (no numbered phase).

## License-boundary note

N/A — no transport or packaging changes. Pure Bash + `systemctl`/`loginctl` verbs over the existing per-user unit model; no GPL source linked, no GPL binary added to the image, no Docker change.

## Test plan

- [x] `shellcheck -x` over `client/ scripts/` (CI parity) — clean.
- [x] `bats client/tests/` (148 tests) — green, incl. 6 new #347 cases:
  - first install → no restart planned
  - same-version re-run → `already installed`, no restart planned
  - upgrade re-run → `upgrade detected (old -> new)` + a per-user restart intent per user
  - real reachability guard: absent runtime dir → logs + no `systemctl --user` call
  - real reachable bus → exactly one `try-restart` per unit
  - real best-effort guarantee: one unit failing → still returns 0, warns, still attempts the others

## Review

First-pass review addressed in `fbadc42`: the per-user restart was fail-fast under `set -e` (a single user's `systemctl --user` failure would abort the whole reconcile) — now warn-and-continue; corrected the reachability wording (`enable-linger` runs just before, so the runtime dir is usually present — the guard only skips when there is no user bus at all); added the best-effort failure-path test.

## Deferred (tracked)

- Part (b) of #347 — the `pct-client` agent `.deb` postinst restarting `pct-client-bridge` / the per-user `pct-client-agent` — depends on the agent `.deb` packaging, which does not exist yet (**#106**). It rides with that packaging work; **#347 stays open** for it, so this PR does not `Closes` it.

Addresses part (a) of #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)