### PR TITLE
feat(e2guardian): render date-scoped calendar-range denies (#385)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -386,8 +386,13 @@ and e2guardian evaluates the constraint itself at request time. This keeps
 enforcement purely *config-file + reload* — no extra scheduler to install or keep
 in sync, and no clock-drift race between a re-push and the window edge. e2guardian
 `#time:` expresses weekday + time-of-day only; calendar **date-scoped** denies
-(`effective_from`/`effective_to`) are not representable this way and ride with the
-date-scoped resolver work (#142).
+(`effective_from`/`effective_to`, #385) are not representable this way, so the
+dashboard resolves them against the push instant instead: a date-scoped deny is
+rendered into the filter group — as a static banned site if it has no recurrence,
+or as a `#time:` window if it does — only while its calendar range is active, and
+a periodic re-push re-evaluates the active set as ranges open and close. This
+stays *config-file + reload* (no client-side scheduler); the re-push cadence
+carries the one boundary-latency trade-off the native `#time:` path avoids.
 
 ## External integrations
 

--- a/docs/plans/385-e2guardian-date-scoped-denies.md
+++ b/docs/plans/385-e2guardian-date-scoped-denies.md
@@ -1,0 +1,113 @@
+# Issue #385 — e2guardian: date-scoped (calendar-range) domain denies
+
+Roadmap: `docs/roadmap.md` → Phase 13. Explicit deferral from #216
+(recurring `#time:` windows). Depends on the date-scoped resolver work
+**#142** (merged, PR #398): `resolve.ts` already carries the date gate
+(`effective_from ≤ T < effective_to`).
+
+## Problem
+
+`buildE2guardianPlan` (`server/src/transport/ansible/e2guardian.ts`) renders
+two of the three `deny` shapes and deliberately skips the third:
+
+- **always-on** denies (#90) → static per-UID banned-site list (`bannedSites`).
+- **recurring** weekday/time-of-day windows (#216) → an e2guardian
+  `#time:`-tagged `.Include` the daemon evaluates itself (`windows`).
+- **date-scoped** denies (`effective_from`/`effective_to` set) → currently
+  **excluded** by both `isAlwaysOn` and `isRecurringWindow`, with a unit test
+  asserting the skip.
+
+e2guardian's `#time:` grammar expresses weekday + time-of-day only, **not** a
+calendar date range, so "no social media until 2026-09-01" or a "blocked for
+exam week" deny cannot be represented natively.
+
+## Mechanism decision (per the issue)
+
+The resolver already answers "is this rule active on calendar day D?". So we
+resolve date-scoped denies **to the active-now set at plan-build time** and
+rely on a periodic **re-push** to re-evaluate at the date boundary — keeping
+enforcement purely *config-file + reload* (the #216 mechanism decision,
+`docs/architecture.md` → "Enforcement responsibilities"). No client-side
+scheduler, no e2guardian date grammar. Two sub-shapes, keyed on whether the
+date-scoped rule *also* carries a recurrence window:
+
+1. **date-scoped, non-recurring** (a plain calendar range): active continuously
+   while `now ∈ [from, to)` → render into the **static banned list**, exactly
+   like an always-on deny, but only while in range.
+2. **date-scoped + recurring** (calendar range *and* weekday/time window):
+   render the `#time:` window while `now ∈ [from, to)` and omit it outside the
+   range → the daemon evaluates the intra-day/weekday part; the dashboard's
+   re-push gates the calendar range.
+
+Both gate on a **date-only** predicate (`now ∈ [from, to)`); the recurrence
+part (case 2) stays daemon-side. No new schema/DTO shape is needed — case 1
+reuses `bannedSites`, case 2 reuses the existing `E2guardianWindow`/`#time:`
+mechanism.
+
+## Changes
+
+### 1. `server/src/policy/resolve.ts` — extract + export the date gate
+
+`isRuleActiveAt` inlines the date gate (`effective_from ≤ T < effective_to`,
+either bound open). Extract it as an exported pure helper so e2guardian (which
+must apply the **date gate only**, not the full recurrence predicate) shares
+one source of truth for the ADR-0005 semantics:
+
+```ts
+export function withinEffectiveDateRange(rule: ScheduleRule, at: Date): boolean;
+```
+
+Refactor `isRuleActiveAt` to call it — behaviour identical, existing resolver
+tests unchanged.
+
+### 2. `server/src/transport/ansible/e2guardian.ts`
+
+- Add `at?: Date` to `BuildE2guardianPlanOptions` (default `new Date()`); thread
+  it through `buildE2guardianPlan` → `resolveBannedSites` / `resolveWindowedDenies`.
+- Add small local predicates `isDateScoped(rule)` and `hasRecurrence(rule)`.
+- `resolveBannedSites`: include a deny when `isAlwaysOn(rule)` **or**
+  (`isDateScoped(rule) && !hasRecurrence(rule) && withinEffectiveDateRange(rule, at)`).
+- `resolveWindowedDenies`: include a deny when `isRecurringWindow(rule)` **or**
+  (`isDateScoped(rule) && hasRecurrence(rule) && withinEffectiveDateRange(rule, at)`).
+- Update the module/helper doc comments (they currently say date-scoped denies
+  are deferred to #142).
+
+### 3. `docs/architecture.md` → "Enforcement responsibilities"
+
+Update the paragraph that defers date-scoped e2guardian denies to #142: they
+are now handled by resolve-at-push-time + periodic re-push (config-file +
+reload), while recurring windows stay native `#time:`.
+
+## Tests (`server/tests/transport/ansible/e2guardian.test.ts`)
+
+Update the two tests that assert the old skip (behaviour intentionally changes —
+not a weakening), and add boundary coverage:
+
+- date-scoped **non-recurring** deny, `at` inside range → static banned site.
+- date-scoped non-recurring deny, `at` **before** `effective_from` → skipped.
+- date-scoped non-recurring deny, `at` **at/after** `effective_to` → skipped.
+- open-ended bounds (from-only; to-only) gate correctly.
+- date-scoped **recurring** deny, in range → `#time:` window; out of range → skipped.
+- a date-scoped-recurring window collapses with an identical-tag pure-recurring
+  window (shared `#time:` list).
+- allow/extend date-scoped rules still produce nothing.
+
+Plus a resolver unit test for `withinEffectiveDateRange` and a guard that
+`isRuleActiveAt` is unchanged.
+
+## License boundary
+
+None. Pure TypeScript + Drizzle reads. e2guardian stays configured by writing
+config files and signalling a reload, driven by `ansible-playbook` as a
+subprocess — no linkage, import, or vendoring (`CLAUDE.md` → "License
+boundaries" 3 & 6).
+
+## Deferred (tracked → follow-up issue)
+
+The **date-boundary re-push cadence** — a periodic rebuild+push of the
+e2guardian plan so a date-scoped deny switches on/off as its range opens/closes
+— is out of scope. It rides on the e2guardian push boot-wiring, which is itself
+already deferred (`pushE2guardianFiltering` has no production caller yet; the
+`transport/reapply` scheduler re-runs playbooks but does not rebuild plans from
+policy). This PR makes the pure `buildE2guardianPlan` seam correct for any
+injected instant; a follow-up issue tracks wiring the periodic re-push.

--- a/server/src/policy/index.ts
+++ b/server/src/policy/index.ts
@@ -24,6 +24,7 @@ export {
   type ActivityQuota,
   type EffectivePolicy,
   type EffectivePolicyInput,
+  withinEffectiveDateRange,
   isRuleActiveAt,
   ruleActiveAt,
   effectivePolicy,

--- a/server/src/policy/resolve.ts
+++ b/server/src/policy/resolve.ts
@@ -205,6 +205,25 @@ function isAlwaysOn(rule: ScheduleRule): boolean {
 }
 
 /**
+ * The **date gate** alone (ADR 0005): does instant `at` fall inside the rule's
+ * `[effective_from, effective_to)` calendar range, with either bound open?
+ *
+ * The bounds are stored as instants fixed at local-day boundaries (ADR 0005),
+ * so this is a pure instant comparison — timezone-independent. Split out from
+ * {@link isRuleActiveAt} so a caller that must apply *only* the date gate — and
+ * evaluate the recurrence part elsewhere — shares the exact same semantics.
+ * e2guardian date-scoped denies (#385) are the motivating case: the daemon
+ * evaluates the recurrence window itself via its native `#time:` tag, so the
+ * renderer needs the calendar-range gate without the recurrence gate.
+ */
+export function withinEffectiveDateRange(rule: ScheduleRule, at: Date): boolean {
+  const t = at.getTime();
+  if (rule.effectiveFrom !== null && t < rule.effectiveFrom.getTime()) return false;
+  if (rule.effectiveTo !== null && t >= rule.effectiveTo.getTime()) return false;
+  return true;
+}
+
+/**
  * Is `rule` active at instant `T` in `tz`? Implements the predicate ADR 0005
  * defines (the one {@link import("./schedule-precedence.js")} leaves
  * injectable): the **date gate** (`effective_from ≤ T < effective_to`, either
@@ -217,11 +236,8 @@ function isAlwaysOn(rule: ScheduleRule): boolean {
  * but at day granularity for the recurrence window it projects.
  */
 export function isRuleActiveAt(rule: ScheduleRule, at: Date, tz: string): boolean {
-  const t = at.getTime();
-
   // Date gate: [effective_from, effective_to), either bound open.
-  if (rule.effectiveFrom !== null && t < rule.effectiveFrom.getTime()) return false;
-  if (rule.effectiveTo !== null && t >= rule.effectiveTo.getTime()) return false;
+  if (!withinEffectiveDateRange(rule, at)) return false;
 
   if (isAlwaysOn(rule)) return true;
 

--- a/server/src/transport/ansible/e2guardian.ts
+++ b/server/src/transport/ansible/e2guardian.ts
@@ -6,9 +6,10 @@
  * subprocess dispatch is a thin, injected seam:
  *
  * 1. {@link buildE2guardianPlan} resolves a typed, validated **filter plan**
- *    from the policy store — for each supervised user on a client, the set of
- *    domains that are *always-on denied*, assigned a deterministic e2guardian
- *    filter group + listen port.
+ *    from the policy store — for each supervised user on a client, the domains
+ *    denied in each of the three `deny` shapes (always-on, recurring `#time:`
+ *    windows #216, and date-scoped calendar ranges #385), assigned a
+ *    deterministic e2guardian filter group + listen port.
  * 2. {@link pushE2guardianFiltering} hands that plan to the existing
  *    {@link AnsibleRunner} as `--extra-vars` and records the run in the audit
  *    log. The playbook (`client/ansible/playbooks/e2guardian-filtering.yml`)
@@ -27,6 +28,7 @@ import { getActivity, listClientLinks, listGroupActivities } from "../../policy/
 import type { PolicyDb } from "../../policy/db.js";
 import { gatherUserScheduleRules } from "../../policy/group-resolution.js";
 import { MINUTES_PER_DAY } from "../../policy/recurrence.js";
+import { withinEffectiveDateRange } from "../../policy/resolve.js";
 import type { ScheduleRule } from "../../policy/schedule-precedence.js";
 import { redactArgv, type AuditEntry, type AuditSink } from "../audit/index.js";
 
@@ -87,12 +89,18 @@ export const e2guardianUserFilterSchema = z.object({
   filterGroup: z.number().int().min(FIRST_MANAGED_FILTER_GROUP),
   /** TCP port this user's filter group listens on; the iptables redirect target. */
   listenPort: z.number().int().min(1).max(65535),
-  /** Domains denied for this user, deduplicated and sorted (always-on denies only). */
+  /**
+   * Domains statically denied for this user, deduplicated and sorted: always-on
+   * denies plus any date-scoped, non-recurring deny whose calendar range is
+   * active at build time (#385).
+   */
   bannedSites: z.array(z.string().min(1)),
   /**
-   * Recurring time-window denies (#216), each grouped by its `#time:` tag so one
-   * window list serves all its domains. Empty ⇒ the user has only always-on
-   * denies (or, combined with an empty `bannedSites`, would not be in the plan).
+   * Time-window denies, each grouped by its `#time:` tag so one window list
+   * serves all its domains: recurring windows (#216) plus any date-scoped
+   * recurring window active at build time (#385). Empty ⇒ the user has only
+   * static denies (or, combined with an empty `bannedSites`, would not be in
+   * the plan).
    */
   windows: z.array(e2guardianWindowSchema),
 });
@@ -119,6 +127,14 @@ export interface BuildE2guardianPlanOptions {
   proxyPort?: number;
   /** Override the redirected destination ports (default `[80, 443]`). */
   redirectPorts?: readonly number[];
+  /**
+   * The instant to resolve date-scoped denies against (#385) — a date-scoped
+   * `deny` is rendered only while its `effective_from`/`effective_to` range
+   * covers this instant. Defaults to now. Always-on and pure recurring denies
+   * ignore it. Injected so the resolution is deterministic in tests and so the
+   * eventual re-push loop can re-evaluate the active set at the date boundary.
+   */
+  at?: Date;
 }
 
 /**
@@ -138,21 +154,34 @@ function isAlwaysOn(rule: ScheduleRule): boolean {
   );
 }
 
-/**
- * A schedule is a *recurring window* (#216) when it carries at least one
- * recurrence field (weekday mask and/or intra-day window) **and** is not
- * date-scoped (`effective_from`/`effective_to` both null). e2guardian's `#time:`
- * grammar expresses weekday + time-of-day but not calendar date ranges, so
- * date-scoped denies are deliberately excluded and ride with the date-scoped
- * resolver work (#142).
- */
-function isRecurringWindow(rule: ScheduleRule): boolean {
-  if (rule.effectiveFrom !== null || rule.effectiveTo !== null) return false;
+/** Does the rule carry any recurrence field (weekday mask and/or intra-day window)? */
+function hasRecurrence(rule: ScheduleRule): boolean {
   return (
     rule.recurrenceDays !== null ||
     rule.recurrenceStartMinute !== null ||
     rule.recurrenceEndMinute !== null
   );
+}
+
+/** Is the rule date-scoped — does it carry an `effective_from`/`effective_to` bound? */
+function isDateScoped(rule: ScheduleRule): boolean {
+  return rule.effectiveFrom !== null || rule.effectiveTo !== null;
+}
+
+/**
+ * A schedule is a *recurring window* (#216) when it carries at least one
+ * recurrence field (weekday mask and/or intra-day window) **and** is not
+ * date-scoped (`effective_from`/`effective_to` both null). Such a window is
+ * emitted unconditionally — e2guardian evaluates the weekday/time-of-day
+ * constraint itself via a `#time:` tag.
+ *
+ * A rule that is *both* recurring **and** date-scoped is handled separately
+ * (#385): its `#time:` window is emitted only while the calendar range is
+ * active (see {@link resolveWindowedDenies}), because e2guardian's `#time:`
+ * grammar expresses weekday + time-of-day but not a calendar date range.
+ */
+function isRecurringWindow(rule: ScheduleRule): boolean {
+  return !isDateScoped(rule) && hasRecurrence(rule);
 }
 
 /**
@@ -226,32 +255,69 @@ function domainsForRule(db: PolicyDb, rule: ScheduleRule): string[] {
 }
 
 /**
- * Collect the domains a single user *always-on* denies, deduplicated and sorted.
- * Reads the user's effective schedules — own rules plus inherited group denies
- * (#362) — via {@link gatherUserScheduleRules}.
+ * Should this deny contribute to the *static* banned-site list at instant `at`?
+ * Two shapes belong in the always-blocking list:
+ *
+ * - an **always-on** deny (no recurrence, no date scope), and
+ * - a **date-scoped, non-recurring** deny (a plain calendar range) whose range
+ *   covers `at` (#385) — active continuously while in range, so it blocks like
+ *   an always-on deny until the range closes and the next re-push drops it.
+ *
+ * A date-scoped deny that *also* carries a recurrence window is a windowed
+ * deny, not a static one — see {@link resolveWindowedDenies}.
  */
-function resolveBannedSites(db: PolicyDb, userId: number): string[] {
+function isActiveStaticDeny(rule: ScheduleRule, at: Date): boolean {
+  if (isAlwaysOn(rule)) return true;
+  return isDateScoped(rule) && !hasRecurrence(rule) && withinEffectiveDateRange(rule, at);
+}
+
+/**
+ * Collect the domains a single user statically denies at instant `at`,
+ * deduplicated and sorted — always-on denies plus any date-scoped,
+ * non-recurring deny whose calendar range is active (#385). Reads the user's
+ * effective schedules — own rules plus inherited group denies (#362) — via
+ * {@link gatherUserScheduleRules}.
+ */
+function resolveBannedSites(db: PolicyDb, userId: number, at: Date): string[] {
   const sites = new Set<string>();
   for (const rule of gatherUserScheduleRules(db, userId)) {
-    if (rule.action !== "deny" || !isAlwaysOn(rule)) continue;
+    if (rule.action !== "deny" || !isActiveStaticDeny(rule, at)) continue;
     for (const domain of domainsForRule(db, rule)) sites.add(domain);
   }
   return [...sites].sort();
 }
 
 /**
- * Collect a single user's recurring time-window domain denies (#216), grouped by
+ * Should this deny contribute a `#time:` window at instant `at`? Two shapes:
+ *
+ * - a **recurring, non-date-scoped** window (#216) — emitted unconditionally;
+ *   e2guardian evaluates the weekday/time-of-day constraint itself, and
+ * - a **date-scoped recurring** window (#385) — emitted only while the calendar
+ *   range covers `at`, since e2guardian's `#time:` grammar cannot express the
+ *   date range; the dashboard's re-push gates it and the daemon evaluates the
+ *   intra-day/weekday part.
+ */
+function isActiveWindowedDeny(rule: ScheduleRule, at: Date): boolean {
+  if (isRecurringWindow(rule)) return true;
+  return isDateScoped(rule) && hasRecurrence(rule) && withinEffectiveDateRange(rule, at);
+}
+
+/**
+ * Collect a single user's time-window domain denies at instant `at`, grouped by
  * their e2guardian `#time:` tag so denies sharing an identical window collapse to
- * one list. Sites within a window are deduplicated and sorted; windows are sorted
- * by tag — so re-running against unchanged policy yields an identical plan and
- * the playbook stays idempotent. Reads effective schedules via
+ * one list. Includes recurring windows (#216) and any date-scoped recurring
+ * window whose calendar range is active (#385) — a date-scoped-recurring deny
+ * whose window matches an existing tag simply joins that list. Sites within a
+ * window are deduplicated and sorted; windows are sorted by tag — so re-running
+ * against unchanged policy at the same instant yields an identical plan and the
+ * playbook stays idempotent. Reads effective schedules via
  * {@link gatherUserScheduleRules}, so inherited group recurring denies are
  * honoured too (the recurring half of #362's group-deny deferral).
  */
-function resolveWindowedDenies(db: PolicyDb, userId: number): E2guardianWindow[] {
+function resolveWindowedDenies(db: PolicyDb, userId: number, at: Date): E2guardianWindow[] {
   const sitesByTag = new Map<string, Set<string>>();
   for (const rule of gatherUserScheduleRules(db, userId)) {
-    if (rule.action !== "deny" || !isRecurringWindow(rule)) continue;
+    if (rule.action !== "deny" || !isActiveWindowedDeny(rule, at)) continue;
     const domains = domainsForRule(db, rule);
     if (domains.length === 0) continue;
     const tag = e2guardianTimeTag(
@@ -271,13 +337,18 @@ function resolveWindowedDenies(db: PolicyDb, userId: number): E2guardianWindow[]
 /**
  * Build the e2guardian filter plan for a client from the policy store.
  *
- * Every supervised user linked to the client that has at least one always-on
- * domain deny **or** a recurring window deny (#216) gets a managed filter group;
- * users with nothing to block are omitted entirely (their traffic stays on the
- * permissive baseline, so we add neither a group nor an iptables redirect for
- * them). A windowed-only user still gets a group + redirect: outside the window
- * their list is inactive, so nothing is blocked — which is the intended
- * behaviour. Group numbers and listen ports are assigned deterministically in
+ * Every supervised user linked to the client with at least one deny active at
+ * `options.at` (default now) — always-on, a recurring window (#216), or a
+ * date-scoped calendar range (#385) — gets a managed filter group; users with
+ * nothing to block *at that instant* are omitted entirely (their traffic stays
+ * on the permissive baseline, so we add neither a group nor an iptables
+ * redirect for them). A windowed-only user still gets a group + redirect:
+ * outside the window their list is inactive, so nothing is blocked — which is
+ * the intended behaviour. Because a date-scoped deny is resolved against `at`,
+ * the plan is a snapshot for that instant; a periodic re-push re-evaluates the
+ * active set as calendar ranges open and close (config-file + reload — the #216
+ * mechanism decision, `docs/architecture.md` → "Enforcement responsibilities").
+ * Group numbers and listen ports are assigned deterministically in
  * `listClientLinks` order (ascending user id), so re-running against unchanged
  * policy produces an identical plan — the playbook is idempotent.
  *
@@ -294,11 +365,12 @@ export function buildE2guardianPlan(
 ): E2guardianPlan {
   const proxyPort = options.proxyPort ?? DEFAULT_PROXY_PORT;
   const redirectPorts = [...(options.redirectPorts ?? DEFAULT_REDIRECT_PORTS)];
+  const at = options.at ?? new Date();
 
   const users: E2guardianUserFilter[] = [];
   for (const link of listClientLinks(db, clientId)) {
-    const bannedSites = resolveBannedSites(db, link.userId);
-    const windows = resolveWindowedDenies(db, link.userId);
+    const bannedSites = resolveBannedSites(db, link.userId, at);
+    const windows = resolveWindowedDenies(db, link.userId, at);
     if (bannedSites.length === 0 && windows.length === 0) continue;
     const index = users.length;
     users.push({

--- a/server/tests/policy/resolve.test.ts
+++ b/server/tests/policy/resolve.test.ts
@@ -14,6 +14,7 @@ import {
   overallDailySecondsForWeekday,
   ruleActiveAt,
   selectBudgetsForWeekday,
+  withinEffectiveDateRange,
   type BudgetInput,
   type EffectivePolicyInput,
   type ExceptionInput,
@@ -71,6 +72,37 @@ function mkInput(overrides: Partial<EffectivePolicyInput> = {}): EffectivePolicy
     ...overrides,
   };
 }
+
+describe("withinEffectiveDateRange — the date gate alone", () => {
+  const at = new Date("2024-06-03T12:00:00Z");
+
+  it("an unscoped rule (both bounds null) is always in range", () => {
+    expect(withinEffectiveDateRange(mkRule(), at)).toBe(true);
+  });
+
+  it("is false before effective_from and true at/after it (inclusive lower bound)", () => {
+    const rule = mkRule({ effectiveFrom: at });
+    expect(withinEffectiveDateRange(rule, new Date(at.getTime() - 1))).toBe(false);
+    expect(withinEffectiveDateRange(rule, at)).toBe(true);
+  });
+
+  it("treats effective_to as an exclusive upper bound", () => {
+    const rule = mkRule({ effectiveTo: at });
+    expect(withinEffectiveDateRange(rule, new Date(at.getTime() - 1))).toBe(true);
+    expect(withinEffectiveDateRange(rule, at)).toBe(false);
+  });
+
+  it("ignores recurrence fields — it gates only on the calendar range", () => {
+    // A recurring window whose weekday/time would not match `at` is still
+    // within the (open) date range: the recurrence gate is a separate concern.
+    const rule = mkRule({
+      recurrenceDays: MONDAY,
+      recurrenceStartMinute: 0,
+      recurrenceEndMinute: 1,
+    });
+    expect(withinEffectiveDateRange(rule, at)).toBe(true);
+  });
+});
 
 describe("isRuleActiveAt — date gate", () => {
   const at = new Date("2024-06-03T12:00:00Z");

--- a/server/tests/transport/ansible/e2guardian.test.ts
+++ b/server/tests/transport/ansible/e2guardian.test.ts
@@ -111,7 +111,7 @@ describe("buildE2guardianPlan", () => {
     db.$client.close();
   });
 
-  it("ignores allow/extend rules and date-scoped denies (no static or windowed filter)", () => {
+  it("ignores allow/extend rules and out-of-range date-scoped denies (no static or windowed filter)", () => {
     const db = testDb();
     const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
     const alice = addLinkedUser(db, clientId, "Alice", "alice", 1001);
@@ -125,8 +125,9 @@ describe("buildE2guardianPlan", () => {
       targetId: tiktok.id,
       action: "allow",
     });
-    // deny but date-scoped → e2guardian's #time: can't express a calendar range,
-    // so it is neither always-on nor a windowed deny here (deferred to #142).
+    // A date-scoped deny whose calendar range has not opened yet: resolved
+    // against an instant before `effective_from`, so it is inactive and renders
+    // no filter (#385). The active case is covered below.
     createSchedule(db, {
       userId: alice,
       targetKind: "activity",
@@ -135,8 +136,69 @@ describe("buildE2guardianPlan", () => {
       effectiveFrom: new Date("2026-01-01T00:00:00Z"),
     });
 
-    const plan = buildE2guardianPlan(db, clientId);
+    const plan = buildE2guardianPlan(db, clientId, { at: new Date("2025-12-01T00:00:00Z") });
     expect(plan.users).toEqual([]);
+    db.$client.close();
+  });
+
+  it("renders a date-scoped non-recurring deny as a static banned site while active (#385)", () => {
+    const db = testDb();
+    const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+    const alice = addLinkedUser(db, clientId, "Alice", "alice", 1001);
+    const social = createActivity(db, { kind: "domain", matcher: "social.example" });
+    // "No social media until 2026-09-01" — a plain calendar range, no recurrence.
+    createSchedule(db, {
+      userId: alice,
+      targetKind: "activity",
+      targetId: social.id,
+      action: "deny",
+      effectiveTo: new Date("2026-09-01T00:00:00Z"),
+    });
+
+    const plan = buildE2guardianPlan(db, clientId, { at: new Date("2026-06-15T12:00:00Z") });
+    expect(plan.users[0]?.bannedSites).toEqual(["social.example"]);
+    expect(plan.users[0]?.windows).toEqual([]);
+    db.$client.close();
+  });
+
+  it("skips a date-scoped non-recurring deny before its range opens (#385)", () => {
+    const db = testDb();
+    const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+    const alice = addLinkedUser(db, clientId, "Alice", "alice", 1001);
+    const social = createActivity(db, { kind: "domain", matcher: "social.example" });
+    createSchedule(db, {
+      userId: alice,
+      targetKind: "activity",
+      targetId: social.id,
+      action: "deny",
+      effectiveFrom: new Date("2026-09-01T00:00:00Z"),
+    });
+
+    // `at` before effective_from → not yet active.
+    const plan = buildE2guardianPlan(db, clientId, { at: new Date("2026-06-15T12:00:00Z") });
+    expect(plan.users).toEqual([]);
+    db.$client.close();
+  });
+
+  it("treats effective_to as exclusive — a deny is inactive exactly at its end instant (#385)", () => {
+    const db = testDb();
+    const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+    const alice = addLinkedUser(db, clientId, "Alice", "alice", 1001);
+    const social = createActivity(db, { kind: "domain", matcher: "social.example" });
+    const end = new Date("2026-09-01T00:00:00Z");
+    createSchedule(db, {
+      userId: alice,
+      targetKind: "activity",
+      targetId: social.id,
+      action: "deny",
+      effectiveTo: end,
+    });
+
+    // Gate is [from, to): at === effective_to is already outside the range.
+    expect(buildE2guardianPlan(db, clientId, { at: end }).users).toEqual([]);
+    // One millisecond earlier is still inside.
+    const justBefore = buildE2guardianPlan(db, clientId, { at: new Date(end.getTime() - 1) });
+    expect(justBefore.users[0]?.bannedSites).toEqual(["social.example"]);
     db.$client.close();
   });
 
@@ -484,12 +546,14 @@ describe("buildE2guardianPlan — recurring time-window denies (#216)", () => {
     db.$client.close();
   });
 
-  it("skips a date-scoped recurring deny (deferred to #142)", () => {
+  it("renders a date-scoped recurring deny as a #time: window while its range is active (#385)", () => {
     const db = testDb();
     const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
     const alice = addLinkedUser(db, clientId, "Alice", "alice", 1001);
     const reddit = createActivity(db, { kind: "domain", matcher: "reddit.com" });
-    // Recurrence set AND date-scoped → excluded (e2guardian #time: can't express a date range).
+    // Recurrence set AND date-scoped: e2guardian's #time: expresses the weekday/
+    // time-of-day part, and the dashboard gates the calendar range by rendering
+    // the window only while `at` is inside [effective_from, effective_to).
     createSchedule(db, {
       userId: alice,
       targetKind: "activity",
@@ -499,9 +563,73 @@ describe("buildE2guardianPlan — recurring time-window denies (#216)", () => {
       recurrenceStartMinute: 16 * 60,
       recurrenceEndMinute: 18 * 60,
       effectiveFrom: new Date("2026-01-01T00:00:00Z"),
+      effectiveTo: new Date("2026-12-31T00:00:00Z"),
     });
 
-    expect(buildE2guardianPlan(db, clientId).users).toEqual([]);
+    const active = buildE2guardianPlan(db, clientId, { at: new Date("2026-06-15T12:00:00Z") });
+    expect(active.users[0]?.windows).toEqual([
+      { timeTag: "16 0 18 0 12345", sites: ["reddit.com"] },
+    ]);
+    expect(active.users[0]?.bannedSites).toEqual([]);
+    db.$client.close();
+  });
+
+  it("skips a date-scoped recurring deny once its range has closed (#385)", () => {
+    const db = testDb();
+    const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+    const alice = addLinkedUser(db, clientId, "Alice", "alice", 1001);
+    const reddit = createActivity(db, { kind: "domain", matcher: "reddit.com" });
+    createSchedule(db, {
+      userId: alice,
+      targetKind: "activity",
+      targetId: reddit.id,
+      action: "deny",
+      recurrenceDays: 0b0011111,
+      recurrenceStartMinute: 16 * 60,
+      recurrenceEndMinute: 18 * 60,
+      effectiveFrom: new Date("2026-01-01T00:00:00Z"),
+      effectiveTo: new Date("2026-12-31T00:00:00Z"),
+    });
+
+    // `at` at/after effective_to → the range is closed (gate is [from, to)).
+    const closed = buildE2guardianPlan(db, clientId, { at: new Date("2027-01-01T00:00:00Z") });
+    expect(closed.users).toEqual([]);
+    db.$client.close();
+  });
+
+  it("collapses a date-scoped recurring deny into an identically-tagged recurring window (#385)", () => {
+    const db = testDb();
+    const clientId = createClient(db, { hostname: "mint-01", sshUser: "pct-agent" }).id;
+    const alice = addLinkedUser(db, clientId, "Alice", "alice", 1001);
+    const reddit = createActivity(db, { kind: "domain", matcher: "reddit.com" });
+    const tumblr = createActivity(db, { kind: "domain", matcher: "tumblr.com" });
+    // A plain recurring deny (always emitted) …
+    createSchedule(db, {
+      userId: alice,
+      targetKind: "activity",
+      targetId: reddit.id,
+      action: "deny",
+      recurrenceDays: 0b0011111,
+      recurrenceStartMinute: 16 * 60,
+      recurrenceEndMinute: 18 * 60,
+    });
+    // … and a date-scoped recurring deny sharing the same #time: tag, active now.
+    createSchedule(db, {
+      userId: alice,
+      targetKind: "activity",
+      targetId: tumblr.id,
+      action: "deny",
+      recurrenceDays: 0b0011111,
+      recurrenceStartMinute: 16 * 60,
+      recurrenceEndMinute: 18 * 60,
+      effectiveFrom: new Date("2026-01-01T00:00:00Z"),
+      effectiveTo: new Date("2026-12-31T00:00:00Z"),
+    });
+
+    const plan = buildE2guardianPlan(db, clientId, { at: new Date("2026-06-15T12:00:00Z") });
+    expect(plan.users[0]?.windows).toEqual([
+      { timeTag: "16 0 18 0 12345", sites: ["reddit.com", "tumblr.com"] },
+    ]);
     db.$client.close();
   });
 


### PR DESCRIPTION
## Summary

- Close the **third `deny` shape** in `buildE2guardianPlan`: date-scoped (`effective_from`/`effective_to`) domain denies — the case #216 deferred because e2guardian's native `#time:` grammar expresses weekday + time-of-day but not a calendar date range. A date-scoped, non-recurring deny renders as a **static banned site** while its range is active; a date-scoped *recurring* deny renders as its **`#time:` window** while its range is active (the daemon still evaluates the intra-day/weekday part).
- Resolution is against an **injected instant** (`options.at`, default now), so the plan is a snapshot for that instant and a periodic re-push re-evaluates the active set at the date boundary — keeping enforcement *config-file + reload*, no client-side scheduler (the #216 mechanism decision).
- Extract the ADR-0005 date gate as `withinEffectiveDateRange` in the resolver and reuse it in both `isRuleActiveAt` (behaviour unchanged) and the e2guardian renderer — one source of truth for the calendar-range semantics.

## Plan

Linked plan: `docs/plans/385-e2guardian-date-scoped-denies.md`
Roadmap: `docs/roadmap.md` → Phase 13. Depends on #142 (date-scoped resolver, merged PR #398) and extends #216 (recurring `#time:` windows).

## Docs

Updated `docs/architecture.md` → "Enforcement responsibilities": the paragraph that deferred date-scoped e2guardian denies to #142 now describes the resolve-against-push-instant + periodic-re-push mechanism.

## License-boundary note

None. Pure TypeScript + Drizzle reads. e2guardian stays configured **only** by writing config files and signalling a reload, driven by `ansible-playbook` as a subprocess — no linkage, import, or vendoring (`CLAUDE.md` → "License boundaries" 3 & 6). No GPL binary added to the image; no transport/packaging change.

## Test plan

- [x] date-scoped **non-recurring** deny: active-in-range → static banned site; before `effective_from` → skipped; at/after `effective_to` → skipped (exclusive upper bound, with a one-ms boundary check); open-ended bounds.
- [x] date-scoped **recurring** deny: in-range → `#time:` window (no static entry); out-of-range → skipped; collapses with an identically-tagged pure-recurring window.
- [x] allow/extend rules and out-of-range date-scoped denies still render nothing (updated the two tests that previously asserted the unconditional skip — behaviour intentionally changes, not weakened; both re-express the correct new behaviour with an injected, non-time-bomb `at`).
- [x] resolver: direct `withinEffectiveDateRange` unit tests; `isRuleActiveAt` date/recurrence gates unchanged.
- [x] Full gate green: `format:check`, `lint`, `typecheck`, `npm test` — **1986 passing**, overall coverage 98.91% (resolve.ts 99.15%, e2guardian.ts 100% lines).

## Deferred (tracked → #433)

The **periodic re-push cadence** that flips a date-scoped deny on/off as its range opens/closes is out of scope: it rides on the e2guardian push boot-wiring, which is itself still deferred (`pushE2guardianFiltering` has no production caller; `transport/reapply` re-runs playbook files but does not rebuild plans from policy). This PR makes the pure `buildE2guardianPlan` seam correct for any injected instant; #433 tracks wiring the re-push loop.

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QX9dBXuptYRg2r7AVR8Q87)_