### PR TITLE
feat(timekpr-mirror): serve the cached .deb over the LAN + advertise it at enrol (#393)

### DIFF
--- a/docs/plans/393-timekpr-mirror-serve-advertise.md
+++ b/docs/plans/393-timekpr-mirror-serve-advertise.md
@@ -1,0 +1,178 @@
+# Plan — #393: serve `/apt/timekpr/*` and advertise the mirror at enrol
+
+Part of the server-hosted `timekpr-next` mirror epic (**#389**), the third
+implementation slice. The config seam
+([#391](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/391),
+merged) built the `PCT_TIMEKPR_MIRROR` mode + `/data/apt/timekpr` layout; the
+background fetch/refresh job
+([#392](https://github.com/BenSeymourODB/linux-parental-controls-toolkit/issues/392),
+merged) keeps that directory current with the upstream `.deb`. This slice
+**exposes** what #392 caches and **tells clients about it**.
+
+ADR: [`0011-server-hosted-upstream-package-mirror.md`](../adr/0011-server-hosted-upstream-package-mirror.md).
+Roadmap: `docs/roadmap.md` → Phase 3.
+
+Dependency order in the epic is **#392 → #393 → #394; #395 last**. #392 (fetch)
+is merged, so this is unblocked; the client baseline repo path that consumes the
+advertisement is #394.
+
+## Scope — the ADR MVP (mode B), not the signed index
+
+ADR 0011 is explicit: **ship the MVP first** (serve the cached `.deb` over the
+LAN, advertised at enrol), **then graduate to the signed apt repo** under the
+Phase-14 fleet-lifecycle umbrella (epic #163). #393's own body says the same:
+"MVP shortcut (per the ADR): skip signing and serve the `.deb` as a plain file
+first, add signing later."
+
+So this PR delivers the MVP:
+
+1. **Serve** the runtime-cached `.deb` from the managed mirror's `dataDir` at a
+   stable LAN URL, plus a small JSON manifest describing what is currently
+   cached.
+2. **Advertise** the mirror (mode + coordinates + current version/filename) in
+   the enrol response, so #394's installer can fetch the package from the
+   dashboard instead of round-tripping to `launchpad.net`.
+
+**Deferred to a Phase-14 follow-up (new issue, linked from the PR):** GPG-signed
+`InRelease`/`Release.gpg` apt-index generation and full `apt update`/pinning/
+rollback repo semantics. Until that lands, the MVP contract is a **direct
+`.deb` download** (`apt-get install ./file.deb`), which correctly resolves the
+package's own `Depends` from the client's existing distro repos — so the MVP is
+functionally complete for install without a hand-synthesised, dependency-less
+`Packages` index (which would be actively wrong on dependencies).
+
+## Why direct-download, not a synthesised flat index (for the MVP)
+
+A `[trusted=yes]` flat apt repo needs a `Packages` stanza carrying the package's
+real `Depends`/`Pre-Depends`. Reproducing those faithfully means extracting the
+Debian control member from the `.deb` (`ar` → `control.tar.{gz,xz,zst}` →
+`control`), i.e. an `xz`/`zstd` decompressor the Node stdlib doesn't fully
+provide, or shelling out to packaging tools we deliberately keep out of the
+image. A hand-written stanza that omits `Depends` would install `timekpr-next`
+**without its dependencies** — a real breakage. `apt-get install ./local.deb`
+reads the `.deb`'s own embedded control and pulls deps from the distro, so the
+direct-download MVP is both simpler and correct. Faithful index generation is
+exactly the signed-index slice's job and lands with it.
+
+## License boundary (non-negotiable, ADR 0011)
+
+Pure TypeScript + Fastify + Node.js `fs` streaming. The `.deb` served is the one
+#392 fetched at runtime into `/data`; it is **never** baked into the image
+(`license-guard.yml` scans the image and stays green). Nothing here links,
+imports, or vendors GPL code, and nothing shells out to GPL packaging tooling —
+serving a file is not a code-level integration. `CLAUDE.md` → "License
+boundaries" rules 1 & 5; `docs/licensing-analysis.md`.
+
+## Contract
+
+### Serving (root app, alongside `GET /install-client.sh`)
+
+Registered only in `managed` mode (`external` points clients at a repo the
+homelab hosts; `disabled` serves nothing) under a stable path
+`TIMEKPR_MIRROR_APT_PATH = "/apt/timekpr"`:
+
+- `GET /apt/timekpr/manifest.json` → `{ package, version, filename }` describing
+  the currently-cached `.deb`, or **404** when the refresh job has not yet
+  written one (cold start before the first successful fetch).
+- `GET /apt/timekpr/:filename` → streams the `.deb` with
+  `Content-Type: application/vnd.debian.binary-package`. `:filename` is validated
+  against a strict `^[A-Za-z0-9][A-Za-z0-9._+~-]*\.deb$` allow-list (Fastify
+  params never span `/`, and the resolved path is asserted to stay within
+  `dataDir` as defence-in-depth), so the sentinel dotfile and traversal are
+  rejected with 404. The static `manifest.json` route wins over the param route
+  by Fastify's segment priority.
+
+### Mirror state read (`transport/timekpr-mirror/state.ts`)
+
+`readMirrorState(config, deps?) → { version, filename, path } | null`: reads the
+`.pct-timekpr-mirror-version` sentinel #392 writes and confirms the matching
+`.deb` exists on disk. `null` when nothing is cached yet. Every fs boundary is an
+injected seam (mirrors `refresh.ts`) so it is unit-testable without disk. Reuses
+`VERSION_SENTINEL` and `debFilename` from the existing module — no duplicated
+filename logic.
+
+### Enrol advertisement (`api/clients`)
+
+`enrolResponseSchema` gains a `timekprMirror` discriminated union mirroring the
+config's own trichotomy:
+
+- `{ mode: "disabled" }`
+- `{ mode: "external", url }` — the homelab repo URL the client points apt at.
+- `{ mode: "managed", aptPath, package, version, debFilename }` — `aptPath` is
+  the relative path root (`/apt/timekpr`) the client joins onto its
+  `--server-url`; `version`/`debFilename` are `null` until the first refresh has
+  cached a `.deb` (client falls back to distro/PPA in that window, #394).
+
+`buildTimekprMirrorAdvertisement(mirror, state)` is a **pure** mapping (new
+`api/clients/mirror-advertisement.ts`), unit-tested in isolation. The enrol
+**route** reads `settings.timekprMirror` + `readMirrorState` (disk, managed mode
+only — enrol is rare, so the couple of stat/read calls are fine) and passes the
+built advertisement into `enrolClient` via `EnrolOptions`; the service echoes it
+into the response, staying disk-free and unit-testable.
+
+## Files
+
+New:
+
+- `server/src/transport/timekpr-mirror/state.ts` — `readMirrorState` + seams;
+  re-exported from `index.ts`.
+- `server/src/web/timekpr-mirror.ts` — `registerTimekprMirror(app, settings)` +
+  `TIMEKPR_MIRROR_APT_PATH`.
+- `server/src/api/clients/mirror-advertisement.ts` —
+  `buildTimekprMirrorAdvertisement` (pure).
+
+Changed:
+
+- `server/src/api/clients/dtos.ts` — `timekprMirrorAdvertisementSchema` +
+  `timekprMirror` on `enrolResponseSchema`.
+- `server/src/api/clients/service.ts` — `EnrolOptions.timekprMirror`; echo into
+  the response; `EnrolServiceResult` gains the field.
+- `server/src/api/clients/routes.ts` — read state + build advertisement, thread
+  into `enrolClient`.
+- `server/src/web/app.ts` — `registerTimekprMirror(app, settings)`.
+
+Tests mirror the layout: `server/tests/transport/timekpr-mirror/state.test.ts`,
+`server/tests/web/timekpr-mirror.test.ts`,
+`server/tests/api/clients/mirror-advertisement.test.ts`, plus an enrol-route
+assertion that the advertisement appears (disabled default + a managed case).
+
+## Phasing (commit + push per phase → draft PR on first push)
+
+1. **`state.ts` + serving module + wiring + tests** — the read + expose half.
+2. **Enrol advertisement** — DTO + pure builder + route/service wiring + tests.
+3. **Docs + follow-up issue + finalize** — `server-deployment.md` gains the
+   serving endpoints + enrol-advertisement shape; file the Phase-14 signed-index
+   follow-up and link it; mark ready.
+
+## Test plan
+
+- `state.ts`: sentinel + matching `.deb` present → state; sentinel present but
+  `.deb` missing → `null`; no sentinel → `null`; version drift handled by
+  reading the sentinel as the source of truth.
+- `web/timekpr-mirror.ts`: managed mode serves the cached `.deb` (correct
+  content-type + bytes) and `manifest.json`; cold start (no `.deb`) → 404 on both
+  the file and the manifest; traversal / non-`.deb` / sentinel filename → 404;
+  disabled/external mode registers nothing (routes 404).
+- `mirror-advertisement.ts`: each mode maps correctly; managed with `null` state
+  → `version`/`debFilename` null; managed with state → populated.
+- enrol route/service: response carries `timekprMirror` (disabled by default; a
+  managed case surfaces the advertised coordinates).
+
+## Quality gate (each phase, from `server/`)
+
+`npm run format` · `npm run lint:fix` · `npm run typecheck` · `npm test`
+(coverage ≥ 80%). No new runtime dependency — Fastify, zod, croner,
+better-sqlite3 are already present; serving uses `node:fs` only.
+
+## Deferred (tracked, not this slice)
+
+- **Signed apt index** (`InRelease`/`Release.gpg`, repo signing key in `/data`)
+  + faithful `Packages`/`Release` generation + `apt update`/pinning/rollback
+  semantics → **new Phase-14 follow-up issue** under epic #163 (linked from the
+  PR). This is where cryptographic repo integrity lands.
+- Client `install-baseline-tools.sh` mirror repo path + orchestrator/enrol
+  plumbing that consumes this advertisement → **#394**.
+- Docs (`licensing-analysis.md` runtime-mirror note) + license-guard
+  confirmation → **#395** (this PR touches `server-deployment.md` only for the
+  new endpoints/advertisement it introduces).
+- Optional upstream **source-package** mirroring → epic #389 enhancement.

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -231,11 +231,14 @@ modelled on the AdGuard Home trichotomy above and decided in
 [`docs/adr/0011-server-hosted-upstream-package-mirror.md`](adr/0011-server-hosted-upstream-package-mirror.md)
 (tracking issue #389).
 
-> **Status:** this release ships the configuration seam only (issue #391).
-> The background fetch/refresh job (#392), the served apt index + enrol-time
-> advertisement (#393), and the client-side repo path (#394) land in
-> subsequent Phase-14 slices; setting `managed`/`external` has no runtime
-> effect yet.
+> **Status:** `managed` mode now fetches and serves. The config seam (#391),
+> the background fetch/refresh job (#392), and the served `.deb` + enrol-time
+> advertisement (#393, the ADR 0011 MVP) have landed. Still ahead: the
+> **client-side repo path** (#394, so the installer actually consumes the
+> advertisement) and the **GPG-signed apt index** with full `apt`
+> update/pinning/rollback semantics (the Phase-14 end-state under epic #163).
+> Until the client path lands, setting `managed` fetches + serves but no
+> installer points at it yet.
 
 | Mode | What the dashboard does | When to use it |
 |---|---|---|
@@ -264,6 +267,39 @@ PCT_TIMEKPR_MIRROR_URL=https://apt.lan/timekpr
 The mirrored **package/channel is chosen on the server**
 (`PCT_TIMEKPR_MIRROR_PACKAGE`, stable or beta), so a client never has to
 know which channel it gets.
+
+### What `managed` mode serves (the MVP)
+
+Once the background job (#392) has fetched a `.deb`, the dashboard serves it
+over the LAN from the same Fastify process, alongside `/install-client.sh`:
+
+| Route | Response |
+|---|---|
+| `GET /apt/timekpr/manifest.json` | `{ "package", "version", "filename" }` for the currently-cached `.deb`, or `404` before the first successful fetch. |
+| `GET /apt/timekpr/<file>.deb` | The cached package bytes (`Content-Type: application/vnd.debian.binary-package`). Only a validated `.deb` basename that exists under the mirror dir is served; anything else `404`s. |
+
+At enrol, the response advertises these coordinates so the client
+(#394) can install without a Launchpad round-trip. The `timekprMirror`
+field mirrors the config trichotomy:
+
+```jsonc
+// managed, once a version is cached
+"timekprMirror": {
+  "mode": "managed",
+  "aptPath": "/apt/timekpr",          // join onto --server-url
+  "package": "timekpr-next",
+  "version": "0.5.5",                 // null until the first refresh
+  "debFilename": "timekpr-next_0.5.5_all.deb"  // null until the first refresh
+}
+// external: { "mode": "external", "url": "https://apt.lan/timekpr" }
+// disabled: { "mode": "disabled" }
+```
+
+The MVP contract is a **direct `.deb` download** (`apt-get install
+./<file>.deb`, which resolves the package's own dependencies from the
+client's existing distro repos). Signed apt-index semantics
+(`InRelease`/`Release.gpg`, `apt update`/pinning/rollback) are the
+Phase-14 end-state and are tracked separately.
 
 ### License posture
 

--- a/server/src/api/clients/dtos.ts
+++ b/server/src/api/clients/dtos.ts
@@ -162,6 +162,40 @@ export const enrolClientSchema = z.object({
   reportedIps: z.array(reportedIpSchema).max(16).optional(),
 });
 
+/**
+ * The managed `timekpr-next` mirror coordinates advertised to a client at enrol
+ * (#393, epic #389), mirroring the server's own `disabled | external | managed`
+ * config trichotomy so the client knows where to get the package without a
+ * `launchpad.net` round-trip (ADR 0011). The client baseline installer (#394)
+ * consumes this to point apt at the dashboard.
+ */
+export const timekprMirrorAdvertisementSchema = z.discriminatedUnion("mode", [
+  /** No mirror: the client installs from the distro repo (the PPA stays opt-in). */
+  z.object({ mode: z.literal("disabled") }),
+  /** The homelab hosts its own apt repo; the client points apt straight at `url`. */
+  z.object({ mode: z.literal("external"), url: z.url() }),
+  z.object({
+    mode: z.literal("managed"),
+    /**
+     * The stable LAN URL path root the dashboard serves the mirror at, relative
+     * to the client's `--server-url` (e.g. `/apt/timekpr`). Advertised rather
+     * than hardcoded on the client so the serving path stays server-owned.
+     */
+    aptPath: z.string().min(1),
+    /** The upstream package/channel served (`timekpr-next` / `timekpr-next-beta`). */
+    package: z.string().min(1),
+    /**
+     * The version currently cached and served, or `null` before the refresh job
+     * has fetched one — in which case the client falls back to the distro/PPA
+     * path (#394) rather than waiting on the mirror.
+     */
+    version: z.string().min(1).nullable(),
+    /** The `.deb` filename to download under `aptPath`, or `null` (see `version`). */
+    debFilename: z.string().min(1).nullable(),
+  }),
+]);
+export type TimekprMirrorAdvertisement = z.infer<typeof timekprMirrorAdvertisementSchema>;
+
 export const enrolResponseSchema = z.object({
   clientId: z.number().int(),
   hostname: z.string(),
@@ -187,6 +221,12 @@ export const enrolResponseSchema = z.object({
    * not set it. Surfaced so the install script and admin UI agree on the value.
    */
   platform: platformSchema,
+  /**
+   * Where and how to get `timekpr-next` (#393): the server-configured mirror
+   * mode + coordinates, so the client can install without a Launchpad
+   * round-trip. `{ mode: "disabled" }` on a default deployment.
+   */
+  timekprMirror: timekprMirrorAdvertisementSchema,
 });
 
 export type EnrolClientRequest = z.infer<typeof enrolClientSchema>;

--- a/server/src/api/clients/mirror-advertisement.ts
+++ b/server/src/api/clients/mirror-advertisement.ts
@@ -1,0 +1,73 @@
+/**
+ * Build the `timekpr-next` mirror advertisement returned in the enrol response
+ * (#393, epic #389).
+ *
+ * Maps the server's `PCT_TIMEKPR_MIRROR` config + the mirror's current on-disk
+ * state onto the wire {@link TimekprMirrorAdvertisement} the client consumes
+ * (#394). Kept separate from the enrol service so the mapping is a pure,
+ * independently-testable unit and the service stays disk-free — the route reads
+ * the state (a couple of `fs` calls, managed mode only) and hands the built
+ * advertisement in.
+ *
+ * License boundary: none touched — plain TypeScript reading config + a version
+ * string; the `.deb` it points at was fetched at runtime into `/data` by #392,
+ * never baked into the image (ADR 0011).
+ */
+import type { Settings } from "../../config.js";
+import {
+  readMirrorState,
+  type MirrorState,
+  type MirrorStateDeps,
+} from "../../transport/timekpr-mirror/index.js";
+import type { TimekprMirrorAdvertisement } from "./dtos.js";
+
+/**
+ * Stable LAN URL path root the managed mirror is served at (relative to the
+ * client's `--server-url`). Owned here as part of the enrol contract; the web
+ * serving module (`web/timekpr-mirror.ts`) imports it to register the routes, so
+ * the advertised path and the served path can never drift apart.
+ */
+export const TIMEKPR_MIRROR_APT_PATH = "/apt/timekpr";
+
+/**
+ * Map a mirror config slice + its current on-disk state onto the advertisement.
+ * Pure: `state` is `null` when nothing is cached yet (managed cold start), which
+ * surfaces as `version`/`debFilename` `null` so the client falls back to the
+ * distro/PPA path (#394) rather than waiting on the mirror.
+ */
+export function buildTimekprMirrorAdvertisement(
+  mirror: Settings["timekprMirror"],
+  state: MirrorState | null,
+): TimekprMirrorAdvertisement {
+  switch (mirror.mode) {
+    case "disabled":
+      return { mode: "disabled" };
+    case "external":
+      return { mode: "external", url: mirror.url };
+    case "managed":
+      return {
+        mode: "managed",
+        aptPath: TIMEKPR_MIRROR_APT_PATH,
+        package: mirror.package,
+        version: state?.version ?? null,
+        debFilename: state?.filename ?? null,
+      };
+  }
+}
+
+/**
+ * Resolve the advertisement for the enrol response: reads the current mirror
+ * state from disk in `managed` mode (nothing to read in `disabled`/`external`)
+ * and builds the advertisement from it. The `deps` seam keeps it unit-testable
+ * without touching real disk.
+ */
+export function resolveTimekprMirrorAdvertisement(
+  mirror: Settings["timekprMirror"],
+  deps?: MirrorStateDeps,
+): TimekprMirrorAdvertisement {
+  const state =
+    mirror.mode === "managed"
+      ? readMirrorState({ dataDir: mirror.dataDir, package: mirror.package }, deps)
+      : null;
+  return buildTimekprMirrorAdvertisement(mirror, state);
+}

--- a/server/src/api/clients/routes.ts
+++ b/server/src/api/clients/routes.ts
@@ -31,6 +31,7 @@ import {
   type EnrolResponse,
   type EnrolmentTokenResponse,
 } from "./dtos.js";
+import { resolveTimekprMirrorAdvertisement } from "./mirror-advertisement.js";
 import { enrolClient, mintEnrolmentToken } from "./service.js";
 
 /**
@@ -112,6 +113,10 @@ export function registerClientEnrolmentRoutes(scope: FastifyInstance, settings: 
         const result = enrolClient(scope.db, token, request.body, {
           sshPublicKeyPath: settings.sshPublicKeyPath,
           log: request.log,
+          // Tell the client where/how to get timekpr-next (#393): the
+          // server-configured mirror mode + the version currently cached. Read
+          // per request so a just-completed refresh is reflected immediately.
+          timekprMirror: resolveTimekprMirrorAdvertisement(settings.timekprMirror),
           // `request.ip` is the direct socket peer unless `trustProxy` is set
           // (#235), in which case Fastify derives the real client IP from a
           // trusted `X-Forwarded-For` — the documented reverse-proxy posture, so

--- a/server/src/api/clients/service.ts
+++ b/server/src/api/clients/service.ts
@@ -16,7 +16,11 @@ import * as enrolmentRepo from "../../policy/enrolment.js";
 import * as repo from "../../policy/repository.js";
 import type { ComponentVersions } from "../../policy/schema.js";
 import { ApiError } from "../errors.js";
-import type { EnrolClientRequest, MintEnrolmentTokenRequest } from "./dtos.js";
+import type {
+  EnrolClientRequest,
+  MintEnrolmentTokenRequest,
+  TimekprMirrorAdvertisement,
+} from "./dtos.js";
 import { loadServerSshPublicKey } from "./ssh-identity.js";
 
 /** What {@link mintEnrolmentToken} hands back to the route (token shown once). */
@@ -40,6 +44,8 @@ export interface EnrolServiceResult {
   componentVersions: ComponentVersions | null;
   /** The client's OS family (#229) — `linux` today; the enrol request never sets it. */
   platform: Platform;
+  /** Where/how to get `timekpr-next` — the advertised mirror coordinates (#393). */
+  timekprMirror: TimekprMirrorAdvertisement;
 }
 
 /**
@@ -109,6 +115,12 @@ export interface EnrolOptions {
    * when the route couldn't determine one (e.g. a synthetic/injected call).
    */
   sourceIp?: string | null;
+  /**
+   * The `timekpr-next` mirror advertisement to return (#393), resolved by the
+   * route from `settings.timekprMirror` + the mirror's current on-disk state.
+   * Threaded in (rather than read here) so the service stays disk-free.
+   */
+  timekprMirror: TimekprMirrorAdvertisement;
 }
 
 /**
@@ -243,6 +255,7 @@ export function enrolClient(
     agentVersion: result.client.agentVersion,
     componentVersions: result.client.componentVersions,
     platform: result.client.platform,
+    timekprMirror: options.timekprMirror,
   };
 }
 

--- a/server/src/transport/timekpr-mirror/index.ts
+++ b/server/src/transport/timekpr-mirror/index.ts
@@ -20,6 +20,7 @@ export {
 } from "./release.js";
 export {
   VERSION_SENTINEL,
+  readVersionSentinel,
   refreshTimekprMirror,
   TimekprMirrorDownloadError,
   TimekprMirrorInvalidPackageError,
@@ -28,6 +29,12 @@ export {
   type RefreshDeps,
   type RefreshResult,
 } from "./refresh.js";
+export {
+  readMirrorState,
+  type MirrorState,
+  type MirrorStateConfig,
+  type MirrorStateDeps,
+} from "./state.js";
 export {
   DEFAULT_REFRESH_BACKOFF,
   DEFAULT_REFRESH_PATTERN,

--- a/server/src/transport/timekpr-mirror/refresh.ts
+++ b/server/src/transport/timekpr-mirror/refresh.ts
@@ -136,7 +136,13 @@ interface ResolvedDeps {
   retryBaseMs: number;
 }
 
-function defaultReadSentinel(path: string): string | null {
+/**
+ * Read the version sentinel #392 writes beside the mirrored `.deb`, or `null`
+ * when it is absent/unreadable. Shared with the serving layer (#393,
+ * `state.ts`) so both halves agree on the single source of truth for "what
+ * version is currently cached".
+ */
+export function readVersionSentinel(path: string): string | null {
   try {
     return readFileSync(path, "utf8").trim();
   } catch {
@@ -148,7 +154,7 @@ function resolveDeps(deps: RefreshDeps): ResolvedDeps {
   return {
     fetch: deps.fetch ?? ((input, init) => fetch(input, init)),
     fileExists: deps.fileExists ?? existsSync,
-    readSentinel: deps.readSentinel ?? defaultReadSentinel,
+    readSentinel: deps.readSentinel ?? readVersionSentinel,
     makeDir: deps.makeDir ?? ((path) => void mkdirSync(path, { recursive: true })),
     writeDeb: deps.writeDeb ?? ((path, contents) => writeFileSync(path, contents)),
     writeSentinel: deps.writeSentinel ?? ((path, value) => writeFileSync(path, `${value}\n`)),

--- a/server/src/transport/timekpr-mirror/state.ts
+++ b/server/src/transport/timekpr-mirror/state.ts
@@ -1,0 +1,81 @@
+/**
+ * Read the current on-disk state of the managed `timekpr-next` mirror (#393,
+ * epic #389).
+ *
+ * The complement of {@link ./refresh.ts refreshTimekprMirror}: refresh *writes*
+ * the newest `.deb` + version sentinel into the mirror's data volume; this
+ * *reads* back what is currently cached, so the serving layer
+ * (`web/timekpr-mirror.ts`) and the enrol advertisement (`api/clients`) can tell
+ * a client which package/version the dashboard is offering. The version sentinel
+ * #392 writes is the single source of truth for "what is cached"; the `.deb`
+ * filename is derived from it via the shared {@link debFilename}, so the two
+ * halves never disagree on the name.
+ *
+ * Pure read with injected filesystem seams (mirrors `refresh.ts`), so it is
+ * unit-testable without touching real disk.
+ *
+ * License boundary: none touched — reads a version string and stats a file;
+ * nothing links, imports, or vendors GPL code, and the `.deb` it points at was
+ * fetched at runtime into `/data` by #392, never baked into the image
+ * (`CLAUDE.md` → "License boundaries" rules 1 & 5; ADR 0011).
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { readVersionSentinel, VERSION_SENTINEL } from "./refresh.js";
+import { debFilename } from "./release.js";
+
+/** The slice of the managed mirror config the state read needs. */
+export interface MirrorStateConfig {
+  /** Data-volume directory the mirror's `.deb` + sentinel live under. */
+  readonly dataDir: string;
+  /** The upstream package/channel mirrored (`timekpr-next` / `timekpr-next-beta`). */
+  readonly package: string;
+}
+
+/** The `.deb` the mirror currently has cached and can serve. */
+export interface MirrorState {
+  /** The cached upstream version (from the sentinel). */
+  readonly version: string;
+  /** The `.deb` filename derived from the package + version. */
+  readonly filename: string;
+  /** Absolute path to the cached `.deb`. */
+  readonly path: string;
+}
+
+/** Injectable filesystem seams so tests never touch real disk. */
+export interface MirrorStateDeps {
+  /** Read the recorded version sentinel, or `null` if absent/unreadable. */
+  readSentinel?: (path: string) => string | null;
+  /** Existence check for the `.deb`; defaults to `node:fs` `existsSync`. */
+  fileExists?: (path: string) => boolean;
+}
+
+/**
+ * Return the `.deb` the managed mirror currently has cached, or `null` when
+ * nothing is cached yet (no sentinel, or the sentinel names a `.deb` that is not
+ * on disk). A `null` return is the normal cold-start state before the refresh
+ * job's first successful fetch — the caller degrades gracefully (a 404 from the
+ * serving routes; `version`/`filename` reported as `null` in the enrol
+ * advertisement, so the client falls back to the distro/PPA path).
+ */
+export function readMirrorState(
+  config: MirrorStateConfig,
+  deps: MirrorStateDeps = {},
+): MirrorState | null {
+  const readSentinel = deps.readSentinel ?? readVersionSentinel;
+  const fileExists = deps.fileExists ?? existsSync;
+
+  const version = readSentinel(join(config.dataDir, VERSION_SENTINEL));
+  if (version === null || version === "") {
+    return null;
+  }
+
+  const filename = debFilename(config.package, version);
+  const path = join(config.dataDir, filename);
+  if (!fileExists(path)) {
+    return null;
+  }
+
+  return { version, filename, path };
+}

--- a/server/src/web/app.ts
+++ b/server/src/web/app.ts
@@ -28,6 +28,7 @@ import { type TimekprMirrorRefreshHandle } from "../transport/timekpr-mirror/ind
 import { buildAppServices } from "./app-services.js";
 import { registerFrontend } from "./frontend.js";
 import { registerInstallScript } from "./install-script.js";
+import { registerTimekprMirror } from "./timekpr-mirror.js";
 import { REQUEST_ID_HEADER, buildLoggerOptions, genRequestId, type LogStream } from "./logger.js";
 
 declare module "fastify" {
@@ -248,6 +249,12 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   // Serve the client install script at /install-client.sh. Skipped (with a
   // warning) when the bundled file is absent, so other routes are unaffected.
   registerInstallScript(app, settings);
+
+  // Serve the managed timekpr-next mirror at /apt/timekpr/* (#393). A no-op
+  // outside `managed` mode, so disabled/external deployments expose no mirror
+  // surface; in managed mode it streams whatever `.deb` the refresh job (#392)
+  // has cached under the data volume.
+  registerTimekprMirror(app, settings);
 
   // Serve the prerendered SvelteKit build at /admin and /app (#40). Skipped
   // (with a warning) when the build directory is absent, so /, /healthz, and

--- a/server/src/web/timekpr-mirror.ts
+++ b/server/src/web/timekpr-mirror.ts
@@ -1,0 +1,113 @@
+/**
+ * Serve the managed `timekpr-next` package mirror over the LAN (#393, epic #389).
+ *
+ * The ADR 0011 MVP (mode B): expose the `.deb` the background refresh job (#392)
+ * caches under the mirror's data volume, plus a small JSON manifest describing
+ * what is currently cached, so a client can install `timekpr-next` from the
+ * dashboard instead of round-tripping to `launchpad.net` at enrol time. The
+ * enrol response advertises the coordinates (`api/clients`); the client baseline
+ * installer consumes them (#394).
+ *
+ * Registered only in `managed` mode: `external` points clients at a repo the
+ * homelab already hosts (nothing for us to serve) and `disabled` serves nothing.
+ * Two routes on the root app, alongside `GET /install-client.sh`:
+ *
+ *   GET /apt/timekpr/manifest.json  -> { package, version, filename } | 404
+ *   GET /apt/timekpr/<file>.deb     -> the cached package bytes        | 404
+ *
+ * The signed apt index (`InRelease`/`Release.gpg`) + full `apt update`/pinning
+ * repo semantics are the Phase-14 end-state (epic #163), tracked as a follow-up;
+ * the MVP contract is a direct `.deb` download (`apt-get install ./file.deb`),
+ * which resolves the package's own `Depends` from the client's distro repos.
+ *
+ * License boundary: none touched — plain Fastify + Node.js `fs` streaming of a
+ * file #392 fetched at runtime into `/data`; nothing links, imports, or vendors
+ * GPL code, and no GPL binary enters the image (`CLAUDE.md` → "License
+ * boundaries" rules 1 & 5; ADR 0011; `license-guard.yml` stays green).
+ */
+import { createReadStream, existsSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
+
+import type { FastifyInstance } from "fastify";
+
+import { TIMEKPR_MIRROR_APT_PATH } from "../api/clients/mirror-advertisement.js";
+import type { Settings } from "../config.js";
+import { readMirrorState } from "../transport/timekpr-mirror/index.js";
+
+/** Debian package media type (`apt`/`dpkg` convention). */
+const DEB_CONTENT_TYPE = "application/vnd.debian.binary-package";
+
+/**
+ * Allow-list for the `:filename` route param. A `.deb` basename only: it must
+ * start with an alphanumeric and carry no path separator, so the version
+ * sentinel dotfile (leading `.`) and any traversal attempt (`..`, absent a
+ * `.deb` suffix and a leading alphanumeric) are rejected. Fastify route params
+ * never span `/`, so this is belt-and-braces over that guarantee.
+ */
+const DEB_FILENAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+~-]*\.deb$/;
+
+/**
+ * Register the mirror-serving routes on the root app.
+ *
+ * A no-op outside `managed` mode, so `disabled`/`external` deployments expose no
+ * `/apt/timekpr/*` surface at all. In `managed` mode the current cached `.deb`
+ * is discovered per request via {@link readMirrorState} (the refresh job can
+ * replace it at any time), degrading to 404 before the first successful fetch.
+ */
+export function registerTimekprMirror(app: FastifyInstance, settings: Settings): void {
+  const mirror = settings.timekprMirror;
+  if (mirror.mode !== "managed") {
+    return;
+  }
+
+  const { dataDir } = mirror;
+  const stateConfig = { dataDir, package: mirror.package };
+  // Precompute the resolved data dir + trailing separator once for the
+  // defence-in-depth containment check below.
+  const dataDirPrefix = resolve(dataDir) + sep;
+
+  app.get(`${TIMEKPR_MIRROR_APT_PATH}/manifest.json`, async (_request, reply) => {
+    const state = readMirrorState(stateConfig);
+    if (state === null) {
+      return reply
+        .code(404)
+        .type("application/json")
+        .send({ error: "no timekpr package is cached yet" });
+    }
+    return reply.type("application/json").send({
+      package: mirror.package,
+      version: state.version,
+      filename: state.filename,
+    });
+  });
+
+  app.get<{ Params: { filename: string } }>(
+    `${TIMEKPR_MIRROR_APT_PATH}/:filename`,
+    async (request, reply) => {
+      const { filename } = request.params;
+      if (!DEB_FILENAME_PATTERN.test(filename)) {
+        return reply.code(404).type("text/plain").send("not found");
+      }
+
+      const filePath = join(dataDir, filename);
+      // The pattern already forbids separators and a leading dot, so the join
+      // cannot escape dataDir; assert containment anyway (defence in depth).
+      if (!resolve(filePath).startsWith(dataDirPrefix)) {
+        return reply.code(404).type("text/plain").send("not found");
+      }
+      if (!existsSync(filePath)) {
+        return reply.code(404).type("text/plain").send("not found");
+      }
+
+      const stream = createReadStream(filePath);
+      stream.on("error", (err) => {
+        if (!reply.sent) {
+          void reply.code(500).type("text/plain").send("failed to read package");
+        } else {
+          app.log.error({ err, filename }, "timekpr mirror .deb stream error after headers sent");
+        }
+      });
+      return reply.type(DEB_CONTENT_TYPE).send(stream);
+    },
+  );
+}

--- a/server/src/web/timekpr-mirror.ts
+++ b/server/src/web/timekpr-mirror.ts
@@ -66,6 +66,12 @@ export function registerTimekprMirror(app: FastifyInstance, settings: Settings):
   // defence-in-depth containment check below.
   const dataDirPrefix = resolve(dataDir) + sep;
 
+  // Both routes read the mirror state / stat the file synchronously per request
+  // rather than caching at registration like install-script.ts: the refresh job
+  // (#392) replaces the cached .deb under dataDir at runtime, so a
+  // registration-time snapshot would go stale. Enrol + install traffic on a LAN
+  // is low-volume, so the per-request syscall is a fine trade for correctness.
+
   app.get(`${TIMEKPR_MIRROR_APT_PATH}/manifest.json`, async (_request, reply) => {
     const state = readMirrorState(stateConfig);
     if (state === null) {
@@ -92,6 +98,10 @@ export function registerTimekprMirror(app: FastifyInstance, settings: Settings):
       const filePath = join(dataDir, filename);
       // The pattern already forbids separators and a leading dot, so the join
       // cannot escape dataDir; assert containment anyway (defence in depth).
+      // Note this is a *lexical* check — it does not resolve symlinks, so a
+      // symlink planted inside dataDir could still point outside. That is out of
+      // scope: only the server process writes /data (no client or supervised
+      // user can), and CLAUDE.md caps client-side hardening here.
       if (!resolve(filePath).startsWith(dataDirPrefix)) {
         return reply.code(404).type("text/plain").send("not found");
       }

--- a/server/tests/api/clients-enrolment.test.ts
+++ b/server/tests/api/clients-enrolment.test.ts
@@ -5,7 +5,7 @@
  * userId, missing/invalid/expired/used bearer, user-set mismatch, duplicate
  * hostname) — per docs/testing.md → "HTTP routes".
  */
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ENROL_RATE_LIMIT_MAX_ATTEMPTS } from "../../src/api/clients/routes.js";
 import { hashToken } from "../../src/auth/secret-token.js";
 import { SESSION_COOKIE } from "../../src/auth/session.js";
+import { VERSION_SENTINEL } from "../../src/transport/timekpr-mirror/index.js";
 import { loadSettings, type Settings } from "../../src/config.js";
 import { clients, enrolmentTokens } from "../../src/policy/schema.js";
 import { buildTestApp, type TestApp } from "../helpers/app.js";
@@ -194,6 +195,46 @@ describe("client enrolment routes", () => {
     expect(links.json()).toEqual([
       { userId, clientId: body.clientId, osUsername: "alice", osUserRef: "1000" },
     ]);
+  });
+
+  it("advertises a disabled timekpr mirror by default (#393)", async () => {
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+
+    const res = await enrol(token, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ osUsername: "alice", osUserRef: "1000" }],
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().timekprMirror).toEqual({ mode: "disabled" });
+  });
+
+  it("advertises the managed mirror coordinates + cached version at enrol (#393)", async () => {
+    // Restart the app in managed mode over a data dir that already holds a
+    // cached .deb + version sentinel (as the refresh job #392 would leave it).
+    await harness.close();
+    const mirrorDir = join(tmpDir, "apt-timekpr");
+    mkdirSync(mirrorDir, { recursive: true });
+    writeFileSync(join(mirrorDir, "timekpr-next_0.5.5_all.deb"), "!<arch>\npayload");
+    writeFileSync(join(mirrorDir, VERSION_SENTINEL), "0.5.5\n");
+    await start(settingsWith({ PCT_TIMEKPR_MIRROR: "managed", PCT_TIMEKPR_MIRROR_DIR: mirrorDir }));
+
+    const userId = await createUser("Alice");
+    const token = await mintFor(userId, "alice");
+    const res = await enrol(token, {
+      hostname: "mint-01",
+      sshUser: "pct-agent",
+      supervisedUsers: [{ osUsername: "alice", osUserRef: "1000" }],
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().timekprMirror).toEqual({
+      mode: "managed",
+      aptPath: "/apt/timekpr",
+      package: "timekpr-next",
+      version: "0.5.5",
+      debFilename: "timekpr-next_0.5.5_all.deb",
+    });
   });
 
   it("records reported component versions at enrolment and echoes them back (#164)", async () => {

--- a/server/tests/api/clients/mirror-advertisement.test.ts
+++ b/server/tests/api/clients/mirror-advertisement.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the enrol-time timekpr mirror advertisement builder (#393).
+ *
+ * The pure `buildTimekprMirrorAdvertisement` maps each config mode; the
+ * `resolveTimekprMirrorAdvertisement` wrapper reads on-disk state in managed
+ * mode (via injected seams here, so no real disk) and never reads in
+ * disabled/external mode.
+ */
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { Settings } from "../../../src/config.js";
+import {
+  buildTimekprMirrorAdvertisement,
+  resolveTimekprMirrorAdvertisement,
+  TIMEKPR_MIRROR_APT_PATH,
+} from "../../../src/api/clients/mirror-advertisement.js";
+import { VERSION_SENTINEL } from "../../../src/transport/timekpr-mirror/index.js";
+
+const DATA_DIR = "/data/apt/timekpr";
+
+const managed = (overrides: Partial<Settings["timekprMirror"]> = {}): Settings["timekprMirror"] =>
+  ({
+    mode: "managed",
+    dataDir: DATA_DIR,
+    package: "timekpr-next",
+    refreshCron: "0 3 * * *",
+    ...overrides,
+  }) as Settings["timekprMirror"];
+
+describe("buildTimekprMirrorAdvertisement", () => {
+  it("advertises nothing to configure when disabled", () => {
+    expect(buildTimekprMirrorAdvertisement({ mode: "disabled" }, null)).toEqual({
+      mode: "disabled",
+    });
+  });
+
+  it("passes through the external repo URL", () => {
+    expect(
+      buildTimekprMirrorAdvertisement({ mode: "external", url: "https://apt.lan/timekpr" }, null),
+    ).toEqual({ mode: "external", url: "https://apt.lan/timekpr" });
+  });
+
+  it("advertises the served path + package with a populated version when cached", () => {
+    const state = {
+      version: "0.5.5",
+      filename: "timekpr-next_0.5.5_all.deb",
+      path: join(DATA_DIR, "timekpr-next_0.5.5_all.deb"),
+    };
+    expect(buildTimekprMirrorAdvertisement(managed(), state)).toEqual({
+      mode: "managed",
+      aptPath: TIMEKPR_MIRROR_APT_PATH,
+      package: "timekpr-next",
+      version: "0.5.5",
+      debFilename: "timekpr-next_0.5.5_all.deb",
+    });
+  });
+
+  it("reports null version/filename on a managed cold start (nothing cached)", () => {
+    expect(
+      buildTimekprMirrorAdvertisement(managed({ package: "timekpr-next-beta" }), null),
+    ).toEqual({
+      mode: "managed",
+      aptPath: TIMEKPR_MIRROR_APT_PATH,
+      package: "timekpr-next-beta",
+      version: null,
+      debFilename: null,
+    });
+  });
+});
+
+describe("resolveTimekprMirrorAdvertisement", () => {
+  it("reads managed state from disk (seams) and reflects the cached version", () => {
+    const filename = "timekpr-next_0.5.5_all.deb";
+    const path = join(DATA_DIR, filename);
+    const ad = resolveTimekprMirrorAdvertisement(managed(), {
+      readSentinel: (p) => (p === join(DATA_DIR, VERSION_SENTINEL) ? "0.5.5" : null),
+      fileExists: (p) => p === path,
+    });
+    expect(ad).toEqual({
+      mode: "managed",
+      aptPath: TIMEKPR_MIRROR_APT_PATH,
+      package: "timekpr-next",
+      version: "0.5.5",
+      debFilename: filename,
+    });
+  });
+
+  it("reflects a managed cold start as null coordinates", () => {
+    const ad = resolveTimekprMirrorAdvertisement(managed(), {
+      readSentinel: () => null,
+      fileExists: () => false,
+    });
+    expect(ad).toMatchObject({ mode: "managed", version: null, debFilename: null });
+  });
+
+  it("does not read disk for disabled/external modes", () => {
+    // A throwing seam would surface if the resolver read state; it must not.
+    const throwing = {
+      readSentinel: () => {
+        throw new Error("must not read disk when not managed");
+      },
+      fileExists: () => {
+        throw new Error("must not read disk when not managed");
+      },
+    };
+    expect(resolveTimekprMirrorAdvertisement({ mode: "disabled" }, throwing)).toEqual({
+      mode: "disabled",
+    });
+    expect(
+      resolveTimekprMirrorAdvertisement({ mode: "external", url: "https://apt.lan/x" }, throwing),
+    ).toEqual({ mode: "external", url: "https://apt.lan/x" });
+  });
+});

--- a/server/tests/transport/timekpr-mirror/state.test.ts
+++ b/server/tests/transport/timekpr-mirror/state.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the timekpr-mirror on-disk state read (#393).
+ *
+ * The sentinel read and existence check are injected, so no test touches real
+ * disk. Covers the cold-start `null` returns (no sentinel, empty sentinel,
+ * sentinel names a missing `.deb`), the populated case, and that the `.deb`
+ * filename is derived from the shared {@link debFilename} keyed on the package.
+ */
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { VERSION_SENTINEL } from "../../../src/transport/timekpr-mirror/refresh.js";
+import { readMirrorState } from "../../../src/transport/timekpr-mirror/state.js";
+
+const DATA_DIR = "/data/apt/timekpr";
+const PKG = "timekpr-next";
+
+/** Build seams from an in-memory map of path -> sentinel value / file present. */
+function seams(sentinel: string | null, presentFiles: string[]) {
+  const present = new Set(presentFiles);
+  return {
+    readSentinel: (path: string) => (path === join(DATA_DIR, VERSION_SENTINEL) ? sentinel : null),
+    fileExists: (path: string) => present.has(path),
+  };
+}
+
+describe("readMirrorState", () => {
+  it("returns the cached .deb when the sentinel + file are present", () => {
+    const filename = `${PKG}_0.5.5_all.deb`;
+    const path = join(DATA_DIR, filename);
+    const state = readMirrorState({ dataDir: DATA_DIR, package: PKG }, seams("0.5.5", [path]));
+    expect(state).toEqual({ version: "0.5.5", filename, path });
+  });
+
+  it("derives the filename from the configured package/channel", () => {
+    const filename = "timekpr-next-beta_0.5.6_all.deb";
+    const path = join(DATA_DIR, filename);
+    const state = readMirrorState(
+      { dataDir: DATA_DIR, package: "timekpr-next-beta" },
+      seams("0.5.6", [path]),
+    );
+    expect(state?.filename).toBe(filename);
+  });
+
+  it("strips a Debian epoch from the filename (never the on-disk name) but keeps the version", () => {
+    const filename = `${PKG}_0.5.5_all.deb`;
+    const path = join(DATA_DIR, filename);
+    const state = readMirrorState({ dataDir: DATA_DIR, package: PKG }, seams("1:0.5.5", [path]));
+    // The sentinel version is reported verbatim; only the filename drops the epoch.
+    expect(state).toEqual({ version: "1:0.5.5", filename, path });
+  });
+
+  it("returns null when no sentinel is present (cold start)", () => {
+    expect(readMirrorState({ dataDir: DATA_DIR, package: PKG }, seams(null, []))).toBeNull();
+  });
+
+  it("returns null when the sentinel is empty", () => {
+    expect(readMirrorState({ dataDir: DATA_DIR, package: PKG }, seams("", []))).toBeNull();
+  });
+
+  it("returns null when the sentinel names a .deb that is not on disk", () => {
+    // Sentinel says 0.5.5 but nothing is present — a half-written/removed cache.
+    expect(readMirrorState({ dataDir: DATA_DIR, package: PKG }, seams("0.5.5", []))).toBeNull();
+  });
+});

--- a/server/tests/web/timekpr-mirror.test.ts
+++ b/server/tests/web/timekpr-mirror.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the managed timekpr-next mirror serving routes (#393).
+ *
+ * Follows the install-script.test.ts fixture pattern: materialise a temp mirror
+ * data dir (a fake `.deb` + the version sentinel #392 writes), point
+ * `PCT_TIMEKPR_MIRROR_DIR` at it in `managed` mode, and exercise the routes via
+ * `app.inject()` — no sockets. Covers the served `.deb` + manifest, the cold
+ * start 404, traversal/sentinel/non-`.deb` rejection, and that disabled/external
+ * modes expose no mirror surface at all.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+
+import { loadSettings } from "../../src/config.js";
+import { VERSION_SENTINEL } from "../../src/transport/timekpr-mirror/index.js";
+import { buildApp } from "../../src/web/app.js";
+import { testDb, type TestDb } from "../helpers/db.js";
+
+const VERSION = "0.5.5";
+const DEB_FILENAME = `timekpr-next_${VERSION}_all.deb`;
+/** A minimal valid `.deb`: the Debian ar global header followed by content. */
+const DEB_BYTES = Buffer.concat([Buffer.from("!<arch>\n", "ascii"), Buffer.from("payload")]);
+
+function buildManagedApp(dataDir: string, db: TestDb): FastifyInstance {
+  return buildApp({
+    settings: loadSettings({
+      PCT_LOG_LEVEL: "silent",
+      PCT_TIMEKPR_MIRROR: "managed",
+      PCT_TIMEKPR_MIRROR_DIR: dataDir,
+    }),
+    db,
+  });
+}
+
+describe("GET /apt/timekpr/* (managed mode, package cached)", () => {
+  let app: FastifyInstance;
+  let db: TestDb;
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pct-timekpr-mirror-"));
+    writeFileSync(join(dir, DEB_FILENAME), DEB_BYTES);
+    writeFileSync(join(dir, VERSION_SENTINEL), `${VERSION}\n`);
+    db = testDb();
+    app = buildManagedApp(dir, db);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("streams the cached .deb with the Debian content type", async () => {
+    const res = await app.inject({ method: "GET", url: `/apt/timekpr/${DEB_FILENAME}` });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/vnd.debian.binary-package");
+    expect(res.rawPayload.equals(DEB_BYTES)).toBe(true);
+  });
+
+  it("serves a manifest describing the cached package", async () => {
+    const res = await app.inject({ method: "GET", url: "/apt/timekpr/manifest.json" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      package: "timekpr-next",
+      version: VERSION,
+      filename: DEB_FILENAME,
+    });
+  });
+
+  it("404s a filename that is not on disk", async () => {
+    const res = await app.inject({ method: "GET", url: "/apt/timekpr/timekpr-next_9.9.9_all.deb" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("404s a non-.deb filename (e.g. the version sentinel)", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/apt/timekpr/${encodeURIComponent(VERSION_SENTINEL)}`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("404s a traversal-shaped filename", async () => {
+    // Fastify params never span '/', and the allow-list rejects a leading dot;
+    // an encoded traversal segment still resolves to a single param value.
+    const res = await app.inject({ method: "GET", url: "/apt/timekpr/..%2f..%2fpolicy.sqlite" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("does not shadow other routes", async () => {
+    const health = await app.inject({ method: "GET", url: "/healthz" });
+    expect(health.statusCode).toBe(200);
+    expect(health.json()).toEqual({ status: "ok" });
+  });
+});
+
+describe("GET /apt/timekpr/* (managed mode, cold start — nothing cached)", () => {
+  let app: FastifyInstance;
+  let db: TestDb;
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pct-timekpr-mirror-cold-"));
+    db = testDb();
+    app = buildManagedApp(dir, db);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("404s the manifest before the first fetch", async () => {
+    const res = await app.inject({ method: "GET", url: "/apt/timekpr/manifest.json" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("404s a well-formed .deb name that is not cached yet", async () => {
+    const res = await app.inject({ method: "GET", url: `/apt/timekpr/${DEB_FILENAME}` });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("GET /apt/timekpr/* (mirror not managed)", () => {
+  let app: FastifyInstance;
+  let db: TestDb;
+
+  afterEach(async () => {
+    await app.close();
+    db.$client.close();
+  });
+
+  it("exposes no mirror surface when disabled (default)", async () => {
+    db = testDb();
+    app = buildApp({ settings: loadSettings({ PCT_LOG_LEVEL: "silent" }), db });
+    const manifest = await app.inject({ method: "GET", url: "/apt/timekpr/manifest.json" });
+    expect(manifest.statusCode).toBe(404);
+    const file = await app.inject({ method: "GET", url: `/apt/timekpr/${DEB_FILENAME}` });
+    expect(file.statusCode).toBe(404);
+  });
+
+  it("exposes no mirror surface in external mode (client points apt elsewhere)", async () => {
+    db = testDb();
+    app = buildApp({
+      settings: loadSettings({
+        PCT_LOG_LEVEL: "silent",
+        PCT_TIMEKPR_MIRROR: "external",
+        PCT_TIMEKPR_MIRROR_URL: "https://apt.lan/timekpr",
+      }),
+      db,
+    });
+    const manifest = await app.inject({ method: "GET", url: "/apt/timekpr/manifest.json" });
+    expect(manifest.statusCode).toBe(404);
+  });
+});

--- a/server/tests/web/timekpr-mirror.test.ts
+++ b/server/tests/web/timekpr-mirror.test.ts
@@ -116,9 +116,11 @@ describe("GET /apt/timekpr/* (managed mode, cold start — nothing cached)", () 
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("404s the manifest before the first fetch", async () => {
+  it("404s the manifest before the first fetch, with a JSON body", async () => {
     const res = await app.inject({ method: "GET", url: "/apt/timekpr/manifest.json" });
     expect(res.statusCode).toBe(404);
+    expect(res.headers["content-type"]).toContain("application/json");
+    expect(res.json()).toEqual({ error: "no timekpr package is cached yet" });
   });
 
   it("404s a well-formed .deb name that is not cached yet", async () => {


### PR DESCRIPTION
## Summary

The **ADR 0011 MVP** (mode B) for the managed `timekpr-next` mirror — the third slice of epic #389, after the config seam (#391) and the background fetch/refresh job (#392):

- **Serve** the runtime-cached `.deb` over the LAN: `GET /apt/timekpr/manifest.json` (`{ package, version, filename }`) and `GET /apt/timekpr/<file>.deb`, in `managed` mode only (disabled/external expose nothing), with a strict `.deb` basename allow-list + dataDir-containment guard and a 404 cold-start path.
- **Advertise** the mirror in the enrol response (`timekprMirror`: a `disabled | external | managed` discriminated union carrying the served `aptPath` + `package` + the currently-cached `version`/`debFilename`), so the client installer (#394) can point apt at the dashboard instead of round-tripping to `launchpad.net`.
- **`readMirrorState`** reads back the version sentinel #392 writes + confirms the `.deb` exists (injectable fs seams); the pure `buildTimekprMirrorAdvertisement` maps config → wire, and the service stays disk-free.

### Scope / deferred

Per ADR 0011's explicit "ship the MVP first, then graduate to the signed apt repo" rollout, this PR is the direct-download MVP (`apt-get install ./<file>.deb`, which resolves the package's own `Depends` from the client's distro repos). The **GPG-signed apt index** + full `apt update`/pinning/rollback semantics are the Phase-14 end-state under epic #163 — tracked as new follow-up issue **#437** (linked under #163). A hand-synthesised, dependency-less `Packages` index was deliberately avoided because it would install the package without its dependencies; the reasoning is captured in the plan.

## Plan

Linked plan: `docs/plans/393-timekpr-mirror-serve-advertise.md`
Roadmap: `docs/roadmap.md` → Phase 3

## License-boundary note

**No boundary crossed.** Plain Fastify + `node:fs` streaming of a `.deb` that #392 fetched at runtime into `/data`; nothing links, imports, or vendors GPL code, and no GPL binary enters the image (`CLAUDE.md` → "License boundaries" rules 1 & 5; ADR 0011). `license-guard.yml` scans the image and is unaffected. No packaging tooling is shelled out to in this slice. No new dependencies.

## Test plan

- [x] `state.ts`: cached present → state; missing `.deb`/empty/no sentinel → `null`; epoch stripped from filename only.
- [x] `web/timekpr-mirror.ts`: managed serves the `.deb` (content-type + bytes) + manifest; cold-start 404; traversal / non-`.deb` / sentinel-name → 404; disabled/external expose nothing.
- [x] `mirror-advertisement.ts`: each mode maps; managed cold-start → null coords; resolver reads disk in managed only (throwing seam proves disabled/external don't).
- [x] enrol route: disabled by default; managed surfaces the advertised coordinates + cached version.
- [x] `npm run format:check` · `lint` · `typecheck` · `npm test` (coverage ≥ 80%) all green.

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BigaT1fB8rTYJr5CweKmdo)_