### PR TITLE
docs(adr): pause-on-lock model & authority — ADR 0015 (#314)

### DIFF
--- a/docs/adr/0015-pause-on-lock.md
+++ b/docs/adr/0015-pause-on-lock.md
@@ -60,10 +60,14 @@ respect rather than assume away:
   `server/src/events/protocol.ts`, and after `accept` processes only WebSocket
   `pong` heartbeats. Server→client frames are a zod discriminated union on
   `type` (`server/src/events/taxonomy.ts`: `grant.applied`, `policy.changed`,
-  `enforce.force_close`, `enforce.session_lock`, `lockout.cleared`), each gated
-  by an exhaustive `capabilityForEvent` switch (`server/src/events/
-  capabilities.ts`, advertised set `CLIENT_CAPABILITIES`). A client-reported
-  lock is a **new frame in a new direction**.
+  `enforce.force_close`, `enforce.session_lock`, `lockout.cleared`), routed
+  through an exhaustive `capabilityForEvent` switch (`server/src/events/
+  capabilities.ts`) that gates them **where applicable** — the `enforce.*`
+  frames are capability-gated, while `grant.applied` / `policy.changed` are
+  baseline (return `null`). `CLIENT_CAPABILITIES` is the server-side
+  vocabulary of gate-able capability strings; a client advertises its own
+  subset in the `hello`. A client-reported lock is a **new frame in a new
+  direction**.
 - **The force-close trigger has no cancel handle.** `ForceCloseTrigger.enforce`
   (`server/src/enforcement/force-close.ts`) schedules a kill after
   `graceSeconds` and de-dups via a `#pending` set that is cleared *only when the
@@ -186,14 +190,26 @@ means:
   these frame types (`socket.on`, not just the one-shot `hello`), validating
   each and rejecting unknown/malformed inbound frames without tearing down the
   stream.
-- A new capability string (e.g. **`pause_on_lock`**) added to
+- A new capability string — **`session_state`** — added to
   `CLIENT_CAPABILITIES` (`server/src/events/capabilities.ts`). Advertising it in
-  the `hello` tells the server both that the client *will report* lock/unlock
-  and that pause semantics apply to it.
+  the `hello` tells the server the client *will report* session lock/unlock.
+  (This is the **wire capability**, deliberately named apart from the per-user
+  `pause_on_lock` **policy knob** of decision 6 — the capability says "this
+  client can report locks"; the knob says "this user's locks should pause the
+  budget". Distinct surfaces, distinct names, so #316 and the schema work in
+  #317 don't conflate them.)
 
 Per [ADR 0007 §4](0007-event-stream-version-compatibility.md) this is
-**additive**: a new capability-gated frame is not a breaking change and **does
-not bump `eventProtocol`**. The "upgrade the server first" rule
+**additive**: it costs no `eventProtocol` bump. One extension beyond §4 is
+explicit here: §4's capability *gate* is defined for **outbound** frames (the
+server withholds a server→client frame type a client didn't advertise). This
+ADR **extends the same capability concept to authorize a new inbound
+(client→server) frame** — the `session_state` capability tells the server to
+*accept and act on* `session.*` frames from that client. The additive /
+no-bump conclusion still holds by §1/§4 (a new capability + a frame in a schema
+separate from `serverEventSchema` is not an envelope break); #316 should not
+expect the existing outbound `capabilityForEvent` gate to cover the inbound
+path. The "upgrade the server first" rule
 ([ADR 0007 §3](0007-event-stream-version-compatibility.md)) guarantees the
 server understands the inbound frame before any client is capable of sending it;
 an un-upgraded client simply never advertises the capability and never sends it.
@@ -215,9 +231,11 @@ device sleep), the open interval is closed out by the first of:
 
 - **`max_pause_minutes`** (decision 6) — the server auto-closes an open interval
   at `lockedAt + max_pause_minutes`.
