### PR TITLE
feat(client): package pct-client agent as a .deb bundling its own Node runtime (#106)

### DIFF
--- a/.claude/plans/issue-106-package-client-agent-deb.md
+++ b/.claude/plans/issue-106-package-client-agent-deb.md
@@ -1,0 +1,198 @@
+# Plan — Issue #106: Package the client agent as a `.deb` bundling its own Node runtime
+
+Phase 8b. Ships the `pct-client` Debian package that installs the
+`pct-client-bridge` (system service, one per client) and
+`pct-client-agent` (`systemd --user`, per supervised user) daemons —
+authoritative layout in
+[`docs/client-install.md`](../../docs/client-install.md) §5a and
+[`docs/client-notifications.md`](../../docs/client-notifications.md) §1/§2.
+
+The bridge/agent TypeScript codebases (#101, #103) already exist under
+`client/agent/`. Neither is packaged yet: `install-client.sh` (#76) has a
+gap where "install the `pct-client` agent package" should go, and the
+issue #106 tracks that packaging surface.
+
+## Boundary posture
+
+- **License**: nothing here changes the boundary. The bundled Node
+  runtime is MIT/BSD and lives on the *client* only, never in the
+  dashboard image (`CLAUDE.md` → License boundaries, rule 5 stays
+  intact). No GPL linkage in the process (bridge/agent are our own TS
+  daemons; `timekpra`/`ansible` are subprocesses only, invoked out of
+  scope of this PR).
+- **Tamper resistance**: within bounds — a plain notification / event
+  relay daemon package, no anti-tamper, no `/etc`/`/usr`/boot lockdown
+  (`CLAUDE.md` → "Tamper resistance is deliberately bounded").
+
+## Layout the `.deb` installs (matches the docs verbatim)
+
+```
+/usr/lib/pct-client/
+├── node/                              # bundled Node.js 22 runtime
+│   ├── bin/node
+│   └── LICENSE
+├── dist/                              # compiled TS output
+│   ├── main.js                        # bridge entry (pct-client-bridge)
+│   ├── agent/main.js                  # agent entry (pct-client-agent)
+│   ├── bridge/*.js
+│   └── agent/*.js
+├── node_modules/                      # production deps: ws, zod
+│   ├── ws/
+│   └── zod/
+└── VERSION                            # the package version string
+
+/usr/lib/systemd/system/pct-client-bridge.service        # system unit
+/usr/lib/systemd/user/pct-client-agent.service           # user unit
+/usr/lib/tmpfiles.d/pct-client.conf                      # /run/pct dir
+/etc/default/pct-client-bridge                           # env, conffile
+```
+
+- **Bridge unit** runs `node dist/main.js` as `pct-agent` (created by
+  `provision-agent-user.sh` on enrol, #78 — the package `Depends: adduser`
+  and the `postinst` creates the user idempotently if missing so
+  `dpkg -i pct-client_*.deb` also works in a lab / test setup).
+- **Agent unit** runs `node dist/agent/main.js` under
+  `systemd --user` for each supervised Linux user (the installer enables
+  the user unit per supervised uid; the package's job is to ship the
+  unit file only).
+- **`/etc/default/pct-client-bridge`** carries `PCT_BRIDGE_SERVER_URL`,
+  `PCT_BRIDGE_TOKEN`, `PCT_BRIDGE_USERS` (the `EnvironmentFile=` for the
+  bridge unit). Conffile so a `dpkg` upgrade preserves the local values.
+
+## Build pipeline (`client/agent/build-deb.sh`)
+
+Single shell script under `client/agent/`, invoked by dev and CI. Runs
+without root — uses `dpkg-deb --build --root-owner-group` (fakeroot
+optional). Steps:
+
+1. **Emit compiled JS** — `npx tsc -p tsconfig.build.json` produces
+   `dist/` under a staged root.
+2. **Stage production deps** — `npm ci --omit=dev --prefix <stage>` so
+   `node_modules/` contains only `ws` + `zod`.
+3. **Fetch the pinned Node runtime** — `NODE_VERSION` is pinned in a
+   `client/agent/NODE_VERSION` sentinel file (single source of truth).
+   The script downloads
+   `https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz`
+   and verifies against a SHA-256 pinned in the sentinel file
+   (`SHA256_LINUX_X64`). `PCT_NODE_TARBALL=<path>` short-circuits the
+   download so tests can inject a stub tarball with no network. The
+   extracted `node` binary and `LICENSE` file land under
+   `usr/lib/pct-client/node/`.
+4. **Compose DEBIAN/**
+   - `control` — `Package: pct-client`, `Architecture: amd64` (matches
+     the bundled runtime), `Depends: systemd, adduser`, `Version:` from
+     an env var / `git describe --tags --always` fallback.
+   - `postinst` — create the `pct-agent` system user idempotently
+     (`getent passwd pct-agent >/dev/null || useradd --system --user-group
+     --home-dir /var/lib/pct-agent --shell /usr/sbin/nologin pct-agent`),
+     `systemd-tmpfiles --create` for `/run/pct`, then
+     `systemctl daemon-reload` and `systemctl enable pct-client-bridge`.
+     `dpkg-triggers` on `daemon-reload` is not used to keep the script
+     legible.
+   - `prerm` — `systemctl disable --now pct-client-bridge` on remove.
+   - `postrm` — on `purge` only, tidy `/etc/default/pct-client-bridge`.
+   - `conffiles` — the one `/etc/default/pct-client-bridge` line.
+5. **Emit** — `dpkg-deb --build --root-owner-group <stage>
+   pct-client_<version>_amd64.deb`.
+
+Output path controlled by `--output <path>` (default:
+`client/agent/dist/pct-client_<version>_amd64.deb`).
+
+**Reproducibility**: sorted `find`+`tar` inside the staging root, no
+timestamps that vary with wall-clock; not bit-for-bit reproducible in
+this slice, but structurally stable so `dpkg-deb --info` diffs cleanly
+between runs on the same source.
+
+## Tests
+
+Two layers, both live with the code they exercise:
+
+- **`client/tests/build-deb.bats`** — same pattern as
+  `build-install-bundle.bats`: build the `.deb` with a stub Node
+  tarball, then assert against `dpkg-deb --info`, `--contents`, and the
+  extracted control scripts. Fifteen-ish tests covering:
+  - the package name/architecture/dependencies
+  - the `/usr/lib/pct-client/{node,dist,node_modules}/` layout is
+    populated (bridge main + agent main present; `ws` and `zod` present)
+  - the two systemd unit files land in the right dirs, `ExecStart`
+    points at the bundled node + bundled dist, and the bridge unit
+    references `/etc/default/pct-client-bridge`
+  - the tmpfiles.d entry creates `/run/pct` with the documented perms
+  - `postinst` / `prerm` are executable, contain the user-add and
+    daemon-reload hooks, and the tmpfiles create call
+  - `conffiles` lists `/etc/default/pct-client-bridge`
+  - build fails cleanly on a missing sentinel / wrong SHA-256
+- **`.github/workflows/ci.yml`** — extend the `client-agent` job (or add
+  a sibling `client-agent-package` job — see phasing) that runs
+  `bash client/agent/build-deb.sh` on the Ubuntu runner (dpkg-deb + real
+  network to nodejs.org), then `dpkg-deb --info` on the artifact.
+
+The existing `client-agent` job (lint / typecheck / vitest) is
+unchanged; the compiled emit is validated in a *new* CI step so a broken
+build-tsconfig fails independently of the unit tests.
+
+## Documentation
+
+- `docs/client-install.md` §5a — add a "How the package is built" note
+  linking to `client/agent/build-deb.sh`; keep the runtime steps as-is
+  (they already describe enabling the units).
+- `client/agent/README.md` — a short "Building the `.deb`" section
+  documenting `build-deb.sh` args and env (`PCT_NODE_TARBALL`,
+  `--output`, `--version`).
+- No ADR needed — this is packaging plumbing for a design already
+  captured in `docs/client-install.md` / `docs/client-notifications.md`.
+
+## Explicitly out of scope (tracked as follow-ups on the PR)
+
+- **Publishing the `.deb`** from `release.yml` over the chosen channel
+  (GitHub Release attachment vs an apt repo). That is #168 (Phase 14),
+  which itself depends on the channel decision in #167. Filed as a
+  follow-up if #168 lacks the concrete "release.yml step" scope.
+- **`install-client.sh` fetching + installing the `.deb`.** The issue
+  lists this as an "optional/late step". Without a publish channel it
+  would fetch from nowhere. The install-client hook ships as a **passive
+  env-guarded step**: `PCT_AGENT_DEB=<path>` (an already-fetched local
+  file) triggers `dpkg -i` + `systemctl enable --now` for the per-user
+  units. Full "fetch from the enrol response's advertised URL" is a
+  follow-up that lands with #168 / the timekpr-mirror publish path
+  (#389 epic).
+- **Narrow bridge `sudoers` drop-in.** The bridge's privileged actions
+  (`timekpra --kill-session` for `enforce.session_lock`, PAM lockout
+  set/clear) are Phase 8c (#107 / #108), not yet implemented. `#345` is
+  the ADR on the dashboard-side privilege model; the bridge-side
+  sudoers drop-in will follow that decision. This PR ships the package
+  with **no** privileged commands and **no** loosened sudoers config —
+  the empty posture is the safe default. Filed as a Phase-8c follow-up
+  linked from the PR.
+- **Rich `pct-client-agent@<supervised-user>.service` templating** for
+  enabling the user unit per supervised uid at package-install time.
+  The `enrol` step in `install-client.sh` (#76 §5a) is the right place
+  to enable user units per supervised uid (it already knows the
+  supervised-user list); the package's job is to ship the unit file
+  only.
+- **Signing the `.deb` / apt index.** Ties to #393 (the server-hosted
+  mirror's signed apt index). Not needed for a GitHub Release
+  attachment.
+
+## Phasing (commit + push per phase; first push opens the draft PR)
+
+- **Phase 1** — Build pipeline + emit:
+  `client/agent/tsconfig.build.json`, `client/agent/package.json` gains
+  a `build` script, `client/agent/build-deb.sh` skeleton that builds an
+  otherwise-empty `.deb` under a stub Node tarball, first `.bats` test
+  asserting the `.deb` builds and `dpkg-deb --info` runs. Push → draft
+  PR opens.
+- **Phase 2** — Complete the package payload + full bats coverage:
+  systemd units (bridge system + agent user), tmpfiles.d entry,
+  DEBIAN/{control,postinst,prerm,postrm,conffiles}, and the rest of the
+  bats assertions. Node runtime staging (still via stub tarball in
+  tests).
+- **Phase 3** — CI + docs + follow-ups. `.github/workflows/ci.yml` gains
+  the package-build step (real Node download). `client/agent/README.md`
+  build-deb section. `docs/client-install.md` §5a note. Mark PR ready,
+  run review subagent, open follow-up issues (install-client.sh fetch
+  hook, Phase-8c sudoers drop-in).
+
+Each phase leaves the tree clean (`server`'s quality gate + `client/agent`'s
+`format:check` / `lint` / `typecheck` / `test` + bats all green) before
+pushing.

--- a/client/agent/NODE_VERSION
+++ b/client/agent/NODE_VERSION
@@ -1,0 +1,13 @@
+# Pinned Node.js runtime for the pct-client .deb (issue #106).
+#
+# The package bundles its OWN Node runtime under /usr/lib/pct-client/node so it
+# does not depend on the distro's Node packages (CLAUDE.md -> "Client agent").
+# build-deb.sh sources this file, downloads the matching official tarball from
+# nodejs.org, and verifies it against the SHA-256 pinned here.
+#
+# To bump: change NODE_VERSION and update BOTH SHA-256 lines from
+#   https://nodejs.org/dist/v<NODE_VERSION>/SHASUMS256.txt
+# (the node-v<ver>-linux-x64.tar.xz and node-v<ver>-linux-arm64.tar.xz rows).
+NODE_VERSION=22.22.2
+SHA256_LINUX_X64=88fd1ce767091fd8d4a99fdb2356e98c819f93f3b1f8663853a2dee9b438068a
+SHA256_LINUX_ARM64=e9e1930fd321a470e29bb68f30318bf58e3ecb4acb4f1533fb19c58328a091fe

--- a/client/agent/README.md
+++ b/client/agent/README.md
@@ -39,7 +39,6 @@ The bridge reads its configuration from the environment (see
 - **Privileged enforcement actions** (`timekpra --kill-session`, lockout
   set/clear) and the narrow `sudoers` rule — Phase 8c (#107 / #108).
 - The **`pct-client-agent`** per-user notification daemon — #103.
-- **`.deb` packaging, systemd units, `/run/pct` provisioning** — #106.
 
 ## Develop
 
@@ -48,3 +47,34 @@ cd client/agent
 npm ci
 npm run format:check && npm run lint && npm run typecheck && npm test
 ```
+
+## Building the `.deb` (#106)
+
+`build-deb.sh` produces the `pct-client` Debian package: it compiles the agent
+TypeScript, stages the production deps (`ws`, `zod`), downloads and
+SHA-256-verifies the pinned Node runtime, and assembles the package with
+`dpkg-deb`. The pinned Node version + hashes live in `NODE_VERSION`.
+
+```bash
+cd client/agent
+npm ci
+./build-deb.sh --version 0.1.0            # -> dist/pct-client_0.1.0_amd64.deb
+./build-deb.sh --arch arm64 --version 0.1.0
+```
+
+| Flag / env         | Meaning                                                                |
+| ------------------ | ---------------------------------------------------------------------- |
+| `--output PATH`    | where to write the `.deb` (default `dist/pct-client_<ver>_<arch>.deb`) |
+| `--version VER`    | package version (default `$PCT_DEB_VERSION`, else `git describe`)      |
+| `--arch ARCH`      | `amd64` (default) or `arm64`                                           |
+| `PCT_NODE_TARBALL` | pre-fetched Node tarball to skip the download (offline builds)         |
+| `PCT_NODE_SHA256`  | override the expected tarball hash (e.g. an injected stub)             |
+
+The package installs the bundled runtime + daemons under `/usr/lib/pct-client/`,
+the two systemd units, a `tmpfiles.d` entry for `/run/pct`, and the
+`/etc/default/pct-client-bridge` conffile. `postinst` creates the `pct-agent`
+account and **enables** (not starts) the bridge — `install-client.sh` writes the
+enrolment token to the conffile and starts it. See
+[`docs/client-install.md`](../../docs/client-install.md) §5a. Publishing the
+package (GitHub Release / apt) is #168; `client/tests/build-deb.bats` covers the
+build offline.

--- a/client/agent/build-deb.sh
+++ b/client/agent/build-deb.sh
@@ -111,7 +111,14 @@ if [ -z "$VERSION" ]; then
 	VERSION="$(git -C "$SCRIPT_DIR" describe --tags --always 2>/dev/null || true)"
 	VERSION="${VERSION#v}"
 fi
-[ -n "$VERSION" ] || VERSION="0.0.0"
+# A Debian upstream version must start with a digit. `git describe --always`
+# with no tags yields a bare commit hash (often letter-led), so fall back to a
+# sortable dev version rather than emit a policy-nonconforming one. Releases
+# pass --version explicitly (#168).
+case "$VERSION" in
+[0-9]*) : ;;
+*) VERSION="0.0.0+${VERSION:-unknown}" ;;
+esac
 
 : "${OUTPUT:=${SCRIPT_DIR}/dist/pct-client_${VERSION}_${ARCH}.deb}"
 
@@ -142,7 +149,7 @@ cp -r "${SCRIPT_DIR}/dist" "${PKG_ROOT}/dist"
 # pulls transitive deps, switch this to `npm ci --omit=dev` into a staging dir.
 echo "build-deb.sh: staging production node_modules"
 mkdir -p "${PKG_ROOT}/node_modules"
-PROD_DEPS="$(node -e 'const p=require("./package.json");process.stdout.write(Object.keys(p.dependencies||{}).join("\n"))' <"${SCRIPT_DIR}/package.json" 2>/dev/null || node -e 'const p=require(process.argv[1]);process.stdout.write(Object.keys(p.dependencies||{}).join("\n"))' "${SCRIPT_DIR}/package.json")"
+PROD_DEPS="$(node -e 'const p=require(process.argv[1]);process.stdout.write(Object.keys(p.dependencies||{}).join("\n"))' "${SCRIPT_DIR}/package.json")"
 while IFS= read -r dep; do
 	[ -n "$dep" ] || continue
 	src="${SCRIPT_DIR}/node_modules/${dep}"

--- a/client/agent/build-deb.sh
+++ b/client/agent/build-deb.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+#
+# build-deb.sh — build the pct-client Debian package (#106).
+#
+# What it produces
+# ----------------
+# A single `.deb` that installs the two supervised-client daemons and a Node.js
+# runtime bundled just for them:
+#
+#   /usr/lib/pct-client/node/bin/node       bundled, pinned Node runtime
+#   /usr/lib/pct-client/dist/main.js        pct-client-bridge entry point
+#   /usr/lib/pct-client/dist/agent/main.js  pct-client-agent entry point
+#   /usr/lib/pct-client/node_modules/       production deps (ws, zod)
+#   /usr/lib/systemd/system/pct-client-bridge.service   system unit
+#   /usr/lib/systemd/user/pct-client-agent.service      systemd --user unit
+#   /usr/lib/tmpfiles.d/pct-client.conf                 /run/pct socket dir
+#   /etc/default/pct-client-bridge                      bridge EnvironmentFile
+#
+# The bundled runtime is why this exists: the distro's Node packages lag behind
+# what the agent needs, so the package ships its own (CLAUDE.md -> "Client
+# agent"; docs/client-install.md step 5a; docs/client-notifications.md).
+#
+# License boundary (docs/licensing-analysis.md): this packages only this repo's
+# own permissively-licensed TypeScript plus its MIT deps (ws, zod) and the
+# official Node runtime (MIT/BSD/ASL-2.0). No GPL code is linked or vendored,
+# and this touches the CLIENT package only — never the dashboard image, whose
+# GPL-free invariant (license-guard.yml) is unaffected. GPL client tools
+# (Timekpr-nExT, e2guardian) are installed separately from apt by the installer.
+#
+# Usage:
+#   client/agent/build-deb.sh [--output PATH] [--version VER] [--arch ARCH]
+#
+#   --output PATH   Where to write the .deb
+#                   (default: <script dir>/dist/pct-client_<version>_<arch>.deb).
+#   --version VER   Package version (default: $PCT_DEB_VERSION, else the git
+#                   tag via `git describe`, else 0.0.0).
+#   --arch ARCH     Debian architecture: amd64 (default) or arm64.
+#
+# Environment (mainly for tests / offline builds):
+#   PCT_NODE_TARBALL  Path to a pre-fetched node-vX-linux-ARCH.tar.xz; skips the
+#                     download. Still SHA-256 verified (see PCT_NODE_SHA256).
+#   PCT_NODE_SHA256   Override the expected tarball SHA-256 (defaults to the pin
+#                     in ./NODE_VERSION). Lets a test inject a stub tarball.
+#   PCT_DEB_VERSION   Default for --version.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NODE_DOWNLOAD_BASE="${PCT_NODE_DOWNLOAD_BASE:-https://nodejs.org/dist}"
+
+die() {
+	echo "build-deb.sh: $*" >&2
+	exit 1
+}
+
+usage() {
+	sed -n '/^# Usage:/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# --- Parse arguments --------------------------------------------------------
+OUTPUT=""
+VERSION="${PCT_DEB_VERSION:-}"
+ARCH="amd64"
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--output)
+		OUTPUT="${2:?--output needs a path}"
+		shift 2
+		;;
+	--version)
+		VERSION="${2:?--version needs a value}"
+		shift 2
+		;;
+	--arch)
+		ARCH="${2:?--arch needs a value}"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1 (try --help)"
+		;;
+	esac
+done
+
+# --- Resolve architecture ---------------------------------------------------
+case "$ARCH" in
+amd64) NODE_ARCH="x64" ;;
+arm64) NODE_ARCH="arm64" ;;
+*) die "unsupported --arch: $ARCH (want amd64 or arm64)" ;;
+esac
+
+# --- Load the pinned Node runtime descriptor --------------------------------
+[ -f "${SCRIPT_DIR}/NODE_VERSION" ] || die "missing ${SCRIPT_DIR}/NODE_VERSION"
+# shellcheck source=/dev/null
+. "${SCRIPT_DIR}/NODE_VERSION"
+[ -n "${NODE_VERSION:-}" ] || die "NODE_VERSION not set in NODE_VERSION file"
+
+if [ "$NODE_ARCH" = "x64" ]; then
+	EXPECTED_SHA="${PCT_NODE_SHA256:-${SHA256_LINUX_X64:-}}"
+else
+	EXPECTED_SHA="${PCT_NODE_SHA256:-${SHA256_LINUX_ARM64:-}}"
+fi
+[ -n "$EXPECTED_SHA" ] || die "no expected SHA-256 for arch $ARCH"
+
+# --- Resolve version --------------------------------------------------------
+if [ -z "$VERSION" ]; then
+	VERSION="$(git -C "$SCRIPT_DIR" describe --tags --always 2>/dev/null || true)"
+	VERSION="${VERSION#v}"
+fi
+[ -n "$VERSION" ] || VERSION="0.0.0"
+
+: "${OUTPUT:=${SCRIPT_DIR}/dist/pct-client_${VERSION}_${ARCH}.deb}"
+
+echo "build-deb.sh: building pct-client ${VERSION} (${ARCH}) with Node ${NODE_VERSION}"
+
+# --- Staging area -----------------------------------------------------------
+STAGE="$(mktemp -d)"
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$STAGE" "$WORK"; }
+trap cleanup EXIT
+
+PKG_ROOT="${STAGE}/usr/lib/pct-client"
+mkdir -p "$PKG_ROOT" \
+	"${STAGE}/usr/lib/systemd/system" \
+	"${STAGE}/usr/lib/systemd/user" \
+	"${STAGE}/usr/lib/tmpfiles.d" \
+	"${STAGE}/etc/default" \
+	"${STAGE}/DEBIAN"
+
+# --- Compile the TypeScript -------------------------------------------------
+echo "build-deb.sh: compiling TypeScript -> dist/"
+(cd "$SCRIPT_DIR" && npm run --silent build)
+cp -r "${SCRIPT_DIR}/dist" "${PKG_ROOT}/dist"
+
+# --- Stage production node_modules ------------------------------------------
+# ws and zod are dependency-free, so copying the named production deps from the
+# already-installed tree is correct and fully offline. If a future prod dep
+# pulls transitive deps, switch this to `npm ci --omit=dev` into a staging dir.
+echo "build-deb.sh: staging production node_modules"
+mkdir -p "${PKG_ROOT}/node_modules"
+PROD_DEPS="$(node -e 'const p=require("./package.json");process.stdout.write(Object.keys(p.dependencies||{}).join("\n"))' <"${SCRIPT_DIR}/package.json" 2>/dev/null || node -e 'const p=require(process.argv[1]);process.stdout.write(Object.keys(p.dependencies||{}).join("\n"))' "${SCRIPT_DIR}/package.json")"
+while IFS= read -r dep; do
+	[ -n "$dep" ] || continue
+	src="${SCRIPT_DIR}/node_modules/${dep}"
+	[ -d "$src" ] || die "production dependency '${dep}' not installed (run npm ci first)"
+	cp -r "$src" "${PKG_ROOT}/node_modules/${dep}"
+done <<EOF
+$PROD_DEPS
+EOF
+
+# A minimal package.json so Node treats the bundle as ESM and resolves the
+# bundled node_modules; the source uses "type": "module" + .js import specifiers.
+cat >"${PKG_ROOT}/package.json" <<EOF
+{
+  "name": "pct-client",
+  "version": "${VERSION}",
+  "private": true,
+  "type": "module"
+}
+EOF
+printf '%s\n' "$VERSION" >"${PKG_ROOT}/VERSION"
+
+# --- Bundle the Node runtime ------------------------------------------------
+TARBALL_NAME="node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz"
+if [ -n "${PCT_NODE_TARBALL:-}" ]; then
+	TARBALL="$PCT_NODE_TARBALL"
+	[ -f "$TARBALL" ] || die "PCT_NODE_TARBALL not found: $TARBALL"
+	echo "build-deb.sh: using provided Node tarball: $TARBALL"
+else
+	TARBALL="${WORK}/${TARBALL_NAME}"
+	echo "build-deb.sh: downloading ${TARBALL_NAME}"
+	curl -fsSL --retry 3 -o "$TARBALL" "${NODE_DOWNLOAD_BASE}/v${NODE_VERSION}/${TARBALL_NAME}" ||
+		die "failed to download ${TARBALL_NAME}"
+fi
+
+echo "build-deb.sh: verifying Node tarball SHA-256"
+ACTUAL_SHA="$(sha256sum "$TARBALL" | cut -d' ' -f1)"
+[ "$ACTUAL_SHA" = "$EXPECTED_SHA" ] ||
+	die "Node tarball SHA-256 mismatch: got ${ACTUAL_SHA}, expected ${EXPECTED_SHA}"
+
+echo "build-deb.sh: extracting Node runtime"
+tar -xJf "$TARBALL" -C "$WORK"
+NODE_SRC="${WORK}/node-v${NODE_VERSION}-linux-${NODE_ARCH}"
+[ -x "${NODE_SRC}/bin/node" ] || die "extracted tarball has no bin/node at ${NODE_SRC}"
+mkdir -p "${PKG_ROOT}/node/bin"
+cp "${NODE_SRC}/bin/node" "${PKG_ROOT}/node/bin/node"
+[ -f "${NODE_SRC}/LICENSE" ] && cp "${NODE_SRC}/LICENSE" "${PKG_ROOT}/node/LICENSE"
+
+# --- Static package files ---------------------------------------------------
+PKG="${SCRIPT_DIR}/packaging"
+cp "${PKG}/systemd/pct-client-bridge.service" "${STAGE}/usr/lib/systemd/system/"
+cp "${PKG}/systemd/pct-client-agent.service" "${STAGE}/usr/lib/systemd/user/"
+cp "${PKG}/tmpfiles.d/pct-client.conf" "${STAGE}/usr/lib/tmpfiles.d/"
+cp "${PKG}/default/pct-client-bridge" "${STAGE}/etc/default/pct-client-bridge"
+
+# --- DEBIAN control + maintainer scripts ------------------------------------
+sed -e "s/@VERSION@/${VERSION}/" -e "s/@ARCH@/${ARCH}/" \
+	"${PKG}/debian/control.in" >"${STAGE}/DEBIAN/control"
+cp "${PKG}/debian/conffiles" "${STAGE}/DEBIAN/conffiles"
+for script in postinst prerm postrm; do
+	cp "${PKG}/debian/${script}" "${STAGE}/DEBIAN/${script}"
+	chmod 0755 "${STAGE}/DEBIAN/${script}"
+done
+
+# Deterministic file modes: dirs 0755, files 0644, then re-arm executables.
+find "$STAGE" -path "${STAGE}/DEBIAN" -prune -o -type d -exec chmod 0755 {} +
+find "$STAGE" -path "${STAGE}/DEBIAN" -prune -o -type f -exec chmod 0644 {} +
+chmod 0755 "${PKG_ROOT}/node/bin/node"
+
+# --- Build the .deb ---------------------------------------------------------
+mkdir -p "$(dirname "$OUTPUT")"
+dpkg-deb --build --root-owner-group "$STAGE" "$OUTPUT" >/dev/null
+echo "build-deb.sh: wrote $OUTPUT"

--- a/client/agent/package.json
+++ b/client/agent/package.json
@@ -15,7 +15,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --coverage"
+    "test": "vitest run --coverage",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist"
   },
   "dependencies": {
     "ws": "^8.18.1",

--- a/client/agent/packaging/debian/conffiles
+++ b/client/agent/packaging/debian/conffiles
@@ -1,0 +1,1 @@
+/etc/default/pct-client-bridge

--- a/client/agent/packaging/debian/control.in
+++ b/client/agent/packaging/debian/control.in
@@ -1,0 +1,15 @@
+Package: pct-client
+Version: @VERSION@
+Section: admin
+Priority: optional
+Architecture: @ARCH@
+Depends: systemd, adduser
+Maintainer: Ben Seymour <BenSeymourODB@users.noreply.github.com>
+Homepage: https://github.com/BenSeymourODB/linux-parental-controls-toolkit
+Description: Parental Controls Toolkit client agent (bridge + per-user agent)
+ Installs pct-client-bridge (a system service that holds the outbound event
+ stream to the dashboard) and pct-client-agent (a systemd --user daemon that
+ renders notifications and computes the time-remaining cadence for each
+ supervised user). The package bundles its own Node.js runtime under
+ /usr/lib/pct-client/node so it does not depend on the distribution's Node
+ packages.

--- a/client/agent/packaging/debian/control.in
+++ b/client/agent/packaging/debian/control.in
@@ -3,7 +3,8 @@ Version: @VERSION@
 Section: admin
 Priority: optional
 Architecture: @ARCH@
-Depends: systemd, adduser
+Depends: systemd
+Recommends: libnotify-bin, libcanberra-gtk3-module
 Maintainer: Ben Seymour <BenSeymourODB@users.noreply.github.com>
 Homepage: https://github.com/BenSeymourODB/linux-parental-controls-toolkit
 Description: Parental Controls Toolkit client agent (bridge + per-user agent)

--- a/client/agent/packaging/debian/postinst
+++ b/client/agent/packaging/debian/postinst
@@ -5,13 +5,16 @@ set -e
 
 case "$1" in
 configure)
-	# The bridge runs as this low-privilege account (docs/client-install.md
-	# step 7 / #78). Create it if the installer has not already; --system so it
-	# gets no login and no expiry. Idempotent: skip when it already exists.
+	# The bridge runs as this low-privilege account, which is ALSO the SSH
+	# principal the dashboard connects as to run timekpra (docs/client-install.md
+	# step 7 / #78). It must therefore have a real login shell and a home for
+	# ~/.ssh/authorized_keys. Create it identically to
+	# client/lib/provision-agent-user.sh so whichever of the two runs first
+	# yields the same account (both are idempotent "skip if exists"): --system,
+	# --create-home (=> /home/pct-agent), --shell /bin/bash (the SSH exec
+	# channel needs a shell). useradd is from the essential passwd package.
 	if ! getent passwd pct-agent >/dev/null 2>&1; then
-		adduser --system --group --home /var/lib/pct-agent \
-			--shell /usr/sbin/nologin \
-			--gecos "Parental Controls Toolkit agent" pct-agent
+		useradd --system --create-home --shell /bin/bash pct-agent
 	fi
 
 	# Only touch systemd when it is the running init (skips containers/chroots).
@@ -22,6 +25,11 @@ configure)
 		# /etc/default/pct-client-bridge first, which install-client.sh does
 		# before starting the unit.
 		systemctl enable pct-client-bridge.service || true
+		# On upgrade, pick up the new dist/ + bundled runtime if the bridge is
+		# already running. try-restart is a no-op when the unit is stopped (a
+		# fresh install before enrolment), so it never starts an unconfigured
+		# bridge.
+		systemctl try-restart pct-client-bridge.service || true
 	fi
 	;;
 abort-upgrade | abort-remove | abort-deconfigure) ;;

--- a/client/agent/packaging/debian/postinst
+++ b/client/agent/packaging/debian/postinst
@@ -1,0 +1,34 @@
+#!/bin/sh
+# postinst for pct-client (#106). POSIX sh; keep it idempotent so a re-install
+# or upgrade is a no-op where the state already exists.
+set -e
+
+case "$1" in
+configure)
+	# The bridge runs as this low-privilege account (docs/client-install.md
+	# step 7 / #78). Create it if the installer has not already; --system so it
+	# gets no login and no expiry. Idempotent: skip when it already exists.
+	if ! getent passwd pct-agent >/dev/null 2>&1; then
+		adduser --system --group --home /var/lib/pct-agent \
+			--shell /usr/sbin/nologin \
+			--gecos "Parental Controls Toolkit agent" pct-agent
+	fi
+
+	# Only touch systemd when it is the running init (skips containers/chroots).
+	if [ -d /run/systemd/system ]; then
+		systemd-tmpfiles --create /usr/lib/tmpfiles.d/pct-client.conf || true
+		systemctl daemon-reload || true
+		# Enable (not start): the bridge needs the enrolment token written to
+		# /etc/default/pct-client-bridge first, which install-client.sh does
+		# before starting the unit.
+		systemctl enable pct-client-bridge.service || true
+	fi
+	;;
+abort-upgrade | abort-remove | abort-deconfigure) ;;
+*)
+	echo "postinst called with unknown argument \`$1'" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/client/agent/packaging/debian/postrm
+++ b/client/agent/packaging/debian/postrm
@@ -1,7 +1,7 @@
 #!/bin/sh
 # postrm for pct-client (#106). On purge, remove the local config conffile and
-# reload systemd so the removed unit is forgotten. The pct-agent account and
-# /var/lib/pct-agent are left in place: they may hold the server's SSH key and
+# reload systemd so the removed unit is forgotten. The pct-agent account and its
+# home (/home/pct-agent) are left in place: they hold the server's SSH key and
 # are shared with the installer-provisioned orchestration user (#78).
 set -e
 

--- a/client/agent/packaging/debian/postrm
+++ b/client/agent/packaging/debian/postrm
@@ -1,0 +1,22 @@
+#!/bin/sh
+# postrm for pct-client (#106). On purge, remove the local config conffile and
+# reload systemd so the removed unit is forgotten. The pct-agent account and
+# /var/lib/pct-agent are left in place: they may hold the server's SSH key and
+# are shared with the installer-provisioned orchestration user (#78).
+set -e
+
+case "$1" in
+purge)
+	rm -f /etc/default/pct-client-bridge
+	if [ -d /run/systemd/system ]; then
+		systemctl daemon-reload || true
+	fi
+	;;
+remove | upgrade | failed-upgrade | abort-install | abort-upgrade | disappear) ;;
+*)
+	echo "postrm called with unknown argument \`$1'" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/client/agent/packaging/debian/prerm
+++ b/client/agent/packaging/debian/prerm
@@ -1,0 +1,20 @@
+#!/bin/sh
+# prerm for pct-client (#106). Stop + disable the system bridge on removal.
+# The per-user agent units are systemd --user and were enabled by the installer
+# per supervised uid; they are torn down with the user session, not here.
+set -e
+
+case "$1" in
+remove | deconfigure)
+	if [ -d /run/systemd/system ]; then
+		systemctl disable --now pct-client-bridge.service || true
+	fi
+	;;
+upgrade | failed-upgrade) ;;
+*)
+	echo "prerm called with unknown argument \`$1'" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/client/agent/packaging/default/pct-client-bridge
+++ b/client/agent/packaging/default/pct-client-bridge
@@ -1,0 +1,17 @@
+# Environment for pct-client-bridge.service (EnvironmentFile).
+#
+# The enrolment step of install-client.sh writes the real values here after the
+# dashboard issues the per-client token (#77). This shipped file carries only
+# commented examples so a fresh install has a valid, inert config file; the
+# bridge refuses to start until PCT_BRIDGE_SERVER_URL / PCT_BRIDGE_TOKEN /
+# PCT_BRIDGE_USERS are set (client/agent/src/bridge/config.ts).
+#
+# PCT_BRIDGE_SERVER_URL=wss://dashboard.example.lan/api/events/stream
+# PCT_BRIDGE_TOKEN=<per-client bearer token issued at enrolment>
+# PCT_BRIDGE_USERS=[{"userId":1,"linuxUid":1001}]
+#
+# Optional overrides (defaults in config.ts):
+# PCT_BRIDGE_SOCKET_DIR=/run/pct
+# PCT_BRIDGE_SOCKET_MODE=0o600
+# PCT_BRIDGE_BACKOFF_BASE_MS=1000
+# PCT_BRIDGE_BACKOFF_MAX_MS=60000

--- a/client/agent/packaging/systemd/pct-client-agent.service
+++ b/client/agent/packaging/systemd/pct-client-agent.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Parental Controls Toolkit per-user agent (notifications, cadence)
+Documentation=https://github.com/BenSeymourODB/linux-parental-controls-toolkit
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+# The socket the bridge listens on for this user is deterministic from the
+# running uid (%U); the policy User.id and any overrides come from the per-user
+# env file the installer writes. The file is optional (leading '-') so the unit
+# can be enabled before enrolment populates it.
+Environment=PCT_AGENT_SOCKET=/run/pct/%U.sock
+EnvironmentFile=-%h/.config/pct-client/agent.env
+ExecStart=/usr/lib/pct-client/node/bin/node /usr/lib/pct-client/dist/agent/main.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/client/agent/packaging/systemd/pct-client-bridge.service
+++ b/client/agent/packaging/systemd/pct-client-bridge.service
@@ -14,10 +14,11 @@ Group=pct-agent
 # Populated by the enrolment step of install-client.sh: PCT_BRIDGE_SERVER_URL,
 # PCT_BRIDGE_TOKEN, PCT_BRIDGE_USERS. A conffile, so it survives package upgrades.
 EnvironmentFile=/etc/default/pct-client-bridge
-# Owns /run/pct/<linux-uid>.sock; RuntimeDirectory is 0755 so a supervised
-# user's agent can traverse to reach its own socket.
-RuntimeDirectory=pct
-RuntimeDirectoryMode=0755
+# /run/pct is created (owned by pct-agent, mode 0755) by the tmpfiles.d entry,
+# not by RuntimeDirectory=: the socket dir must persist across bridge restarts
+# so a supervised user's agent keeps its socket, and dispatch.ts deliberately
+# leaves creating it to packaging (#106). RuntimeDirectory= would tear it down
+# on every stop.
 ExecStart=/usr/lib/pct-client/node/bin/node /usr/lib/pct-client/dist/main.js
 Restart=on-failure
 RestartSec=5

--- a/client/agent/packaging/systemd/pct-client-bridge.service
+++ b/client/agent/packaging/systemd/pct-client-bridge.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Parental Controls Toolkit client bridge (dashboard event stream)
+Documentation=https://github.com/BenSeymourODB/linux-parental-controls-toolkit
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Low-privilege account created by the client installer (#78) / this package's
+# postinst. Holds the outbound WebSocket to the dashboard; never trusts the
+# local user (docs/client-notifications.md -> "pct-client-bridge").
+User=pct-agent
+Group=pct-agent
+# Populated by the enrolment step of install-client.sh: PCT_BRIDGE_SERVER_URL,
+# PCT_BRIDGE_TOKEN, PCT_BRIDGE_USERS. A conffile, so it survives package upgrades.
+EnvironmentFile=/etc/default/pct-client-bridge
+# Owns /run/pct/<linux-uid>.sock; RuntimeDirectory is 0755 so a supervised
+# user's agent can traverse to reach its own socket.
+RuntimeDirectory=pct
+RuntimeDirectoryMode=0755
+ExecStart=/usr/lib/pct-client/node/bin/node /usr/lib/pct-client/dist/main.js
+Restart=on-failure
+RestartSec=5
+# Standard service sandboxing (bounded hardening, not tamper-proofing):
+# CLAUDE.md -> "Tamper resistance is deliberately bounded".
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/client/agent/packaging/tmpfiles.d/pct-client.conf
+++ b/client/agent/packaging/tmpfiles.d/pct-client.conf
@@ -1,0 +1,4 @@
+# Socket directory the bridge fans per-user events out through
+# (docs/client-notifications.md -> AF_UNIX /run/pct/<linux-uid>.sock).
+# 0755 so each supervised user's agent can traverse to reach its own socket.
+d /run/pct 0755 pct-agent pct-agent -

--- a/client/agent/tsconfig.build.json
+++ b/client/agent/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false,
+    "declaration": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests", "vitest.config.ts", "dist"]
+}

--- a/client/tests/build-deb.bats
+++ b/client/tests/build-deb.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+#
+# Tests for client/agent/build-deb.sh — the builder that produces the pct-client
+# Debian package (#106): pct-client-bridge (system unit) + pct-client-agent
+# (systemd --user unit), bundling their own Node runtime under
+# /usr/lib/pct-client/node.
+#
+# The real Node runtime (~30 MB) is NOT downloaded here: setup_file synthesises
+# a tiny STUB tarball with the expected `node-vX-linux-x64/bin/node` layout and
+# passes it via PCT_NODE_TARBALL + PCT_NODE_SHA256, so the packaging is exercised
+# fully offline and fast. The real download + SHA-256 pin is validated at release
+# time (#168); a dedicated test below checks the mismatch path.
+
+setup_file() {
+	AGENT_DIR="$(cd "${BATS_TEST_DIRNAME}/../agent" && pwd)"
+	export AGENT_DIR
+
+	# The build compiles the agent TypeScript, so its devDeps must be present.
+	# Self-provision (like build-install-bundle.bats builds within the test) so
+	# this runs in the deps-free `client-tests` CI job without extra wiring.
+	if [ ! -d "${AGENT_DIR}/node_modules" ]; then
+		(cd "$AGENT_DIR" && npm ci --no-audit --no-fund) >/dev/null 2>&1
+	fi
+
+	WORKDIR="$(mktemp -d)"
+	export WORKDIR
+
+	# Pinned Node version drives the stub tarball's internal directory name.
+	NODE_VER="$(. "${AGENT_DIR}/NODE_VERSION" && printf '%s' "$NODE_VERSION")"
+	export NODE_VER
+	local stubroot="${WORKDIR}/node-v${NODE_VER}-linux-x64"
+	mkdir -p "${stubroot}/bin"
+	printf '#!/bin/sh\necho stub-node\n' >"${stubroot}/bin/node"
+	chmod +x "${stubroot}/bin/node"
+	printf 'stub license\n' >"${stubroot}/LICENSE"
+	STUB_TARBALL="${WORKDIR}/node-stub.tar.xz"
+	export STUB_TARBALL
+	tar -C "$WORKDIR" -cJf "$STUB_TARBALL" "node-v${NODE_VER}-linux-x64"
+	STUB_SHA="$(sha256sum "$STUB_TARBALL" | cut -d' ' -f1)"
+	export STUB_SHA
+
+	DEB="${WORKDIR}/pct-client_9.9.9_amd64.deb"
+	export DEB
+	(cd "$AGENT_DIR" &&
+		PCT_NODE_TARBALL="$STUB_TARBALL" PCT_NODE_SHA256="$STUB_SHA" \
+			./build-deb.sh --output "$DEB" --version 9.9.9) >/dev/null
+
+	EXTRACT="${WORKDIR}/extract"
+	export EXTRACT
+	mkdir -p "$EXTRACT"
+	dpkg-deb -x "$DEB" "$EXTRACT"
+
+	CTRL="${WORKDIR}/control"
+	export CTRL
+	mkdir -p "$CTRL"
+	dpkg-deb -e "$DEB" "$CTRL"
+}
+
+teardown_file() {
+	[ -n "${WORKDIR:-}" ] && rm -rf "$WORKDIR"
+}
+
+# --- Build + control metadata ----------------------------------------------
+
+@test "produces a .deb" {
+	[ -f "$DEB" ]
+}
+
+@test "control declares package name, version, and architecture" {
+	run dpkg-deb --field "$DEB" Package Version Architecture
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"pct-client"* ]]
+	[[ "$output" == *"9.9.9"* ]]
+	[[ "$output" == *"amd64"* ]]
+}
+
+@test "control depends on systemd and adduser" {
+	run dpkg-deb --field "$DEB" Depends
+	[[ "$output" == *"systemd"* ]]
+	[[ "$output" == *"adduser"* ]]
+}
+
+# --- Payload layout ---------------------------------------------------------
+
+@test "bundles both daemon entry points" {
+	[ -f "${EXTRACT}/usr/lib/pct-client/dist/main.js" ]
+	[ -f "${EXTRACT}/usr/lib/pct-client/dist/agent/main.js" ]
+}
+
+@test "bundles the Node runtime binary" {
+	[ -x "${EXTRACT}/usr/lib/pct-client/node/bin/node" ]
+}
+
+@test "bundles the production dependencies (ws, zod)" {
+	[ -d "${EXTRACT}/usr/lib/pct-client/node_modules/ws" ]
+	[ -d "${EXTRACT}/usr/lib/pct-client/node_modules/zod" ]
+}
+
+@test "bundle package.json marks the tree as ESM" {
+	run cat "${EXTRACT}/usr/lib/pct-client/package.json"
+	[[ "$output" == *'"type": "module"'* ]]
+	[[ "$output" == *'"version": "9.9.9"'* ]]
+}
+
+# --- systemd units ----------------------------------------------------------
+
+@test "ships the bridge as a system unit wired to the bundled runtime" {
+	local unit="${EXTRACT}/usr/lib/systemd/system/pct-client-bridge.service"
+	[ -f "$unit" ]
+	run cat "$unit"
+	[[ "$output" == *"User=pct-agent"* ]]
+	[[ "$output" == *"RuntimeDirectory=pct"* ]]
+	[[ "$output" == *"EnvironmentFile=/etc/default/pct-client-bridge"* ]]
+	[[ "$output" == *"ExecStart=/usr/lib/pct-client/node/bin/node /usr/lib/pct-client/dist/main.js"* ]]
+	[[ "$output" == *"WantedBy=multi-user.target"* ]]
+}
+
+@test "ships the agent as a systemd --user unit with a uid-derived socket" {
+	local unit="${EXTRACT}/usr/lib/systemd/user/pct-client-agent.service"
+	[ -f "$unit" ]
+	run cat "$unit"
+	[[ "$output" == *"ExecStart=/usr/lib/pct-client/node/bin/node /usr/lib/pct-client/dist/agent/main.js"* ]]
+	[[ "$output" == *"PCT_AGENT_SOCKET=/run/pct/%U.sock"* ]]
+	[[ "$output" == *"WantedBy=default.target"* ]]
+}
+
+@test "ships a tmpfiles.d entry creating /run/pct for pct-agent" {
+	local conf="${EXTRACT}/usr/lib/tmpfiles.d/pct-client.conf"
+	[ -f "$conf" ]
+	run cat "$conf"
+	[[ "$output" == *"/run/pct"* ]]
+	[[ "$output" == *"pct-agent pct-agent"* ]]
+}
+
+# --- Config / conffiles -----------------------------------------------------
+
+@test "ships the bridge EnvironmentFile as a conffile" {
+	[ -f "${EXTRACT}/etc/default/pct-client-bridge" ]
+	run cat "${CTRL}/conffiles"
+	[[ "$output" == *"/etc/default/pct-client-bridge"* ]]
+}
+
+# --- Maintainer scripts -----------------------------------------------------
+
+@test "maintainer scripts are present, executable, and syntactically valid" {
+	for script in postinst prerm postrm; do
+		[ -x "${CTRL}/${script}" ]
+		run sh -n "${CTRL}/${script}"
+		[ "$status" -eq 0 ]
+	done
+}
+
+@test "postinst creates pct-agent and enables the bridge via systemd" {
+	run cat "${CTRL}/postinst"
+	[[ "$output" == *"adduser --system"* ]]
+	[[ "$output" == *"pct-agent"* ]]
+	[[ "$output" == *"systemd-tmpfiles --create"* ]]
+	[[ "$output" == *"systemctl daemon-reload"* ]]
+	[[ "$output" == *"systemctl enable pct-client-bridge.service"* ]]
+}
+
+@test "prerm stops and disables the bridge on removal" {
+	run cat "${CTRL}/prerm"
+	[[ "$output" == *"systemctl disable --now pct-client-bridge.service"* ]]
+}
+
+@test "postrm removes the config conffile on purge" {
+	run cat "${CTRL}/postrm"
+	[[ "$output" == *"purge"* ]]
+	[[ "$output" == *"rm -f /etc/default/pct-client-bridge"* ]]
+}
+
+# --- Guard rails ------------------------------------------------------------
+
+@test "rejects a Node tarball whose SHA-256 does not match" {
+	run env PCT_NODE_TARBALL="$STUB_TARBALL" PCT_NODE_SHA256="deadbeef" \
+		bash "${AGENT_DIR}/build-deb.sh" --output "${WORKDIR}/bad.deb" --version 0.0.1
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"SHA-256 mismatch"* ]]
+}
+
+@test "rejects an unsupported architecture" {
+	run bash "${AGENT_DIR}/build-deb.sh" --arch ppc64 --output "${WORKDIR}/bad.deb"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"unsupported --arch"* ]]
+}
+
+@test "--help prints usage and exits 0" {
+	run bash "${AGENT_DIR}/build-deb.sh" --help
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"build-deb.sh"* ]]
+	[[ "$output" == *"--output"* ]]
+}

--- a/client/tests/build-deb.bats
+++ b/client/tests/build-deb.bats
@@ -74,10 +74,12 @@ teardown_file() {
 	[[ "$output" == *"amd64"* ]]
 }
 
-@test "control depends on systemd and adduser" {
+@test "control depends on systemd and recommends the desktop stack" {
 	run dpkg-deb --field "$DEB" Depends
 	[[ "$output" == *"systemd"* ]]
-	[[ "$output" == *"adduser"* ]]
+	run dpkg-deb --field "$DEB" Recommends
+	[[ "$output" == *"libnotify-bin"* ]]
+	[[ "$output" == *"libcanberra-gtk3-module"* ]]
 }
 
 # --- Payload layout ---------------------------------------------------------
@@ -87,8 +89,9 @@ teardown_file() {
 	[ -f "${EXTRACT}/usr/lib/pct-client/dist/agent/main.js" ]
 }
 
-@test "bundles the Node runtime binary" {
+@test "bundles the Node runtime binary and its LICENSE" {
 	[ -x "${EXTRACT}/usr/lib/pct-client/node/bin/node" ]
+	[ -f "${EXTRACT}/usr/lib/pct-client/node/LICENSE" ]
 }
 
 @test "bundles the production dependencies (ws, zod)" {
@@ -109,7 +112,6 @@ teardown_file() {
 	[ -f "$unit" ]
 	run cat "$unit"
 	[[ "$output" == *"User=pct-agent"* ]]
-	[[ "$output" == *"RuntimeDirectory=pct"* ]]
 	[[ "$output" == *"EnvironmentFile=/etc/default/pct-client-bridge"* ]]
 	[[ "$output" == *"ExecStart=/usr/lib/pct-client/node/bin/node /usr/lib/pct-client/dist/main.js"* ]]
 	[[ "$output" == *"WantedBy=multi-user.target"* ]]
@@ -150,13 +152,20 @@ teardown_file() {
 	done
 }
 
-@test "postinst creates pct-agent and enables the bridge via systemd" {
+@test "postinst creates pct-agent with an SSH-capable shell and home" {
+	# Must match client/lib/provision-agent-user.sh: pct-agent is the SSH
+	# principal the dashboard execs timekpra as, so it needs /bin/bash + a home.
 	run cat "${CTRL}/postinst"
-	[[ "$output" == *"adduser --system"* ]]
-	[[ "$output" == *"pct-agent"* ]]
+	[[ "$output" == *"useradd --system --create-home --shell /bin/bash pct-agent"* ]]
+	[[ "$output" != *"nologin"* ]]
+}
+
+@test "postinst enables and (on upgrade) restarts the bridge via systemd" {
+	run cat "${CTRL}/postinst"
 	[[ "$output" == *"systemd-tmpfiles --create"* ]]
 	[[ "$output" == *"systemctl daemon-reload"* ]]
 	[[ "$output" == *"systemctl enable pct-client-bridge.service"* ]]
+	[[ "$output" == *"systemctl try-restart pct-client-bridge.service"* ]]
 }
 
 @test "prerm stops and disables the bridge on removal" {
@@ -190,4 +199,24 @@ teardown_file() {
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"build-deb.sh"* ]]
 	[[ "$output" == *"--output"* ]]
+}
+
+@test "builds an arm64 package from the arm64 stub + SHA" {
+	# Exercises the arch -> NODE_ARCH mapping and the SHA256_LINUX_ARM64 branch.
+	local root="${WORKDIR}/arm64/node-v${NODE_VER}-linux-arm64"
+	mkdir -p "${root}/bin"
+	printf '#!/bin/sh\necho stub-node\n' >"${root}/bin/node"
+	chmod +x "${root}/bin/node"
+	printf 'stub license\n' >"${root}/LICENSE"
+	local tarball="${WORKDIR}/arm64/node-arm64.tar.xz"
+	tar -C "${WORKDIR}/arm64" -cJf "$tarball" "node-v${NODE_VER}-linux-arm64"
+	local sha
+	sha="$(sha256sum "$tarball" | cut -d' ' -f1)"
+	local deb="${WORKDIR}/pct-client_9.9.9_arm64.deb"
+
+	run env PCT_NODE_TARBALL="$tarball" PCT_NODE_SHA256="$sha" \
+		bash "${AGENT_DIR}/build-deb.sh" --arch arm64 --version 9.9.9 --output "$deb"
+	[ "$status" -eq 0 ]
+	run dpkg-deb --field "$deb" Architecture
+	[[ "$output" == *"arm64"* ]]
 }

--- a/docs/client-install.md
+++ b/docs/client-install.md
@@ -178,6 +178,15 @@ separately:
    - The bridge is given a per-client bearer token (issued by the
      dashboard at enrolment time) so it can authenticate to
      `/api/events/stream`.
+
+   > **How the package is built (#106).** The `pct-client` `.deb` is
+   > produced by `client/agent/build-deb.sh`, which compiles the agent
+   > TypeScript, bundles a pinned, SHA-256-verified Node runtime under
+   > `/usr/lib/pct-client/node`, and ships the two systemd units plus the
+   > `/etc/default/pct-client-bridge` conffile. The package's `postinst`
+   > creates the `pct-agent` account and *enables* the bridge; this step
+   > writes the enrolment token to the conffile and then *starts* it.
+   > Publishing the package over a release channel is #168.
 6. **Configure e2guardian**
    - Generate a default config with per-UID filter groups corresponding
      to each supervised user.


### PR DESCRIPTION
## Summary

- Adds `client/agent/build-deb.sh`, which builds the **`pct-client`** Debian package: it installs `pct-client-bridge` (system service) and `pct-client-agent` (`systemd --user`) with their own pinned Node.js runtime bundled under `/usr/lib/pct-client/node`, so no client install depends on the distro's Node packages (CLAUDE.md → "Client agent"; `docs/client-install.md` §5a; `docs/client-notifications.md`).
- Ships the packaging assets under `client/agent/packaging/`: the two systemd units, a `tmpfiles.d` entry for `/run/pct`, the `/etc/default/pct-client-bridge` conffile, and DEBIAN `control`/`postinst`/`prerm`/`postrm`.
- Adds `client/agent/tsconfig.build.json` + a `build` npm script to emit `dist/`, and `client/tests/build-deb.bats` (20 tests) that build the package offline with a stub Node tarball and assert the whole layout.

## Plan

Linked plan: `.claude/plans/issue-106-package-client-agent-deb.md`
Roadmap: `docs/roadmap.md` → Phase 8b

## What the `.deb` installs

```
/usr/lib/pct-client/node/bin/node          bundled Node 22 runtime (pinned + SHA-256 verified)
/usr/lib/pct-client/dist/main.js           pct-client-bridge entry
/usr/lib/pct-client/dist/agent/main.js     pct-client-agent entry
/usr/lib/pct-client/node_modules/{ws,zod}  production deps
/usr/lib/systemd/system/pct-client-bridge.service   runs as pct-agent
/usr/lib/systemd/user/pct-client-agent.service      uid-derived socket (/run/pct/%U.sock)
/usr/lib/tmpfiles.d/pct-client.conf                 creates + owns /run/pct
/etc/default/pct-client-bridge             EnvironmentFile (conffile)
```

`postinst` creates the `pct-agent` account **identically to `client/lib/provision-agent-user.sh`** (`useradd --system --create-home --shell /bin/bash` — pct-agent is the SSH principal the dashboard execs `timekpra` as, so both creators must agree), **enables** (not starts) the bridge — it needs the enrolment token written to `/etc/default/pct-client-bridge` first — and `try-restart`s it on upgrade so new code takes effect. `/run/pct` is managed by the tmpfiles.d entry (not `RuntimeDirectory=`) so the socket dir survives bridge restarts, matching `dispatch.ts`.

Verified locally end-to-end: a real build downloads + SHA-256-verifies Node 22.22.2, produces a ~32 MB `.deb`, and the **bundled** runtime runs both the bridge and agent entrypoints self-contained (deps resolve from the bundled `node_modules`).

## License-boundary note

No GPL linkage and no change to the dashboard image. This packages only this repo's own TypeScript plus its MIT deps (`ws`, `zod`) and the official Node runtime, and touches the **client** package only — the dashboard image's GPL-free invariant (`license-guard.yml`) is unaffected. GPL client tools (Timekpr-nExT, e2guardian) are still installed separately from apt by the installer. No new npm dependencies added.

## Tamper-resistance note

Within the documented ceiling: a plain notification/relay daemon package. Standard service sandboxing only (`NoNewPrivileges`, `PrivateTmp`, `ProtectHome`); no anti-tamper, no `/etc`/`/usr`/boot lockdown. **No** privileged commands or sudoers changes ship here.

## First-pass review

A review subagent flagged one blocker (the `pct-agent` shell/home would have diverged from the installer and broken the SSH transport) and one major (no restart on upgrade), plus minors — all addressed in the second commit (matched `useradd` attributes, added `try-restart`, dropped redundant `RuntimeDirectory`, `Depends: systemd` + `Recommends` for the desktop stack, tightened the version fallback, and added arm64 / shell / LICENSE test coverage).

## Deferred (tracked)

- **`install-client.sh` fetching + installing the `.deb`** and enabling per-user units — **#443** (new; the fetch path binds to the publish channel #168 settles).
- **Publishing the `.deb`** from `release.yml` over the chosen channel — **#168** (depends on the channel decision #167). The real Node-download build path is validated locally here and will run at release time.
- **Narrow bridge `sudoers` drop-in** for the bridge's privileged actions (`timekpra --kill-session`, PAM lockout) — Phase 8c (**#107** / **#108**), following the privilege-model ADR (**#345**). The package ships with no privileged config, the safe default.

## Test plan

- [x] `client/agent`: `format:check`, `lint`, `typecheck`, `test` (99% coverage) all pass.
- [x] `client/tests/build-deb.bats` — 20 tests, green (offline stub build, incl. arm64 path + SHA-mismatch guard).
- [x] `shellcheck` clean on `build-deb.sh` and the `sh` maintainer scripts.
- [x] Real end-to-end build (Node download + SHA verify) produces an installable `.deb`; bundled runtime runs both daemons self-contained.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)