-- **Bridge disconnect** — the stream's existing disconnect handling finalises
-  the client's open pause intervals (closed at last-seen), since a dropped
-  bridge means the lock can no longer be trusted to still hold.
+- **Bridge disconnect** — the pause ledger (#317) hooks into the stream's
+  existing disconnect handling (`stream.ts` `socket.on("close")`, which today
+  only unregisters + touches `last_seen`) to finalise the client's open pause
+  intervals (closed at last-seen), since a dropped bridge means the lock can no
+  longer be trusted to still hold.
 - **Reconcile on reconnect** — a fresh `hello` with no corresponding open lock
   closes any stale open interval at last-seen.
 

--- a/docs/adr/0015-pause-on-lock.md
+++ b/docs/adr/0015-pause-on-lock.md
@@ -1,0 +1,344 @@
+# ADR 0015 — Pause-on-lock: model & authority
+
+- **Status:** Accepted (2026-08-24) — decision only; implementation lands across
+  the sibling sub-issues of the epic.
+- **Issue:** [#314](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/314)
+  (epic [#313](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/313))
+- **Phase:** 8b (client agent + event stream), with one Phase-4 Timekpr piece
+  ([#318](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/318))
+  and one Phase-9 UI piece
+  ([#320](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/320)).
+
+## Context
+
+The pause-on-lock epic ([#313](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/313))
+gives the supervised user a **one-step "I'm taking a break" lever**: locking the
+screen pauses their screen-time budget, unlocking resumes it. Kids want every
+granted minute, and a deliberate lock is the discoverable, no-UI way to stop the
+clock.
+
+This has to be settled **before** any of the sibling sub-issues are coded,
+because the forks below shape three different surfaces at once — the policy
+schema, the event-stream wire protocol, and *which component owns the "paused"
+authority*. Getting the authority question wrong means either two components
+fighting over the same clock, or a signal that arrives too late to matter.
+
+### What is already true (and why pause-on-lock is not just AFK)
+
+Per-activity budgets are **already AFK-aware**. The ActivityWatch normaliser
+clips credited time to `aw-watcher-afk`'s `not-afk` intervals
+(`server/src/transport/activitywatch/normalise.ts` — `normaliseWindowEvents`,
+with `notAfkIntervals` / `intersectWithAllowed`), and the rollups only sum the
+stored, already-clipped samples (`server/src/policy/usage.ts` —
+`overlapSeconds`, `usageByActivityInWindow`). Idle/away time is therefore
+already not charged on the per-activity path.
+
+So the genuinely *new* value of pause-on-lock is twofold, exactly as the epic
+frames it:
+
+1. **Immediacy.** AFK detection only trips after `aw-watcher-afk`'s idle timeout
+   (~180 s of no input). A deliberate lock should pause the clock **now**.
+2. **The overall clock.** AFK clipping governs the per-activity AW path only. The
+   **overall daily/weekly/monthly screen-time budget is Timekpr-nExT's** at the
+   logind level (see [ADR 0010](0010-per-activity-enforcement-mechanism.md) —
+   "overall session limits remain Timekpr-enforced locally"), and it keeps
+   counting an unlocked-but-idle session until Timekpr's own idle handling
+   trips. Pausing the overall clock is a *different mechanism* from the AW clip.
+
+### What the code does **not** have yet (constraints on the decision)
+
+A survey of the relevant modules turned up three gaps the decisions below must
+respect rather than assume away:
+
+- **No lock signal source exists in the AW pipeline.** Only two watchers feed
+  the normaliser — `currentwindow` and `afkstatus`
+  (`server/src/transport/activitywatch/schemas.ts`). There is no "screen
+  locked" event today; the lock has to arrive by a new path.
+- **The event stream has no post-handshake client→server application frame
+  path.** `server/src/events/stream.ts` reads exactly one inbound frame — the
+  `hello` (`socket.once("message", …)`) — negotiates it via
+  `server/src/events/protocol.ts`, and after `accept` processes only WebSocket
+  `pong` heartbeats. Server→client frames are a zod discriminated union on
+  `type` (`server/src/events/taxonomy.ts`: `grant.applied`, `policy.changed`,
+  `enforce.force_close`, `enforce.session_lock`, `lockout.cleared`), each gated
+  by an exhaustive `capabilityForEvent` switch (`server/src/events/
+  capabilities.ts`, advertised set `CLIENT_CAPABILITIES`). A client-reported
+  lock is a **new frame in a new direction**.
+- **The force-close trigger has no cancel handle.** `ForceCloseTrigger.enforce`
+  (`server/src/enforcement/force-close.ts`) schedules a kill after
+  `graceSeconds` and de-dups via a `#pending` set that is cleared *only when the
+  timer fires*; `schedule` returns `void`, so a pending grace force-close cannot
+  currently be aborted or suspended. (This same gap is already noted by
+  [#292](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/292)
+  Part 2, which needs a cancel handle to abort a force-close when a grant tops
+  the budget back up.)
+- **No Timekpr "pause the clock" lever is wrapped.** `server/src/transport/
+  timekpr/commands.ts` wraps `--setalloweddays`, `--setallowedhours`,
+  `--settimelimits`/`week`/`month`, `--settimeleft (+|-|=)` (the #257 same-day
+  adjustment), the `--setplaytime*` family, and `--userinfo`. There is **no**
+  `--settrackinactive` / idle / pause / `--kill-session` wrapper. The closest
+  existing overall-clock lever is the ephemeral `--settimeleft`.
+
+### Scope boundaries carried from the epic and `CLAUDE.md`
+
+- **Detection is observational only** — logind / screensaver session signals via
+  the desktop's own tooling (D-Bus / `gdbus`) as subprocesses in
+  `pct-client-agent`. **No anti-tamper hooks, no kernel/eBPF, no `/etc`
+  lockdown.** A child who locks to "bank" time is simply not using the device —
+  the intended outcome, under the documented tamper-resistance ceiling
+  (`CLAUDE.md` → "Tamper resistance is deliberately bounded").
+- **License boundary unchanged** — Timekpr driven only as a `timekpra`
+  subprocess over SSH; ActivityWatch only over REST; no GPL linkage; no new
+  binaries in the image.
+
+## Decisions
+
+### 1. Overall-clock authority → Timekpr-native; the server never runs a second overall clock
+
+The overall budget is Timekpr's at logind level, and this ADR keeps it that way.
+Pausing it on lock is realised through **Timekpr-nExT's own inactivity
+handling** — a new thin `--settrackinactive <user> false` command builder
+(the work of [#318](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/318),
+alongside the existing wrappers in `server/src/transport/timekpr/commands.ts`),
+pushed for users who have `pause_on_lock` enabled — so logind-level idle/locked
+time stops accruing against the overall budget at the source that owns the
+clock.
+
+The explicit `session.locked` signal (decision 3) is deliberately **not** used
+to drive the overall Timekpr clock per-event:
+
+- There is no clean per-event Timekpr "pause now / resume now" primitive to
+  drive (see Context); the only per-event overall lever is `--settimeleft`,
+  which is a *refund*, not a freeze.
+- A server-maintained overall clock that subtracts paused spans and re-pushes
+  the residual would **duplicate and fight** the authority
+  [ADR 0010](0010-per-activity-enforcement-mechanism.md) assigns to Timekpr, and
+  would have to reconcile with grants, the resolver, and Timekpr's own count on
+  every pause — more surface, more ways to disagree, no capability gain.
+
+**Consequence, stated honestly:** the overall-clock pause is only as immediate
+and as lock-specific as Timekpr's inactivity detection allows (a locked session
+that logind still reports as *active* may keep counting until Timekpr's idle
+timeout trips). That granularity is accepted. The product's *immediacy* promise
+is delivered where it is both cheap and exact — on the per-activity path
+(decision 2) and in the UX freeze (decision 5) — not by inventing a rival
+overall clock.
+
+**Recorded fallback (not adopted now):** if a deliberate-lock, explicit-signal-
+driven overall pause later proves necessary, the natural backstop is a
+`--settimeleft (+)` refund of the paused span on resume — the same additive
+nudge grants already make to the overall budget, bounded and idempotent by the
+pause ledger (decision 4). Adopting it would require updating this ADR and
+defining how the refund reconciles with Timekpr's own count and with grants,
+rather than silently running both.
+
+### 2. Per-activity authority → authoritative server-side exclusion via the pause ledger, with AFK as defense-in-depth
+
+The server records each explicit lock as a **pause interval**
+`[lockedAt, unlockedAt]` in a pause ledger (the work of
+[#317](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/317)),
+and per-activity consumption **excludes** the overlap of those intervals —
+deterministically and immediately, without waiting for AFK's ~180 s timeout.
+
+- **Authority:** the pause ledger is authoritative for "was this span a
+  deliberate break?"; paused spans are **never charged** to per-activity /
+  per-group budgets.
+- **Seam (preference, left to #317):** exclusion is best applied at the **same
+  clip point the normaliser already uses for AFK** — pass the closed, known
+  pause spans in as additional *deny* intervals subtracted from the not-afk
+  allow-set, so stored `usage_samples` are already pause-clipped and
+  `server/src/policy/usage.ts` stays a pure sum with no new exclusion concept.
+  Where a pause is still open at telemetry-pull time, clip up to "now" and let
+  the next pull finish the span once it closes. The alternative — subtracting
+  paused overlap in the rollup readers at query time — is available if
+  late-closing spans make normalise-time clipping lossy; #317 picks the seam,
+  this ADR fixes the *semantics*.
+- **Defense-in-depth:** the existing AFK clip stays exactly as-is. If the
+  explicit lock/unlock signal is ever lost, AFK still prevents over-charging the
+  idle span — the pause ledger sharpens immediacy; it does not replace the AFK
+  safety net.
+
+### 3. Signal direction & shape → new capability-gated client→server frames
+
+Define **`session.locked` / `session.unlocked`** as the client→server frames
+(matching sub-issue
+[#316](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/316)),
+carrying:
+
+- `userId` — the supervised `User` the lock belongs to.
+- `at` — ISO-8601 UTC instant of the lock/unlock, per the project's
+  UTC-internal convention ([ADR 0001](0001-budget-timezone.md)).
+- `sessionId` — the local logind session id, so a multi-session box (fast user
+  switching, multiple seats) can attribute and pair lock/unlock correctly.
+- `lockId` — a client-generated id stable across the matching lock→unlock pair,
+  the idempotency key for decision 4.
+
+These are the **first post-handshake client→server application frames** on the
+stream — a mild, deliberate expansion that `docs/client-notifications.md`
+already anticipated ("WebSocket is chosen over SSE because the channel must also
+carry client→server liveness pings and acknowledgements"). Concretely this
+means:
+
+- A new inbound zod schema (a small discriminated union, **separate** from the
+  server→client `serverEventSchema`) in `server/src/events/`, with the inferred
+  type shared with the bridge — the established DTO pattern.
+- New inbound handling in `server/src/events/stream.ts`: after `accept`, read
+  these frame types (`socket.on`, not just the one-shot `hello`), validating
+  each and rejecting unknown/malformed inbound frames without tearing down the
+  stream.
+- A new capability string (e.g. **`pause_on_lock`**) added to
+  `CLIENT_CAPABILITIES` (`server/src/events/capabilities.ts`). Advertising it in
+  the `hello` tells the server both that the client *will report* lock/unlock
+  and that pause semantics apply to it.
+
+Per [ADR 0007 §4](0007-event-stream-version-compatibility.md) this is
+**additive**: a new capability-gated frame is not a breaking change and **does
+not bump `eventProtocol`**. The "upgrade the server first" rule
+([ADR 0007 §3](0007-event-stream-version-compatibility.md)) guarantees the
+server understands the inbound frame before any client is capable of sending it;
+an un-upgraded client simply never advertises the capability and never sends it.
+
+> **Naming note.** These inbound `session.*` frames (voluntary, client→server)
+> are distinct from the existing **outbound** `enforce.session_lock`
+> (involuntary budget-exhaustion lock, server→client). Different direction,
+> different namespace, different meaning — keep them from being conflated.
+
+### 4. Reconciliation & safety bounds
+
+A pause interval is opened by `session.locked` and closed by the matching
+`session.unlocked`, **idempotent** on `(userId, clientId, sessionId, lockId)`
+— a duplicate `session.locked` (reconnect replay) does not open a second
+interval, and an `unlocked` with no open match is a no-op.
+
+When the `unlocked` never arrives (bridge disconnect mid-pause, agent crash,
+device sleep), the open interval is closed out by the first of:
+
+- **`max_pause_minutes`** (decision 6) — the server auto-closes an open interval
+  at `lockedAt + max_pause_minutes`.
+- **Bridge disconnect** — the stream's existing disconnect handling finalises
+  the client's open pause intervals (closed at last-seen), since a dropped
+  bridge means the lock can no longer be trusted to still hold.
+- **Reconcile on reconnect** — a fresh `hello` with no corresponding open lock
+  closes any stale open interval at last-seen.
+
+Bounds that hold by construction: an interval is never negative and never
+credited beyond `max_pause_minutes`. Because decision 1 keeps the overall clock
+on Timekpr's native handling and decision 2 keeps AFK as the per-activity
+backstop, a lost unlock degrades to "AFK + Timekpr idle bound the over-credit",
+never to an unbounded free pause.
+
+### 5. Interaction with the rest of the system
+
+While a user is paused:
+
+- **Enforcement grace timers** (`server/src/enforcement/force-close.ts`) — a
+  voluntary lock during an active grace countdown **suspends** the countdown and
+  **resumes the remaining grace on unlock**, so an app is never force-closed
+  while the user is deliberately away mid-save. The trigger has no cancel/suspend
+  handle today; this reuses the **same cancel handle
+  [#292](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/292)
+  Part 2 must add** for grant top-ups — the two features converge on one
+  mechanism rather than each bolting on its own. (A lock does *not* cancel the
+  force-close outright: the budget is still exhausted, so on resume the remaining
+  grace runs and, if still over quota, the close fires.)
+- **Warning cadence** (the 15/5/1-minute rules,
+  `DEFAULT_WARNING_MINUTES = [15,10,5,4,3,2,1]` in
+  `server/src/policy/notification.ts`) — the cadence is computed and emitted
+  **client-side** by `pct-client-agent`
+  ([#319](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/319)),
+  which freezes it locally while paused. Server-side there is nothing to freeze:
+  because paused time is not charged (decision 2), remaining time stops
+  decreasing, so the agent's locally-computed countdown naturally holds.
+- **Parent low-time push** (
+  [#65](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/65))
+  — not built yet (doc-only, a Phase-9 `/app` feature). Forward note: when built
+  it must treat a paused budget as *not* "running low" — a break is not an
+  imminent time-out and must not fire a "5 minutes left" push at the parent.
+- **Grants arriving mid-pause** behave normally: a grant is an additive
+  adjustment (`CLAUDE.md` → grants) and is independent of pause. It does **not**
+  auto-resume the session; it simply means more remaining time once the user
+  unlocks.
+- **Coexistence with the involuntary lockout marker** (
+  [#107](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/107)
+  /
+  [#108](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/108))
+  — voluntary pause is the *inverse* of `locked_out`. A pause must **never** set
+  or clear the `locked_out` marker. If a user is already locked out (overall
+  budget exhausted), a voluntary lock is a budget no-op (nothing left to burn),
+  and unlock/`lockout.cleared` semantics are unchanged.
+
+### 6. Policy knob
+
+A per-user **`pause_on_lock` boolean**, **default `true`**, lives on the
+per-user policy-knobs table `notificationPolicies`
+(`server/src/policy/schema.ts`), beside `enabled` / `grace_seconds` /
+`sound_profile` — mirroring the `enabled` master-switch idiom
+(`integer(..., { mode: "boolean" }).notNull().default(...)`), with its default
+single-sourced in `server/src/policy/notification.ts` and a DTO in
+`server/src/api/policy/`. Default-on because it is the intended one-tap "bank my
+time" lever, it is observational-only, and it sits under the tamper ceiling —
+there is no reason to make a household opt in to letting a child *stop* using
+the device.
+
+A companion **`max_pause_minutes`** (nullable integer; `null` = bounded only by
+the daily window + the Timekpr/AFK fallbacks of decisions 1–2 and 4) gives the
+admin an explicit safety cap, with a range `CHECK` when set, defaults/bounds in
+`notification.ts` like `grace_seconds`. A per-policy default for both knobs is
+provided so the admin sets them once rather than per user.
+
+## Consequences
+
+- **One overall clock, one per-activity authority.** Timekpr keeps the overall
+  budget (decision 1, consistent with ADR 0010); the server pause ledger is
+  authoritative for per-activity exclusion and for observability (decision 2).
+  Nothing runs a second copy of a clock another component owns.
+- **The scarce N-1 window is untouched.** Pause-on-lock ships entirely on an
+  additive capability and new capability-gated frames (decision 3), so it costs
+  **zero** `eventProtocol` bumps and does not consume the two-major
+  compatibility window ([ADR 0007](0007-event-stream-version-compatibility.md)).
+- **A shared cancel handle for the force-close trigger.** Decisions 5 and
+  [#292](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/292)
+  now have a single, agreed reason to add a cancel/suspend handle to
+  `ForceCloseTrigger` — it should be built once, to serve both.
+- **Safe failure direction.** Every unreconciled edge (lost unlock, bridge drop,
+  sleep) degrades to *less* pausing, never to an unbounded free pass: Timekpr
+  idle bounds the overall clock, AFK bounds the per-activity path, and
+  `max_pause_minutes` bounds the ledger.
+- **New per-user schema + a new inbound frame direction.** The cost is a
+  `notificationPolicies` migration (two columns) and the stream's first
+  post-handshake client→server handler — both small, both isolated to the sibling
+  sub-issues this ADR unblocks.
+- **Sibling sub-issues are now unambiguous.** #315 (detector) emits `gdbus`
+  logind/screensaver signals; #316 wires the two `session.*` frames + capability;
+  #317 builds the ledger and the per-activity exclusion seam; #318 wraps
+  `--settrackinactive`; #319 freezes the client countdown/cadence; #320 surfaces
+  "paused / on a break".
+
+## Alternatives considered
+
+- **Server-authoritative overall clock (pause ledger subtracts paused spans,
+  re-push the residual to Timekpr).** Rejected: duplicates the logind-level clock
+  Timekpr owns (against ADR 0010), and forces reconciliation with Timekpr's own
+  count and with grants on every pause — maximal surface for the two authorities
+  to disagree, for no capability the Timekpr-native path lacks.
+- **`--settimeleft (+)` refund of the paused span on resume, as the *primary*
+  overall mechanism.** Attractive because it is driven by the explicit signal and
+  uses an already-wrapped lever — but it makes the counter visibly burn down while
+  locked and jump back on unlock, and it needs careful idempotency to avoid
+  double-refunds. Kept as the **recorded fallback** in decision 1 rather than the
+  default, to preserve a single overall-clock authority.
+- **Treat the lock purely as an AFK accelerant (no ledger; feed a synthetic
+  `not-afk`→`afk` edge into the normaliser).** Rejected as the *authority*: it
+  buys immediacy but leaves the exclusion implicit and un-auditable, gives the
+  admin nothing to surface as "paused", and cannot express `max_pause_minutes`.
+  The AFK clip is kept as defense-in-depth (decision 2), not as the mechanism.
+- **A server→client `budget.paused` acknowledgement event.** Considered for
+  symmetry, but the pause is a *client-observed fact*, not a server decision the
+  client must obey. The "paused" UX (decision 5, #320) reads ledger state through
+  the existing `/api/*` surfaces; a dedicated outbound frame would be an
+  additional gated event type for no behaviour the UI can't already poll. Left
+  out; can be added additively later if a live push proves worthwhile.
+- **A boolean on the `users` table instead of `notificationPolicies`.** Rejected:
+  the `users` table is deliberately minimal (id, displayName, tz), and behavioural
+  toggles already live on the per-user `notificationPolicies` row beside
+  `grace_seconds` — the consistent home.

--- a/docs/client-notifications.md
+++ b/docs/client-notifications.md
@@ -317,6 +317,16 @@ of normal policy distribution:
   decided in
   [`docs/adr/0007-event-stream-version-compatibility.md`](adr/0007-event-stream-version-compatibility.md);
   the frame envelope is fixed against that contract.
+- **Pause-on-lock** — a voluntary screen lock pausing the budget (and the
+  first *client→server* application frames on this stream,
+  `session.locked` / `session.unlocked`, the "liveness pings and
+  acknowledgements" this channel was chosen to carry). Its model &
+  authority — how the overall clock and the per-activity path each pause,
+  how the countdown/cadence freeze while paused, and the `pause_on_lock`
+  policy knob — is decided in
+  [`docs/adr/0015-pause-on-lock.md`](adr/0015-pause-on-lock.md) (epic
+  [#313](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/313)),
+  not here.
 - Push notifications to the *parent*'s phone when a child's budget
   is running low. That's a feature of the `/app` PWA, covered in
   [`roadmap.md`](roadmap.md) Phase 9, not of this client-side agent.

--- a/docs/plans/314-pause-on-lock-adr.md
+++ b/docs/plans/314-pause-on-lock-adr.md
@@ -1,0 +1,85 @@
+# Plan — #314: ADR for the pause-on-lock model & authority
+
+Root sub-issue of the pause-on-lock epic (**#313**). Roadmap:
+`docs/roadmap.md` → Phase 8b (with one Phase-4 Timekpr piece and one Phase-9
+UI piece). This is a **decision/design** deliverable — an ADR that must land
+**before** any of the sibling code sub-issues (#315–#320), because the forks
+it settles shape the schema, the wire protocol, and which component owns the
+"paused" authority.
+
+## Goal
+
+Commit `docs/adr/0015-pause-on-lock.md` recording, with rationale, a decision
+for each of the six forks in #314, then cross-reference the roadmap and
+`client-notifications.md`, and annotate the sibling sub-issue bodies so the
+downstream PRs build against the chosen model.
+
+ADR number: **0015** — 0014 is claimed by the in-flight ADR PR #431 (#345), so
+we skip it to avoid a merge collision (the repo hand-numbers ADRs; there is
+already a `0007` duplicate we do not want to repeat).
+
+## The six decisions (with the direction this ADR takes)
+
+1. **Overall-clock authority → Timekpr-native.** The overall daily/weekly/
+   monthly clock is Timekpr's at logind level (ADR 0010; epic #313). Realise
+   "don't burn the overall budget while locked/idle" through Timekpr's own
+   inactive-tracking setting pushed via `timekpra`, **not** a server clock that
+   duplicates Timekpr's. The server pause-ledger is kept for *observability*
+   and for the per-activity path, not as the overall-clock authority. Accept
+   that overall-clock pause immediacy is bounded by Timekpr's idle detection;
+   the deliberate-lock immediacy is delivered on the per-activity path and the
+   UX (frozen countdown).
+
+2. **Per-activity authority → authoritative server-side exclusion.** The pause
+   ledger records explicit `[lockedAt, unlockedAt]` spans and `usage.ts` /
+   `normalise.ts` exclude them from per-activity consumption — deterministic and
+   immediate, not waiting for AFK's ~180 s idle timeout. Existing AFK clipping
+   stays as **defense-in-depth** that bounds over-credit if the explicit signal
+   is ever lost. (Matches sub-issue #317's own title.)
+
+3. **Signal direction & shape → new client→server frames.** `session.locked` /
+   `session.unlocked`, carrying `userId`, `at` (ISO-8601), the local Linux
+   session id (multi-session boxes), and a `lockId`. Additive per ADR 0007
+   (a new frame type gated by a `pause_on_lock` **capability** in the `hello`
+   handshake — no `eventProtocol` bump). First non-handshake client→server
+   frame, which `client-notifications.md` already anticipated ("liveness pings
+   and acknowledgements").
+
+4. **Reconciliation & safety bounds.** Idempotent open/close keyed by
+   `(user, client, session, lockedAt)`. Missing unlock (bridge drop, crash,
+   sleep) closed out by: AFK + Timekpr idle as the bound; an optional
+   `max_pause_minutes` auto-close; and reconcile-on-reconnect. Never credit a
+   negative or unbounded span.
+
+5. **Interaction with the rest of the system.** While paused: suspend/cancel
+   enforcement grace timers (coordinate with #292), freeze the 15/5/1-min
+   warning cadence (#103), suppress parent low-time push (#65). A grant arriving
+   mid-pause is additive and does not auto-resume. Must coexist with the
+   *involuntary* `locked_out` marker (#107/#108) — voluntary pause is its
+   inverse and must not clear or be confused with it.
+
+6. **Policy knob.** Per-user (and per-policy default) `pause_on_lock` boolean,
+   **default on** (it is the intended one-tap "bank my time" lever and is
+   observational-only, under the tamper ceiling), plus the optional
+   `max_pause_minutes` safety bound from (4). Lives on the policy and is pushed
+   with the rest of policy, like the existing notification/grace knobs.
+
+## Steps
+
+1. Ground the decisions in the actual code (AFK clip in
+   `transport/activitywatch/normalise.ts`, rollups in `policy/usage.ts`, the
+   event frames in `events/`, grace timers in `enforcement/force-close*.ts`,
+   `timekpra` command coverage in `transport/timekpr/commands.ts`, policy knobs
+   in `policy/schema.ts` + `policy/notification.ts`).
+2. Write `docs/adr/0015-pause-on-lock.md` in the house ADR format
+   (Status / Phase / Issue → Context → Decision (per fork) → Consequences →
+   Alternatives).
+3. Cross-reference: add the ADR to `docs/roadmap.md` (Phase 8b) and to
+   `docs/client-notifications.md`.
+4. Annotate sub-issue bodies #315–#320 with the chosen model.
+
+## Non-goals
+
+No code. No schema migration, no protocol module, no detector — those are the
+sibling sub-issues this ADR unblocks. License boundary and tamper ceiling are
+unchanged and restated in the ADR.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -242,6 +242,20 @@ expiry, lock + grant-unlock on overall-screen-time expiry.
   is decided in
   [`docs/adr/0007-event-stream-version-compatibility.md`](adr/0007-event-stream-version-compatibility.md);
   this phase implements it.
+- **Pause-on-lock** — a voluntary screen lock pauses the supervised user's
+  budget and unlocking resumes it (the one-tap "I'm taking a break" lever).
+  The model & authority — Timekpr-native for the overall clock, an
+  authoritative server pause-ledger for the per-activity path, new
+  capability-gated `session.locked` / `session.unlocked` client→server
+  frames, reconciliation bounds, and the `pause_on_lock` policy knob — is
+  decided in
+  [`docs/adr/0015-pause-on-lock.md`](adr/0015-pause-on-lock.md); epic
+  [#313](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/313)
+  implements it across Phase 8b (client agent + event stream), with one
+  Phase-4 Timekpr piece
+  ([#318](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/318))
+  and one Phase-9 UI piece
+  ([#320](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/320)).
 
 ## Phase 8c — Lockout / grant-unlock flow
 


### PR DESCRIPTION
## Summary

- Adds `docs/adr/0015-pause-on-lock.md`, settling the six decision forks of #314 (the root sub-issue of the pause-on-lock epic #313) **before** any sibling code lands — grounded in the actual code seams so the downstream PRs have an unambiguous target.
- Cross-references the ADR from `docs/roadmap.md` (Phase 8b) and `docs/client-notifications.md`.
- Adds the plan doc `docs/plans/314-pause-on-lock-adr.md`.

### Decisions recorded

1. **Overall-clock authority → Timekpr-native.** The server runs no second overall clock (consistent with ADR 0010). Mechanism is a new `--settrackinactive` wrapper (#318); an explicit-signal `--settimeleft` refund is the recorded, **un-adopted** fallback. Overall-clock pause granularity is bounded by Timekpr's idle detection — accepted, and stated honestly (see "For maintainer sign-off" below).
2. **Per-activity authority → authoritative server pause-ledger.** Explicit `[lockedAt, unlockedAt]` spans are excluded from consumption (immediate, deterministic); the existing AFK clip in `normalise.ts` stays as defense-in-depth.
3. **Signal shape → new capability-gated `session.locked` / `session.unlocked` client→server frames** — the stream's first post-handshake inbound frames. Additive per ADR 0007 (new `session_state` capability + frame type, **no `eventProtocol` bump**).
4. **Reconciliation & bounds** — idempotent open/close on `(user, client, session, lockId)`, `max_pause_minutes` auto-close, reconcile-on-reconnect; every edge degrades to *less* pausing.
5. **Interactions** — suspend/resume the force-close grace timer via a **cancel handle shared with #292 Part 2**; the client freezes the 15/5/1-min cadence (#319); the (unbuilt) parent low-time push #65 must treat paused as not-low; coexist with the involuntary `locked_out` marker (#107/#108).
6. **Policy knob** — per-user `pause_on_lock` boolean (default on) + `max_pause_minutes`, on `notificationPolicies`.

Notable code-grounded findings the ADR builds on: the event stream has **no post-handshake client→server frame path** today (`events/stream.ts` reads only `hello`); `ForceCloseTrigger` has **no cancel handle** (`enforcement/force-close.ts`); and **no Timekpr idle/`settrackinactive` lever is wrapped** (only `--settimeleft`).

## Plan

Linked plan: `docs/plans/314-pause-on-lock-adr.md`
Roadmap: `docs/roadmap.md` → Phase 8b (epic #313)

## License-boundary note

N/A — no code, transport, or packaging changes. Docs only. The ADR **restates** the boundaries it must preserve: Timekpr only via `timekpra` subprocess, ActivityWatch only via REST, detection observational-only under the tamper-resistance ceiling, no new binaries in the image.

## First-pass review

Ran an adversarial review subagent to verify the ADR's factual claims and consistency. It confirmed all six code-seam claims, both cross-doc consistency claims (ADR 0007 §3/§4, ADR 0010), the ADR number/links, and tamper/license compliance — **no Critical findings**. The minor wording/precision nits it raised are applied in the second commit (`capabilityForEvent` gates "where applicable"; wire capability named `session_state` to keep it distinct from the `pause_on_lock` policy knob; the §4 outbound-gate concept is being *extended* to a new inbound direction; the pause-ledger disconnect finalisation is new work hooking the existing close handler).

## For maintainer sign-off

One substantive judgement call worth a conscious accept: **Decision 1 narrows the epic's "immediacy" promise for the *overall* clock.** #313's Context frames "a deliberate lock should pause the clock *now*" as a core value; ADR 0015 delivers that immediacy on the per-activity path and the UX freeze, but the *overall* budget only stops when Timekpr's own idle detection trips (not the instant of lock), because there is no clean per-event Timekpr "pause now" primitive and a server-side overall clock would duplicate/fight Timekpr's authority (ADR 0010). The `--settimeleft` refund fallback is recorded if instant overall-clock pause later proves required. Happy to switch to that model if you'd prefer instant overall-clock pause over a single overall-clock authority.

## Test plan

- [x] Docs-only change; no server code touched. Full CI (16 checks: lint, unit, SvelteKit build, Docker build, pre-commit, ansible-lint, migrations, etc.) is **green**.
- [x] Trailing-whitespace / EOF-newline pre-commit hooks clean on all touched docs.
- [x] Internal relative links resolve (`adr/0015-…`, sibling ADRs, issue links).

## Follow-ups

Sub-issues #315–#320 annotated with the model each must build against (per this issue's acceptance criteria).

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)